### PR TITLE
Fix two small visual bugs on tasks page

### DIFF
--- a/tasks.php
+++ b/tasks.php
@@ -1140,7 +1140,7 @@ function select_and_list_tasks($sql_condition)
         }
     }
     else {
-        echo "<tr><td colspan='7'><center>No tasks found!</center></td></tr>";
+        echo "<tr><td colspan='9'><center>No tasks found!</center></td></tr>";
     }
     echo "</table><br>\n";
     // if 2 tasks or more found, display the number of reported tasks

--- a/tasks.php
+++ b/tasks.php
@@ -973,7 +973,8 @@ td.taskvalue       { width: 60%; border-bottom: #CCCCCC 1px solid; }
 
 select.taskselect  { font-size: small; color:#03008F; background-color:#EEF7FF; }
 input[type="number"],
-input[type="text"] { font-size: small; border:1px solid #000000; margin:2px; padding:0px; background-color:#EEF7FF; width: 4em; }
+input[type="text"] { font-size: small; border:1px solid #000000; margin:2px; padding:0px; background-color:#EEF7FF; }
+input[type="number"] { width: 4em; }
 input[type="button"],
 input[type="submit"] { font-size: small; color:#FFFFFF; font-weight:bold; border:1px ridge #000000; margin:2px; padding: 0px 5px; background-color:#838AB5; }
 input[type="button"]:disabled,


### PR DESCRIPTION
## "No tasks found!" message does not fill the whole row

### Before:

![image](https://user-images.githubusercontent.com/3049847/50568484-dbf11500-0d52-11e9-9dbb-2c7cbb1c3936.png)

 * https://www.pgdp.net/c/tasks.php?search_text=abcdefg

### After:

![image](https://user-images.githubusercontent.com/3049847/50568478-cc71cc00-0d52-11e9-9ed9-9b3316f37188.png)

 * https://www.pgdp.org/~mlazaric/c/tasks.php?search_text=abcdefg

## Small `search_text` input field

### Before:

![image](https://user-images.githubusercontent.com/3049847/50568505-312d2680-0d53-11e9-8292-4083aa2354c8.png)

 * https://www.pgdp.org/c/tasks.php

### After:

![image](https://user-images.githubusercontent.com/3049847/50568511-3db17f00-0d53-11e9-91fc-20644d25976d.png)

 * https://www.pgdp.org/~mlazaric/c/tasks.php
