### PR TITLE
Fix unit tests

### DIFF
--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -27,8 +27,9 @@ class SettingsTest extends PHPUnit_Framework_TestCase
                     sitemanager = 'no',
                     active = 0
             ";
-            $result = mysqli_query(DPDatabase::get_connection(), $sql)
-                or die("Unable to create test user");
+            $result = mysqli_query(DPDatabase::get_connection(), $sql);
+            if(!$result)
+                throw new Exception("Unable to create test user");
         }
         else
         {
@@ -40,8 +41,9 @@ class SettingsTest extends PHPUnit_Framework_TestCase
             INSERT INTO usersettings
             SET username='%s', setting = '%ssetting', value = 'blah'
         ", $this->TEST_USERNAME, $this->PREFIX);
-        $result = mysqli_query(DPDatabase::get_connection(), $sql)
-            or die("Unable to create test usersetting");
+        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        if(!$result)
+            throw new Exception("Unable to create test usersetting");
     }
 
     protected function tearDown()

--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -22,9 +22,6 @@ class SettingsTest extends PHPUnit_Framework_TestCase
                     real_name = '$this->TEST_USERNAME',
                     username = '$this->TEST_USERNAME',
                     email = '$this->TEST_USERNAME@localhost',
-                    manager = 'no',
-                    postprocessor = 'no',
-                    sitemanager = 'no',
                     active = 0
             ";
             $result = mysqli_query(DPDatabase::get_connection(), $sql);

--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -24,8 +24,9 @@ class UserTest extends PHPUnit_Framework_TestCase
                     sitemanager = 'no',
                     active = 0
             ";
-            $result = mysqli_query(DPDatabase::get_connection(), $sql)
-                or die("Unable to create test user 1");
+            $result = mysqli_query(DPDatabase::get_connection(), $sql);
+            if(!$result)
+                throw new Exception("Unable to create test user 1");
 
             $sql = "
                 INSERT INTO users
@@ -38,8 +39,9 @@ class UserTest extends PHPUnit_Framework_TestCase
                     sitemanager = 'no',
                     active = 0
             ";
-            $result = mysqli_query(DPDatabase::get_connection(), $sql)
-                or die("Unable to create test user 2");
+            $result = mysqli_query(DPDatabase::get_connection(), $sql);
+            if(!$result)
+                throw new Exception("Unable to create test user 2");
         }
         else
         {

--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -19,9 +19,6 @@ class UserTest extends PHPUnit_Framework_TestCase
                     real_name = '$this->TEST_USERNAME',
                     username = '$this->TEST_USERNAME',
                     email = '$this->TEST_USERNAME@localhost',
-                    manager = 'no',
-                    postprocessor = 'no',
-                    sitemanager = 'no',
                     active = 0
             ";
             $result = mysqli_query(DPDatabase::get_connection(), $sql);
@@ -34,9 +31,6 @@ class UserTest extends PHPUnit_Framework_TestCase
                     real_name = '$this->TEST_USERNAME-2',
                     username = '$this->TEST_USERNAME-2',
                     email = '$this->TEST_USERNAME@localhost',
-                    manager = 'no',
-                    postprocessor = 'no',
-                    sitemanager = 'no',
                     active = 0
             ";
             $result = mysqli_query(DPDatabase::get_connection(), $sql);


### PR DESCRIPTION
Unit tests frameworks are only useful for highlighting errors when you don't do something stupid like `die()` in a setUp fixture.