### PR TITLE
Pm new get

### DIFF
--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -14,7 +14,7 @@ class ProjectSearchWidget
         }
     }
 
-    function get_html_control($search_data)
+    function get_html_control()
     {
         # make all widgets 100% width
         $size_attr = "style='width: 100%;'";
@@ -32,9 +32,9 @@ class ProjectSearchWidget
 
         if ( $this->type == 'text' )
         {
-            if ( isset($search_data[$this->id]) )
+            if ( isset($_GET[$this->id]) )
             {
-                $value_attr = "value='" . attr_safe($search_data[$this->id]) . "'";
+                $value_attr = "value='" . attr_safe($_GET[$this->id]) . "'";
             }
             else // initial_value is set for base class widget
             {
@@ -55,12 +55,12 @@ class ProjectSearchWidget
             }
             foreach ( $this->options as $option_value => $option_label )
             {
-                if(isset($search_data[$this->id]))
+                if(isset($_GET[$this->id]))
                 {
-                    if(($this->can_be_multiple) && is_array($search_data[$this->id]))
-                        $selected = in_array($option_value, $search_data[$this->id]);
+                    if(($this->can_be_multiple) && is_array($_GET[$this->id]))
+                        $selected = in_array($option_value, $_GET[$this->id]);
                     else
-                        $selected = ($option_value == $search_data[$this->id]);
+                        $selected = ($option_value == $_GET[$this->id]);
                 }
                 else
                     $selected = ($option_value == $this->initial_value);
@@ -72,21 +72,19 @@ class ProjectSearchWidget
         }
     }
 
-    function echo_search_item($search_data)
+    function echo_search_item()
     {
         // could fix width of heading cells so they line up when 2nd table is below
         echo "
             <tr>
                 <th class='right-align top-align'>$this->label</th>
-                <td class='search-input top-align left-align'>".$this->get_html_control($search_data)."</td>
+                <td class='search-input top-align left-align'>".$this->get_html_control()."</td>
             </tr>";
     }
 
-    function get_sql_contribution($search_data)
+    function get_sql_contribution()
     {
-        if (!isset($search_data[$this->id]))
-            return NULL;
-        $value = $search_data[$this->id];
+        $value = array_get($_GET, $this->id, '');
         if ( $value == '' )
             return NULL;
         list($column_name,$comparator) = $this->q_contrib;
@@ -143,26 +141,42 @@ class ProjectSearchWidget
 
 class HoldWidget extends ProjectSearchWidget
 {
-    public function get_html_control($search_data)
+    public function get_html_control()
     {
-        $check = isset($search_data[$this->id]) ? " checked" : "";
+        $check = isset($_GET[$this->id]) ? " checked" : "";
         return "<input type='checkbox' name='$this->id'$check>";
     }
 
-    public function get_sql_contribution($search_data)
+    public function get_sql_contribution()
     {
-        if(isset($search_data[$this->id])) // can only be 'on'
+        if(isset($_GET[$this->id])) // can only be 'on'
             return 'project_holds.projectid IS NOT NULL';
         else
             return '';
     }
 }
 
+function make_lang_list()
+{
+    $sql = "
+        SELECT DISTINCT language
+        FROM projects
+    ";
+    $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+    var_dump(mysqli_num_rows($result));
+    while ($project_assoc = mysqli_fetch_assoc($result))
+    {
+        var_dump($project_assoc);
+    }
+}
+
+
 class ProjectSearchForm
 {
     public function __construct()
     {
         $this->define_form_widgets();
+        make_lang_list();
     }
 
     private function _get_options_special_day()
@@ -334,14 +348,11 @@ class ProjectSearchForm
 
     public function render()
     {
-        if(isset($_SESSION['search_data']))
-            $search_data = $_SESSION['search_data'];
-        else
-            $search_data = array(); // empty array to avoid problems
         echo "<p>" . _("Search for projects matching the following criteria:")."</p>\n";
-        // query data can be too big for GET so use POST
+        // query data can be too big for GET
         echo "<div class='search-columns'>
-            <form style='display: inline;' method='POST' action='{$_SERVER['PHP_SELF']}?show=p_search'>";
+            <form style='display: inline;' method='GET'>
+            <input type='hidden' name='show' value='search'>";
         // split the widgets into two tables which can be side-by-side if there
         // is enough room
         $widget_index = 0;
@@ -349,17 +360,17 @@ class ProjectSearchForm
         $table_header = "<table class='search-column'>";
         echo $table_header;
         while($widget_index < 9)
-            $this->widgets[$widget_index++]->echo_search_item($search_data);
+            $this->widgets[$widget_index++]->echo_search_item();
         echo "</table>$table_header";
         while($widget_index < $widget_count)
-            $this->widgets[$widget_index++]->echo_search_item($search_data);
+            $this->widgets[$widget_index++]->echo_search_item();
         echo "
             </table>
             <div class='center-align' style='clear: both;'></div>
             <input type='submit' value='", attr_safe(_("Search")), "'>
-            <input type='button' onclick=\"window.location.assign('{$_SERVER['PHP_SELF']}?show=blank_search_form');\" value='", attr_safe(_("Clear form")), "'>
+            <input type='button' onclick=\"window.location.assign('{$_SERVER['PHP_SELF']}?show=search_form');\" value='", attr_safe(_("Clear form")), "'>
             </form>";
-        echo get_search_configure_button("show=search_form");
+        echo get_search_configure_button();
         echo "</div>";
         echo "<p>
             "._("For terms that you type in, matching is case-insensitive and unanchored; so, for instance, 'jim' matches both 'Jimmy Olsen' and 'piggyjimjams'. This doesn't apply to PG etext numbers, for which you should type in the complete number.")."
@@ -371,33 +382,15 @@ class ProjectSearchForm
         ";
     }
 
-    private function get_widget_contribution($search_data)
+    public function get_condition()
     {
         $condition = '1';
         foreach ( $this->widgets as $widget )
         {
-            $contribution = $widget->get_sql_contribution($search_data);
+            $contribution = $widget->get_sql_contribution();
             if ( $contribution == '' )
                 continue;
             $condition .= "\nAND $contribution";
-        }
-        return $condition;
-    }
-
-    public function get_condition($show_view)
-    {
-        if(($show_view == 'p_search') && !$_POST)
-        {
-            $condition = array_get($_SESSION, 'search_condition', "1");
-        }
-        else // (p_search && have POST) or search with GET data
-        {
-            // Construct the search query.
-            $condition = $this->get_widget_contribution($_REQUEST);
-            // save the condition to use for paging or changing configuration or sorting
-            $_SESSION['search_condition'] = $condition;
-            // save the POST data to use to initialise the search form if refining
-            $_SESSION['search_data'] = $_REQUEST;
         }
         return $condition;
     }

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -5,6 +5,7 @@ class ProjectSearchWidget
 {
     public $can_be_multiple = false;
     public $initial_value = '';
+    public $has_invert = false;
 
     function __construct( $properties )
     {
@@ -68,6 +69,11 @@ class ProjectSearchWidget
                 $r .= "<option value='" . attr_safe($option_value) . "' $selected_attr>" . html_safe($option_label) . "</option>\n";
             }
             $r .= "</select>\n";
+            if($this->has_invert)
+            {
+                $check = isset($_GET[$this->id . "_inv"]) ? " checked" : "";
+                $r .= "<br>" . _("Invert filter") . "<input type='checkbox' name='{$this->id}_inv'$check>";
+            }
             return $r;
         }
     }
@@ -112,15 +118,16 @@ class ProjectSearchWidget
 
             $values = array_map("escape_value", $values);
 
+            $inv = isset($_GET[$this->id . "_inv"]) ? " NOT " : "";
             if ( $comparator == '=' )
             {
                 $values_list = surround_and_join( $values, "'", "'", "," );
-                $contribution = "$column_name IN ($values_list)";
+                $contribution = "$column_name$inv IN ($values_list)";
             }
             elseif ( $comparator == 'LIKE' )
             {
                 $likes_str = surround_and_join( $values, "$column_name LIKE '%", "%'", ' OR ' );
-                $contribution = "($likes_str)";
+                $contribution = "$inv($likes_str)";
             }
         }
         else
@@ -156,27 +163,11 @@ class HoldWidget extends ProjectSearchWidget
     }
 }
 
