### PR TITLE
Fix missed break in switch syntax for sr_reported

### DIFF
--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -159,6 +159,7 @@ function notify_project_event_subscribers( $project, $event, $extras=array() )
         case 'sr_reported':
             $msg_body .=
                 _("A new smooth-reading report has been uploaded.");
+            break;
 
         case 'sr_complete':
             $msg_body .=


### PR DESCRIPTION
This missed break caused the notification message body for sr_reported events to include sr_complete text as well.