### PR TITLE
Only alert if both word lists are empty

### DIFF
--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -432,15 +432,15 @@ function _test_project_for_word_lists($projectid)
     $details .= "<li>" . _("Number of bad words") . ": $num_bad_words</li>";
     $details .= "</ul></p>";
 
-    if($num_good_words && $num_bad_words)
+    if($num_good_words || $num_bad_words)
     {
         $status = _("Success");
-        $summary = _("Both the good and bad word lists have entries.");
+        $summary = _("At least one of the good and bad word lists have entries.");
     }
     else
     {
         $status = _("Warning");
-        $summary = _("One or both of the word lists are empty.");
+        $summary = _("Both of the word lists are empty.");
     }
 
     return array(


### PR DESCRIPTION
Rather than issuing a warning if one of the word lists is empty,
only alert if both of them are empty. This was both the original
ask and what was announced, but not what was coded.