### PR TITLE
Enabling including site_vars multiple times

### DIFF
--- a/SETUP/MediaWiki_extensions/dpExtensions.php
+++ b/SETUP/MediaWiki_extensions/dpExtensions.php
@@ -41,7 +41,7 @@ function wfPgFormats()
 function getPgFormats( $input, $argv ) 
 {
     global $relPath, $code_url;
-    include_once($relPath.'site_vars.php');
+    include($relPath.'site_vars.php');
     include_once($relPath.'DPDatabase.inc');
 
     DPDatabase::connect();
@@ -87,7 +87,7 @@ function wfProjectInfo() {
 function showProjectInfo($input, $argv, $parser)
 {
     global $relPath, $code_url;
-    include_once($relPath.'site_vars.php');
+    include($relPath.'site_vars.php');
     include_once($relPath.'DPDatabase.inc');
     include_once($relPath.'project_states.inc');
 

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -31,8 +31,8 @@ $wikihiero_url = '<<WIKIHIERO_URL>>';
 
 $archive_projects_dir = '<<ARCHIVE_PROJECTS_DIR>>';
 
-define('PHPBB_VERSION', '<<PHPBB_VERSION>>');
-define('PHPBB_TABLE_PREFIX', '<<PHPBB_TABLE_PREFIX>>');
+defined('PHPBB_VERSION') or define('PHPBB_VERSION', '<<PHPBB_VERSION>>');
+defined('PHPBB_TABLE_PREFIX') or define('PHPBB_TABLE_PREFIX', '<<PHPBB_TABLE_PREFIX>>');
 $forums_dir = '<<FORUMS_DIR>>';
 $forums_url = '<<FORUMS_URL>>';
 


### PR DESCRIPTION
I've finally found yet another bundle of hard-to-track-down error reported in php_errors:
```
   PHP Notice:  Undefined variable: waiting_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 158
   PHP Notice:  Undefined variable: site_supports_metadata in /data/htdocs/c/pinc/project_states.inc on line 164
   PHP Notice:  Undefined variable: pp_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 266
   PHP Notice:  Undefined variable: pp_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 275
   PHP Notice:  Undefined variable: pp_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 285
   PHP Notice:  Undefined variable: pp_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 295
   PHP Notice:  Undefined variable: pp_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 305
   PHP Notice:  Undefined variable: pp_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 314
   PHP Notice:  Undefined variable: posted_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 327
   PHP Notice:  Undefined variable: site_supports_corrections_after_posting in /data/htdocs/c/pinc/project_states.inc on line 333
   PHP Notice:  Undefined variable: completed_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 361
   PHP Notice:  Undefined variable: deleted_projects_forum_idx in /data/htdocs/c/pinc/project_states.inc on line 372
```

The root cause is that the DP MediaWiki extension needs to include the site_vars.php upon every call so that the variables are in scope for project_states.inc. To do that, we need to ensure that we only define the PHPBB variables once.