-function make_lang_list()
-{
-    $sql = "
-        SELECT DISTINCT language
-        FROM projects
-    ";
-    $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
-    var_dump(mysqli_num_rows($result));
-    while ($project_assoc = mysqli_fetch_assoc($result))
-    {
-        var_dump($project_assoc);
-    }
-}
-
-
 class ProjectSearchForm
 {
     public function __construct()
     {
         $this->define_form_widgets();
-        make_lang_list();
     }
 
     private function _get_options_special_day()
@@ -305,6 +296,7 @@ class ProjectSearchForm
                 'can_be_multiple' => TRUE,
                 'initial_value'   => '',
                 'q_contrib'  => array('language', 'LIKE'),
+                'has_invert' => true,
             )),
             new ProjectSearchWidget( array(
                 'id'         => 'genre',

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -72,7 +72,7 @@ class ProjectSearchWidget
             if($this->has_invert)
             {
                 $check = isset($_GET[$this->id . "_inv"]) ? " checked" : "";
-                $r .= "<br>" . _("Invert filter") . "<input type='checkbox' name='{$this->id}_inv'$check>";
+                $r .= "<br>$this->invert_label<input type='checkbox' name='{$this->id}_inv'$check>";
             }
             return $r;
         }
@@ -297,6 +297,7 @@ class ProjectSearchForm
                 'initial_value'   => '',
                 'q_contrib'  => array('language', 'LIKE'),
                 'has_invert' => true,
+                'invert_label' => _("Invert language filter"),
             )),
             new ProjectSearchWidget( array(
                 'id'         => 'genre',

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -1,5 +1,6 @@
 <?php
 include_once($relPath.'iso_lang_list.inc');
+include_once($relPath."misc.inc"); // attr_safe, array_get
 
 class ProjectSearchWidget
 {
@@ -342,7 +343,6 @@ class ProjectSearchForm
     public function render()
     {
         echo "<p>" . _("Search for projects matching the following criteria:")."</p>\n";
-        // query data can be too big for GET
         echo "<div class='search-columns'>
             <form style='display: inline;' method='GET'>
             <input type='hidden' name='show' value='search'>";
@@ -361,7 +361,7 @@ class ProjectSearchForm
             </table>
             <div class='center-align' style='clear: both;'></div>
             <input type='submit' value='", attr_safe(_("Search")), "'>
-            <input type='button' onclick=\"window.location.assign('{$_SERVER['PHP_SELF']}?show=search_form');\" value='", attr_safe(_("Clear form")), "'>
+            <input type='button' onclick=\"window.location.assign('?show=search_form');\" value='", attr_safe(_("Clear form")), "'>
             </form>";
         echo get_search_configure_button();
         echo "</div>";

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -105,7 +105,9 @@ class Column
                 $dir_code = "A";
                 $marker = "";
                 if($sec_sort == $this->id)
+                {
                     $sec_sorter = "&nbsp;^";
+                }
                 else
                 {
                     $new_array = array('sec_sort' => $this->id, 'results_offset' => 0);
@@ -644,12 +646,12 @@ class ProjectSearchResults
 function get_search_configure_link()
 {
     $origin = urlencode($_SERVER['REQUEST_URI']);
-    return "<a href='{$_SERVER['PHP_SELF']}?show=config&amp;origin=$origin'>" . _("Configure Result") . "</a>";
+    return "<a href='?show=config&amp;origin=$origin'>" . _("Configure Result") . "</a>";
 }
 
 function make_link($new_array, $text, $anchor = '')
 {
-    $url = "{$_SERVER['PHP_SELF']}?" . http_build_query(array_replace($_GET, $new_array)) . "$anchor";
+    $url = "?" . http_build_query(array_replace($_GET, $new_array)) . "$anchor";
     return "<a href='" . attr_safe($url) . "'>$text</a>";
 }
 

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -80,7 +80,7 @@ class Column
         return $value === 'yes';
     }
 
-    public function echo_header_cell($sort_column_id, $sql_sort_dir, $show_param, $sec_sort)
+    public function echo_header_cell($sort_column_id, $sql_sort_dir, $sec_sort)
     {
         $label = $this->get_label();
         if($this->sortable)
@@ -107,9 +107,13 @@ class Column
                 if($sec_sort == $this->id)
                     $sec_sorter = "&nbsp;^";
                 else
-                    $sec_sorter = "&nbsp;<a href='{$_SERVER['PHP_SELF']}?show=$show_param&amp;sec_sort=$this->id&amp;results_offset=0#head'>^</a>";
+                {
+                    $ar1 = array('sec_sort' => $this->id, 'results_offset' => 0);
+                    $sec_sorter = "&nbsp;" . make_ref($ar1, "^", "#head");
+                }
             }
-            $label = "<a href='{$_SERVER['PHP_SELF']}?show=$show_param&amp;sort=$this->id$dir_code&amp;results_offset=0#head'>$label</a>$marker$sec_sorter";
+            $ar1 = array('sort' => "$this->id$dir_code", 'results_offset' => 0);
+            $label = make_ref($ar1, $label, "#head") . "$marker$sec_sorter";
         }
         echo "<th class='$this->css_class' title='", attr_safe($this->get_tooltip()), "'>$label</th>\n";
     }
@@ -415,7 +419,7 @@ class ColumnData
 
 class ProjectSearchResults
 {
-    public function __construct($show_param, $search_origin)
+    public function __construct($search_origin)
     {
         global $pguser;
 
@@ -423,8 +427,6 @@ class ProjectSearchResults
 
         $this->userSettings =& Settings::get_Settings($pguser);
         $this->search_origin = $search_origin;
-        $this->show_param = $show_param;
-
         $option_data = new OptionData($this->userSettings, $this->search_origin);
         $this->page_size = $option_data->results_per_page->get_value();
         $time_format = $option_data->time_format->get_value();
@@ -449,14 +451,11 @@ class ProjectSearchResults
 
     private function results_navigator($numrows, $num_found_rows, $results_offset)
     {
-        $url_base = "{$_SERVER['PHP_SELF']}?show=$this->show_param&amp;";
-
         if ( $results_offset > 0 )
         {
-            $text = _('Previous');
             $prev_offset = max(0, $results_offset - $this->page_size);
-            $url = $url_base . "results_offset=$prev_offset#head";
-            echo "<a href='$url'>$text</a> | ";
+            echo make_ref(array('results_offset' => $prev_offset), _('Previous'), "#head") . " | ";
+
         }
         echo sprintf(
             // TRANSLATORS: these are paging results: eg: "Projects 1 to 100 of 495"
@@ -469,10 +468,8 @@ class ProjectSearchResults
 
         if ( $results_offset + $numrows < $num_found_rows )
         {
-            $text = _('Next');
             $next_offset = $results_offset + $this->page_size;
-            $url = $url_base . "results_offset=$next_offset#head";
-            echo " | <a href='$url'>$text</a>";
+            echo " | " . make_ref(array('results_offset' => $next_offset), _('Next'), "#head");
         }
     }
 
@@ -563,12 +560,6 @@ class ProjectSearchResults
         return $result;
     }
 
-    public function get_search_configure_link()
-    {
-        $results_offset = intval(@$_GET['results_offset']);
-        return get_search_configure_link("show=$this->show_param&amp;results_offset=$results_offset");
-    }
-
     public function render($where_condition)
     {
         global $pguser, $theme, $code_url;
@@ -596,14 +587,14 @@ class ProjectSearchResults
         if(!empty($warning))
             echo "\n<p class='warning'>$warning</p>\n";
 
-        echo "<p>" . _("To set primary sort term, click on the column name; to set secondary sort term, click on the <u>^</u> that follows the column name.") . "</p>";
+        echo "<p id='head'>" . _("To set primary sort term, click on the column name; to set secondary sort term, click on the <u>^</u> that follows the column name.") . "</p>";
         $this->results_navigator($numrows, $num_found_rows, $results_offset);
 
         echo "\n<table class='themed theme_striped'>\n";
         echo "<tr>\n";
         foreach($this->active_columns as $column)
         {
-            $column->echo_header_cell($this->sort_column_id, $this->sql_sort_dir, $this->show_param, $this->sec_sort);
+            $column->echo_header_cell($this->sort_column_id, $this->sql_sort_dir, $this->sec_sort);
         }
         echo "</tr>\n";
 
@@ -650,9 +641,21 @@ class ProjectSearchResults
     }
 }
 
+function get_search_configure_link()
+{
+    $origin = urlencode($_SERVER['REQUEST_URI']);
+    return "<a href='{$_SERVER['PHP_SELF']}?show=config&amp;origin=$origin'>" . _("Configure Result") . "</a>";
+}
+
+function make_ref($ar1, $txt, $anchor = '')
+{
+    $url = "{$_SERVER['PHP_SELF']}?" . http_build_query(array_replace($_GET, $ar1)) . "$anchor";
+    return "<a href='" . attr_safe($url) . "'>$txt</a>";
+}
+
 function get_refine_search_link()
 {
-    return "<a href='{$_SERVER['PHP_SELF']}?show=search_form'>" . _("Refine Search") . "</a>";
+    return make_ref(array('show' => 'search_form'), _("Refine Search"));
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -108,12 +108,12 @@ class Column
                     $sec_sorter = "&nbsp;^";
                 else
                 {
-                    $ar1 = array('sec_sort' => $this->id, 'results_offset' => 0);
-                    $sec_sorter = "&nbsp;" . make_ref($ar1, "^", "#head");
+                    $new_array = array('sec_sort' => $this->id, 'results_offset' => 0);
+                    $sec_sorter = "&nbsp;" . make_link($new_array, "^", "#head");
                 }
             }
-            $ar1 = array('sort' => "$this->id$dir_code", 'results_offset' => 0);
-            $label = make_ref($ar1, $label, "#head") . "$marker$sec_sorter";
+            $new_array = array('sort' => "$this->id$dir_code", 'results_offset' => 0);
+            $label = make_link($new_array, $label, "#head") . "$marker$sec_sorter";
         }
         echo "<th class='$this->css_class' title='", attr_safe($this->get_tooltip()), "'>$label</th>\n";
     }
@@ -454,7 +454,7 @@ class ProjectSearchResults
         if ( $results_offset > 0 )
         {
             $prev_offset = max(0, $results_offset - $this->page_size);
-            echo make_ref(array('results_offset' => $prev_offset), _('Previous'), "#head") . " | ";
+            echo make_link(array('results_offset' => $prev_offset), _('Previous'), "#head") . " | ";
 
         }
         echo sprintf(
@@ -469,7 +469,7 @@ class ProjectSearchResults
         if ( $results_offset + $numrows < $num_found_rows )
         {
             $next_offset = $results_offset + $this->page_size;
-            echo " | " . make_ref(array('results_offset' => $next_offset), _('Next'), "#head");
+            echo " | " . make_link(array('results_offset' => $next_offset), _('Next'), "#head");
         }
     }
 
@@ -647,15 +647,15 @@ function get_search_configure_link()
     return "<a href='{$_SERVER['PHP_SELF']}?show=config&amp;origin=$origin'>" . _("Configure Result") . "</a>";
 }
 
