### PR TITLE
Do SR completion notifications at end of the hour

### DIFF
--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -4,7 +4,7 @@
 
 # hourly:
 03 * * * * URL=<<CODE_URL>>/crontab/update_user_counts.php; <<URL_DUMP_PROGRAM>> $URL
-03 * * * * URL=<<CODE_URL>>/crontab/finish_smoothreading.php; <<URL_DUMP_PROGRAM>> $URL
+55 * * * * URL=<<CODE_URL>>/crontab/finish_smoothreading.php; <<URL_DUMP_PROGRAM>> $URL
 
 # daily:
 01  0 * * * URL=<<CODE_URL>>/crontab/take_tally_snapshots.php; <<URL_DUMP_PROGRAM>> $URL


### PR DESCRIPTION
SR completion notifications run once an hour and send notifications for any projects that finish SR within that hour, even if the projects won't finish SR until the end of the hour after the job runs. To minimize the chances that the notification will be sent out before the project actually leaves SR, do the notifications at the end, rather than the beginning, of the hour.

This moves the notifications to be sent out at 55 minutes after the hour rather than 3 minutes after the hour.