### PR TITLE
Fix php errors caused by includes on login redirects

### DIFF
--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -114,10 +114,13 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
 }
 
 // Output HTML page footer to close the page
-function output_html_footer()
+function output_html_footer($extra_args=array())
 {
     // close up the page
-    echo "\n</body>\n";
+
+    // framesets don't have <body> elements
+    if(!isset($extra_args['frameset']))
+        echo "\n</body>\n";
     echo "</html>\n";
 }
 

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -1,0 +1,158 @@
+<?php
+include_once($relPath."languages.inc"); // html_lang_header();
+include_once($relPath."misc.inc"); // html_safe(), ends_with()
+
+define('NO_STATSBAR',   False);
+define('SHOW_STATSBAR', True);
+
+// This file is used by both theme.inc and slim_header.inc for functions that
+// output the HTML header and footer for all pages that show output to the
+// user.
+
+// Output the opening HTML page code, including pulling in common styles,
+// page title, etc. eg:
+function output_html_header($nameofpage, $extra_args = array(), $show_statsbar = True)
+{
+    global $code_url, $site_abbreviation, $userP;
+    global $charset;
+
+    $intlang = get_desired_language();
+
+    // HTML 5 dictates that ISO-8859-1 documents should declare their charset
+    // as windows-1252 (which is what web browsers actually treat ISO-8859-1 as).
+    if(strcasecmp($charset, 'ISO-8859-1') == 0)
+        $output_charset = 'windows-1252';
+    else
+        $output_charset = $charset;
+
+    echo "<!DOCTYPE html>\n"; // HTML 5
+    echo "<html ".lang_html_header($intlang).">\n<head>\n";
+    echo "<meta charset='$output_charset'>\n";
+
+    # iOS and Android icons
+    echo "<link rel='apple-touch-icon' href='$code_url/graphics/dp-mark-180px-white.png'>\n";
+    echo "<link rel='icon' href='$code_url/graphics/dp-mark-180px-white.png'>\n";
+    # standard favicon.ico -- this has to be after the rel='icon' above due to
+    # a FF bug: https://bugzilla.mozilla.org/show_bug.cgi?id=751712
+    echo "<link rel='shortcut icon' href='$code_url/graphics/dp-mark-32px.ico'>\n";
+
+    echo "<title>$site_abbreviation";
+    if (isset($nameofpage))
+    {
+        echo ": ", html_safe($nameofpage);
+    }
+    echo "</title>\n";
+
+    // Global CSS
+    $theme_name = array_get($userP, 'i_theme', "project_gutenberg");
+    $css_files = array(
+        "$code_url/styles/themes/$theme_name.css",
+        "$code_url/styles/layout.css",
+        "$code_url/styles/global.css",
+    );
+
+    // Statsbar CSS
+    if ($show_statsbar)
+        $css_files[] = "$code_url/styles/statsbar.css";
+
+    // Per-page CSS
+    if (isset($extra_args['css_files']))
+        $css_files = array_merge($css_files, $extra_args['css_files']);
+
+    foreach($css_files as $css_file)
+    {
+        $cache_fixer = get_local_file_browser_cache_key($css_file);
+        echo "<link type='text/css' rel='Stylesheet' href='$css_file$cache_fixer'>\n";
+    }
+
+    // Any additional style definitions requested by the caller
+    if (isset($extra_args['css_data']))
+    {
+        echo "<style type='text/css'>\n" .
+             $extra_args['css_data'] .
+             "</style>\n";
+    }
+
+    // Global JS
+    $js_files = array(
+        "$code_url/pinc/3rdparty/jquery/jquery-3.3.1.js",
+    );
+
+    // Per-page JS
+    if (isset($extra_args['js_files']))
+        $js_files = array_merge($js_files, $extra_args['js_files']);
+
+    foreach($js_files as $js_file)
+    {
+        $cache_fixer = get_local_file_browser_cache_key($js_file);
+        echo "<script language='JavaScript' type='text/javascript' src='$js_file$cache_fixer'></script>\n";
+    }
+
+    // Per-page Javascript
+    if (isset($extra_args['js_data']))
+    {
+        echo "<script type='text/javascript'>\n" .
+            $extra_args['js_data'] .
+            "</script>\n";
+    }
+
+    // Any additional head tags
+    if(isset($extra_args['head_data']))
+    {
+        echo $extra_args['head_data'];
+    }
+
+    echo "</head>\n\n";
+    // framesets don't have <body> elements
+    if(!isset($extra_args['frameset']))
+    {
+        echo "<body";
+        if(isset($extra_args['body_attributes']))
+            echo " " . $extra_args['body_attributes'];
+        echo ">\n\n";
+    }
+}
+
+// Output HTML page footer to close the page
+function output_html_footer()
+{
+    // close up the page
+    echo "\n</body>\n";
+    echo "</html>\n";
+}
+
+// Browser caches are great, but they are a real PITA when we want to change
+// CSS/JS and it's still serving up the older version. This is particularly bad
+// when we're doing things like changing page editing interfaces.
+// To address that, append the file's timestamp as a query parameter to the file.
+// Apache will ignore this but when the value changes the browser will reread
+// the file. PHP's statcache should make this fast.
+function get_local_file_browser_cache_key($url)
+{
+    global $code_url, $code_dir;
+
+    $cache_fixer = "";
+    if(strpos($url, $code_url) !== FALSE)
+    {
+        $local_file = $code_dir . substr($url, strlen($code_url));
+
+        // PHP files should never be cached
+        if(endswith($local_file, ".php"))
+        {
+            $timestamp = time();
+        }
+        else
+        {
+            $stats = stat($local_file);
+            if($stats)
+                $timestamp = $stats["mtime"];
+        }
+
+        if($timestamp)
+            $cache_fixer = "?" . strftime("%Y%m%d%H%M%S", $timestamp);
+    }
+
+    return $cache_fixer;
+}
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -85,13 +85,13 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     foreach($js_files as $js_file)
     {
         $cache_fixer = get_local_file_browser_cache_key($js_file);
-        echo "<script language='JavaScript' type='text/javascript' src='$js_file$cache_fixer'></script>\n";
+        echo "<script src='$js_file$cache_fixer'></script>\n";
     }
 
     // Per-page Javascript
     if (isset($extra_args['js_data']))
     {
-        echo "<script type='text/javascript'>\n" .
+        echo "<script>\n" .
             $extra_args['js_data'] .
             "</script>\n";
     }

