### PR TITLE
Option to remove formatting before diff

### DIFF
--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -708,5 +708,40 @@ function project_recalculate_page_counts( $projectid )
     ") or die(mysqli_error(DPDatabase::get_connection()));
 }
 
+function remove_formatting($text, $unwrap)
+{
+    $text = str_replace( "\r\n", "\n", $text);
+    // remove out-of-line tags [Illustration] (without text), users' notes
+    // these can leave blank lines so do first
+    $text = preg_replace("/\/[\*#]|[\*#]\/|\[Illustration\]|\[\*\*[^\]]+\]/", "", $text);
+    // remove inline tags and <tb>
+    $text = preg_replace("/<\/?(?:[ibfgu]|sc|tb)>/", "", $text);
+    // change alphabetic footnote anchors to *
+    $text = preg_replace("/\[[A-Z]\]/", "[*]", $text);
+    // Adjust footnotes
+    $text = preg_replace("/\[Footnote (\d+):([^\]]+)\]/", "$1$2", $text);
+    $text = preg_replace("/\[Footnote [A-Z]:([^\]]+)\]/", "*$1", $text);
+    // Ilustration with text, Sidenote
+    $text = preg_replace("/\[(?:Illustration|Sidenote): ([^\]]+)\]/", "$1", $text);
+    if($unwrap)
+    {
+        // change one or more newlines or spaces to a single space
+        $text = preg_replace("/\s+/", " ", $text);
+        // remove space at beginning or end
+        return preg_replace("/^ | $/", "", $text);
+    }
+    else
+    {
+        // remove leading spaces
+        $text = preg_replace("/(?<=\n|^)\ +/", "", $text);
+        // remove trailing spaces
+        $text = preg_replace("/\ +(?=\n|$)/", "", $text);
+        // remove blank lines - one or more \n -> one \n
+        $text = preg_replace("/\n+/", "\n", $text);
+        // remove blank line at beginning or end
+        return preg_replace("/^\n|\n$/", "", $text);
+    }
+}
+
 // vim: sw=4 ts=4 expandtab
 ?>

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -583,6 +583,29 @@ XML;
         }
         return FALSE;
     }
+    
+    public function check_pages_table_exists()
+    {
+        if (!$this->pages_table_exists)
+        {
+            echo "<p class='warning'>";
+            if ($this->archived != 0)
+            {
+                echo _("The project has been archived, so page details are not available.");
+            }
+            elseif ($this->state == PROJ_DELETE)
+            {
+                echo _("The project has been deleted, so page details are not available.");
+            }
+            else
+            {
+                echo _("Page details are not available for this project.");
+            }
+            echo "</p>";
+            return false;
+        }
+        return true;
+    }
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -584,26 +584,25 @@ XML;
         return FALSE;
     }
     