-function make_ref($ar1, $txt, $anchor = '')
+function make_link($new_array, $text, $anchor = '')
 {
-    $url = "{$_SERVER['PHP_SELF']}?" . http_build_query(array_replace($_GET, $ar1)) . "$anchor";
-    return "<a href='" . attr_safe($url) . "'>$txt</a>";
+    $url = "{$_SERVER['PHP_SELF']}?" . http_build_query(array_replace($_GET, $new_array)) . "$anchor";
+    return "<a href='" . attr_safe($url) . "'>$text</a>";
 }
 
 function get_refine_search_link()
 {
-    return make_ref(array('show' => 'search_form'), _("Refine Search"));
+    return make_link(array('show' => 'search_form'), _("Refine Search"));
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/ProjectSearchResultsConfig.inc
+++ b/pinc/ProjectSearchResultsConfig.inc
@@ -13,6 +13,7 @@ class Selector
         ";
     }
 }
+
 class ColumnSelector extends Selector
 {
     public function __construct($column, $userSettings, $search_origin)
@@ -110,14 +111,11 @@ class ConfigForm extends ColumnData
         global $code_url, $pguser;
 
         echo "<h1>$page_title</h1>\n";
-        if(isset($_GET['params']))
-            $params = $_GET['params'];
-        else
-            $origin = "$code_url/activity_hub.php";
+        $origin = array_get($_GET, 'origin', '$code_url/activity_hub.php' );
         echo "<div style='clear: both;'>
             <form method='GET'>
             <input type='hidden' name='show' value='set_columns'>
-            <input type='hidden' name='params' value='", $params , "'>
+            <input type='hidden' name='origin' value='", $origin , "'>
         ";
         // split the controls across two columns using tables within divs
         $index = 0;
@@ -189,22 +187,15 @@ class ConfigSaver extends ColumnData
     }
 }
 
