### PR TITLE
Enforce tally_name values for mdetail page

### DIFF
--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -36,7 +36,7 @@ if(!$testing)
     function production_exception_handler($exception)
     {
         echo "<br>\n";
-        echo $exception->getMessage();
+        echo html_safe($exception->getMessage());
     }
     set_exception_handler('production_exception_handler');
 }

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -82,14 +82,16 @@ function get_enumerated_param( $arr, $key, $default, $choices, $allownull = fals
         {
             if (!is_numeric($s))
             {
-                throw new InvalidArgumentException(
-                    "parameter '$key' ('$s') is not numeric");
+                throw new InvalidArgumentException(sprintf(
+                    _("Parameter '%1\$s' ('%2\$s') is not numeric"),
+                    $key, $s));
             }
             $s = 0 + $s;
             if (!is_int($s))
             {
-                throw new InvalidArgumentException(
-                    "parameter '$key' ('$s') is not an integer");
+                throw new InvalidArgumentException(sprintf(
+                    _("Parameter '%1\$s' ('%2\$s') is not an integer"),
+                    $key, $s));
             }
         }
 
@@ -99,8 +101,9 @@ function get_enumerated_param( $arr, $key, $default, $choices, $allownull = fals
         }
         else
         {
-            throw new InvalidArgumentException(
-                "parameter '$key' ('$s') is not valid");
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' ('%2\$s') is not valid"),
+                $key, $s));
         }
     }
     else
@@ -109,8 +112,9 @@ function get_enumerated_param( $arr, $key, $default, $choices, $allownull = fals
         if ( is_null($default) && !$allownull )
         {
             // There is no default. The parameter is required.
-            throw new InvalidArgumentException(
-                "parameter '$key' is required");
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' is reqiured"),
+                $key));
         }
         else
         {
@@ -193,8 +197,9 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
             }
             else
             {
-                throw new InvalidArgumentException(
-                    "parameter '$key' ('$s') is not an integer");
+                throw new InvalidArgumentException(sprintf(
+                    _("Parameter '%1\$s' ('%2\$s') is not an integer"),
+                    $key, $s));
             }
         }
         elseif ( $type == 'float' )
@@ -208,21 +213,24 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
             }
             else
             {
-                throw new InvalidArgumentException(
-                    "parameter '$key' ('$s') is not a float");
+                throw new InvalidArgumentException(sprintf(
+                    _("Parameter '%1\$s' ('%2\$s') is not a float"),
+                    $key, $s));
             }
         }
 
         if ( !is_null($min) && $i < $min )
         {
-            throw new InvalidArgumentException(
-                "parameter '$key' ($s) is less than the minimum $min");
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' ('%2\$s') is less than the minimum %3\$d"),
+                $key, $s, $min));
         }
 
         if ( !is_null($max) && $i > $max )
         {
-            throw new InvalidArgumentException(
-                "parameter '$key' ($s) is greater than the maximum $max");
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' ('%2\$s') is greater than the maximum %3\$d"),
+                $key, $s, $max));
         }
 
         return $i;
@@ -233,8 +241,9 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
         if ( is_null($default) && !$allownull )
         {
             // There is no default. The parameter is required.
-            throw new InvalidArgumentException(
-                "parameter '$key' is required");
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' is required"),
+                $key));
         }
         else
         {
@@ -288,8 +297,9 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull=false
         }
         else
         {
-            throw new InvalidArgumentException(
-                "parameter '$key' ('$s') does not match the regex $regex");
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' ('%2\$s') does not match the regex %3\$s"),
+                $key, $s, $regex));
         }
     }
     else
