### PR TITLE
Remove duplicate hidden input tag for task search

### DIFF
--- a/tasks.php
+++ b/tasks.php
@@ -1015,7 +1015,7 @@ EOS;
     echo "<input type='submit' value='Go!'>\n";
     echo "</form>";
     echo "</td></tr></table><br>\n";
-    echo "<form action='$tasks_url' method='post'><input type='hidden' name='action' value='search'>";
+    echo "<form action='$tasks_url' method='post'>";
     echo "<table class='tasks'>\n";
     echo "<tr><td><b><small class='task'>Search:</small></b></td>\n";
     echo "<td>";


### PR DESCRIPTION
A few lines after this one, the `SearchParams_echo_controls()` function is called which already prints:

    <input type='hidden' name='action' value='search'>

So the removed line is a duplicate. Since it is a POST form, the duplicated input is overwritten, but if we edit it to use GET, the duplication is plain to see.

### Example

    https://www.pgdp.net/c/tasks.php?action=search&action=search...
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^