### PR TITLE
Don't hard-code DPCustomMono2 anywhere

### DIFF
--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -18,6 +18,7 @@
 //
 // See 3rdparty/mediawiki/README.md for which MediaWiki version this maps to.
 include_once($relPath."misc.inc"); // html_safe() in following includes
+include_once($relPath."prefs_options.inc"); // get_user_proofreading_font()
 include_once($relPath."3rdparty/mediawiki/DiffFormatter.php");
 include_once($relPath."3rdparty/mediawiki/TableDiffFormatter.php");
 include_once($relPath."3rdparty/mediawiki/DairikiDiff.php");
@@ -152,6 +153,10 @@ function get_DifferenceEngine_css_files() {
 
 // Override default css for DP customizations
 function get_DifferenceEngine_css_data() {
+    list($font_family, $font_size) = get_user_proofreading_font();
+    if($font_family != '')
+        $font_family = "$font_family,";
+
     return "
 td.diff-otitle,
 td.diff-ntitle {
@@ -161,7 +166,7 @@ td.diff-marker,
 td.diff-addedline,
 td.diff-deletedline,
 td.diff-context {
-    font-family: DPCustomMono2, monospace;
+    font-family: $font_family monospace;
     font-size: smaller;
 }
 ";

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -46,6 +46,28 @@ $proofreading_font_sizes = array (
     11 => '26px',
 );
 
+// And a function to return user's current proofreading font
+function get_user_proofreading_font()
+{
+    global $userP, $proofreading_font_sizes, $proofreading_font_faces;
+
+    if ( $userP['i_layout']==1 )   // "vertical"
+    {
+        $font_size_i = $userP['v_fnts'];
+        $font_style_i = $userP['v_fntf'];
+    }
+    else   // "horizontal"
+    {
+        $font_size_i = $userP['h_fnts'];
+        $font_style_i = $userP['h_fntf'];
+    }
+
+    $font_size = $proofreading_font_sizes[$font_size_i];
+    $font_style = $proofreading_font_faces[$font_style_i];
+
+    return array($font_style, $font_size);
+}
+
 // $u_n = show rank neighbors
 $u_n= array('0', '2', '4', '6', '8', '10', '12', '14', '16', '18', '20');
 

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -3,7 +3,7 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'Project.inc');         // $PROJECT_STATES_IN_ORDER
 include_once($relPath.'RoundDescriptor.inc'); // $PAGE_STATES_IN_ORDER
 include_once($relPath.'page_tally.inc');
-include_once($relPath.'prefs_options.inc'); // $proofreading_font_*
+include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 include_once($relPath.'LPage.inc');
 include_once($relPath.'abort.inc');
 include_once($relPath.'misc.inc'); // html_safe()
@@ -196,7 +196,7 @@ class PPage
 
     function echo_proofing_textarea()
     {
-        global $userP, $proofreading_font_faces, $proofreading_font_sizes;
+        global $userP;
 
         $page_text = $this->lpage->get_text();
 
@@ -208,8 +208,6 @@ class PPage
             $n_cols      = $userP['v_tchars'];
             $n_rows      = $userP['v_tlines'];
             $line_wrap   = $userP['v_twrap'];
-            $font_face_i = $userP['v_fntf'];
-            $font_size_i = $userP['v_fnts'];
         }
         else
         {
@@ -217,8 +215,6 @@ class PPage
             $n_cols      = $userP['h_tchars'];
             $n_rows      = $userP['h_tlines'];
             $line_wrap   = $userP['h_twrap'];
-            $font_face_i = $userP['h_fntf'];
-            $font_size_i = $userP['h_fnts'];
         }
 
         echo "<textarea
@@ -230,8 +226,7 @@ class PPage
         ";
 
         echo "style='";
-        $font_face = $proofreading_font_faces[$font_face_i];
-        $font_size = $proofreading_font_sizes[$font_size_i];
+        list($font_face, $font_size) = get_user_proofreading_font();
         if ( $font_face != '' )
         {
             echo "font-family: $font_face;";

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'wordcheck_engine.inc');
+include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 include_once($relPath.'misc.inc');  // attr_safe(), javascript_safe()
 
 // Arguments:
@@ -176,27 +177,6 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
     $returnString.="<input id='sptotal' type='hidden' name='sptotal' value='$numBadWords'>";
 
     return array($returnString,$languages,$messages);
-}
-
-function get_user_proofreading_font()  // logic originally copied from PPage.inc
-{
-    global $userP, $proofreading_font_sizes, $proofreading_font_faces;
-
-    if ( $userP['i_layout']==1 )   // "vertical"
-    {
-        $font_size_i = $userP['v_fnts'];
-        $font_style_i = $userP['v_fntf'];
-    }
-    else   // "horizontal"
-    {
-        $font_size_i = $userP['h_fnts'];
-        $font_style_i = $userP['h_fntf'];
-    }
-
-    $font_size = $proofreading_font_sizes[$font_size_i];
-    $font_style = $proofreading_font_faces[$font_style_i];
-
-    return array($font_style, $font_size);
 }
 
 // adds HTML code to punctuation to highlight it

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -46,13 +46,17 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
 
     // ok, at this point we have a finalized list of bad words.
     // start preparing the page
-    $font_size_style = get_user_font_size();
+    list($font_style, $font_size) = get_user_proofreading_font();
+    if($font_size != '')
+        $font_size = "font-size: $font_size";
+    if($font_style != '')
+        $font_style = "$font_style,";
     // define the styles used for the interface (highlight for the punctuation, AW button, etc)
     $returnString.="<style type='text/css'>" .
-                   " pre { $font_size_style } " .
+                   " pre { $font_size }".
+                   "  .proofingfont { font-family: $font_style monospace; }" .
                    "  .hl { background-color: yellow; color: black; }" .
                    "  img.aw { border: 0; margin-left: 5px; }" .
-                   "  .dpmono { font-family: DPCustomMono2,monospace; $font_size_style }" .
                    "  span.aw { background-color: white; color: black; }" .
                    "</style>";
     $returnString.="<pre>\n";
@@ -150,7 +154,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
                 // create the edit box
                 $replaceString.=
                     "<input type='hidden' name='posit{$numBadWords}' value='$origLineNum|$lineIndex|$wordLen'>" .
-                    "<input type='text' id='input_$wordID' name='sp$numBadWords' size='$textBoxLen' value='$wordSafe' class='dpmono'$onChange>";
+                    "<input type='text' id='input_$wordID' name='sp$numBadWords' size='$textBoxLen' value='$wordSafe' class='proofingfont'$onChange>";
 
                 // if the AW button is wanted, add the closing span and the button
                 if($badWordHash[$word] == WC_WORLD ) {
@@ -174,20 +178,25 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
     return array($returnString,$languages,$messages);
 }
 
-function get_user_font_size()  // logic copied from PPage.inc
+function get_user_proofreading_font()  // logic originally copied from PPage.inc
 {
-    global $userP, $proofreading_font_sizes;
+    global $userP, $proofreading_font_sizes, $proofreading_font_faces;
 
     if ( $userP['i_layout']==1 )   // "vertical"
+    {
         $font_size_i = $userP['v_fnts'];
+        $font_style_i = $userP['v_fntf'];
+    }
     else   // "horizontal"
+    {
         $font_size_i = $userP['h_fnts'];
+        $font_style_i = $userP['h_fntf'];
+    }
 
     $font_size = $proofreading_font_sizes[$font_size_i];
-    if ( $font_size != '' )
-        return ("font-size: $font_size;");
-    else
-        return "";
+    $font_style = $proofreading_font_faces[$font_style_i];
+
+    return array($font_style, $font_size);
 }
 
 // adds HTML code to punctuation to highlight it


### PR DESCRIPTION
Now that all (modern) web browsers can use DPCustomMono2 because it's a web font, it's being used in a few places that many users don't expect although they aren't new. This changes those places to use the user's preferred proofreading font instead, giving them control over what is used and making it consistent in several places.