### PR TITLE
Allow call-out to local customization script

### DIFF
--- a/SETUP/update_from_github
+++ b/SETUP/update_from_github
@@ -8,7 +8,8 @@ fi
 this_script_file=$0
 site_config_file=$1
 
-script_dir=`dirname $this_script_file`
+export script_dir=`dirname $this_script_file`
+export config_dir=`dirname $site_config_file`
 
 # ------------------------------------------------------------------------------
 
@@ -92,6 +93,14 @@ check "get_git_clone"
 
 configure_script_file=$script_dir/configure
 $configure_script_file $site_config_file $_CODE_DIR.new
+
+# ------------------------------------------------------------------------------
+# Apply any local customizations.
+
+if [ -e $config_dir/customize_deployment ]; then
+    echo "Running local deployment customization script..."
+    . $config_dir/customize_deployment
+fi
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
The pgdp.net production server had customized the `update_from_sf` script to do local filesystem changes (copy over files, apply patches). This abstracts that functionality such that customization is still possible without changing code in source control that we have to then manually patch.