### PR TITLE
Include family in friends referrer

### DIFF
--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -239,7 +239,7 @@ class User
             "blog" => _("Distributed Proofreaders Blog"),
             "twitter" => _("Twitter"),
             "facebook" => _("Facebook"),
-            "friend" => _("Friend"),
+            "friend" => _("Friend/Family"),
             "news" => _("News Article"),
             "pg" => _("Project Gutenberg"),
             "search" => _("Search Engine"),


### PR DESCRIPTION
Include 'Family' in the 'Friends' referrer option.