### PR TITLE
Pull delete_pages tool from noncvs and standardize tool styles

### DIFF
--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -17,20 +17,15 @@ if ( !user_is_a_sitemanager() )
     die( "You are not authorized to invoke this script." );
 }
 
-$copy_pages_url = "$code_url/tools/site_admin/copy_pages.php";
-
 $extra_args["css_data"] = "
-    table.copy { margin-left: 3em;}
-    table.copy th { text-align: left;}
     input[type=text] { font-family: monospace; }
 ";
 
-$title = _("Copy Pages from One Project to Another");
+$title = _("Copy Pages");
 output_header($title, NO_STATSBAR, $extra_args);
-echo "<br>\n";
 echo "<h1>" . $title . "</h1>\n";
-echo "<hr>\n";
 
+echo "<p>" . _("This tool will allow you to copy pages from one project to another.") . "</p>";
 // Validate the $projectid_ and $from_image_ 'by hand'
 $projectid_  = array_get( $_POST, 'projectid_',  NULL );
 if (is_array($projectid_))
@@ -68,7 +63,7 @@ switch ($action)
                   $transfer_notifications, $add_deletion_reason, 
                   $merge_wordcheck_files, TRUE );
 
-        echo "<form method='post' action='" . attr_safe($copy_pages_url). "'>\n";
+        echo "<form method='post'>\n";
         display_hiddens($projectid_, $from_image_, $page_name_handling, 
                         $transfer_notifications, $add_deletion_reason, 
                         $merge_wordcheck_files);
@@ -79,14 +74,14 @@ switch ($action)
         break;
 
     case 'docopy':
