### PR TITLE
Improve identification of all upper-case small-cap string

### DIFF
--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -495,6 +495,8 @@ var makePreview = function (txt, viewMode, styler) {
                 return match;
             }
             noNote = removeComments(p1);
+            // remove tags so that all uppercase string is correctly identified
+            noNote = noNote.replace(/&lt;\/?.&gt;/g, '');
             if (noNote === noNote.toUpperCase()) { // found no lower-case
                 return sc1 + '<span class="tt">' + p1 + endSpan + sc2;
             } else {


### PR DESCRIPTION
Remove any tags in the string before testing for all upper case. An all-upper-case small-cap string should be shown as small caps, but if it contains any lower-case characters it will be shown Upper-case with the lower-case chars as small caps.