-    public function check_pages_table_exists()
+    public function check_pages_table_exists(&$message)
     {
         if (!$this->pages_table_exists)
         {
-            echo "<p class='warning'>";
             if ($this->archived != 0)
             {
-                echo _("The project has been archived, so page details are not available.");
+                $message = _("The project has been archived, so page details are not available.");
             }
             elseif ($this->state == PROJ_DELETE)
             {
-                echo _("The project has been deleted, so page details are not available.");
+                $message = _("The project has been deleted, so page details are not available.");
             }
             else
             {
-                echo _("Page details are not available for this project.");
+                $message = _("Page details are not available for this project.");
             }
-            echo "</p>";
             return false;
         }
+        $message = "";
         return true;
     }
 }

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -6,6 +6,7 @@ include_once($relPath.'forum_interface.inc'); // topic_create
 include_once($relPath.'SettingsClass.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'MARCRecord.inc');
+include_once($relPath.'stages.inc'); // is_formatting_round()
 
 class NonexistentProjectException extends Exception { }
 
@@ -565,6 +566,22 @@ XML;
         $updated_record->load_yaz_array(unserialize(base64_decode($row["updated_array"])));
 
         return $updated_record;
+    }
+
+    // check if project has entered a formatting round
+    public function has_entered_formatting_round()
+    {
+        global $PROJECT_STATES_IN_ORDER;
+        $state_index = array_search($this->state, $PROJECT_STATES_IN_ORDER);
+        for($i=$state_index; $i>=0; $i--)
+        {
+            $round = get_Round_for_project_state($PROJECT_STATES_IN_ORDER[$i]);
+            if($round && is_formatting_round($round))
+            {
+                return TRUE;
+            }
+        }
+        return FALSE;
     }
 }
 

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -524,14 +524,14 @@ function round_project_listing_presort( $round )
 // If you don't want any criteria to take precedence over column-sorts,
 // return NULL or the empty string.
 {
-    if ( startswith($round->id, 'P') )
+    if(is_proofreading_round($round))
     {
         return "
             (difficulty = 'beginner') DESC,
             (nameofwork LIKE '%Newcomers Only%' OR nameofwork LIKE '%Rapid Review%') DESC
         ";
     }
-    else if ( startswith($round->id, 'F') )
+    else if(is_formatting_round($round))
     {
         return "
             (
@@ -545,6 +545,16 @@ function round_project_listing_presort( $round )
     {
         assert( FALSE );
     }
+}
+
+function is_proofreading_round($round)
+{
+    return startswith($round->id, 'P');
+}
+
+function is_formatting_round($round)
+{
+    return startswith($round->id, 'F');
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/project.php
+++ b/project.php
@@ -688,7 +688,7 @@ function do_project_info_table()
         }
         else
         {
-            if ($project->pages_table_exists)
+            if($project->check_pages_table_exists($detail))
             {
                 $url = "$code_url/tools/project_manager/page_detail.php?project=$projectid&amp;show_image_size=0";
                 $blurb = _("Images, Pages Proofread, & Differences");
@@ -700,16 +700,6 @@ function do_project_info_table()
                     $url3 = "$code_url/tools/project_manager/page_compare.php?project=$projectid";
                     $blurb3 = _("Compare without formatting");
                     $detail .= " &middot; <a href='$url3'>$blurb3</a>";
-                }
-            }
-            else
-            {
-                if ($project->archived != 0) {
-                    $detail = _("The project has been archived, so page details are not available.");
-                } elseif ($project->state == PROJ_DELETE) {
-                    $detail = _("The project has been deleted, so page details are not available.");
-                } else {
-                    $detail = _("Page details are not available for this project.");
                 }
             }
             echo_row_a( _("Page Detail"), $detail);

--- a/project.php
+++ b/project.php
@@ -694,12 +694,12 @@ function do_project_info_table()
                 $blurb = _("Images, Pages Proofread, & Differences");
                 $url2 = "$url&amp;select_by_user";
                 $blurb2 = _("Just my pages");
-                $detail = "<a href='$url'>$blurb</a> | <a href='$url2'>$blurb2</a>";
+                $detail = "<a href='$url'>$blurb</a> &middot; <a href='$url2'><b>$blurb2</b></a>";
                 if($project->has_entered_formatting_round())
                 {
                     $url3 = "$code_url/tools/project_manager/page_compare.php?project=$projectid";
                     $blurb3 = _("Compare without formatting");
-                    $detail .= " | <a href='$url3'>$blurb3</a>";
+                    $detail .= " &middot; <a href='$url3'>$blurb3</a>";
                 }
             }
             else

--- a/project.php
+++ b/project.php
@@ -694,7 +694,13 @@ function do_project_info_table()
                 $blurb = _("Images, Pages Proofread, & Differences");
                 $url2 = "$url&amp;select_by_user";
                 $blurb2 = _("Just my pages");
-                $detail = "<a href='$url'>$blurb</a> &gt;&gt;<a href='$url2'>$blurb2</a>&lt;&lt;";
+                $detail = "<a href='$url'>$blurb</a> | <a href='$url2'>$blurb2</a>";
+                if($project->has_entered_formatting_round())
+                {
+                    $url3 = "$code_url/tools/project_manager/page_compare.php?project=$projectid";
+                    $blurb3 = _("Compare without formatting");
+                    $detail .= " | <a href='$url3'>$blurb3</a>";
+                }
             }
             else
             {
@@ -2160,4 +2166,3 @@ function do_page_table()
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 // vim: sw=4 ts=4 expandtab
-?>

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -817,5 +817,13 @@ table.search-column tr th {
 #pm_links li {
   margin-top: 3px;
 }
+/* ------------------------------------------------------------------------ */
+/* Page compare grid */
+.grid-wrapper {
+  display: grid;
+  grid-template-columns: max-content max-content;
+  grid-column-gap: 2em;
+  grid-row-gap: 2px;
+}
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -881,5 +881,15 @@ table.search-column {
     }
 }
 
+/* ------------------------------------------------------------------------ */
+/* Page compare grid */
+
+.grid-wrapper {
+    display: grid;
+    grid-template-columns: max-content max-content;
+    grid-column-gap: 2em;
+    grid-row-gap: 2px;
+}
+
 /* vim: sw=4 ts=4 expandtab
 */

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -67,19 +67,10 @@ else
     $R_format = is_formatting_round($R_round);
 }
 
-
-switch($format)
+if(!$format) // no parameter passed
 {
-    case "keep":
-        $remove_format = false;
-        break;
-    case "remove":
-        $remove_format = true;
-        break;
-    default:
-        // remove format if only one of the rounds is formatting
-        $remove_format = ($L_format xor $R_format);
-        break;
+    // default to remove format if only one of the rounds is formatting
+    $format = ($L_format xor $R_format) ? "remove" : "keep";
 }
 
 $query = "
@@ -96,7 +87,7 @@ if ( $can_see_names_for_this_page) {
     $R_label .= " ($R_user)";
 }
 