-        do_stuff( $projectid_, $from_image_, $page_name_handling, 
-                  $transfer_notifications, $add_deletion_reason, 
+        do_stuff( $projectid_, $from_image_, $page_name_handling,
+                  $transfer_notifications, $add_deletion_reason,
                   $merge_wordcheck_files, FALSE );
 
         echo "<hr>\n";
         $url = "$code_url/tools/project_manager/page_detail.php?project={$projectid_['to']}&amp;show_image_size=0";
         echo sprintf(_("<p><a href='%s'>Go to destination project's detail page</a></p>\n"), $url);
-        echo "<form method='post' action='" . attr_safe($copy_pages_url). "'>\n";
+        echo "<form method='post'>\n";
         echo "<fieldset>\n";
         echo "<legend>" . _("Copy more pages...") . "</legend>";
         echo "<input type='radio' name='repeat_project' id='rp-1' value='FROM'>";
@@ -117,8 +112,7 @@ function display_form($projectid_, $from_image_, $page_name_handling,
                       $transfer_notifications, $add_deletion_reason, 
                       $merge_wordcheck_files, $repeat_project, $repeating)
 {
-    global $copy_pages_url;
-    echo "<form method='post' action='" . attr_safe($copy_pages_url). "'>\n";
+    echo "<form method='post'>\n";
     echo "<table class='copy'>\n";
 
     // always leave the page numbers blank

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -1,0 +1,219 @@
+<?php
+$relPath='./../../pinc/';
+include_once($relPath.'base.inc');
+include_once($relPath.'misc.inc');
+include_once($relPath.'user_is.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath.'Project.inc');
+include_once($relPath.'../tools/project_manager/page_operations.inc');
+
+require_login();
+
+if ( !user_is_a_sitemanager() )
+{
+    die( "You are not authorized to invoke this script." );
+}
+
+$extra_args["css_data"] = "
+    input[type=text] { font-family: monospace; }
+";
+
+$title = _("Delete Pages");
+output_header($title, NO_STATSBAR, $extra_args);
+
+echo "<h1>$title</h1>";
+
+echo "<p>" . _("This tool will allow you to delete pages out of a project.") . "</p>";
+
+// validate inputs
+$projectid  = array_get( $_POST, 'projectid',  NULL );
+if($projectid)
+    $projectid = validate_projectID("projectid", $projectid);
+$from_image_ = array_get( $_POST, 'from_image_', NULL );
+if (is_array($from_image_))
+    foreach($from_image_ as $which => $filename)
+        if($filename)
+            validate_page_image_filename("from_image_[$which]", $filename);
+
+$action = get_enumerated_param($_POST, 'action', 'showform', array('showform', 'check', 'dodelete'));
+
+switch($action)
+{
+    case 'showform':
+        display_form('showform', $projectid, $from_image_);
+        break;
+
+    case 'check':
+        do_stuff( $projectid, $from_image_, TRUE );
+        display_form('check', $projectid, $from_image_);
+
+        break;
+
+    case 'dodelete':
+        do_stuff( $projectid, $from_image_, FALSE );
+
+        $url = "$code_url/tools/project_manager/page_detail.php?project={$projectid}&amp;show_image_size=0";
+        echo "<a href='$url'>" . _("Project's detail page") . "</a>\n";
+
+        break;
+}
+
+function display_form($action, $projectid, $from_image_)
+{
+    echo "<form method='post'>\n";
+    echo "<table class='delete'>\n";
+
+    if($action == "showform")
+    {
+        echo "<tr>\n";
+        echo "<th>" . _("Delete Page(s):") . "</th>\n";
+        echo "<td><input type='text' name='from_image_[lo]' size='12'
+            value='" . attr_safe(@$from_image_['lo']) . "'>";
+        echo " &ndash; <input type='text' name='from_image_[hi]' size='12'
+            value='" . attr_safe(@$from_image_['hi']) . "'>";
+        echo "</td></tr>\n";
+        echo "<tr><th>" . _("Project:") . "</th>\n";
+        echo "<td><input type='text' name='projectid' size='28'
+            value='" . attr_safe(@$projectid) . "'>
+            (projectid)</td></tr>\n";
+
+        echo "<tr>";
+        echo "<td></td><td>";
+        echo "<input type='hidden' name='action' value='check'>\n";
+        echo "<input type='submit' name='submit_button' value='" . _("Check") . "'>";
+        echo "</td>";
+        echo "</tr>";
+    }
+    elseif($action == "check")
+    {
+        echo "<tr>";
+        echo "<td>";
+        echo "<input type='hidden' name='from_image_[lo]' value='" . attr_safe($from_image_['lo']) . "'>";
+        echo "<input type='hidden' name='from_image_[hi]' value='" . attr_safe($from_image_['hi']) . "'>";
+        echo "<input type='hidden' name='projectid' value='" . attr_safe($projectid) . "'>";
+        echo "<input type='hidden' name='action' value='dodelete'>\n";
+        echo "<input type='submit' name='submit_button' value='" . _("Do it!") . "'>";
+        echo "</td>";
+        echo "</tr>";
+    }
+    echo "</table>\n";
+    echo "</form>";
+
+    echo "<p><b>Note:</b> 'pages' are specified by their designation in the project table: e.g., '001.png'</p>\n";
+}
+
+function do_stuff( $projectid, $from_image_, $just_checking )
+{
+    echo "<pre>";
+
+    if ( is_null($projectid) )
+    {
+        die( "Error: no projectid supplied" );
+    }
+
+    echo "    projectid: $projectid\n";
+
+    $res = mysqli_query(DPDatabase::get_connection(), "
+            SELECT nameofwork
+            FROM projects
+            WHERE projectid='$projectid'
+        ") or die(mysqli_error(DPDatabase::get_connection()));
+
+    $n_projects = mysqli_num_rows($res);
+    if ( $n_projects == 0 )
+    {
+        die( "projects table has no match for projectid='$projectid'" );
+    }
+    else if ( $n_projects > 1 )
+    {
+        die( "projects table has $n_projects matches for projectid='$projectid'. (Can't happen)" );
+    }
+
+    list($title) = mysqli_fetch_row($res);
+
+    echo "    title    : $title\n";
+
+    // ------------
+
+    $res = mysqli_query(DPDatabase::get_connection(), "
+            SELECT image, fileid
+            FROM $projectid
+            ORDER BY image
+        ") or die(mysqli_error(DPDatabase::get_connection()));
+
+    $n_pages = mysqli_num_rows($res);
+
+    echo "    # pages  : $n_pages\n";
+
+    if ( $n_pages == 0 )
+    {
+        die( "project has no pages to delete" );
+    }
+
+    $all_image_values = array();
+    while ( list($image,$fileid) = mysqli_fetch_row($res) )
+    {
+        $all_image_values[] = $image;
+    }
+
+    // ----------------------
+
+    $lo = trim($from_image_['lo']);
+    $hi = trim($from_image_['hi']);
+
+    if ( $lo == '' && $hi == '' )
+    {
+        die( "no pages specified for deletion" );
+    }
+    elseif ( $hi == '' )
+    {
+        $hi = $lo;
+    }
+
+    echo "    pages to delete: $lo - $hi\n";
+
+    $lo_i = array_search( $lo, $all_image_values );
+    $hi_i = array_search( $hi, $all_image_values );
+
+    if ( $lo_i === FALSE )
+    {
+        die( "project does not have a page with image='$lo'" );
+    }
+
+    if ( $hi_i === FALSE )
+    {
+        die( "project does not have a page with image='$hi'" );
+    }
+
+    if ( $lo_i > $hi_i )
+    {
+        die( "low end of range ($lo) is greater than high end ($hi)" );
+    }
+
+    $n_pages_to_delete = 1 + $hi_i - $lo_i;
+    echo "    ($n_pages_to_delete pages)\n";
+    echo "</pre>";
+
+    if ( $just_checking )
+    {
+        return;
+    }
+
+    // ----------------------------------------------------
+
+    echo "<hr>";
+    echo "<pre>";
+
+    for ( $i = $lo_i; $i <= $hi_i; $i++ )
+    {
+        $image = $all_image_values[$i];
+        echo "image=$image: ";
+        $err = page_del( $projectid, $image );
+        echo ( $err ? $err : "success" );
+        echo "<br>";
+    }
+
+    echo "</pre>";
+}
+
+// vim: sw=4 ts=4 expandtab

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -26,8 +26,9 @@ $sections = array(
         "edit_mail_address_for_non_activated_user.php" => _("Resend Account Activation Email"),
     ),
     _("Project") => array(
-        "copy_pages.php" => _("Copy Pages from One Project to Another"),
-        "rename_pages.php" => _("Rename pages"),
+        "copy_pages.php" => _("Copy Pages"),
+        "delete_pages.php" => _("Delete Pages"),
+        "rename_pages.php" => _("Rename Pages"),
     ),
     _("Site") => array(
         "sitenews.php" => _("Manage Site News"),

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -2,7 +2,7 @@
 $relPath='../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'slim_header.inc');
+include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'user_is.inc');
 
@@ -13,17 +13,23 @@ if ( !user_is_a_sitemanager() )
     die( "You are not allowed to run this script." );
 }
 
-slim_header(_("Rename Pages"));
+$extra_args["css_data"] = "
+    input[type=text] { font-family: monospace; }
+";
 
-echo "<h2>" . _("Rename Pages") . "</h2>";
-echo "<pre>\n";
+$title = _("Rename Pages");
+output_header($title, NO_STATSBAR, $extra_args);
+
+echo "<h1>$title</h1>";
+
+echo "<p>" . _("This tool will allow you to rename pages in a project.") . "</p>";
 
 $projectid = validate_projectID('projectid', @$_REQUEST['projectid'], true);
 
 if ( !$projectid )
 {
     echo "<form method='GET'>";
-    echo "Please specify a project: ";
+    echo "Project: ";
     echo "<input type='text' name='projectid' size='23'>";
     echo "<input type='submit' value='Go'>";
     echo "</form>\n";
@@ -33,9 +39,10 @@ if ( !$projectid )
 $project = new Project($projectid);
 $title = $project->nameofwork;
 
+echo "<pre>";
 echo "projectid: $projectid\n";
 echo "title    : $title\n";
-echo "\n";
+echo "</pre>\n";
 
 $res = mysqli_query(DPDatabase::get_connection(), "
     SELECT fileid, image
@@ -61,21 +68,28 @@ switch ( $submit_button )
         echo "<input type='hidden' name='projectid' value='$projectid'>\n";
 
         echo "<hr>";
+        echo "<p>";
         echo "If you just want to number all pages serially\n";
         echo "(while maintaining their current order), check here,\n";
         echo "and specify a starting name (including any leading zeroes).\n";
-        echo "<input type='checkbox' name='renumber_from_n'>Renumber from ";
+        echo "</p>";
+
+        echo "<input type='checkbox' name='renumber_from_n'> Renumber from ";
         echo "<input type='text' size='4' name='renumbering_start' value='001'>\n";
-        echo "\n";
+        echo "<br>";
+        echo "<input type='submit' name='submit_button' value='Check renamings'>";
 
         echo "<hr>";
+        echo "<p>";
         echo "Otherwise, for each page that you wish to rename, type in the new fileid.\n";
         echo "('.png' will automatically be appended to obtain the new image name.)\n";
+        echo "</p>";
+        echo "<p>";
         echo "Please note that <b>leading zeroes are significant</b>.\n";
         echo "Leave a box blank if you don't want to rename that page.\n";
-        echo "\n";
+        echo "</p>";
 
-        echo "<table>\n";
+        echo "<table class='basic striped'>\n";
 
         echo "<tr>";
         echo "<th>fileid</th>";
@@ -88,8 +102,6 @@ switch ( $submit_button )
 
         echo "</table>";
 
-        echo "<hr>";
-        echo "\n";
         echo "<input type='submit' name='submit_button' value='Check renamings'>";
 
         echo "</form>\n";
@@ -108,8 +120,10 @@ switch ( $submit_button )
             $n_matches = preg_match( '/^(\D*)(\d+)(\D*)$/', $start_str, $matches );
             if ($n_matches == 0)
             {
+                echo "<p class='error'>";
                 echo "Starting name '$start_str' is invalid.\n";
                 echo "Please hit 'Back' and fix.\n";
+                echo "</p>";
                 return;
             }
 
@@ -121,8 +135,10 @@ switch ( $submit_button )
             $end_number = $start_number + count($current_image_for_fileid_) - 1;
             if ( $end_number >= pow(10,$n_digits) )
             {
+                echo "<p class='error'>";
                 echo "The last page would be numbered $end_number, which exceeds $n_digits digits.\n";
                 echo "Please hit 'Back' and fix.\n";
+                echo "</p>";
                 return;
             }
 
@@ -142,7 +158,7 @@ switch ( $submit_button )
         }
 
         echo "You requested:\n";
-        echo "<table>\n";
+        echo "<table class='basic striped'>\n";
 
         echo "<tr>";
         echo "<th colspan='2'>old</th>";
@@ -154,7 +170,7 @@ switch ( $submit_button )
         echo "<tr>";
         echo "<th>fileid</th>";
         echo "<th>image</th>";
-        echo "<th>|</th>";
+        echo "<th></th>";
         echo "<th>fileid</th>";
         echo "<th>image</th>";
         echo "</tr>";
@@ -193,8 +209,9 @@ switch ( $submit_button )
         {
             if ( $new_fileid != '' && $freq > 1 )
             {
+                echo "<p class='error'>";
                 echo "Error: You have requested $new_fileid as the new fileid for $freq different pages.\n";
-                echo "\n";
+                echo "</p>\n";
                 $n_errors++;
             }
         }
@@ -213,6 +230,7 @@ switch ( $submit_button )
 
         $direction_that_works = NULL;
 
+        echo "<pre>";
         foreach ( array( 'forward', 'backward' ) as $direction )
         {
             echo "<hr>";
@@ -294,6 +312,8 @@ switch ( $submit_button )
             die( "Neither forward nor backward works." );
         }
 
+        echo "</pre>";
+
         // ------------
 
         echo "<hr>";
@@ -322,6 +342,8 @@ switch ( $submit_button )
         {
             die( "direction param is '$direction'" );
         }
+
+        echo "<pre>";
 
         echo "Doing renamings $direction ...\n\n";
 
@@ -400,14 +422,13 @@ switch ( $submit_button )
                 echo "\n";
             }
         }
+        echo "</pre>";
         break;
 
     default:
         echo "Whaaaa? submit_button='$submit_button'";
         break;
 }
-
-echo "</pre>";
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -445,7 +466,7 @@ function echo_name_mapping_subform()
         echo "<tr>";
         echo "<td>$fileid</td>";
         echo "<td>$image</td>";
-        echo "<td><input type='text' size='8' name='nff_[$k][$fileid]'><td>";
+        echo "<td><input type='text' style='width: 97%'; name='nff_[$k][$fileid]'></td>";
         echo "</tr>";
         echo "\n";
     }


### PR DESCRIPTION
This pulls `noncvs/delete_pages.php` into the code proper. While here I standardized the output & styles some across the copy/rename/delete tools so they look less odd. They still make liberal use of `<pre/>` tags, but such is the life of an admin. 