-function get_search_configure_button($params)
+function get_search_configure_button()
 {
     global $code_url;
     return "
         <form style='display: inline;' method='GET'>
         <input type='submit' value='" . attr_safe(_("Configure Result")) . "'>
         <input type='hidden' name='show' value='config'>
-        <input type='hidden' name='params' value='" . attr_safe($params) . "'>
+        <input type='hidden' name='origin' value='" . attr_safe($_SERVER['REQUEST_URI']) . "'>
         </form>";
-}
-
-function get_search_configure_link($params)
-{
-    global $code_url;
-    $params = urlencode($params);
-    return "<a href='{$_SERVER['PHP_SELF']}?show=config&amp;params=$params'>" . _("Configure Result") . "</a>";
 }
 
 function handle_set_cols($show_view, $search_origin)
@@ -216,8 +207,8 @@ function handle_set_cols($show_view, $search_origin)
         $userSettings =& Settings::get_Settings($pguser);
         $config_saver = new ConfigSaver($userSettings, $search_origin);
         $config_saver->store_data();
-        $params = array_get($_GET, 'params', '' );
-        metarefresh(0, $_SERVER['PHP_SELF'] . "?$params");
+        $origin = array_get($_GET, 'origin', '$code_url/activity_hub.php' );
+        metarefresh(0, $origin);
     }
 }
 

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -85,7 +85,10 @@ elseif($show_view == "user_all")
 elseif ($show_view == "user_active")
 {
     $condition = "$PROJECT_IS_ACTIVE_sql AND username = '$pguser'";
-    $_GET = array_merge($_GET, array('project_manager' => $pguser, 'state' => array_diff($PROJECT_STATES_IN_ORDER, array(PROJ_SUBMIT_PG_POSTED, PROJ_DELETE))));
+    $_GET = array_merge($_GET, array(
+        'project_manager' => $pguser,
+        'state' => array_diff($PROJECT_STATES_IN_ORDER, array(PROJ_SUBMIT_PG_POSTED, PROJ_DELETE))
+    ));
     // TRANSLATORS: Abbreviation for Project Manager
     $sub_title = sprintf(_("Active PM projects: %s"), $pguser);
 }