@@ -298,8 +308,9 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull=false
         if ( is_null($default) && !$allownull )
         {
             // There is no default. The parameter is required.
-            throw new InvalidArgumentException(
-                "parameter '$key' is required");
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' is required"),
+                $key));
         }
         else
         {

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -82,14 +82,14 @@ function get_enumerated_param( $arr, $key, $default, $choices, $allownull = fals
         {
             if (!is_numeric($s))
             {
-                throw new InvalidArgumentException(html_safe(
-                    "parameter '$key' ('$s') is not numeric"));
+                throw new InvalidArgumentException(
+                    "parameter '$key' ('$s') is not numeric");
             }
             $s = 0 + $s;
             if (!is_int($s))
             {
-                throw new InvalidArgumentException(html_safe(
-                    "parameter '$key' ('$s') is not an integer"));
+                throw new InvalidArgumentException(
+                    "parameter '$key' ('$s') is not an integer");
             }
         }
 
@@ -99,8 +99,8 @@ function get_enumerated_param( $arr, $key, $default, $choices, $allownull = fals
         }
         else
         {
-            throw new InvalidArgumentException(html_safe(
-                "parameter '$key' ('$s') is not valid"));
+            throw new InvalidArgumentException(
+                "parameter '$key' ('$s') is not valid");
         }
     }
     else
@@ -109,8 +109,8 @@ function get_enumerated_param( $arr, $key, $default, $choices, $allownull = fals
         if ( is_null($default) && !$allownull )
         {
             // There is no default. The parameter is required.
-            throw new InvalidArgumentException(html_safe(
-                "parameter '$key' is required"));
+            throw new InvalidArgumentException(
+                "parameter '$key' is required");
         }
         else
         {
@@ -193,8 +193,8 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
             }
             else
             {
-                throw new InvalidArgumentException(html_safe(
-                    "parameter '$key' ('$s') is not an integer"));
+                throw new InvalidArgumentException(
+                    "parameter '$key' ('$s') is not an integer");
             }
         }
         elseif ( $type == 'float' )
@@ -208,21 +208,21 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
             }
             else
             {
-                throw new InvalidArgumentException(html_safe(
-                    "parameter '$key' ('$s') is not a float"));
+                throw new InvalidArgumentException(
+                    "parameter '$key' ('$s') is not a float");
             }
         }
 
         if ( !is_null($min) && $i < $min )
         {
-            throw new InvalidArgumentException(html_safe(
-                "parameter '$key' ($s) is less than the minimum $min"));
+            throw new InvalidArgumentException(
+                "parameter '$key' ($s) is less than the minimum $min");
         }
 
         if ( !is_null($max) && $i > $max )
         {
-            throw new InvalidArgumentException(html_safe(
-                "parameter '$key' ($s) is greater than the maximum $max"));
+            throw new InvalidArgumentException(
+                "parameter '$key' ($s) is greater than the maximum $max");
         }
 
         return $i;
@@ -233,8 +233,8 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
         if ( is_null($default) && !$allownull )
         {
             // There is no default. The parameter is required.
-            throw new InvalidArgumentException(html_safe(
-                "parameter '$key' is required"));
+            throw new InvalidArgumentException(
+                "parameter '$key' is required");
         }
         else
         {
@@ -288,8 +288,8 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull=false
         }
         else
         {
-            throw new InvalidArgumentException(html_safe(
-                "parameter '$key' ('$s') does not match the regex $regex"));
+            throw new InvalidArgumentException(
+                "parameter '$key' ('$s') does not match the regex $regex");
         }
     }
     else
@@ -298,8 +298,8 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull=false
         if ( is_null($default) && !$allownull )
         {
             // There is no default. The parameter is required.
-            throw new InvalidArgumentException(html_safe(
-                "parameter '$key' is required"));
+            throw new InvalidArgumentException(
+                "parameter '$key' is required");
         }
         else
         {

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -102,8 +102,8 @@ function get_enumerated_param( $arr, $key, $default, $choices, $allownull = fals
         else
         {
             throw new InvalidArgumentException(sprintf(
-                _("Parameter '%1\$s' ('%2\$s') is not valid"),
-                $key, $s));
+                _("Parameter '%1\$s' ('%2\$s') is not one of %3\$s"),
+                $key, $s, implode(", ", $choices)));
         }
     }
     else

--- a/stats/members/mdetail.php
+++ b/stats/members/mdetail.php
@@ -3,17 +3,17 @@ $relPath="./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'privacy.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'page_tally.inc');
+include_once($relPath.'page_tally.inc'); // $page_tally_names
 include_once($relPath.'misc.inc'); // array_get(), get_integer_param()
 include_once($relPath.'User.inc');
 include_once('../includes/team.inc');
 include_once('../includes/member.inc');
 
-$tally_name = array_get( $_GET, 'tally_name', null );
-
 $id = get_integer_param($_GET, 'id', null, 0, null);
-
 $user = User::load_from_uid($id);
+
+$valid_tally_names = array_keys($page_tally_names);
+$tally_name = get_enumerated_param($_GET, 'tally_name', null, $valid_tally_names, true);
 
 $can_reveal = can_reveal_details_about( $user->username, $user->u_privacy );
 if ( $can_reveal )


### PR DESCRIPTION
Validate tally_name at the top of the mdetail page instead of letting the error show up later in the page render.

This was in the php_error logs.