### PR TITLE
Allow denying user-requested access

### DIFF
--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -148,6 +148,11 @@ class User
         $this->_change_access("request", $activity, 'n/a', $use_access_suffix);
     }
 
+    public function deny_access($activity, $requester, $use_access_suffix=TRUE)
+    {
+        $this->_change_access("deny_request_for", $activity, $requester, $use_access_suffix);
+    }
+
     private function _change_access($action_type, $activity, $requester, $use_access_suffix)
     {
         if($use_access_suffix)
@@ -158,6 +163,8 @@ class User
         $userSettings =& Settings::get_Settings($this->username);
         if($action_type == "request")
             $userSettings->set_value("$activity$suffix", "requested");
+        elseif($action_type == "deny_request_for")
+            $userSettings->set_value("$activity$suffix", NULL);
         else
             $userSettings->set_boolean("$activity$suffix", $action_type == 'grant');
         log_access_change($this->username, $requester, $activity, $action_type);

--- a/tools/modify_access.php
+++ b/tools/modify_access.php
@@ -145,6 +145,8 @@ foreach ( $actions as $activity_id => $action_type )
 
     if($action_type == 'grant')
         $user->grant_access($activity_id, $pguser);
+    elseif($action_type == 'deny_request_for')
+        $user->deny_access($activity_id, $pguser);
     else
         $user->revoke_access($activity_id, $pguser);
 }


### PR DESCRIPTION
In addition to grant/revoke, admins and evaluators have the ability to deny a request for access too. This fixes a regression from the merge of cleanup_users_table in commit a99d656f.