### PR TITLE
Validate uploaded zip files are actually zip files

### DIFF
--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -398,6 +398,13 @@ function validate_uploaded_file()
         if (0 == $uploaded_file['size']) {
             die( _("File is empty") );
         }
+
+        // ensure that it's a valid zip
+        exec("zipinfo -1 " . $uploaded_file['tmp_name'], $zipinfo_output, $return_code);
+        if($return_code != 0) {
+            die( _("Not a valid zip file") );
+        }
+
         return $uploaded_file['tmp_name'];
     }
 


### PR DESCRIPTION
Right now users can uploaded non-zip files by just renaming the file with a .zip extension. This validates that the files uploaded are valid zip files.