@@ -114,7 +117,7 @@ $search_results->render($condition);
 function create_shortcut_link($text, $show_val, $show_view="")
 {
     if($show_view != $show_val)
-        return "<a href='{$_SERVER['PHP_SELF']}?show=$show_val'>$text</a>";
+        return "<a href='?show=$show_val'>$text</a>";
     else
         return $text;
 }

--- a/tools/search.php
+++ b/tools/search.php
@@ -61,10 +61,7 @@ $condition = $search_form->get_condition();
 echo "<h1>", _("Search Results"), "</h1>\n";
 
 $search_results = new ProjectSearchResults("PS");
-echo "<p><a href='{$_SERVER['PHP_SELF']}?show=search_form'>" . _("Start New Search") . "</a> | " . get_refine_search_link() . " | " . get_search_configure_link() . "</p>";
+echo "<p><a href='?show=search_form'>" . _("Start New Search") . "</a> | " . get_refine_search_link() . " | " . get_search_configure_link() . "</p>";
 $search_results->render($condition);
-
-//---------------------------------------------------------------------------
-
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/search.php
+++ b/tools/search.php
@@ -11,20 +11,14 @@ include_once($relPath.'ProjectSearchResults.inc');
 require_login();
 
 try {
-    $show_view = get_enumerated_param($_GET, 'show', 'blank_search_form',
-        array('search_form', 'search', 'p_search', 'blank_search_form', 'set_columns', 'config'));
+    $show_view = get_enumerated_param($_GET, 'show', 'search_form',
+        array('search_form', 'search', 'set_columns', 'config'));
 } catch(Exception $e) {
-    $show_view = 'blank_search_form';
+    $show_view = 'search_form';
 }
 
 // exits if handled
 handle_set_cols($show_view, "PS");
