### PR TITLE
Add 'required' attribute to HTML form elements

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -145,7 +145,7 @@ printf(_("Please check the e-mail being sent to you for further information abou
 echo "<p class='large'>"._("Enter your password below to sign in and start proofreading!!") . "</p>";
 echo "<form action='login.php' method='post'>
 <input type='hidden' name='userNM' value='".attr_safe($user->username)."'>
-<input type='password' name='userPW'>
+<input type='password' name='userPW' required>
 <input type='submit' value='".attr_safe(_("Sign In"))."'></form>";
 
 // vim: sw=4 ts=4 expandtab

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -139,24 +139,24 @@ foreach($form_data_inserters as $func)
 echo "<table class='register'>";
 echo "<tr>";
 echo "  <th>" . _("Real Name") . ":</th>";
-echo "  <td><input type='text' name='real_name' value='". attr_safe($real_name) ."'></td>";
+echo "  <td><input type='text' name='real_name' value='". attr_safe($real_name) ."' required></td>";
 echo "</tr>\n<tr>";
 echo "  <th>" . _("User Name") . ":</th>";
-echo "  <td><input type='text' name='userNM' value='" . attr_safe($username) . "'><br><small>$valid_username_chars_statement_for_reg_form</small></td>";
+echo "  <td><input type='text' name='userNM' value='" . attr_safe($username) . "' required><br><small>$valid_username_chars_statement_for_reg_form</small></td>";
 echo "</tr>\n<tr>";
 echo "  <th>" . _("Password") . ":</th>";
-echo "  <td><input type='password' name='userPW'></td>";
+echo "  <td><input type='password' name='userPW' required></td>";
 echo "</tr>\n<tr>";
 echo "  <th>" . _("Confirm Password") . ":</th>";
-echo "  <td><input type='password' name='userPW2'></td>";
+echo "  <td><input type='password' name='userPW2' required></td>";
 echo "</tr>\n";
 if (!$testing) {
     echo "<tr>";
     echo "  <th>" . _("E-mail Address") . ":</th>";
-    echo "  <td><input type='text' name='email' value='". attr_safe($email) . "'></td>";
+    echo "  <td><input type='text' name='email' value='". attr_safe($email) . "' required></td>";
     echo "</tr>\n<tr>";
     echo "  <th>" . _("Confirm E-mail Address") . ":</th>";
-    echo "  <td><input type='text' name='email2' value='" . attr_safe($email2) . "'></td>";
+    echo "  <td><input type='text' name='email2' value='" . attr_safe($email2) . "' required></td>";
     echo "</tr>\n";
 }
 echo "<tr>";

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -153,10 +153,10 @@ echo "</tr>\n";
 if (!$testing) {
     echo "<tr>";
     echo "  <th>" . _("E-mail Address") . ":</th>";
-    echo "  <td><input type='text' name='email' value='". attr_safe($email) . "' required></td>";
+    echo "  <td><input type='email' name='email' value='". attr_safe($email) . "' required></td>";
     echo "</tr>\n<tr>";
     echo "  <th>" . _("Confirm E-mail Address") . ":</th>";
-    echo "  <td><input type='text' name='email2' value='" . attr_safe($email2) . "' required></td>";
+    echo "  <td><input type='email' name='email2' value='" . attr_safe($email2) . "' required></td>";
     echo "</tr>\n";
 }
 echo "<tr>";

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -223,8 +223,10 @@ function html_navbar()
 
         // login link text
         // TRANSLATORS: ID is an abbreviation for username in the navbar
-        $login_form .= "<label for='loginform-userNM'>" . _("ID") . ":</label> <input type='text' id='loginform-userNM' name='userNM' size='10' maxlength='50'>&nbsp;";
-        $login_form .= "<label for='loginform-userPW'>" . _("Password") . ":</label> <input type='password' id='loginform-userPW' name='userPW' size='10' maxlength='50'>&nbsp;";
+        $login_form .= "<label for='loginform-userNM'>" . _("ID") . ":</label> ";
+        $login_form .= "<input type='text' id='loginform-userNM' name='userNM' style='width: 7em;' required>&nbsp;";
+        $login_form .= "<label for='loginform-userPW'>" . _("Password") . ":</label> ";
+        $login_form .= "<input type='password' id='loginform-userPW' name='userPW' style='width: 7em;' required>&nbsp;";
         $login_form .= "<input type='submit' value='" . _("Sign In") ."'>";
         $login_form .= "</div></form>";
 

--- a/project.php
+++ b/project.php
@@ -974,7 +974,7 @@ function do_early_uploads()
         echo "<b>", _("Add title page and verso from directory or zip file:"), "</b>";
         echo "<br>\n";
         $initial_rel_source = "$user_dir/";
-        echo "~$uploads_account/ <input type='text' name='rel_source' size='50' value='$initial_rel_source'>";
+        echo "~$uploads_account/ <input type='text' name='rel_source' size='50' value='$initial_rel_source' required>";
         echo "<br>\n";
         echo "<input type='submit' value='", attr_safe(_("Add")), "'>";
         echo "<br>\n";
@@ -996,7 +996,7 @@ function do_early_uploads()
             echo _("Add/Replace text and images from directory or zip file:");
             echo "<br>\n";
             $initial_rel_source = "Users/$user_dir/";
-            echo "~$uploads_account/ <input type='text' name='rel_source' size='50' value='$initial_rel_source'>";
+            echo "~$uploads_account/ <input type='text' name='rel_source' size='50' value='$initial_rel_source' required>";
         echo "<br>\n";
         echo "<p>\n";
         echo _("Remember to upload the illustration files as well as the page files!");

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -481,7 +481,7 @@ function showEdit($tname,$ttext,$twebpage,$tedit,$tsid)
 
     echo "<tr>";
     echo "<td class='right-align'><b>"._("Team Name")."</b>:</td>";
-    echo "<td class='left-align'><input type='text' value='" . attr_safe($tname) . "' name='teamname' size='50'>&nbsp;<b><a href=\"JavaScript:newHelpWin('teamname');\">?</a></b></td>";
+    echo "<td class='left-align'><input type='text' value='" . attr_safe($tname) . "' name='teamname' size='50' required>&nbsp;<b><a href=\"JavaScript:newHelpWin('teamname');\">?</a></b></td>";
     echo "</tr>";
 
     echo "<tr>";

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -22,7 +22,7 @@ show_news_for_page("STATS");
 <tr>
     <td>
     <form action='<?php echo $code_url; ?>/stats/members/mbr_list.php' method='post'>
-        <input type='text' name='uname' size='20' style='margin-left: 0;'>
+        <input type='text' name='uname' size='20' style='margin-left: 0;' required>
         <input type='submit' value='<?php echo attr_safe(_("Member Search")); ?>'>
         <br>
         <input type='checkbox' name='uexact' value='yes' style='margin-left: 0;'> <?php echo _("Exact match"); ?>
@@ -32,7 +32,7 @@ show_news_for_page("STATS");
     </td>
     <td>
     <form action='<?php echo $code_url; ?>/stats/teams/tlist.php' method='post'>
-        <input type='text' name='tname' size='20' style='margin-left: 0;'>
+        <input type='text' name='tname' size='20' style='margin-left: 0;' required>
         <input type='submit' value='<?php echo attr_safe(_("Team Search")); ?>'>
         <br>
         <input type='checkbox' name='texact' value='yes' style='margin-left: 0;'> <?php echo _("Exact match"); ?>

--- a/tasks.php
+++ b/tasks.php
@@ -1018,7 +1018,7 @@ EOS;
     echo "<form action='$tasks_url' method='get'><input type='hidden' name='action' value='show'>";
     echo "<b><small class='task'>Show Task #</small></b>";
     echo "&nbsp;\n";
-    echo "<input type='number' name='task_id' min='1'>&nbsp;\n";
+    echo "<input type='number' name='task_id' min='1' required>&nbsp;\n";
     echo "<input type='submit' value='Go!'>\n";
     echo "</form>";
     echo "</td></tr></table><br>\n";
@@ -1177,7 +1177,7 @@ function TaskForm($task)
     echo "<td colspan='2'>";
     echo "<b>" . property_get_label('task_summary', FALSE) . "&nbsp;</b>";
     echo "&nbsp;&nbsp;";
-    echo "<input type='text' name='task_summary' value=\"$task_summary_enc\" size='60' maxlength='80'>";
+    echo "<input type='text' name='task_summary' value=\"$task_summary_enc\" size='60' maxlength='80' required>";
     echo "</td>";
     echo "</tr>\n";
     echo "<tr><td width='50%'><table class='taskplain'>\n";
@@ -1200,7 +1200,7 @@ function TaskForm($task)
     echo "</table></td></tr><tr><td>\n";
     echo "<table class='taskplain'><tr><td width='5%'><b>Details</b>&nbsp;&nbsp;</td>\n";
     echo "<td width='95%'>";
-    echo "<textarea name='task_details' cols='60' rows='5'>$task_details_enc</textarea>";
+    echo "<textarea name='task_details' cols='60' rows='5' required>$task_details_enc</textarea>";
     echo "</td>";
     echo "</tr>";
     echo "</table>\n";
@@ -1678,7 +1678,7 @@ function RelatedTasks($tid)
     echo "<form action='$tasks_url' method='post'>";
     echo "<input type='hidden' name='action' value='add_related_task'>";
     echo "<input type='hidden' name='task_id' value='$tid'>";
-    echo "<input type='number' name='related_task' min='1'>&nbsp;&nbsp;";
+    echo "<input type='number' name='related_task' min='1' required>&nbsp;&nbsp;";
     echo "<input type='submit' value='Add'>\n";
     echo " (Add the number of an existing, related task. This is optional.)";
     echo "</form>";
@@ -1724,7 +1724,7 @@ function RelatedPostings($tid)
     echo "<form action='$tasks_url' method='post'>";
     echo "<input type='hidden' name='action' value='add_related_topic'>";
     echo "<input type='hidden' name='task_id' value='$tid'>";
-    echo "<input type='number' name='related_posting' min='1'>&nbsp;&nbsp;";
+    echo "<input type='number' name='related_posting' min='1' required>&nbsp;&nbsp;";
     echo "<input type='submit' value='Add'>\n";
     echo " (Optional)";
     echo "</form>";

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -115,7 +115,7 @@ elseif ($frame=="top") {
     echo "<form method='get' action='view_page_text_image.php' target='_top'>\n";
     if(!$project) {
         echo _("Project ID") . ":&nbsp;";
-        echo "<input type='text' maxlength='25' name='projectid' size='25' value='" . attr_safe($projectid) . "'> \n";
+        echo "<input type='text' maxlength='25' name='projectid' size='25' value='" . attr_safe($projectid) . "' required> \n";
         echo "<input type='submit' value='"._("Select Project")."'> &nbsp; &nbsp;";
     } else {
         echo "<input type='hidden' name='projectid' value='" . attr_safe($projectid) . "'>";
@@ -206,7 +206,7 @@ elseif ($frame=="image") {
 <form method="get" action="view_page_text_image.php">
 <input type="hidden" name="projectid" value="<?php echo $projectid; ?>">
 <input type="hidden" name="page" value="<?php echo $page; ?>">
-<input type="number" name="percent" value="<?php echo $percent; ?>" min="1" max="100">%
+<input type="number" name="percent" value="<?php echo $percent; ?>" min="1" max="100" required>%
 <input type="hidden" name="round_id" value="<?php echo $round_id; ?>">
 <input type="hidden" name="frame" value="image">
 <input type="submit" value="<?php echo _("Resize"); ?>" size="3">

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -52,7 +52,7 @@ if (!isset($_REQUEST['project']))
     $prompt = _("Please enter a project ID:");
     echo "
         <form method='get'>
-        $prompt <input type='text' name='project'>
+        $prompt <input type='text' name='project' required>
         <input type='submit'>
         </form>
     ";

--- a/tools/project_manager/project_quick_check.php
+++ b/tools/project_manager/project_quick_check.php
@@ -29,7 +29,7 @@ echo "<form method='GET'>";
 echo "<table>";
 echo  "<tr>";
 echo   "<td>" . _("Project ID") . "</td>";
-echo   "<td><input name='projectid' type='text' value='$projectid' size='40'></td>";
+echo   "<td><input name='projectid' type='text' value='$projectid' size='40' required></td>";
 echo  "</tr>";
 echo "</table>";
 echo "<input type='submit' value='Test'>";

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -594,7 +594,7 @@ function do_showmkdir()
     output_header($page_title, NO_STATSBAR);
     echo "<h1>$page_title</h1>\n";
 
-    $form_content = _("Name of subfolder to create") .":&nbsp;<input type='text' name='new_dir_name' size='50' maxsize='50'>";
+    $form_content = _("Name of subfolder to create") .":&nbsp;<input type='text' name='new_dir_name' size='50' maxsize='50' required>";
     show_form(
         'mkdir',
         $curr_relpath,
@@ -646,7 +646,7 @@ function do_showrename()
     $form_content .= sprintf(
         _('Rename <b>%1$s</b> as %2$s'),
         html_safe($item_name),
-        "<input type='text' name='new_item_name' size='50' value='" . attr_safe($item_name) . "'>"
+        "<input type='text' name='new_item_name' size='50' value='" . attr_safe($item_name) . "' required>"
     );
 
     show_form(

--- a/tools/proofers/mktable.php
+++ b/tools/proofers/mktable.php
@@ -43,8 +43,8 @@ $horiz_align = array_pad($horiz_align, $col, STR_PAD_RIGHT);
 <body>
 <form method="POST">
 <input type="submit" value="Create">
-<input type="number" name="row" value="<?php echo $row; ?>" min='1' style='width: 3em;'> rows and
-<input type="number" name="col" value="<?php echo $col; ?>" min='1' style='width: 3em;'> columns table
+<input type="number" name="row" value="<?php echo $row; ?>" min='1' style='width: 3em;' required> rows and
+<input type="number" name="col" value="<?php echo $col; ?>" min='1' style='width: 3em;' required> columns table
 <select name="border">
 <option value="1"<?php echo $bord?" selected":""; ?>>with</option>
 <option value="0"<?php echo $bord?"":" selected"; ?>>without</option>

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -44,7 +44,7 @@ if ( user_is_a_sitemanager() || user_is_proj_facilitator() )
 {
     echo "<form action='#' method='get'><p>";
     echo _("See projects that another user has worked on") . ": ";
-    echo "<input type='text' name='username' value='$username'>";
+    echo "<input type='text' name='username' value='$username' required>";
     echo "<input type='submit' value='" . attr_safe(_("Refresh")) . "'>";
     echo "</p></form>\n";
 }

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -59,7 +59,7 @@ if (user_is_a_sitemanager() ||
     // only let site admins or reviewers to access non-self records and eval query
     echo  "<tr>";
     echo   "<td>" . _("Username") . "</td>";
-    echo   "<td><input name='username' type='text' size='26' value='$username'></td>";
+    echo   "<td><input name='username' type='text' size='26' value='$username' required></td>";
     echo  "</tr>";
     echo  "<tr>";
     echo   "<td>" . _("Use Evaluation Query") . "</td>";
@@ -82,11 +82,11 @@ echo     "</select>";
 echo  "</tr>";
 echo  "<tr>";
 echo   "<td>" . _("Max days since last save") . "</td>";
-echo   "<td><input name='days' type='number' min='0' value='$days'></td>";
+echo   "<td><input name='days' type='number' min='0' value='$days' required></td>";
 echo  "</tr>";
 echo  "<tr>";
 echo   "<td>" . _("Max diffs to show") . "</td>";
-echo   "<td><input name='sample_limit' type='number' min='0' value='$sampleLimit'></td>";
+echo   "<td><input name='sample_limit' type='number' min='0' value='$sampleLimit' required></td>";
 echo  "</tr>";
 echo "</table>";
 echo "<input type='submit' value='Search'>";

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -130,14 +130,14 @@ function display_form($projectid_, $from_image_, $page_name_handling,
         $val = "value='" . attr_safe($projectid_['from']) . "'";
     }
     echo "<tr><th>" . _("Source Project:") . "</th>\n";
-    echo "<td><input type='text' name='projectid_[from]' size='28' $val> (projectid)</td></tr>\n";
+    echo "<td><input type='text' name='projectid_[from]' size='28' $val required> (projectid)</td></tr>\n";
     $val = '';
     if ($repeating && $repeat_project == 'TO')
     {
         $val = "value='" . attr_safe($projectid_['to']) . "'";
     }
     echo "<tr><th>" . _("Destination Project:") . "</th>\n";
-    echo "<td><input type='text' name='projectid_[to]' size='28' $val> (projectid)</td></tr>\n";
+    echo "<td><input type='text' name='projectid_[to]' size='28' $val required> (projectid)</td></tr>\n";
 
     // If we are repeating, we want the same buttons to be checked
     echo "<tr><td></td><td>\n";

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -68,13 +68,13 @@ function display_form($action, $projectid, $from_image_)
         echo "<tr>\n";
         echo "<th>" . _("Delete Page(s):") . "</th>\n";
         echo "<td><input type='text' name='from_image_[lo]' size='12'
-            value='" . attr_safe(@$from_image_['lo']) . "'>";
+            value='" . attr_safe(@$from_image_['lo']) . "' required>";
         echo " &ndash; <input type='text' name='from_image_[hi]' size='12'
-            value='" . attr_safe(@$from_image_['hi']) . "'>";
+            value='" . attr_safe(@$from_image_['hi']) . "' required>";
         echo "</td></tr>\n";
         echo "<tr><th>" . _("Project:") . "</th>\n";
         echo "<td><input type='text' name='projectid' size='28'
-            value='" . attr_safe(@$projectid) . "'>
+            value='" . attr_safe(@$projectid) . "' required>
             (projectid)</td></tr>\n";
 
         echo "<tr>";

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -35,7 +35,7 @@ if ($action == 'default') {
     ?>
     <br>
     <form method='get'><input type='hidden' name='action' value='get_user'>
-    <?php echo _("Username"); ?>: <input type='text' name='username'>
+    <?php echo _("Username"); ?>: <input type='text' name='username' required>
     <input type='submit' value='<?php echo attr_safe(_("Continue")); ?>'>
     </form>
     <br>
@@ -98,7 +98,7 @@ else if ($action == 'get_user') {
     <input type='hidden' name='username' value='<?php echo attr_safe($username); ?>'>
     <?php echo _("Username"); ?>: <?php echo html_safe($username); ?>
     <br>
-    <?php echo _("E-mail"); ?>: <input type='text' name='email' size='50' value='<?php echo attr_safe($user->email); ?>'>
+    <?php echo _("E-mail"); ?>: <input type='text' name='email' size='50' value='<?php echo attr_safe($user->email); ?>' required>
     <br>
     <input type='submit' value='<?php echo attr_safe(_("Update address and resend activation mail")); ?>'>
     </form>

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -91,7 +91,7 @@ function show_username_form($username)
 {
     echo "<form method='GET'>\n";
     echo "<p>" . _("Username") . ": ";
-    echo "<input name='username' type='text' value='$username' size='20'>\n";
+    echo "<input name='username' type='text' value='$username' size='20' required>\n";
     echo "</p>";
     echo "<input type='submit' value='" . attr_safe(_("Look up this user")) . "'>\n";
     echo "</form>\n";

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -30,7 +30,7 @@ if ( !$projectid )
 {
     echo "<form method='GET'>";
     echo "Project: ";
-    echo "<input type='text' name='projectid' size='23'>";
+    echo "<input type='text' name='projectid' size='23' required>";
     echo "<input type='submit' value='Go'>";
     echo "</form>\n";
     exit;

--- a/userprefs.php
+++ b/userprefs.php
@@ -248,7 +248,7 @@ function echo_general_tab() {
         _('Name'), 'real_name', 'name',
         $user->real_name,
         'textfield',
-        array( '20', '' )
+        array( '20', 'required', '' )
         // About 98% of pgdp.net's users have length(real_name) <= 20
     );
     show_blank();
@@ -268,7 +268,7 @@ function echo_general_tab() {
         _('E-mail'), 'email', 'email',
         $user->email,
         'textfield',
-        array( '26', $email_warning )
+        array( '26', 'required', $email_warning )
         // About 92% of pgdp.net's users have length(email) <= 26
     );
     show_preference(
@@ -423,7 +423,7 @@ function echo_proofreading_tab() {
         _('Current Profile'), 'profilename', 'profilename',
         $userP['profilename'],
         'textfield',
-        array( '20', '' )
+        array( '20', 'required', '' )
         // About 99.96% of pgdp.net's user_profiles have length(profilename) <= 20
     );
     echo "<td colspan='2' class='center-align'>";
@@ -538,14 +538,14 @@ function echo_proofreading_tab() {
         $userP['v_zoom'],
         'numberfield',
         # xgettext:no-php-format
-        array( 3, _("% of 1000 pixels") )
+        array( 3, 'required', _("% of 1000 pixels") )
     );
     show_preference(
         _('Image Zoom'), 'h_zoom', 'h_zoom',
         $userP['h_zoom'],
         'numberfield',
         # xgettext:no-php-format
-        array( 3, _("% of 1000 pixels") )
+        array( 3, 'required', _("% of 1000 pixels") )
     );
     echo "</tr>\n";
 
@@ -555,14 +555,14 @@ function echo_proofreading_tab() {
         $userP['v_tframe'],
         'numberfield',
         # xgettext:no-php-format
-        array( 3, _("% of browser width") )
+        array( 3, 'required', _("% of browser width") )
     );
     show_preference(
         _('Text Frame Size'), 'h_tframe', 'h_textsize',
         $userP['h_tframe'],
         'numberfield',
         # xgettext:no-php-format
-        array( 3, _("% of browser height") )
+        array( 3, 'required', _("% of browser height") )
     );
     echo "</tr>\n";
 
@@ -586,13 +586,13 @@ function echo_proofreading_tab() {
         _('Number of Text Lines'), 'v_tlines', 'v_textlines',
         $userP['v_tlines'],
         'numberfield',
-        array( 3, "" )
+        array( 3, 'required', "" )
     );
     show_preference(
         _('Number of Text Lines'), 'h_tlines', 'h_textlines',
         $userP['h_tlines'],
         'numberfield',
-        array( 3, "" )
+        array( 3, 'required', "" )
     );
     echo "</tr>\n";
 
@@ -601,13 +601,13 @@ function echo_proofreading_tab() {
         _('Length of Text Lines'), 'v_tchars', 'v_textlength',
         $userP['v_tchars'],
         'numberfield',
-        array( 3, " "._("characters") )
+        array( 3, 'required', " "._("characters") )
     );
     show_preference(
         _('Length of Text Lines'), 'h_tchars', 'h_textlength',
         $userP['h_tchars'],
         'numberfield',
-        array( 3, " "._("characters") )
+        array( 3, 'required', " "._("characters") )
     );
     echo "</tr>\n";
 
@@ -744,9 +744,7 @@ function echo_pm_tab() {
     ); 
     echo "</tr>\n"; 
 
-    echo "<tr><td colspan='6' class='center-align'>";
     echo_bottom_button_row();
-    echo "</td></tr>\n";
 }
 
 function save_pm_tab() {
@@ -922,16 +920,16 @@ function _show_radio_group( $field_name, $current_value, $options )
 
 function _show_textfield( $field_name, $current_value, $extras )
 {
-    list($size, $rest) = $extras;
+    list($size, $required, $rest) = $extras;
     $current_value_esc = attr_safe($current_value);
-    echo "<input type='text' style='width: ${size}em' name='$field_name' value='$current_value_esc'>$rest";
+    echo "<input type='text' style='width: ${size}em' name='$field_name' value='$current_value_esc' $required>$rest";
 }
 
 function _show_numberfield( $field_name, $current_value, $extras )
 {
-    list($size, $rest) = $extras;
+    list($size, $required, $rest) = $extras;
     $current_value_esc = attr_safe($current_value);
-    echo "<input type='number' style='width: ${size}em' name='$field_name' value='$current_value_esc' min='1'>$rest";
+    echo "<input type='number' style='width: ${size}em' name='$field_name' value='$current_value_esc' min='1' $required>$rest";
 }
 
 // ---------------------------------------------------------

--- a/userprefs.php
+++ b/userprefs.php
@@ -267,7 +267,7 @@ function echo_general_tab() {
     show_preference(
         _('E-mail'), 'email', 'email',
         $user->email,
-        'textfield',
+        'emailfield',
         array( '26', 'required', $email_warning )
         // About 92% of pgdp.net's users have length(email) <= 26
     );
@@ -918,18 +918,30 @@ function _show_radio_group( $field_name, $current_value, $options )
     }
 }
 
-function _show_textfield( $field_name, $current_value, $extras )
+function _show_text_input_field($field_type, $field_name, $current_value, $extras)
 {
     list($size, $required, $rest) = $extras;
     $current_value_esc = attr_safe($current_value);
-    echo "<input type='text' style='width: ${size}em' name='$field_name' value='$current_value_esc' $required>$rest";
+    if($field_type == "number")
+        $min_attr = "min='1'";
+    else
+        $min_attr = "";
+    echo "<input type='$field_type' style='width: ${size}em' name='$field_name' value='$current_value_esc' $min_attr $required>$rest";
+}
+
+function _show_textfield( $field_name, $current_value, $extras )
+{
+    _show_text_input_field('text', $field_name, $current_value, $extras);
+}
+
+function _show_emailfield( $field_name, $current_value, $extras )
+{
+    _show_text_input_Field('email', $field_name, $current_value, $extras);
 }
 
 function _show_numberfield( $field_name, $current_value, $extras )
 {
-    list($size, $required, $rest) = $extras;
-    $current_value_esc = attr_safe($current_value);
-    echo "<input type='number' style='width: ${size}em' name='$field_name' value='$current_value_esc' min='1' $required>$rest";
+    _show_text_input_field('number', $field_name, $current_value, $extras);
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
HTML5 supports the new 'required' attribute on HTML form elements that are required to submit the form. The browser won't allow the page to be submitted until the element is filled in. This doesn't negate the necessity for server-side validation, but it does provide a nicer user experience.