### PR TITLE
Add link tags for automatic detection of RSS feeds

### DIFF
--- a/list_etexts.php
+++ b/list_etexts.php
@@ -18,21 +18,30 @@ if($x == "g") {
     $title = _("Completed Gold E-Texts");
     $state = SQL_CONDITION_GOLD;
     $info = _("Below is the list of Gold e-texts that have been produced on this site. Gold e-texts are books that have passed through all phases of proofreading, formatting, and post-processing. They have been submitted to Project Gutenberg and are now available for your enjoyment and download.");
+    $rss_content = "posted";
 } elseif ($x == "s") {
     $type = "Silver";
     $title = _("In Progress Silver E-Texts");
     $state = SQL_CONDITION_SILVER;
     $info = _("Below is the list of Silver e-texts that have almost completed processing on our site. Silver e-texts are books that have passed through all phases of proofreading and formatting and are now in the post-processing phase. Post-processing is the final assembly stage in which one volunteer performs a series of checks for consistency and correctness before the e-book is submitted to Project Gutenberg for your enjoyment and download.");
+    $rss_content = "postprocessing";
 } elseif ($x == "b") {
     $type = "Bronze";
     $title = _("Now Proofreading Bronze E-Texts");
     $state = SQL_CONDITION_BRONZE;
     $info = _("Below is the list of Bronze e-texts that are currently available for proofreading on this site. Bronze e-texts are what our newest volunteers see and what you can work on now by logging in. These e-texts are in the initial stages of proofreading where everyone has a chance to correct any OCR errors which may be found. After going through a number of other phases, the e-text then goes to an experienced volunteer for final assembly (post-processing), after which the e-text is submitted to Project Gutenberg for your enjoyment and download.");
+    $rss_content = "proofing";
 } else {
     die("x parameter must be 'g', 's', or 'b'. ('$x')");
 }
 
-output_header($title);
+// Tell RSS feed readers which RSS feed is connected to this page
+$attr_safe_title = attr_safe($title);
+$extra_args = array(
+    "head_data" => "<link rel='alternate' type='application/rss+xml' href='$code_url/feeds/backend.php?content=$rss_content&type=rss' title='$attr_safe_title' />",
+);
+
+output_header($title, SHOW_STATSBAR, $extra_args);
 
 echo "<h1 style='color: $type;'>$title</h1>";
 

--- a/tools/post_proofers/smooth_reading.php
+++ b/tools/post_proofers/smooth_reading.php
@@ -21,8 +21,15 @@ if ($logged_in) {
     $news = "SR_PREV";
 }
 
+// Tell RSS feed readers which RSS feed is connected to this page
+$rss_title = _("Smooth Reading E-Texts");
+$attr_safe_rss_title = attr_safe($rss_title);
+$extra_args = array(
+    "head_data" => "<link rel='alternate' type='application/rss+xml' href='$code_url/feeds/backend.php?content=smoothreading&type=rss' title='$attr_safe_rss_title' />",
+);
+
 // we show more columns when user is logged in, so we don't have room for the stats bar
-output_header( $header_text, $logged_in ? NO_STATSBAR : SHOW_STATSBAR);
+output_header($header_text, $logged_in ? NO_STATSBAR : SHOW_STATSBAR, $extra_args);
 $stage = get_Stage_for_id("SR");
 $stage->page_header( $header_text );
 show_news_for_page($news);


### PR DESCRIPTION
Inspired by [this post](https://developer.mozilla.org/en-US/docs/Web/RSS/Getting_Started/Syndicating#Adding_the_.3Clink.3E), I have added the relevant `link` tags which allow RSS feed readers to determine which RSS feed is connected to that page. 

## Examples of what this allows

### [RSS Feed Reader extension for Chrome](https://chrome.google.com/webstore/detail/rss-feed-reader/pnjaodmkngahhkoihejjehlcdlnohgmp)

If you open `/c/list_etexts.php?x=g` the extension detects the RSS feed and allows you to add it easily, which looks like this.

![image](https://user-images.githubusercontent.com/3049847/43417381-1e03cc3a-943b-11e8-9c33-b9fcee0de782.png)

### Firefox

If you open the same page, you are able to choose the option "Subscribe to This Page..." which allows you to create a Live Bookmark.

![image](https://user-images.githubusercontent.com/3049847/43417553-969e2c1c-943b-11e8-874e-c49b67a0ba6c.png)

## Which pages are connected to which RSS feeds

### Completed Gold E-Texts

- URL: `/c/list_etexts.php?x=g`
- Title of RSS Feed: `Completed Gold E-Texts`
- RSS Feed: `/c/feeds/backend.php?content=posted&type=rss`

### In Progress Silver E-Texts

- URL: `/c/list_etexts.php?x=s`
- Title of RSS Feed: `In Progress Silver E-Texts`
- RSS Feed: `/c/feeds/backend.php?content=postprocessing&type=rss`

### Now Proofreading Bronze E-Texts

- URL: `/c/list_etexts.php?x=b`
- Title of RSS Feed: `Now Proofreading Bronze E-Texts`
- RSS Feed: `/c/feeds/backend.php?content=proofing&type=rss`

### Smooth Reading Pool Preview

- URL: `/c/tools/post_proofers/smooth_reading.php`
- Title of RSS Feed: `Smooth Reading E-Texts`
- RSS Feed: `/c/feeds/backend.php?content=smoothreading&type=rss`