--- a/pinc/js_newwin.inc
+++ b/pinc/js_newwin.inc
@@ -29,7 +29,7 @@ function prep_for_links_to_project_pages()
                 $code_url );
 
         echo "
-            <script type='text/javascript'>
+            <script>
             function newProofWin(winURL)
             {
                 newFeatures='toolbar={$userP['i_toolbar']},status={$userP['i_statusbar']},location=0,directories=0,menubar=0,scrollbars=1,resizable=1,width=$window_width,height=$window_height,top=0,left=5';

--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -1,6 +1,4 @@
 <?php
-include_once($relPath.'site_vars.php');
-include_once($relPath."slim_header.inc");
 include_once($relPath.'misc.inc'); // startswith()
 
 function metarefresh($seconds,$url,$title="",$body="")
@@ -61,6 +59,8 @@ function metarefresh($seconds,$url,$title="",$body="")
 
     $meta_tag_refresh = "<meta http-equiv=\"refresh\" content=\"$sec ;URL=$url\">";
 
+    global $relPath;
+    include_once($relPath."slim_header.inc");
     slim_header($title, array('head_data' => $meta_tag_refresh));
 
     echo "$body\n";

--- a/pinc/slim_header.inc
+++ b/pinc/slim_header.inc
@@ -42,10 +42,7 @@ function slim_footer($extra_args=array())
     if($was_output)
         return;
 
-    // framesets don't have <body> elements
-    if(!isset($extra_args['frameset']))
-        echo "\n</body>\n";
-    echo "</html>\n";
+    output_html_footer($extra_args);
 
     $was_output = true;
 }

--- a/pinc/slim_header.inc
+++ b/pinc/slim_header.inc
@@ -1,5 +1,5 @@
 <?php 
-include_once($relPath."theme.inc");  // html_header()
+include_once($relPath."html_page_common.inc");
 
 // Output valid HTML for a non-themed page. The optional $extra_args variable
 // is an associative array to control what exactly is output. By default an
@@ -21,7 +21,7 @@ function slim_header($title="", $extra_args=array())
         $extra_args['css_files'] = array();
     $extra_args['css_files'][] = "$code_url/styles/slim_header.css";
 
