### PR TITLE
Remove_formatting function improved and put in a class

### DIFF
--- a/SETUP/tests/manual_web/.htaccess
+++ b/SETUP/tests/manual_web/.htaccess
@@ -1,0 +1,1 @@
+Allow from all

--- a/SETUP/tests/manual_web/page_compare_test.php
+++ b/SETUP/tests/manual_web/page_compare_test.php
@@ -1,0 +1,58 @@
+<?php
+$relPath="./../../../pinc/";
+include_once($relPath.'base.inc');
+include_once($relPath.'misc.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath."DPage.inc"); // remove_formatting()
+
+// This page is used to test the remove_formatting() function.
+// It is difficult to test otherwise because it requires test-text in two
+// different rounds.
+
+require_login();
+
+$L_input = array_get($_POST, "Ltex", "");
+$R_input = array_get($_POST, "Rtex", "");
+$unwrap = isset($_POST['Unwrap']); // can only be 'on'
+$ignore_case = isset($_POST['IgnoreCase']);
+
+$title = _('Test Compare pages with formatting removed');
+output_header("$title:", NO_STATSBAR);
+
+echo "<h1>$title</h1>\n";
+
+$check_unwrap = $unwrap ? " checked" : "";
+$check_igc = $ignore_case ? " checked" : "";
+echo "<form action='page_compare_test.php' method='POST'>
+    <p>Paste the texts from the two rounds to compare into the upper two boxes and press 'Go'.
+    The results will appear in the two lower boxes and a message will indicate if there are any differences.
+    To find the differences the result texts can be copied into a text editor which can compare texts.</p>
+    <textarea name='Ltex' rows='10' cols='80'>$L_input</textarea>
+    <textarea name='Rtex' rows='10' cols='80'>$R_input</textarea>
+    <br>
+    Unwrap <input type='checkbox' name='Unwrap'$check_unwrap>
+    Ignore case <input type='checkbox' name='IgnoreCase'$check_igc>
+    <input type='submit' value='Go'></form>\n";
+
+$un_formatter = new UnFormatter();
+$L_text = $un_formatter->remove_formatting($L_input, $unwrap);
+$R_text = $un_formatter->remove_formatting($R_input, $unwrap);
+
+echo "
+    <p>Output</p>
+    <textarea readonly rows='10' cols='80'>$L_text</textarea>
+    <textarea readonly rows='10' cols='80'>$R_text</textarea>
+    \n";
+
+if($ignore_case)
+{
+    $diff = strcasecmp($L_text, $R_text);
+}
+else
+{
+    $diff = strcmp($L_text, $R_text);
+}
+$no = (0 === $diff) ? " no ": " ";
+echo "<p>There are{$no}differences</p>";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -75,11 +75,11 @@ function Pages_prepForRound( $projectid, $round_number )
 
     {
         // For the first round, these queries are mostly redundant,
-        // because when project_add_page() create a page, 
+        // because when project_add_page() create a page,
         // the page gets the first round's avail state.
         // (They're not *entirely* redundant, because the queries will
         // still change the round1_time, but that's fairly unimportant.)
-        // 
+        //
         // However, it's probably better that this function doesn't rely on
         // how project_add_page() sets page-states.
 
@@ -91,7 +91,7 @@ function Pages_prepForRound( $projectid, $round_number )
                 state = '{$round->page_avail_state}',
                 {$round->time_column_name} = $timestamp
         ");
-    
+
         if ($writeBIGtable)
         {
             $result = mysqli_query(DPDatabase::get_connection(), "
@@ -718,38 +718,142 @@ function project_recalculate_page_counts( $projectid )
     ") or die(mysqli_error(DPDatabase::get_connection()));
 }
 
-function remove_formatting($text, $unwrap)
+class UnFormatter
 {
-    $text = str_replace( "\r\n", "\n", $text);
-    // remove out-of-line tags [Illustration] (without text), users' notes
-    // these can leave blank lines so do first
-    $text = preg_replace("/\/[\*#]|[\*#]\/|\[Illustration\]|\[\*\*[^\]]+\]/", "", $text);
-    // remove inline tags and <tb>
-    $text = preg_replace("/<\/?(?:[ibfgu]|sc|tb)>/", "", $text);
-    // change alphabetic footnote anchors to *
-    $text = preg_replace("/\[[A-Z]\]/", "[*]", $text);
-    // Adjust footnotes
-    $text = preg_replace("/\[Footnote (\d+):([^\]]+)\]/", "$1$2", $text);
-    $text = preg_replace("/\[Footnote [A-Z]:([^\]]+)\]/", "*$1", $text);
-    // Ilustration with text, Sidenote
-    $text = preg_replace("/\[(?:Illustration|Sidenote): ([^\]]+)\]/", "$1", $text);
-    if($unwrap)
+    private function find_close($text, $offset)
     {
-        // change one or more newlines or spaces to a single space
-        $text = preg_replace("/\s+/", " ", $text);
-        // remove space at beginning or end
-        return preg_replace("/^ | $/", "", $text);
+        // find next unmatched ]
+        $nest_level = 0;
+        while(true)
+        {
+            // find next [ or ]
+            $match_brak = preg_match("/\[|\]/", $text, $brak_matches, PREG_OFFSET_CAPTURE, $offset);
+            if(!$match_brak) // none found or error
+            {
+                return 0;
+            }
+            if ("[" === $brak_matches[0][0])
+            {
+                $nest_level += 1;
+            }
+            else
+            { // must be ]
+                if($nest_level > 0)
+                {
+                    $nest_level -= 1;
+                }
+                else
+                {
+                    return $brak_matches[0][1];
+                }
+            }
+            $offset = $brak_matches[0][1] + 1;
+        }
     }
-    else
+
+    private function remove_user_notes($text)
     {
-        // remove leading spaces
-        $text = preg_replace("/(?<=\n|^)\ +/", "", $text);
-        // remove trailing spaces
-        $text = preg_replace("/\ +(?=\n|$)/", "", $text);
-        // remove blank lines - one or more \n -> one \n
-        $text = preg_replace("/\n+/", "\n", $text);
-        // remove blank line at beginning or end
-        return preg_replace("/^\n|\n$/", "", $text);
+        $start = strpos($text, "[**");
+        if(FALSE === $start) // not found
+        {
+            return $text;
+        }
+        $end = $this->find_close($text, $start + 3);
+        if(0 === $end) // no ] found
+        {
+            return $text;
+        }
+        return substr($text, 0, $start) . $this->remove_user_notes(substr($text, $end + 1));
+    }
+
+    private function advance_end($text, $end)
+    {
+        // for continuing footnote etc., if * follows ] remove it
+        $new_start = $end + 1;
+        if(($new_start < strlen($text)) && ($text[$new_start] == "*"))
+        {
+            $new_start += 1;
+        }
+        return $new_start;
+    }
+
+    private function adjust_footnotes($text)
+    {
+        // remove "[Footnote" and ":" and "]", if ref. is a letter replace with *
+        $match = preg_match ("/\[Footnote (?:(\d+)|[A-Z]):/", $text, $matches, PREG_OFFSET_CAPTURE);
+        if(!$match) // if no match or error
+        {
+            return $text;
+        }
+        $start = $matches[0][1];
+        if(isset($matches[1]))
+        { // number reference
+            $note_ref = $matches[1][0];
+        }
+        else
+        { // must be a letter
+            $note_ref = "*";
+        }
+        $length = strlen($matches[0][0]);
+        $right_start = $start + $length; // following the :
+        $end = $this->find_close($text, $right_start); // before the closing ]
+        if(0 === $end) // no ] found
+        {
+            return $text;
+        }
+
+        $new_start = $this->advance_end($text, $end);
+        return substr($text, 0, $start) . $note_ref . substr($text, $right_start, $end - $right_start) . $this->adjust_footnotes(substr($text, $new_start));
+    }
+
+    private function adjust_notes($text)
+    {
+        // Illustration with text, Sidenote, continuation Footnote without a ref.
+        $match = preg_match ("/\*\[Footnote: |\*?\[Sidenote: |\[Illustration: /", $text, $matches, PREG_OFFSET_CAPTURE);
+        if(!$match) // if no match or error
+        {
+            return $text;
+        }
+        $start = $matches[0][1];
+        $length = strlen($matches[0][0]);
+        $right_start = $start + $length; // following the :
+        $end = $this->find_close($text, $right_start); // before the closing ]
+        if(0 === $end) // no ] found
+        {
+            return $text;
+        }
+
+        $new_start = $this->advance_end($text, $end);
+        return substr($text, 0, $start) . substr($text, $right_start, $end - $right_start) . $this->adjust_notes(substr($text, $new_start));
+    }
+
+    public function remove_formatting($text, $unwrap)
+    {
+        $text = str_replace( "\r\n", "\n", $text);
+        // these can leave blank lines which will be removed later
+        $text = $this->remove_user_notes($text);
+        // remove tags [Illustration] (without text)
+        $text = preg_replace("/<\/?(?:[ibfgu]|sc|tb)>|\/[\*#]|[\*#]\/|\[Illustration\]/", "", $text);
+        // change alphabetic footnote anchors to *
+        $text = preg_replace("/\[[A-Z]\]/", "[*]", $text);
+        $text = $this->adjust_footnotes($text);
+        $text = $this->adjust_notes($text);
+        if($unwrap)
+        {
+            // change one or more newlines or spaces to a single space
+            $text = preg_replace("/\s+/", " ", $text);
+        }
+        else
+        {
+            // remove leading spaces
+            $text = preg_replace("/(?<=\n|^)\ +/", "", $text);
+            // remove trailing spaces
+            $text = preg_replace("/\ +(?=\n|$)/", "", $text);
+            // remove blank lines - one or more \n -> one \n
+            $text = preg_replace("/\n+/", "\n", $text);
+        }
+        // remove whitespace from beginning and end
+        return trim($text);
     }
 }
 

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -89,9 +89,10 @@ if ( $can_see_names_for_this_page) {
 
 if($format == "remove")
 {
+    $un_formatter = new UnFormatter();
     // also remove blank lines and leading and trailing spaces
-    $L_text = remove_formatting($L_text, false);
-    $R_text = remove_formatting($R_text, false);
+    $L_text = $un_formatter->remove_formatting($L_text, false);
+    $R_text = $un_formatter->remove_formatting($R_text, false);
     $link_text = _('Difference for page %s with formatting removed');
 }
 else

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -131,9 +131,10 @@ class Comparator
         $diff_pages = array();
         while($page_res = mysqli_fetch_assoc($res))
         {
+            $un_formatter = new UnFormatter();
             // also unwrap
-            $L_text = remove_formatting($page_res[$L_text_column_name], true);
-            $R_text = remove_formatting($page_res[$R_text_column_name], true);
+            $L_text = $un_formatter->remove_formatting($page_res[$L_text_column_name], true);
+            $R_text = $un_formatter->remove_formatting($page_res[$R_text_column_name], true);
             if(0 != strcmp($L_text, $R_text))
             {
                 $diff_pages[] = $page_res['image'];


### PR DESCRIPTION
The end of footnotes and other notes is now detected correctly
by passing over paired square brackets. Asterisks for continuation
notes are also removed. A new UnFormatter class is used to avoid
more global functions.
New test file page_compare_test.php added in new directory with
.htaccess file to allow it to be run