### PR TITLE
Make User->load() private

### DIFF
--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -108,44 +108,22 @@ class UserTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($is_valid);
     }
 
-    public function testLoadExistingStrict()
+    /**
+     * @expectedException NonexistentUserException
+     */
+    public function testLoadExistingDifferCase()
     {
-        $user = new User();
-        $user->load("username", $this->TEST_USERNAME);
+        $username = strtoupper($this->TEST_USERNAME);
+        $user = new User($username);
     }
 
     /**
      * @expectedException NonexistentUserException
      */
-    public function testLoadExistingStrictDifferCase()
-    {
-        $username = strtoupper($this->TEST_USERNAME);
-        $user = new User();
-        $user->load("username", $username);
-    }
-
-    /**
-     * @expectedException NonexistentUserException
-     */
-    public function testLoadExistingStrictDifferWhitespace()
+    public function testLoadExistingDifferWhitespace()
     {
         $username = $this->TEST_USERNAME . '   ';
-        $user = new User();
-        $user->load("username", $username);
-    }
-
-    public function testLoadExistingNotStrictDifferCase()
-    {
-        $username = strtoupper($this->TEST_USERNAME);
-        $user = new User();
-        $user->load("username", $username, FALSE);
-    }
-
-    public function testLoadExistingNotStrictDifferWhitespace()
-    {
-        $username = $this->TEST_USERNAME . '   ';
-        $user = new User();
-        $user->load("username", $username, FALSE);
+        $user = new User($username);
     }
 
     /**
@@ -153,26 +131,7 @@ class UserTest extends PHPUnit_Framework_TestCase
      */
     public function testLoadNonexisting()
     {
-        $user = new User();
-        $user->load("username", $this->NONTEST_USERNAME);
-    }
-
-    /**
-     * @expectedException UnexpectedValueException
-     */
-    public function testLoadInvalidField()
-    {
-        $user = new User();
-        $user->load("not_a_field", "blah");
-    }
-
-    /**
-     * @expectedException NonuniqueUserException
-     */
-    public function testLoadMultipleUsers()
-    {
-        $user = new User();
-        $user->load("active", 0);
+        $user = new User($this->NONTEST_USERNAME);
     }
 
     public function testGetters()

--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -22,8 +22,7 @@ catch(NonexistentNonactivatedUserException $exception)
     // back here.
     try
     {
-        $user_test = new User();
-        $user_test->load("id", $ID);
+        $user_test = User::load_from_registration_token($ID);
         $existing_user = $user_test->username;
         if($pguser == $existing_user)
         {

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -63,7 +63,7 @@ class User
         return isset($this->table_row[$name]);
     }
 
-    public function load($field, $value, $strict=TRUE)
+    private function load($field, $value, $strict=TRUE)
     {
         if(in_array($field, $this->string_fields))
         {
@@ -168,6 +168,26 @@ class User
         else
             $userSettings->set_boolean("$activity$suffix", $action_type == 'grant');
         log_access_change($this->username, $requester, $activity, $action_type);
+    }
+
+    // static functions
+
+    // Load a User record by u_id
+    // e.g. $user = User::load_from_uid($u_id);
+    public static function load_from_uid($u_id)
+    {
+        $user = new User();
+        $user->load('u_id', $u_id);
+        return $user;
+    }
+
+    // Load a User record by registration token (ie: the 'id' column)
+    // e.g. $user = User::load_from_registration_token($id);
+    public static function load_from_registration_token($id)
+    {
+        $user = new User();
+        $user->load('id', $id);
+        return $user;
     }
 
     // Static function to determine if the specified username is associated

--- a/stats/includes/common.inc
+++ b/stats/includes/common.inc
@@ -51,8 +51,7 @@ function showChangeInRank( $previous_rank, $current_rank )
 
 function get_username_for_uid($u_id)
 {
-    $user = new User();
-    $user->load('u_id', $u_id);
+    $user = User::load_from_uid($u_id);
     return $user->username;
 }
 

--- a/stats/members/mdetail.php
+++ b/stats/members/mdetail.php
@@ -13,8 +13,7 @@ $tally_name = array_get( $_GET, 'tally_name', null );
 
 $id = get_integer_param($_GET, 'id', null, 0, null);
 
-$user = new User();
-$user->load('u_id', $id);
+$user = User::load_from_uid($id);
 
 $can_reveal = can_reveal_details_about( $user->username, $user->u_privacy );
 if ( $can_reveal )

--- a/tasks.php
+++ b/tasks.php
@@ -483,8 +483,7 @@ function create_task_from_form_submission($formsub)
     // Validate the assignee, skipping the case where it is 0 (Unassigned).
     if($newt_assignee != 0)
     {
-        $task_assignee_user = new User();
-        $task_assignee_user->load('u_id', $newt_assignee);
+        $task_assignee_user = User::load_from_uid($newt_assignee);
     }
 
     $sql_query = "
@@ -1861,8 +1860,7 @@ function private_message_link_for_uid($u_id)
 
 function get_username_for_uid($u_id)
 {
-    $user = new User();
-    $user->load("u_id", $u_id);
+    $user = User::load_from_uid($u_id);
     return $user->username;
 }
 


### PR DESCRIPTION
To reduce the possibility of bugs, make User->load() private. This ensures that an object can only be loaded by the constructor (or the two new static functions), and prevent the case where a developer
has created a loaded object and then loaded different data into part, but not all, of it.

This mirrors what the new NonactivatedUser class does.