-
-if($show_view == 'blank_search_form')
-{
-    unset($_SESSION['search_data']);
-    $show_view = 'search_form';
-}
 
 $header_args = array("js_files" => array("$code_url/tools/dropdown.js"));
 output_header(_("Project Search"), NO_STATSBAR, $header_args);
@@ -61,15 +55,13 @@ if ($show_view == 'search_form')
     exit();
 }
 
-// show must be search or p_search
-$condition = $search_form->get_condition($show_view);
+// show must be search
+$condition = $search_form->get_condition();
 
-echo "<h1 id='head'>", _("Search Results"), "</h1>\n";
+echo "<h1>", _("Search Results"), "</h1>\n";
 
-// use p_search so it will use saved results if needed
-$search_results = new ProjectSearchResults('p_search', "PS");
-echo "<p><a href='{$_SERVER['PHP_SELF']}?show=blank_search_form'>" . _("Start New Search") . "</a> | " . get_refine_search_link() . " | " . $search_results->get_search_configure_link() . "</p>";
-
+$search_results = new ProjectSearchResults("PS");
+echo "<p><a href='{$_SERVER['PHP_SELF']}?show=search_form'>" . _("Start New Search") . "</a> | " . get_refine_search_link() . " | " . get_search_configure_link() . "</p>";
 $search_results->render($condition);
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Changed back to GET instead of POST for project search so that searches can be bookmarked.
Add an invert filter checkbox for the language selector so that it is possible to search for all languages except a few. Otherwise selecting most of the language options would make the url too long. The other multi-selects do not have this problem because there are fewer options. This also simplifies the code slightly.