-if($remove_format)
+if($format == "remove")
 {
     // also remove blank lines and leading and trailing spaces
     $L_text = remove_formatting($L_text, false);
@@ -124,7 +115,7 @@ echo "<h1>$project_title</h1>\n";
 echo "<h2>$image_link</h2>\n";
 
 do_navigation($projectid, $image, $L_round_num, $R_round_num, 
-              $L_user_column_name, $L_user);
+              $L_user_column_name, $L_user, $format);
 echo $navigation_text;
 
 $url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";
@@ -135,7 +126,7 @@ echo "\n<p><a href='$url'>$label</a>\n";
 if($L_format || $R_format)
 {
     // show option to change compare method
-    if($remove_format)
+    if($format == "remove")
     {
         $format_label = _("Compare with formatting");
         $_GET["format"] = "keep";
@@ -170,7 +161,7 @@ if ($L_text != $R_text)
 // build up the text for the navigation bit, so we can repeat it
 // again at the bottom of the page
 function do_navigation($projectid, $image, $L_round_num, $R_round_num, 
-                       $L_user_column_name, $L_user) 
+                       $L_user_column_name, $L_user, $format) 
 {
     global $navigation_text;
     $jump_to_js = "this.form.image.value=this.form.jumpto[this.form.jumpto.selectedIndex].value; this.form.submit();";
@@ -180,6 +171,7 @@ function do_navigation($projectid, $image, $L_round_num, $R_round_num,
     $navigation_text .= "\n<input type='hidden' name='image' value='$image'>";
     $navigation_text .= "\n<input type='hidden' name='L_round_num' value='$L_round_num'>";
     $navigation_text .= "\n<input type='hidden' name='R_round_num' value='$R_round_num'>";
+    $navigation_text .= "\n<input type='hidden' name='format' value='$format'>";
     $navigation_text .= "\n" . _("Jump to") . ": <select name='jumpto' onChange='$jump_to_js'>\n";
 
     $query = "SELECT image, $L_user_column_name  FROM $projectid ORDER BY image ASC";

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -7,6 +7,7 @@ include_once($relPath.'Project.inc');
 include_once($relPath.'links.inc');
 include_once($relPath.'misc.inc'); // get_integer_param(), attr_safe()
 include_once($relPath."DifferenceEngineWrapper.inc");
+include_once($relPath."DPage.inc"); // remove_formatting()
 
 require_login();
 
@@ -14,6 +15,7 @@ $projectid   = validate_projectID('project', @$_GET['project']);
 $image       = validate_page_image_filename('image', @$_GET['image'], true);
 $L_round_num = get_integer_param($_GET, 'L_round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
 $R_round_num = get_integer_param($_GET, 'R_round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
+$format = get_enumerated_param($_GET, "format", null, array("keep", "remove"), true);
 
 $project = new Project( $projectid );
 $state = $project->state;
@@ -38,6 +40,7 @@ if ( $L_round_num == 0 )
     $L_text_column_name = 'master_text';
     $L_user_column_name = "'none'";  // string literal, not column name
     $L_label = _('OCR');
+    $L_format = false;
 }
 else
 {
@@ -45,6 +48,7 @@ else
     $L_text_column_name = $L_round->text_column_name;
     $L_user_column_name = $L_round->user_column_name;
     $L_label = $L_round->id;
+    $L_format = is_formatting_round($L_round);
 }
 
 if ( $R_round_num == 0 )
@@ -52,6 +56,7 @@ if ( $R_round_num == 0 )
     $R_text_column_name = 'master_text';
     $R_user_column_name = "'none'";  // string literal, not column name
     $R_label = _('OCR');
+    $R_format = false;
 }
 else
 {
@@ -59,6 +64,22 @@ else
     $R_text_column_name = $R_round->text_column_name;
     $R_user_column_name = $R_round->user_column_name;
     $R_label = $R_round->id;
+    $R_format = is_formatting_round($R_round);
+}
+
+
+switch($format)
+{
+    case "keep":
+        $remove_format = false;
+        break;
+    case "remove":
+        $remove_format = true;
+        break;
+    default:
+        // remove format if only one of the rounds is formatting
+        $remove_format = ($L_format xor $R_format);
+        break;
 }
 
 $query = "
@@ -74,12 +95,25 @@ if ( $can_see_names_for_this_page) {
     $L_label .= " ($L_user)";
     $R_label .= " ($R_user)";
 }
+
+if($remove_format)
+{
+    // also remove blank lines and leading and trailing spaces
+    $L_text = remove_formatting($L_text, false);
+    $R_text = remove_formatting($R_text, false);
+    $link_text = _('Difference for page %s with formatting removed');
+}
+else
+{
+    $link_text = _('Difference for page %s');
+}
+
 // now have the image, users, labels etc all set up
 // -----------------------------------------------------------------------------
 
 $title = sprintf( _('Difference for page %s'), $image );
 $image_url = "$code_url/tools/project_manager/displayimage.php?project=$projectid&amp;imagefile=$image";
-$image_link = sprintf( _('Difference for page %s'), new_window_link($image_url, $image));
+$image_link = sprintf($link_text, new_window_link($image_url, $image));
 $extra_args = array(
     "css_files" => get_DifferenceEngine_css_files(),
     "css_data"  => get_DifferenceEngine_css_data(),
@@ -96,7 +130,26 @@ echo $navigation_text;
 $url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";
 $label = _("Go to Project Page");
 
-echo "\n<p><a href='$url'>$label</a></p>\n";
+echo "\n<p><a href='$url'>$label</a>\n";
+
+if($L_format || $R_format)
+{
+    // show option to change compare method
+    if($remove_format)
+    {
+        $format_label = _("Compare with formatting");
+        $_GET["format"] = "keep";
+    }
+    else
+    {
+        $format_label = _("Compare without formatting");
+        $_GET["format"] = "remove";
+    }
+    $format_url = "?" . attr_safe(http_build_query($_GET));
+    echo "| <a href='$format_url'>$format_label</a>\n";
+}
+
+echo "</p>\n";
 
 // ---------------------------------------------------------
 

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -59,16 +59,18 @@ class Comparator
 
         // draw the round selectors
         echo "<form action='page_compare.php' method='GET'>
-            <input type='hidden' name='project' value='$this->projectid'>\n
-            <input type='hidden' name='compare'>\n";
-        // TRANSLATORS: %1$s and %2$s are selectors e.g. P3, %3$s etc. are radio button options
-        echo '<p>', sprintf(_('Compare %1$s to %2$s for %3$s %4$s %5$s'),
-            $this->selector_string($this->L_round_id, "L_round_id", $this->L_round_options),
-            $this->selector_string($this->R_round_id, "R_round_id", $this->R_round_options),
-            $this->radio_string('all', _("All pages")),
-            $this->radio_string('left', _("My first")),
-            $this->radio_string('right', _("My second")));
-        echo "<input type='submit' value=", attr_safe(_('Go')), "></p></form>\n";
+            <input type='hidden' name='project' value='$this->projectid'>
+            <input type='hidden' name='compare'>",
+            "<div>", _("Compare rounds:"), "</div>\n",
+            "<div class='grid-wrapper'>\n",
+            // TRANSLATORS: "Round 1" and "Round 2" are repeated below in "Pages I worked on in Round 1" etc.
+            "<div>", _("Round 1"), "</div><div>", $this->selector_string($this->L_round_id, "L_round_id", $this->L_round_options), "</div>\n",
+            "<div>", _("Round 2"), "</div><div>", $this->selector_string($this->R_round_id, "R_round_id", $this->R_round_options), "</div></div>\n",
+            "<p>", _("Show:"), "<br>\n",
+            $this->radio_string('all', _("All pages")), "<br>\n",
+            $this->radio_string('left', _("Pages I worked on in Round 1")), "<br>\n",
+            $this->radio_string('right', _("Pages I worked on in Round 2")), "</p>\n",
+            "<input type='submit' value=", attr_safe(_('Go')), "></form>\n";
 
         // if this is first entry don't do anything else
         if(!$this->go_compare)
@@ -166,14 +168,14 @@ class Comparator
             }
             $sel_str .= ">$round</option>";
         }
-        $sel_str .= "</select>\n";
+        $sel_str .= "</select>";
         return $sel_str;
     }
 
     function radio_string($value, $label)
     {
         $checked = ($this->page_set === $value) ? " checked" : "";
-        return "<input type='radio' name='page_set' value='$value'$checked>" . html_safe($label) ."\n";
+        return "<input type='radio' name='page_set' value='$value'$checked>" . html_safe($label);
     }
 
     function has_project_started_round($round_id)

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -51,8 +51,9 @@ class Comparator
         $label = _("Return to Project Page");
         echo "<p><a href='$project_url'>$label</a></p>\n";
 
-        if(!$this->project->check_pages_table_exists())
+        if(!$this->project->check_pages_table_exists($warn_message))
         {
+            echo "<p class='warning'>$warn_message</p>\n";
             exit();
         }
 

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -8,180 +8,158 @@ include_once($relPath."DPage.inc"); // remove_formatting()
 
 require_login();
 
-$L_round_options = array('P1', 'P2', 'P3', 'F1');
-$R_round_options = array('F1', 'F2');
+$comparator = new Comparator();
+$comparator->get_data();
+$comparator->render();
 
-$projectid = validate_projectID('project', @$_GET['project']);
-$L_round_id = get_enumerated_param($_GET, "L_round_id", "P3", $L_round_options);
-$R_round_id = get_enumerated_param($_GET, "R_round_id", "F1", $R_round_options);
-$page_set = get_enumerated_param($_GET, "page_set", "all", array('left', 'right', 'all'));
-$go_compare = isset($_GET['compare']);
-
-$project = new Project($projectid);
-
-$state = $project->state;
-$title = _('Compare pages with formatting removed');
-$sub_title = $project->nameofwork;
-
-output_header("$title: $sub_title", NO_STATSBAR);
-
-echo "<h1>$title</h1>\n";
-echo "<h2>$sub_title</h2>\n";
-
-$project_url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";
-
-$label = _("Return to Project Page");
-echo "<p><a href='$project_url'>$label</a></p>\n";
-
-if (!$project->pages_table_exists)
+class Comparator
 {
-    echo "<p class='warning'>";
-    if ($project->archived != 0)
+    function __construct()
     {
-        echo _("The project has been archived, so page details are not available.");
-    }
-    elseif ($project->state == PROJ_DELETE)
-    {
-        echo _("The project has been deleted, so page details are not available.");
-    }
-    else
-    {
-        echo _("Page details are not available for this project.");
-    }
-    echo "</p>";
-    exit();
-}
+        global $PROJECT_STATES_IN_ORDER;
 
-$round_selector = new RoundSelector($page_set);
-$round_selector->render($projectid, $L_round_id, $R_round_id);
-
-// if this is first entry don't do anything else
-if(!$go_compare)
-{
-    exit();
-}
-
-$state_index = array_flip($PROJECT_STATES_IN_ORDER);
-
-if(!has_project_started_round($L_round_id, $state_index, $project) || !has_project_started_round($R_round_id, $state_index, $project))
-{
-    exit();
-}
-
-$L_round = get_Round_for_round_id($L_round_id);
-$R_round = get_Round_for_round_id($R_round_id);
-$L_text_column_name = $L_round->text_column_name;
-$R_text_column_name = $R_round->text_column_name;
-$L_round_num = $L_round->round_number;
-$R_round_num = $R_round->round_number;
-
-$right_complete = ($state_index[$project->state] >= $state_index["{$R_round_id}.proj_done"]);
-$username = $pguser;
-
-switch($page_set) {
-    case 'right':
-        $condition = "$R_round->user_column_name = '$username'";
-        break;
-    case 'left':
-        $condition = "$L_round->user_column_name = '$username'";
-        break;
-    default: // all
-        $condition = "1";
-        break;
-}
-
-if(!$right_complete)
-{
-    $condition .= " AND state='$R_round->page_save_state'";
-}
-
-$res = mysqli_query(DPDatabase::get_connection(), "
-    SELECT image, $L_text_column_name, $R_text_column_name
-    FROM $projectid
-    WHERE $condition
-    ORDER BY image ASC
-") or die(mysqli_error(DPDatabase::get_connection()));
-
-$num_rows = mysqli_num_rows($res);
-if($num_rows == 0)
-{
-    echo "<p>", _("There are no pages to compare"), "</p>\n";
-    exit();
-}
-else
-{
-    echo "<p>", sprintf(_("Comparing %d pages"), $num_rows), "</p>\n";
-}
-
-// make an array of imagenames of pages with diffs
-$diff_pages = array();
-while($page_res = mysqli_fetch_assoc($res))
-{
-    // also unwrap
-    $L_text = remove_formatting($page_res[$L_text_column_name], true);
-    $R_text = remove_formatting($page_res[$R_text_column_name], true);
-    if(0 != strcmp($L_text, $R_text))
-    {
-        $diff_pages[] = $page_res['image'];
-    }
-}
-
-if(empty($diff_pages))
-{
-    echo "<p>", _("There are no differences"), "</p>\n";
-    exit();
-}
-
-// Draw the results
-echo "<p>", _("Clicking on a link will show the differences in a new window or tab."), "</p>\n";
-echo "<p>";
-foreach($diff_pages as $imagename)
-{
-    echo "<a href='$code_url/tools/project_manager/diff.php?project=$projectid&amp;image=$imagename&amp;L_round_num=$L_round_num&amp;R_round_num=$R_round_num&amp;format=remove' target='_blank'>$imagename</a>\n";
-}
-echo "</p>";
-
-function has_project_started_round($round_id, $state_index, $project)
-{
-    if($state_index[$project->state] < $state_index["{$round_id}.proj_avail"])
-    {
-        echo "<p>", sprintf(_("%s has not started"), $round_id), "</p>";
-        return false;
-    }
-    return true;
-}
-
-class RoundSelector
-{
-    function __construct($page_set)
-    {
-        $this->page_set = $page_set;
+        $this->L_round_options = array('P1', 'P2', 'P3', 'F1');
+        $this->R_round_options = array('F1', 'F2');
+        $this->state_index = array_flip($PROJECT_STATES_IN_ORDER);
     }
 
-    function render($projectid, $L_round_id, $R_round_id)
+    function get_data()
     {
-        global $Round_for_round_id_, $L_round_options, $R_round_options;
+        $this->projectid = validate_projectID('project', @$_GET['project']);
+        $this->L_round_id = get_enumerated_param($_GET, "L_round_id", "P3", $this->L_round_options);
+        $this->R_round_id = get_enumerated_param($_GET, "R_round_id", "F1", $this->R_round_options);
+        $this->page_set = get_enumerated_param($_GET, "page_set", "all", array('left', 'right', 'all'));
+        $this->go_compare = isset($_GET['compare']);
+    }
 
+    function render()
+    {
+        global $pguser, $code_url;
+
+        $this->project = new Project($this->projectid);
+
+        $title = _('Compare pages with formatting removed');
+        $sub_title = $this->project->nameofwork;
+        output_header("$title: $sub_title", NO_STATSBAR);
+
+        echo "<h1>$title</h1>\n";
+        echo "<h2>$sub_title</h2>\n";
+
+        $state = $this->project->state;
+        $project_url = "$code_url/project.php?id=$this->projectid&amp;expected_state=$state";
+
+        $label = _("Return to Project Page");
+        echo "<p><a href='$project_url'>$label</a></p>\n";
+
+        if(!$this->project->check_pages_table_exists())
+        {
+            exit();
+        }
+
+        // draw the round selectors
         echo "<form action='page_compare.php' method='GET'>
-            <input type='hidden' name='project' value='$projectid'>\n
+            <input type='hidden' name='project' value='$this->projectid'>\n
             <input type='hidden' name='compare'>\n";
         // TRANSLATORS: %1$s and %2$s are selectors e.g. P3, %3$s etc. are radio button options
         echo '<p>', sprintf(_('Compare %1$s to %2$s for %3$s %4$s %5$s'),
-            $this->selector_string($L_round_id, "L_round_id", $L_round_options),
-            $this->selector_string($R_round_id, "R_round_id", $R_round_options),
+            $this->selector_string($this->L_round_id, "L_round_id", $this->L_round_options),
+            $this->selector_string($this->R_round_id, "R_round_id", $this->R_round_options),
             $this->radio_string('all', _("All pages")),
             $this->radio_string('left', _("My first")),
             $this->radio_string('right', _("My second")));
         echo "<input type='submit' value=", attr_safe(_('Go')), "></p></form>\n";
+
+        // if this is first entry don't do anything else
+        if(!$this->go_compare)
+        {
+            exit();
+        }
+
+        if(!$this->has_project_started_round($this->L_round_id) || !$this->has_project_started_round($this->R_round_id))
+        {
+            exit();
+        }
+
+        $L_round = get_Round_for_round_id($this->L_round_id);
+        $R_round = get_Round_for_round_id($this->R_round_id);
+        $L_text_column_name = $L_round->text_column_name;
+        $R_text_column_name = $R_round->text_column_name;
+        $L_round_num = $L_round->round_number;
+        $R_round_num = $R_round->round_number;
+
+        $username = $pguser;
+        switch($this->page_set) {
+            case 'right':
+                $condition = "$R_round->user_column_name = '$username'";
+                break;
+            case 'left':
+                $condition = "$L_round->user_column_name = '$username'";
+                break;
+            default: // all
+                $condition = "1";
+                break;
+        }
+
+        $right_complete = ($this->state_index[$this->project->state] >= $this->state_index["{$this->R_round_id}.proj_done"]);
+        if(!$right_complete)
+        {
+            $condition .= " AND state='$R_round->page_save_state'";
+        }
+
+        $res = mysqli_query(DPDatabase::get_connection(), "
+            SELECT image, $L_text_column_name, $R_text_column_name
+            FROM $this->projectid
+            WHERE $condition
+            ORDER BY image ASC
+        ") or die(mysqli_error(DPDatabase::get_connection()));
+
+        $num_rows = mysqli_num_rows($res);
+        if($num_rows == 0)
+        {
+            echo "<p>", _("There are no pages to compare"), "</p>\n";
+            exit();
+        }
+        else
+        {
+            echo "<p>", sprintf(_("Comparing %d pages"), $num_rows), "</p>\n";
+        }
+
+        // make an array of imagenames of pages with diffs
+        $diff_pages = array();
+        while($page_res = mysqli_fetch_assoc($res))
+        {
+            // also unwrap
+            $L_text = remove_formatting($page_res[$L_text_column_name], true);
+            $R_text = remove_formatting($page_res[$R_text_column_name], true);
+            if(0 != strcmp($L_text, $R_text))
+            {
+                $diff_pages[] = $page_res['image'];
+            }
+        }
+
+        if(empty($diff_pages))
+        {
+            echo "<p>", _("There are no differences"), "</p>\n";
+            exit();
+        }
+
+        // Draw the results
+        echo "<p>", _("Clicking on a link will show the differences in a new window or tab."), "</p>\n";
+        echo "<p>";
+        foreach($diff_pages as $imagename)
+        {
+            echo "<a href='$code_url/tools/project_manager/diff.php?project=$this->projectid&amp;image=$imagename&amp;L_round_num=$L_round_num&amp;R_round_num=$R_round_num&amp;format=remove' target='_blank'>$imagename</a>\n";
+        }
+        echo "</p>";
     }
 
-    function selector_string($selected, $name, $rounds)
+    function selector_string($selected_round, $name, $rounds)
     {
         $sel_str = "<select name=$name>";
         foreach($rounds as $round)
         {
             $sel_str .= "<option value='$round'";
-            if($round == $selected)
+            if($round == $selected_round)
             {
                 $sel_str .= " selected";
             }
@@ -195,6 +173,16 @@ class RoundSelector
     {
         $checked = ($this->page_set === $value) ? " checked" : "";
         return "<input type='radio' name='page_set' value='$value'$checked>" . html_safe($label) ."\n";
+    }
+
+    function has_project_started_round($round_id)
+    {
+        if($this->state_index[$this->project->state] < $this->state_index["{$round_id}.proj_avail"])
+        {
+            echo "<p>", sprintf(_("%s has not started"), $round_id), "</p>";
+            return false;
+        }
+        return true;
     }
 }
 

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -1,0 +1,201 @@
+<?php
+$relPath="./../../pinc/";
+include_once($relPath.'base.inc');
+include_once($relPath.'misc.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath.'Project.inc');
+include_once($relPath."DPage.inc"); // remove_formatting()
+
+require_login();
+
+$L_round_options = array('P1', 'P2', 'P3', 'F1');
+$R_round_options = array('F1', 'F2');
+
+$projectid = validate_projectID('project', @$_GET['project']);
+$L_round_id = get_enumerated_param($_GET, "L_round_id", "P3", $L_round_options);
+$R_round_id = get_enumerated_param($_GET, "R_round_id", "F1", $R_round_options);
+$page_set = get_enumerated_param($_GET, "page_set", "all", array('left', 'right', 'all'));
+$go_compare = isset($_GET['compare']);
+
+$project = new Project($projectid);
+
+$state = $project->state;
+$title = _('Compare pages with formatting removed');
+$sub_title = $project->nameofwork;
+
+output_header("$title: $sub_title", NO_STATSBAR);
+
+echo "<h1>$title</h1>\n";
+echo "<h2>$sub_title</h2>\n";
+
+$project_url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";
+
+$label = _("Return to Project Page");
+echo "<p><a href='$project_url'>$label</a></p>\n";
+
+if (!$project->pages_table_exists)
+{
+    echo "<p class='warning'>";
+    if ($project->archived != 0)
+    {
+        echo _("The project has been archived, so page details are not available.");
+    }
+    elseif ($project->state == PROJ_DELETE)
+    {
+        echo _("The project has been deleted, so page details are not available.");
+    }
+    else
+    {
+        echo _("Page details are not available for this project.");
+    }
+    echo "</p>";
+    exit();
+}
+
+$round_selector = new RoundSelector($page_set);
+$round_selector->render($projectid, $L_round_id, $R_round_id);
+
+// if this is first entry don't do anything else
+if(!$go_compare)
+{
+    exit();
+}
+
+$state_index = array_flip($PROJECT_STATES_IN_ORDER);
+
+if(!has_project_started_round($L_round_id, $state_index, $project) || !has_project_started_round($R_round_id, $state_index, $project))
+{
+    exit();
+}
+
+$L_round = get_Round_for_round_id($L_round_id);
+$R_round = get_Round_for_round_id($R_round_id);
+$L_text_column_name = $L_round->text_column_name;
+$R_text_column_name = $R_round->text_column_name;
+$L_round_num = $L_round->round_number;
+$R_round_num = $R_round->round_number;
+
+$right_complete = ($state_index[$project->state] >= $state_index["{$R_round_id}.proj_done"]);
+$username = $pguser;
+
+switch($page_set) {
+    case 'right':
+        $condition = "$R_round->user_column_name = '$username'";
+        break;
+    case 'left':
+        $condition = "$L_round->user_column_name = '$username'";
+        break;
+    default: // all
+        $condition = "1";
+        break;
+}
+
+if(!$right_complete)
+{
+    $condition .= " AND state='$R_round->page_save_state'";
+}
+
+$res = mysqli_query(DPDatabase::get_connection(), "
+    SELECT image, $L_text_column_name, $R_text_column_name
+    FROM $projectid
+    WHERE $condition
+    ORDER BY image ASC
+") or die(mysqli_error(DPDatabase::get_connection()));
+
+$num_rows = mysqli_num_rows($res);
+if($num_rows == 0)
+{
+    echo "<p>", _("There are no pages to compare"), "</p>\n";
+    exit();
+}
+else
+{
+    echo "<p>", sprintf(_("Comparing %d pages"), $num_rows), "</p>\n";
+}
+
+// make an array of imagenames of pages with diffs
+$diff_pages = array();
+while($page_res = mysqli_fetch_assoc($res))
+{
+    // also unwrap
+    $L_text = remove_formatting($page_res[$L_text_column_name], true);
+    $R_text = remove_formatting($page_res[$R_text_column_name], true);
+    if(0 != strcmp($L_text, $R_text))
+    {
+        $diff_pages[] = $page_res['image'];
+    }
+}
+
+if(empty($diff_pages))
+{
+    echo "<p>", _("There are no differences"), "</p>\n";
+    exit();
+}
+
+// Draw the results
+echo "<p>", _("Clicking on a link will show the differences in a new window or tab."), "</p>\n";
+echo "<p>";
+foreach($diff_pages as $imagename)
+{
+    echo "<a href='$code_url/tools/project_manager/diff.php?project=$projectid&amp;image=$imagename&amp;L_round_num=$L_round_num&amp;R_round_num=$R_round_num&amp;format=remove' target='_blank'>$imagename</a>\n";
+}
+echo "</p>";
+
+function has_project_started_round($round_id, $state_index, $project)
+{
+    if($state_index[$project->state] < $state_index["{$round_id}.proj_avail"])
+    {
+        echo "<p>", sprintf(_("%s has not started"), $round_id), "</p>";
+        return false;
+    }
+    return true;
+}
+
+class RoundSelector
+{
+    function __construct($page_set)
+    {
+        $this->page_set = $page_set;
+    }
+
+    function render($projectid, $L_round_id, $R_round_id)
+    {
+        global $Round_for_round_id_, $L_round_options, $R_round_options;
+
+        echo "<form action='page_compare.php' method='GET'>
+            <input type='hidden' name='project' value='$projectid'>\n
+            <input type='hidden' name='compare'>\n";
+        // TRANSLATORS: %1$s and %2$s are selectors e.g. P3, %3$s etc. are radio button options
+        echo '<p>', sprintf(_('Compare %1$s to %2$s for %3$s %4$s %5$s'),
+            $this->selector_string($L_round_id, "L_round_id", $L_round_options),
+            $this->selector_string($R_round_id, "R_round_id", $R_round_options),
+            $this->radio_string('all', _("All pages")),
+            $this->radio_string('left', _("My first")),
+            $this->radio_string('right', _("My second")));
+        echo "<input type='submit' value=", attr_safe(_('Go')), "></p></form>\n";
+    }
+
+    function selector_string($selected, $name, $rounds)
+    {
+        $sel_str = "<select name=$name>";
+        foreach($rounds as $round)
+        {
+            $sel_str .= "<option value='$round'";
+            if($round == $selected)
+            {
+                $sel_str .= " selected";
+            }
+            $sel_str .= ">$round</option>";
+        }
+        $sel_str .= "</select>\n";
+        return $sel_str;
+    }
+
+    function radio_string($value, $label)
+    {
+        $checked = ($this->page_set === $value) ? " checked" : "";
+        return "<input type='radio' name='page_set' value='$value'$checked>" . html_safe($label) ."\n";
+    }
+}
+
+// vim: sw=4 ts=4 expandtab

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -69,7 +69,7 @@ $label = _("Return to Project Page");
 
 echo "<p><a href='$url'>$label</a></p>\n";
 
-if($project->check_pages_table_exists())
+if($project->check_pages_table_exists($warn_message))
 {
     echo_detail_legend();
 
@@ -102,6 +102,11 @@ if($project->check_pages_table_exists())
 
     echo_page_table( $project, $show_image_size, FALSE, $username_for_page_selection, $round_for_page_selection );
 }
+else
+{
+    echo "<p class='warning'>$warn_message</p>\n";
+}
+
 echo "<br>";
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -69,7 +69,7 @@ $label = _("Return to Project Page");
 
 echo "<p><a href='$url'>$label</a></p>\n";
 
-if ($project->pages_table_exists)
+if($project->check_pages_table_exists())
 {
     echo_detail_legend();
 
@@ -101,16 +101,6 @@ if ($project->pages_table_exists)
     echo "</p>";
 
     echo_page_table( $project, $show_image_size, FALSE, $username_for_page_selection, $round_for_page_selection );
-} else {
-    echo "<p>";
-    if ($project->archived != 0) {
-        echo _("The project has been archived, so page details are not available.");
-    } elseif ($project->state == PROJ_DELETE) {
-        echo _("The project has been deleted, so page details are not available.");
-    } else {
-        echo _("Page details are not available for this project.");
-    }
-    echo "</p>";
 }
 echo "<br>";
 


### PR DESCRIPTION
new file unformat.inc with function to remove formatting
and either completely unwrap or keep line structure but
remove leading and trailing spaces

diff.php: add option to remove formatting (not unwrap)
before compare.
If at least one round is F then show link option to remove
formatting or not.
Default is remove for P to F, keep for F to F

new file page_compare.php to compare pages with format
removed and unwrapped between selected rounds for a
project, either all pages or for the users pages in either
the first or second round. Makes a list of page image names
which link to diff.php

project.php: link added to page_compare.php if project has
reached formatting stage