-    html_header($title, $extra_args, False);
+    output_html_header($title, $extra_args, False);
 
     // Call slim_footer when the main page content has been emitted so we can
     // close the page

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -110,7 +110,7 @@ function output_footer($nameofpage, $show_statsbar = True) {
     echo "<small>\n";
 
     echo _("Copyright")." ". $site_name;
-    echo " ("._("Page Build Time").": ".substr($totaltime, 0, 5).") ";
+    echo " ("._("Page Build Time").": ".substr($totaltime, 0, 5)."s) ";
 
     echo "<a href='$code_url/tasks.php'>";
     echo _("Report a Bug");

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -36,7 +36,7 @@ function theme($nameofpage, $location, $extra_args = array())
 // to close the page after the caller finishes output.
 function output_header($nameofpage, $show_statsbar = True, $extra_args = array())
 {
-    global $code_url, $pguser, $userP;
+    global $pguser, $userP;
 
     // Display stats bar on left (1) or right (0)
     $statsbar_align = isset($pguser) ? $userP['u_align'] : 0;
@@ -81,7 +81,7 @@ function output_header($nameofpage, $show_statsbar = True, $extra_args = array()
 }
 
 function output_footer($nameofpage, $show_statsbar = True) {
-    global $code_url, $pguser, $userP;
+    global $pguser, $userP;
 
     // Display stats bar on left (1) or right (0)
     $statsbar_align = isset($pguser) ? $userP['u_align'] : 0;
@@ -943,8 +943,6 @@ function show_completed_projects($terse = FALSE)
 
 function show_key_help_links()
 {
-    global $code_url, $wiki_url;
-
     $faq_central_url = get_faq_url("faq_central.php");
     $p_guide_url = get_faq_url("proofreading_guidelines.php");
     $f_guide_url = get_faq_url("formatting_guidelines.php");
@@ -985,8 +983,6 @@ function show_key_help_links()
 
 function show_donation_stuff()
 {
-    global $code_url, $site_name, $wiki_url;
-
     $pgdp_wiki_url = "http://www.pgdp.net/wiki";
     $DPF_home_url  = "$pgdp_wiki_url/Distributed_Proofreaders_Foundation";
     $DPF_donor_url = "$pgdp_wiki_url/DPFoundation:Information_for_Donors";

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -2,6 +2,7 @@
 $mtime = explode(" ",microtime());
 $starttime = $mtime[1] + $mtime[0];
 include_once($relPath.'site_vars.php');
+include_once($relPath.'html_page_common.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'prefs_options.inc'); // PRIVACY_*
 include_once($relPath.'pg.inc');
@@ -14,9 +15,6 @@ include_once($relPath.'forum_interface.inc');
 include_once($relPath.'languages.inc');
 include_once($relPath.'misc.inc'); // endswith(), get_enumerated_param(), attr_safe(), endswith()
 include_once($relPath.'faq.inc');
-
-define('NO_STATSBAR',   False);
-define('SHOW_STATSBAR', True);
 
 // Backwards compatibility function. To be removed once all
 // pages transition to output_header()
@@ -48,7 +46,7 @@ function output_header($nameofpage, $show_statsbar = True, $extra_args = array()
 
     // All our themes begin with the initial markup, logo and navbar, and open a
     // table for further layout.
-    html_header($nameofpage, $extra_args, $show_statsbar);
+    output_html_header($nameofpage, $extra_args, $show_statsbar);
     html_logobar();
     echo "\n<div id='page-container'>\n";
     echo "<div id='page-body-container'>\n";
@@ -122,109 +120,7 @@ function output_footer($nameofpage, $show_statsbar = True) {
     echo "</p>\n";
     echo "</div>\n";
 
-    html_footer();
-}
-
-function html_header($nameofpage, $extra_args = array(), $show_statsbar = True)
-{
-    global $code_url, $site_abbreviation, $userP;
-    global $charset;
-
-    $intlang = get_desired_language();
-
-    // HTML 5 dictates that ISO-8859-1 documents should declare their charset
-    // as windows-1252 (which is what web browsers actually treat ISO-8859-1 as).
-    if(strcasecmp($charset, 'ISO-8859-1') == 0)
-        $output_charset = 'windows-1252';
-    else
-        $output_charset = $charset;
-
-    echo "<!DOCTYPE html>\n"; // HTML 5
-    echo "<html ".lang_html_header($intlang).">\n<head>\n";
-    echo "<meta charset='$output_charset'>\n";
-
-    # iOS and Android icons
-    echo "<link rel='apple-touch-icon' href='$code_url/graphics/dp-mark-180px-white.png'>\n";
-    echo "<link rel='icon' href='$code_url/graphics/dp-mark-180px-white.png'>\n";
-    # standard favicon.ico -- this has to be after the rel='icon' above due to
-    # a FF bug: https://bugzilla.mozilla.org/show_bug.cgi?id=751712
-    echo "<link rel='shortcut icon' href='$code_url/graphics/dp-mark-32px.ico'>\n";
-
-    echo "<title>$site_abbreviation";
-    if (isset($nameofpage))
-    {
-        echo ": ", html_safe($nameofpage);
-    }
-    echo "</title>\n";
-
-    // Global CSS
-    $theme_name = array_get($userP, 'i_theme', "project_gutenberg");
-    $css_files = array(
-        "$code_url/styles/themes/$theme_name.css",
-        "$code_url/styles/layout.css",
-        "$code_url/styles/global.css",
-    );
-
-    // Statsbar CSS
-    if ($show_statsbar)
-        $css_files[] = "$code_url/styles/statsbar.css";
-
-    // Per-page CSS
-    if (isset($extra_args['css_files']))
-        $css_files = array_merge($css_files, $extra_args['css_files']);
-
-    foreach($css_files as $css_file)
-    {
-        $cache_fixer = get_local_file_browser_cache_key($css_file);
-        echo "<link type='text/css' rel='Stylesheet' href='$css_file$cache_fixer'>\n";
-    }
-
-    // Any additional style definitions requested by the caller
-    if (isset($extra_args['css_data']))
-    {
-        echo "<style type='text/css'>\n" .
-             $extra_args['css_data'] .
-             "</style>\n";
-    }
-
-    // Global JS
-    $js_files = array(
-        "$code_url/pinc/3rdparty/jquery/jquery-3.3.1.js",
-    );
-
-    // Per-page JS
-    if (isset($extra_args['js_files']))
-        $js_files = array_merge($js_files, $extra_args['js_files']);
-
-    foreach($js_files as $js_file)
-    {
-        $cache_fixer = get_local_file_browser_cache_key($js_file);
-        echo "<script language='JavaScript' type='text/javascript' src='$js_file$cache_fixer'></script>\n";
-    }
-
-    // Per-page Javascript
-    if (isset($extra_args['js_data']))
-    {
-        echo "<script type='text/javascript'>\n" .
-            $extra_args['js_data'] .
-            "</script>\n";
-    }
-
-    // Any additional head tags
-    if(isset($extra_args['head_data']))
-    {
-        echo $extra_args['head_data'];
-    }
-
-    echo "</head>\n\n";
-    // framesets don't have <body> elements
-    if(!isset($extra_args['frameset']))
-    {
-        echo "<body";
-        if(isset($extra_args['body_attributes']))
-            echo " " . $extra_args['body_attributes'];
-        echo ">\n\n";
-    }
+    output_html_footer();
 }
 
 function html_logobar() {
@@ -1028,15 +924,6 @@ function show_donation_stuff()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function html_footer()
-{
-    // close up the page
-    echo "\n</body>\n";
-    echo "</html>\n";
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
 function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_color=TRUE, $color_thresholds=NULL)
 // A simple progress bar can be created by using the following HTML:
 //   <div class='progressbar' style='background-color: $color; width: $width%;'>&nbsp;</div>
@@ -1147,40 +1034,6 @@ function get_translated_graphic_or_text($directory, $image, $text)
         return sprintf("<img src='$dyn_url' alt='%s'>", attr_safe($text));
     else
         return $text;
-}
-
-// Browser caches are great, but they are a real PITA when we want to change
-// CSS/JS and it's still serving up the older version. This is particularly bad
-// when we're doing things like changing page editing interfaces.
-// To address that, append the file's timestamp as a query parameter to the file.
-// Apache will ignore this but when the value changes the browser will reread
-// the file. PHP's statcache should make this fast.
-function get_local_file_browser_cache_key($url)
-{
-    global $code_url, $code_dir;
-
-    $cache_fixer = "";
-    if(strpos($url, $code_url) !== FALSE)
-    {
-        $local_file = $code_dir . substr($url, strlen($code_url));
-
-        // PHP files should never be cached
-        if(endswith($local_file, ".php"))
-        {
-            $timestamp = time();
-        }
-        else
-        {
-            $stats = stat($local_file);
-            if($stats)
-                $timestamp = $stats["mtime"];
-        }
-
-        if($timestamp)
-            $cache_fixer = "?" . strftime("%Y%m%d%H%M%S", $timestamp);
-    }
-
-    return $cache_fixer;
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -81,6 +81,7 @@ function output_header($nameofpage, $show_statsbar = True, $extra_args = array()
 }
 
 function output_footer($nameofpage, $show_statsbar = True) {
+    global $code_url, $site_name, $starttime;
     global $pguser, $userP;
 
     // Display stats bar on left (1) or right (0)
@@ -99,6 +100,28 @@ function output_footer($nameofpage, $show_statsbar = True) {
     }
     // Finally close the table, and emit the footer.
     echo "</div></div>\n";
+
+    // Now the page footer
+    $mtime = explode(" ",microtime());
+    $endtime = $mtime[1] + $mtime[0];
+    $totaltime = ($endtime - $starttime);
+
+    //Bottom Copyright Text
+    echo "\n<div id='footer'>\n";
+    echo "<p>\n";
+    echo "<small>\n";
+
+    echo _("Copyright")." ". $site_name;
+    echo " ("._("Page Build Time").": ".substr($totaltime, 0, 5).") ";
+
+    echo "<a href='$code_url/tasks.php'>";
+    echo _("Report a Bug");
+    echo "</a>";
+
+    echo "</small>\n";
+    echo "</p>\n";
+    echo "</div>\n";
+
     html_footer();
 }
 
@@ -1005,30 +1028,9 @@ function show_donation_stuff()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function html_footer() {
-    global $code_url, $site_name, $starttime;
-
-    $mtime = explode(" ",microtime());
-    $endtime = $mtime[1] + $mtime[0];
-    $totaltime = ($endtime - $starttime);
-
-    //Bottom Copyright Text
-    echo "\n<div id='footer'>\n";
-    echo "<p>\n";
-    echo "<small>\n";
-
-    echo _("Copyright")." ". $site_name;
-    echo " ("._("Page Build Time").": ".substr($totaltime, 0, 5).") ";
-
-    echo "<a href='$code_url/tasks.php'>";
-    echo _("Report a Bug");
-    echo "</a>";
-
-    echo "</small>\n";
-    echo "</p>\n";
-    echo "</div>\n";
-
-    //The End
+function html_footer()
+{
+    // close up the page
     echo "\n</body>\n";
     echo "</html>\n";
 }

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -509,7 +509,7 @@ function maybe_show_language_selector()
         return;
 
     ?>
-    <script type="text/javascript"><!--
+    <script><!--
         function submitLang(i) {
             top.document.forms.langform.submit();
         }

--- a/quiz/generic/wizard/checks.php
+++ b/quiz/generic/wizard/checks.php
@@ -182,7 +182,7 @@ else // we are coming from this page (checks.php)
 }
 ?>
 
-<script type="text/javascript">
+<script>
 
 function nonechecked(x) 
 {

--- a/quiz/small_theme.inc
+++ b/quiz/small_theme.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'base.inc');
-include_once($relPath.'theme.inc');
+include_once($relPath.'html_page_common.inc'); // output_html_header()
+include_once($relPath.'theme.inc'); // headerbar_text_array()
 include_once($relPath.'faq.inc');
 include_once($relPath.'quizzes.inc'); // get_quiz_id_param get_Quiz_with_id
 
@@ -8,8 +9,7 @@ function output_small_header($quiz)
 {
     global $code_url, $site_name, $site_abbreviation;
 
-    // From theme.inc
-    html_header('');
+    output_html_header('');
 
     $quiz_name = $quiz->short_name;
 
@@ -70,8 +70,7 @@ function output_small_header($quiz)
 function output_small_footer()
 {
     echo "</div>\n";
-    echo "</body>\n";
-    echo "</html>\n";
+    output_html_footer();
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/authors/add.php
+++ b/tools/authors/add.php
@@ -192,7 +192,7 @@ function write_days_list($bd, $selected) {
 
 ?>
 
-<script type="text/javascript">
+<script>
 <!--
 /*
 Not validated: That days exists within that month and year.

--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -148,7 +148,7 @@ supposed to prevent you from doing so, but please don\'t try.') . '</p>';
 
 ?>
 
-<SCRIPT LANGUAGE="JavaScript"><!--
+<script><!--
 
 // Holds all the biography-ids in arrays connected to the authors.
 // Built below, after the table
@@ -370,7 +370,7 @@ function evaluateForm(form) {
     }
     return true;
 }
-// --></SCRIPT>
+// --></script>
 
 <?php
 

--- a/tools/project_manager/page_table.inc
+++ b/tools/project_manager/page_table.inc
@@ -390,7 +390,7 @@ function echo_page_table(
     if ( $can_edit )
     {
 ?>
-<script language="JavaScript" type="text/javascript"><!--
+<script><!--
 avail_pages=new Array(<?php echo substr($avail_pages,0,-1); ?>);
 
 function changeSelection(sel) {

--- a/tools/proofers/button_menu.inc
+++ b/tools/proofers/button_menu.inc
@@ -10,7 +10,7 @@ function echo_button_menu( $ppage )
     global $userP;
     global $proofreading_font_faces, $proofreading_font_sizes;
 ?>
-<script language="javascript">
+<script>
 function refuseNonNumeric(event) {
     // Deal with the IE/Firefox/WebKit keycode mess...
     var e = event || window.event;

--- a/tools/proofers/hiero/table.php
+++ b/tools/proofers/hiero/table.php
@@ -59,7 +59,7 @@ function WH_Text( $index )
 
 slim_header("$table - ".WH_Text($table));
 ?>
-<script language="JavaScript" type="text/javascript">
+<script>
 function add(glyph) {
 	text=window.parent.hierodisplay.document.hieroform.hierobox.value;
 	lastc=text.charCodeAt(text.length-1);

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -239,7 +239,7 @@ switch( $tbutton )
         $title = _("Save as 'Done' & Proofread Next Page");
         $body = _("Page Saved.");
         slim_header( $title );
-        echo "<script language='JavaScript'><!--\n";
+        echo "<script><!--\n";
         echo "setTimeout(\"top.proofframe.location.href='$url';\", 1000);\n";
         echo "// --></script>\n";
         echo $body;
@@ -316,7 +316,7 @@ function leave_proofing_interface( $title )
 
     $text =  _("You will be returned to the <a href='%s' target='_top'>Project Page</a> in one second.");
     echo sprintf($text, $url);
-    echo "<script language='JavaScript'><!--\n";
+    echo "<script><!--\n";
     echo "setTimeout(\"top.location.href='$url';\", 1000);\n";
     echo "// --></script>\n";
 }

--- a/tools/proofers/srchrep.php
+++ b/tools/proofers/srchrep.php
@@ -9,7 +9,7 @@ require_login();
 slim_header(_("Search/Replace"));
 ?>
 
-<script type='text/javascript'>
+<script>
 var saved_text = '';
 
 function do_replace()


### PR DESCRIPTION
At pgdp.net we have a script that runs daily and reports on any errors in `php_errors.log`. For *months* we have been getting errors like the below which make no sense:
```
       1   PHP Notice:  Undefined variable: completed_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line <num>
       1   PHP Notice:  Undefined variable: deleted_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line <num>
       1   PHP Notice:  Undefined variable: posted_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line <num>
       6   PHP Notice:  Undefined variable: pp_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line <num>
       1   PHP Notice:  Undefined variable: site_supports_corrections_after_posting in /data/htdocs/c/pinc/project_states.inc on line <num>
       1   PHP Notice:  Undefined variable: site_supports_metadata in /data/htdocs/c/pinc/project_states.inc on line <num>
       1   PHP Notice:  Undefined variable: waiting_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line <num>
       4   PHP Notice:  Undefined variable: wiki_url in /data/htdocs/c/pinc/faq.inc on line <num>
```

They don't make sense because all of those variables are defined in `site_vars.php` which is included first thing in `base.inc` which *all* pages call the very first thing. Today I was finally able to isolate the problem to `require_login()` redirects.

`require_login()` needs `metarefresh()` needs `slim_header()` which needs `html_header()` from theme.inc after the CSS refactor a few months ago. The challenge is that `require_login()` is defined in base.inc so that everything can use it, but we don't want to pull in all of those other dependencies on every page load so we`include_once()` metarefresh.inc from within the function. That's the crux of the problem because then everything downstream is in local scope to that function. So when downstream includes in theme.inc try to access variables like `$wiki_url` in faq.inc it throws a Notice. What's frustrating is that the need for slim_header() in metarefresh() is a rare corner case -- most times redirects are via HTTP headers.

The simplest way to solve this is to stop pulling in theme.inc for when all we need is a page redirect. This PR factors out the common html page output code into `html_page_common.inc`which is used by theme.inc, slim_header.inc, and quiz/small_theme.inc.

I also addressed some other smaller issues I found while debugging the issue and validating the resulting output.

And really, all of this is due to our use of global variables, but that's not something I want to bite off right now.