### PR TITLE
Use Travis-CI for basic testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: php
-install: true
+services:
+    - mysql
+before_install:
+    - mysql -e "CREATE DATABASE dp_db CHARACTER SET LATIN1;"
+    - mysql -e "GRANT ALL ON dp_db.* TO dp_user@localhost IDENTIFIED BY 'dp_password';"
+    - ./SETUP/configure ./SETUP/tests/travis-ci_configuration.sh .
+install:
+    # install the database schema
+    - cd SETUP
+    - php install_db.php
+    - cd ..
 script:
     # linting is SUCH a low bar, but it is a bar!
-    ./SETUP/lint_php_files.sh
+    - ./SETUP/lint_php_files.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+install: true
+script:
+    # linting is SUCH a low bar, but it is a bar!
+    ./SETUP/lint_php_files.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ install:
 script:
     # linting is SUCH a low bar, but it is a bar!
     - ./SETUP/lint_php_files.sh
+    # now lets get crazy and run our meager unit tests...
+    - cd SETUP/tests
+    - phpunit --bootstrap phpunit_bootstrap.php --verbose .

--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -2,19 +2,58 @@
 
 class UserTest extends PHPUnit_Framework_TestCase
 {
-    private $EXISTENT_USERNAME;
-    private $NONEXISTENT_USERNAME = 'blahblahblah';
+    private $TEST_USERNAME = "UserTest_php";
+    private $NONTEST_USERNAME = 'blahblahblah';
 
     protected function setUp()
     {
-        // Load a valid username from the database for use during the tests
-        // We need one with an alphabetic character in it for the user
-        // validation tests.
-        $sql = "SELECT username FROM users WHERE username like '%a%' LIMIT 1";
+        // Attempt to load our test user, if it exists don't create it
+        $sql = "SELECT username FROM users WHERE username = '$this->TEST_USERNAME'";
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         $row = mysqli_fetch_assoc($result);
-        $this->EXISTENT_USERNAME = $row['username'];
-        mysqli_free_result($result);
+        if(!$row)
+        {
+            $sql = "
+                INSERT INTO users
+                SET id = '$this->TEST_USERNAME',
+                    real_name = '$this->TEST_USERNAME',
+                    username = '$this->TEST_USERNAME',
+                    email = '$this->TEST_USERNAME@localhost',
+                    manager = 'no',
+                    postprocessor = 'no',
+                    sitemanager = 'no',
+                    active = 0
+            ";
+            $result = mysqli_query(DPDatabase::get_connection(), $sql)
+                or die("Unable to create test user 1");
+
+            $sql = "
+                INSERT INTO users
+                SET id = '$this->TEST_USERNAME-2',
+                    real_name = '$this->TEST_USERNAME-2',
+                    username = '$this->TEST_USERNAME-2',
+                    email = '$this->TEST_USERNAME@localhost',
+                    manager = 'no',
+                    postprocessor = 'no',
+                    sitemanager = 'no',
+                    active = 0
+            ";
+            $result = mysqli_query(DPDatabase::get_connection(), $sql)
+                or die("Unable to create test user 2");
+        }
+        else
+        {
+            mysqli_free_result($result);
+        }
+    }
+
+    protected function tearDown()
+    {
+        $sql = "
+            DELETE FROM users
+            WHERE id = '$this->TEST_USERNAME' or id = '$this->TEST_USERNAME-2'
+        ";
+        $result = mysqli_query(DPDatabase::get_connection(), $sql);
     }
 
     public function testEmptyConstructor()
@@ -24,59 +63,59 @@ class UserTest extends PHPUnit_Framework_TestCase
 
     public function testNonemptyConstructor()
     {
-        $user = new User($this->EXISTENT_USERNAME);
+        $user = new User($this->TEST_USERNAME);
     }
 
     public function testValidateValidUserStrict()
     {
-        $is_valid = User::is_valid_user($this->EXISTENT_USERNAME);
+        $is_valid = User::is_valid_user($this->TEST_USERNAME);
         $this->assertTrue($is_valid);
     }
 
     public function testValidateValidUserStrictDifferCase()
     {
-        $username=strtoupper($this->EXISTENT_USERNAME);
+        $username=strtoupper($this->TEST_USERNAME);
         $is_valid = User::is_valid_user($username);
         $this->assertFalse($is_valid);
     }
 
     public function testValidateValidUserStrictDifferWhitespace()
     {
-        $username=$this->EXISTENT_USERNAME . "  ";
+        $username=$this->TEST_USERNAME . "  ";
         $is_valid = User::is_valid_user($username);
         $this->assertFalse($is_valid);
     }
 
     public function testValidateValidUserNotStrict()
     {
-        $is_valid = User::is_valid_user($this->EXISTENT_USERNAME, FALSE);
+        $is_valid = User::is_valid_user($this->TEST_USERNAME, FALSE);
         $this->assertTrue($is_valid);
     }
 
     public function testValidateValidUserNotStrictDifferCase()
     {
-        $username=strtoupper($this->EXISTENT_USERNAME);
+        $username=strtoupper($this->TEST_USERNAME);
         $is_valid = User::is_valid_user($username, FALSE);
         $this->assertTrue($is_valid);
     }
 
     public function testValidateValidUserNotStrictDifferWhitespace()
     {
-        $username=$this->EXISTENT_USERNAME . "  ";
+        $username=$this->TEST_USERNAME . "  ";
         $is_valid = User::is_valid_user($username, FALSE);
         $this->assertTrue($is_valid);
     }
 
     public function testValidateInvalidUser()
     {
-        $is_valid = User::is_valid_user($this->NONEXISTENT_USERNAME);
+        $is_valid = User::is_valid_user($this->NONTEST_USERNAME);
         $this->assertFalse($is_valid);
     }
 
     public function testLoadExistingStrict()
     {
         $user = new User();
-        $user->load("username", $this->EXISTENT_USERNAME);
+        $user->load("username", $this->TEST_USERNAME);
     }
 
     /**
@@ -84,7 +123,7 @@ class UserTest extends PHPUnit_Framework_TestCase
      */
     public function testLoadExistingStrictDifferCase()
     {
-        $username = strtoupper($this->EXISTENT_USERNAME);
+        $username = strtoupper($this->TEST_USERNAME);
         $user = new User();
         $user->load("username", $username);
     }
@@ -94,21 +133,21 @@ class UserTest extends PHPUnit_Framework_TestCase
      */
     public function testLoadExistingStrictDifferWhitespace()
     {
-        $username = $this->EXISTENT_USERNAME . '   ';
+        $username = $this->TEST_USERNAME . '   ';
         $user = new User();
         $user->load("username", $username);
     }
 
     public function testLoadExistingNotStrictDifferCase()
     {
-        $username = strtoupper($this->EXISTENT_USERNAME);
+        $username = strtoupper($this->TEST_USERNAME);
         $user = new User();
         $user->load("username", $username, FALSE);
     }
 
     public function testLoadExistingNotStrictDifferWhitespace()
     {
-        $username = $this->EXISTENT_USERNAME . '   ';
+        $username = $this->TEST_USERNAME . '   ';
         $user = new User();
         $user->load("username", $username, FALSE);
     }
@@ -119,7 +158,7 @@ class UserTest extends PHPUnit_Framework_TestCase
     public function testLoadNonexisting()
     {
         $user = new User();
-        $user->load("username", $this->NONEXISTENT_USERNAME);
+        $user->load("username", $this->NONTEST_USERNAME);
     }
 
     /**
@@ -137,14 +176,14 @@ class UserTest extends PHPUnit_Framework_TestCase
     public function testLoadMultipleUsers()
     {
         $user = new User();
-        $user->load("team_1", 0);
+        $user->load("active", 0);
     }
 
     public function testGetters()
     {
-        $user = new User($this->EXISTENT_USERNAME);
+        $user = new User($this->TEST_USERNAME);
         $this->assertEquals(
-            $this->EXISTENT_USERNAME,
+            $this->TEST_USERNAME,
             $user->username
         );
     }
@@ -166,7 +205,7 @@ class UserTest extends PHPUnit_Framework_TestCase
      */
     public function testSetImmutable()
     {
-        $user = new User($this->EXISTENT_USERNAME);
+        $user = new User($this->TEST_USERNAME);
         $user->username = "blah";
     }
 

--- a/SETUP/tests/phpunit_bootstrap.php
+++ b/SETUP/tests/phpunit_bootstrap.php
@@ -7,11 +7,11 @@ include_once($relPath.'misc.inc');
 function dp_class_autoloader($class)
 {
     global $relPath;
-    if(is_file("$relPath$class.inc"))
+    if(is_file($relPath.$class.".inc"))
     {
         include_once($relPath.$class.".inc");
     }
-    else
+    elseif(is_file($relPath.$class."Class.inc"))
     {
         include_once($relPath.$class."Class.inc");
     }

--- a/SETUP/tests/travis-ci_configuration.sh
+++ b/SETUP/tests/travis-ci_configuration.sh
@@ -1,0 +1,133 @@
+# This configuration file is used for environment set up as part of
+# Travis-CI. Very (very) few of these variables are yet used for
+# any part of the automated tests, but they need to be present to
+# make sure the filled-in .template files are valid PHP files.
+
+_DB_SERVER=localhost
+_DB_USER=dp_user
+_DB_PASSWORD=dp_password
+_DB_NAME=dp_db
+_ARCHIVE_DB_NAME=dp_archive
+
+_CODE_DIR=$HOME
+_CODE_URL='http://localhost'
+_DYN_DIR=$HOME
+_DYN_URL='http://localhost'
+
+_PHPBB_VERSION=3
+_PHPBB_TABLE_PREFIX=phpbb3.phpbb
+_FORUMS_DIR=$HOME/phpBB3
+_FORUMS_URL='http://localhost/phpBB3'
+
+_SITE_NAME='Travis-CI'
+_SITE_ABBREVIATION=TCI
+_SITE_SIGNOFF="Ciao!"
+_SITE_URL=$_CODE_URL
+
+_SITE_REGISTRATION_PROTECTION_CODE=
+
+_UPLOADS_DIR=~uploads
+_UPLOADS_HOST=
+_UPLOADS_ACCOUNT=dpscans
+_UPLOADS_PASSWORD=PICK_A_PASSWORD
+
+_ANTIVIRUS_EXECUTABLE=
+
+_PROJECTS_DIR=$HOME/projects
+_PROJECTS_URL='http://localhost/projects'
+
+_ARCHIVE_PROJECTS_DIR=$HOME/projects.archive
+
+_EXTERNAL_CATALOG_LOCATOR='z3950.loc.gov:7090/Voyager'
+
+_PRECEDING_PROOFER_RESTRICTION=not_immediately_preceding
+
+_PUBLIC_PAGE_DETAILS=FALSE
+
+_ASPELL_EXECUTABLE=/usr/bin/aspell
+_ASPELL_PREFIX=/usr
+_ASPELL_TEMP_DIR=/tmp/sp_check
+
+_WIKIHIERO_DIR=
+_WIKIHIERO_URL=
+
+_NO_REPLY_EMAIL_ADDR=no-reply@pgdp.org
+_GENERAL_HELP_EMAIL_ADDR=dphelp@pgdp.net
+_DB_REQUESTS_EMAIL_ADDR=db-req@pgdp.org
+_PPV_REPORTING_EMAIL_ADDR=ppv-reports@pgdp.org
+_PROMOTION_REQUESTS_EMAIL_ADDR=dp-promote@pgdp.org
+_IMAGE_SOURCES_EMAIL_ADDR=ism@pgdp.org
+_TRANSLATION_COORDINATOR_EMAIL_ADDR=translation-coordinator@pgdp.org
+
+_BLOG_URL=
+_WIKI_URL=
+
+_FORUMS_TEAMS_IDX=26
+_FORUMS_PROJECT_WAITING_IDX=2
+_FORUMS_PROJECT_AVAIL_IDX=3
+_FORUMS_PROJECT_PP_IDX=4
+_FORUMS_PROJECT_POSTED_IDX=5
+_FORUMS_PROJECT_DELETED_IDX=48
+_FORUMS_PROJECT_COMPLETED_IDX=48
+_FORUMS_GENERAL_IDX=21
+_FORUMS_BEGIN_SITE_IDX=22
+_FORUMS_BEGIN_PROOF_IDX=23
+_FORUMS_CONTENT_PROVIDERS_IDX=24
+_FORUMS_POST_PROCESSORS_IDX=25
+
+_AUTO_POST_TO_PROJECT_TOPIC=FALSE
+
+_JPGRAPH_DIR=$HOME/jpgraph
+_JPGRAPH_FONT_FACE=15 # FS_ARIAL
+_JPGRAPH_FONT_STYLE=9001 # FS_NORMAL
+
+_USE_PHP_SESSIONS=TRUE
+_USE_SECURE_COOKIES=TRUE
+_COOKIE_ENCRYPTION_KEY=
+
+_TESTING=TRUE
+
+_MAINTENANCE=FALSE
+_MAINTENANCE_MESSAGE=
+
+_METADATA=FALSE
+_CORRECTIONS=FALSE
+
+_ORDINARY_USERS_CAN_SEE_QUEUE_SETTINGS=TRUE
+
+_CHARSET='ISO-8859-1'
+
+_WRITEBIGTABLE=FALSE
+_READBIGTABLE=FALSE
+
+_GETTEXT_LOCALES_DIR=/usr/share/locale
+
+TAG=master
+GROUP=users
+SHIFT_TO_LIVE=yes
+
+_PHP_CLI_EXECUTABLE=`which php`
+_XGETTEXT_EXECUTABLE=`which xgettext`
+
+_URL_DUMP_PROGRAM=
+if [ "$_URL_DUMP_PROGRAM" == "" ]; then
+    # No program explicitly specified, attempt to find: wget, curl, lynx
+    program_test=`which wget`
+    if [ $? -eq 0 ]; then
+        _URL_DUMP_PROGRAM="$program_test --quiet --tries=1 --timeout=0 -O-"
+    else
+        program_test=`which curl`
+        if [ $? -eq 0 ]; then
+            _URL_DUMP_PROGRAM="$program_test --silent"
+        else
+            program_test=`which lynx`
+            if [ $? -eq 0 ]; then
+                _URL_DUMP_PROGRAM="$program_test -source"
+            else
+                echo "ERROR: No program found to dump URLs."
+                echo "       Edit the configuration file and set _URL_DUMP_PROGRAM."
+                exit 1
+            fi
+        fi
+    fi
+fi


### PR DESCRIPTION
This enables testing of the dproofreaders codebase through Travis-CI. So far this is a very (very) low bar, but it does ensure that the following work:
* all files successfully lint
* database schema successfully imports
* our meager unit tests all pass

Hopefully this also sets us up with a base and we can continue adding tests.