### PR TITLE
Added ability to set zoom percent using numpad (task #1531)

### DIFF
--- a/tools/proofers/button_menu.inc
+++ b/tools/proofers/button_menu.inc
@@ -23,7 +23,9 @@ function refuseNonNumeric(event) {
     if (key == 8 || key == 9 || key == 46 || key == 37 || key == 39) return true;
 
     // Finally, allow only the 0-9 keys and only if shift isn't pressed
-    return (key >= 48 && key <= 57 && !e.shiftKey);
+    // 48-57 are the keyCodes for 0-9 on the standard keyboard
+    // 96-105 are the keyCodes for 0-9 on the numeric keypad
+    return (((key >= 48 && key <= 57) || (key >= 96 && key <= 105)) && !e.shiftKey);
 }
 </script>
 <A


### PR DESCRIPTION
[Here](https://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes) is a simple reference for key codes where I got the numpad codes. [Here](https://www.pgdp.net/c/tasks.php?action=notify_me&task_id=1531) is task #1531 which this solves. :)

On a slightly related note, it might be beneficial to allow enter (13) because it would allow users to set the zoom without having to click the button. 