### PR TITLE
Add ability to subscribe to SR end event

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -699,6 +699,7 @@ CREATE TABLE `user_project_info` (
   `iste_round_complete` tinyint(1) NOT NULL default '0',
   `iste_pp_enter` tinyint(1) NOT NULL default '0',
   `iste_sr_available` tinyint(1) NOT NULL default '0',
+  `iste_sr_complete` tinyint(1) NOT NULL default '0',
   `iste_ppv_enter` tinyint(1) NOT NULL default '0',
   `iste_posted` tinyint(1) NOT NULL default '0',
   `iste_sr_reported` tinyint(1) NOT NULL default '0',

--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -4,6 +4,7 @@
 
 # hourly:
 03 * * * * URL=<<CODE_URL>>/crontab/update_user_counts.php; <<URL_DUMP_PROGRAM>> $URL
+03 * * * * URL=<<CODE_URL>>/crontab/finish_smoothreading.php; <<URL_DUMP_PROGRAM>> $URL
 
 # daily:
 01  0 * * * URL=<<CODE_URL>>/crontab/take_tally_snapshots.php; <<URL_DUMP_PROGRAM>> $URL

--- a/SETUP/upgrade/12/20180908_alter_user_project_info.php
+++ b/SETUP/upgrade/12/20180908_alter_user_project_info.php
@@ -1,0 +1,24 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding a new column (iste_sr_complete) to user_project_info...\n";
+$sql = "
+    ALTER TABLE user_project_info
+        ADD COLUMN iste_sr_complete tinyint(1) NOT NULL default '0'
+        AFTER iste_sr_available;
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -1,0 +1,77 @@
+<?php
+$relPath="./../pinc/";
+include_once($relPath.'base.inc');
+include_once($relPath.'misc.inc');
+include_once($relPath.'project_states.inc');
+include_once($relPath.'project_events.inc');
+include_once($relPath.'user_project_info.inc');
+include_once($relPath.'Project.inc');
+
+// check that caller is localhost or bail
+if(!requester_is_localhost())
+    die("You are not authorized to perform this request.");
+
+header('Content-type: text/plain');
+
+$dry_run = array_get( $_GET, 'dry_run', '' );
+if ($dry_run)
+{
+    echo "This is a dry run.\n";
+}
+
+// Interval relative to current time
+//   Select all projects whose smooth reading deadline is within this interval.
+$from =  -60 * 60;
+$to   =   60 * 60;
+
+$result = mysqli_query(DPDatabase::get_connection(), "
+    SELECT *
+    FROM projects
+    WHERE
+        smoothread_deadline >= (UNIX_TIMESTAMP() + $from) 
+        AND smoothread_deadline <= (UNIX_TIMESTAMP() + $to) 
+        AND state = '".PROJ_POST_FIRST_CHECKED_OUT."'
+") or die(mysqli_error(DPDatabase::get_connection()));
+
+$output = "Checking " . mysqli_num_rows($result) . " projects...\n";
+$any_work_done = false;
+
+// Used for checking smoothread_deadline within the loop
+$curr_time = strftime('%Y-%m-%d %H', time());
+
+while ( $project = mysqli_fetch_assoc($result) )
+{
+    $name = $project['nameofwork'];
+    $projectid = $project['projectid'];
+    $objProject = new Project($project);
+
+    // Check if the time is right, with precision of an hour
+    $deadline = strftime('%Y-%m-%d %H', $project['smoothread_deadline']);
+
+    if ($curr_time == $deadline)
+    {
+        $output .= "$name\n";
+        $any_work_done = true;
+
+        if ($dry_run)
+        {
+            $output .= "  Since this is a dry run, we won't send an email and log an event\n";
+        }
+        else
+        {
+            $output .= "  Sending email and logging event...\n";
+            log_project_event( $projectid, '[AUTO]', 'smooth-reading', 'finished' );
+            notify_project_event_subscribers( $objProject, 'sr_complete' );
+        }
+    }
+}
+
+$output .= "finish_smoothreading.php executed.\n";
+
+// Don't output anything if no work was done
+if ($any_work_done)
+{
+    echo $output;
+}
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -37,6 +37,7 @@ $subscribable_project_events = array(
     'pp_enter'        => _("Project enters PP stage"),
     'sr_available'    => _("Project becomes available for smooth-reading"),
     'sr_reported'       => _("User has uploaded a smooth-reading report"),
+    'sr_complete'     => _("Project finishes smooth-reading"),
     'ppv_enter'       => _("Project enters PPV stage"),
     'posted'          => _("Project posted to Project Gutenberg"),
 );
@@ -158,6 +159,10 @@ function notify_project_event_subscribers( $project, $event, $extras=array() )
         case 'sr_reported':
             $msg_body .=
                 _("A new smooth-reading report has been uploaded.");
+
+        case 'sr_complete':
+            $msg_body .=
+                _("This project has finished smooth-reading.");
             break;
 
         case 'ppv_enter':


### PR DESCRIPTION
Based on this task: https://www.pgdp.net/c/tasks.php?action=show&task_id=1317

### Summary

It adds a new subscribable event `sr_complete` which fires when the project finishes smooth reading. The event is triggered by the crontab script `finish_smoothreading.php` which queries projects whose `smoothread_deadline` is within this interval `[current time - 1 hour, current time + 1 hour]` and then checks if the smooth reading deadline coincides with the current time (same year, month, day and hour). If it does, the script logs an event specifying the smooth reading period has ended and fires the `sr_complete` event. 

#### Potential problem

The script runs **hourly** and has a precision of up to an hour, meaning that 7:00 == 7:59 so it could potentially send a premature email.

#### Potential solution

We could add an artificial delay, for example by adding `59 minutes` to the `smoothread_deadline` when checking if the smooth reading period has ended in the script. This should fix any potential premature emails, but it would delay the email and the event that is logged. 

### Images

#### Event list

![image](https://user-images.githubusercontent.com/3049847/45258722-1eb26a00-b3bd-11e8-99f9-466a28047ddd.png)

#### Logged event

![image](https://user-images.githubusercontent.com/3049847/45258875-a8176b80-b3c0-11e8-9ba7-1b21fb496185.png)

#### Script output

![image](https://user-images.githubusercontent.com/3049847/45258884-d006cf00-b3c0-11e8-8e87-7c26f3680380.png)



