### PR TITLE
Add ability to subscribe to SR reports

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -701,6 +701,7 @@ CREATE TABLE `user_project_info` (
   `iste_sr_available` tinyint(1) NOT NULL default '0',
   `iste_ppv_enter` tinyint(1) NOT NULL default '0',
   `iste_posted` tinyint(1) NOT NULL default '0',
+  `iste_sr_reported` tinyint(1) NOT NULL default '0',
   PRIMARY KEY  (`username`,`projectid`),
   KEY `projectid` (`projectid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;

--- a/SETUP/upgrade/12/20180822_alter_user_project_info.php
+++ b/SETUP/upgrade/12/20180822_alter_user_project_info.php
@@ -1,0 +1,24 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding a new column (iste_sr_reported) to user_project_info...\n";
+$sql = "
+    ALTER TABLE user_project_info
+        ADD COLUMN iste_sr_reported tinyint(1) NOT NULL default '0'
+        AFTER iste_posted;
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -155,6 +155,11 @@ function notify_project_event_subscribers( $project, $event, $extras=array() )
                 _("This project has become available for smooth-reading.");
             break;
 
+        case 'sr_reported':
+            $msg_body .=
+                _("A new smooth-reading report has been uploaded.");
+            break;
+
         case 'ppv_enter':
             $msg_body .=
                 _("This project has entered post-processing verification.");

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -36,6 +36,7 @@ $subscribable_project_events = array(
     'round_complete'  => _("Project finishes a round"),
     'pp_enter'        => _("Project enters PP stage"),
     'sr_available'    => _("Project becomes available for smooth-reading"),
+    'sr_reported'       => _("User has uploaded a smooth-reading report"),
     'ppv_enter'       => _("Project enters PPV stage"),
     'posted'          => _("Project posted to Project Gutenberg"),
 );

--- a/project.php
+++ b/project.php
@@ -1138,6 +1138,12 @@ function do_event_subscriptions()
     echo "</tr>\n";
     foreach ( $subscribable_project_events as $event => $label )
     {
+        // Hide SR report posted event for anyone who is not a PP
+        if ($event == 'sr_reported' && !$project->PPer_is_user($pguser))
+        {
+            continue;
+        }
+
         $is_subd = user_is_subscribed_to_project_event( $pguser, $projectid, $event );
         $bgcolor = ( $is_subd ? '#CFC' : '#FFF' );
         $checked = ( $is_subd ? 'checked' : '' );

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -136,9 +136,7 @@ else if ($stage == 'smooth_done')
     $is_file_optional = FALSE;
     $indicator = "_smooth_done_".$pguser;
     // This requirement is in project.php as well
-    $project_is_in_valid_state = (
-        (PROJ_POST_FIRST_CHECKED_OUT == $project->state) && (time() < $project->smoothread_deadline)
-    );
+    $project_is_in_valid_state = $project->is_available_for_smoothreading();
     if(time() >= $project->smoothread_deadline)
     {
         // This string matches one in project.php

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -343,6 +343,11 @@ else
         }
     }
 
+    if ($stage == 'smooth_done')
+    {
+        notify_project_event_subscribers( $project, 'sr_reported' );
+    }
+
     // let them know file uploaded and send back to the right place
     $msg1 = _("File uploaded. Thank you!");
     $msg2 = _("Project returned to pool");


### PR DESCRIPTION
Based on this task: https://www.pgdp.net/c/tasks.php?action=show&task_id=1615

It adds a new event called `sr_posted` which is fired every time someone uploads a new smooth reading report. The event is subscribable and off by default. Only the post proofer of that specific project can subscribe to the event.

### Event subscriptions for a non post proofer

![image](https://user-images.githubusercontent.com/3049847/44789578-3740aa00-ab9d-11e8-9226-4ede36fe0e2c.png)


### Event subscriptions for a post proofer

![image](https://user-images.githubusercontent.com/3049847/44789623-53444b80-ab9d-11e8-8e17-bf1e001d55cb.png)

### Current email message

![image](https://user-images.githubusercontent.com/3049847/44789719-9dc5c800-ab9d-11e8-8bd6-1fcfa9b5e281.png)