### PR TITLE
Settings remove_value() function modified

### DIFF
--- a/pinc/SettingsClass.inc
+++ b/pinc/SettingsClass.inc
@@ -219,7 +219,7 @@ class Settings
     // Remove a setting:value pair
     public function remove_value($settingCode, $value)
     {
-        if(in_array($value, $this->settings_array[$settingCode]))
+        if(array_key_exists($settingCode, $this->settings_array) && in_array($value, $this->settings_array[$settingCode]))
         {
             $this->settings_array[$settingCode] = array_diff(
                 $this->settings_array[$settingCode], array($value));


### PR DESCRIPTION
First check if setting exists. Otherwise an error can occur.
This can happen e.g. if removing a task notification and then
reloading the page. (It would be good to modify the page causing
the problem also so this does not happen).