### PR TITLE
Restrict nameofwork and author inputs to 255 chars

### DIFF
--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -15,10 +15,13 @@ function just_echo( $field_value )
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function text_field( $field_value, $field_name )
+function text_field( $field_value, $field_name, $args=array())
 {
+    $maxlength = array_get($args, "maxlength", NULL);
+    $maxlength_attr = $maxlength ? "maxlength='$maxlength'" : '';
+
     $enc_field_value = attr_safe($field_value);
-    echo "<input type='text' size='67' name='$field_name' value='$enc_field_value'>";
+    echo "<input type='text' size='67' name='$field_name' value='$enc_field_value' $maxlength_attr>";
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -934,8 +934,8 @@ class ProjectInfoHolder
 
             $this->row( _("Related Uber Project"), 'just_echo', $up_nameofwork );
         }
-        $this->row( _("Name of Work"),                'text_field',          $this->nameofwork,      'nameofwork' );
-        $this->row( _("Author's Name"),               'text_field',          $this->authorsname,     'authorsname' );
+        $this->row( _("Name of Work"),                'text_field',          $this->nameofwork,      'nameofwork', '', array("maxlength" => 255));
+        $this->row( _("Author's Name"),               'text_field',          $this->authorsname,     'authorsname', '', array("maxlength" => 255));
         if ( user_is_a_sitemanager() )
         {
             // SAs are the only ones who can change this

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -980,7 +980,7 @@ class ProjectInfoHolder
         }
     }
 
-    function row( $label, $display_function, $field_value, $field_name=NULL, $explan='', $args='' )
+    function row( $label, $display_function, $field_value, $field_name=NULL, $explain='', $args='' )
     {
         echo "<tr>";
         echo   "<th class='label'>";
@@ -989,7 +989,7 @@ class ProjectInfoHolder
         echo   "<td>";
         $display_function( $field_value, $field_name, $args );
         echo   "  ";
-        echo   $explan;
+        echo   $explain;
         echo   "</td>";
         echo "</tr>";
         echo "\n";

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -77,7 +77,7 @@ function show_query_form()
             echo "<tr>";
             echo   "<th class='label'>$field_label</th>";
             echo   "<td>";
-            echo     "<input type='text' size='30' name='$field_name'>";
+            echo     "<input type='text' size='30' name='$field_name' maxlength='255'>";
             echo   "</td>";
             echo "</tr>\n";
         }


### PR DESCRIPTION
The size of the db columns for nameofwork and author is 255. Prior versions of MySQL would silently truncate longer strings to the size of the column, but modern versions throw an error. Prevent users from inputting strings longer than 255 for these columns.

Without a doubt there are other instances where we should be doing this type of enforcement, but this addresses this instance.