### PR TITLE
Update PHP and phpBB version support

### DIFF
--- a/SETUP/installation.txt
+++ b/SETUP/installation.txt
@@ -20,7 +20,8 @@ PHP
     PHP version 5.3.2 is the minimum version supported, although any
     version >= 5.3.2 should work.
 
-    PHP version 7.0 and later may work but has not been tested.
+    PHP version 7.0 is supported. 7.1 and later should work but have
+    not been tested.
 
 MySQL
     MySQL version 5.5 and later is recommended.
@@ -29,10 +30,10 @@ MySQL
     MariaDB version 5.5 and later should also work but has not been tested.
 
 phpBB
-    phpBB 3.0, 3.1, and 3.2 are supported.
+    phpBB 3.1 and 3.2 are supported.
     Version 3.2 is recommended.
 
-    In order to use versions > 3.0, you must disable superglobal checking.
+    For phpBB to work with the DP code, you must disable superglobal checking.
     In the phpBB code edit:
       * 3.1: config/parameters.yml
       * 3.2: config/default/container/parameters.yml


### PR DESCRIPTION
After ea40ee5d merged we know the code works with PHP 7.0.

When we merged ba74ae04, we broke support for phpBB 3.0. This
is because accounts/login.php pulls in metarefresh.inc which
pulls in slim_header.inc. ba74ae04 changed slim_header.inc to
bring in theme.inc which eventually brings in user.inc which
breaks phpBB 3.0 because it also defines a User class. phpBB 3.0
is out of support and phpBB 3.1 was released in Oct 2014 so
rather than trying to hack a fix in, lets just say 3.1 is the
minimum supported version.