### PR TITLE
Val proj

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -25,7 +25,7 @@ class Project
             $row = mysqli_fetch_assoc($res);
             if (!$row)
             {
-                throw new NonexistentProjectException("no project with projectid='$arg'");
+                throw new NonexistentProjectException(sprintf(_("There is no project with projectid '%s'"), html_safe($arg)));
             }
             $row['t_retrieved'] = time();
         }

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -26,7 +26,7 @@ class Project
             $row = mysqli_fetch_assoc($res);
             if (!$row)
             {
-                throw new NonexistentProjectException(sprintf(_("There is no project with projectid '%s'"), html_safe($arg)));
+                throw new NonexistentProjectException(sprintf(_("There is no project with projectid '%s'"), $arg));
             }
             $row['t_retrieved'] = time();
         }
@@ -767,24 +767,8 @@ function does_project_page_table_exist($projectid)
 
 // Checks if $value has the form of a valid project ID, either in its
 // long form (projectID####) or just the project number (####).
-// If it does, it returns it, otherwise dies with a warning.
-function validate_projectID($param_name, $value, $allownull = false)
-{
-    try
-    {
-        return ex_validate_projectID($param_name, $value, $allownull);
-    }
-    catch(InvalidProjectIDException $exception)
-    {
-        die($exception->getMessage());
-    }
-}
-
-// Checks if $value has the form of a valid project ID, either in its
-// long form (projectID####) or just the project number (####).
 // If it does, it returns it, otherwise throws an exception.
-// this is intended to replace validate_projectID()
-function ex_validate_projectID($param_name, $value, $allownull = false)
+function validate_projectID($param_name, $value, $allownull = false)
 {
     if (!isset($value) && $allownull)
         return null;
@@ -794,8 +778,8 @@ function ex_validate_projectID($param_name, $value, $allownull = false)
         return "projectID$value";
     throw new InvalidProjectIDException(sprintf(
         _("The value of parameter '%1\$s' ('%2\$s') is not a valid projectID."),
-        html_safe($param_name),
-        html_safe($value)
+        $param_name,
+        $value
     ));
 }
 

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -9,6 +9,7 @@ include_once($relPath.'MARCRecord.inc');
 include_once($relPath.'stages.inc'); // is_formatting_round()
 
 class NonexistentProjectException extends Exception { }
+class InvalidProjectIDException extends Exception { }
 
 class Project
 {
@@ -769,13 +770,29 @@ function does_project_page_table_exist($projectid)
 // If it does, it returns it, otherwise dies with a warning.
 function validate_projectID($param_name, $value, $allownull = false)
 {
+    try
+    {
+        return ex_validate_projectID($param_name, $value, $allownull);
+    }
+    catch(InvalidProjectIDException $exception)
+    {
+        die($exception->getMessage());
+    }
+}
+
+// Checks if $value has the form of a valid project ID, either in its
+// long form (projectID####) or just the project number (####).
+// If it does, it returns it, otherwise throws an exception.
+// this is intended to replace validate_projectID()
+function ex_validate_projectID($param_name, $value, $allownull = false)
+{
     if (!isset($value) && $allownull)
         return null;
     if (1 == preg_match('/^projectID[0-9a-f]{13}$/', $value))
         return $value;
     if (1 == preg_match('/^[0-9a-f]{13}$/', $value))
         return "projectID$value";
-    die(sprintf(
+    throw new InvalidProjectIDException(sprintf(
         _("The value of parameter '%1\$s' ('%2\$s') is not a valid projectID."),
         html_safe($param_name),
         html_safe($value)

--- a/pinc/project_continuity.inc
+++ b/pinc/project_continuity.inc
@@ -39,9 +39,7 @@ function project_continuity_test($projectid, $orig_state, $no_more_pages)
     }
     catch(NonexistentProjectException $exception)
     {
-        return sprintf(
-            _("There is no project with projectid='%s'."),
-                   $projectid );
+        return $exception->getMessage();
     }
 
     $curr_state = $project->state;

--- a/project.php
+++ b/project.php
@@ -52,7 +52,14 @@ $detail_level   = get_integer_param($_GET, 'detail_level', $DEFAULT_DETAIL_LEVEL
 
 // -----------------------------------------------------------------------------
 
-$project = new Project( $projectid );
+try
+{
+    $project = new Project( $projectid );
+}
+catch(NonexistentProjectException $exception)
+{
+    die($exception->getMessage());
+}
 
 // TRANSLATORS: this is the project page title.
 // In a tabbed browser, the page-title passed to output_header() will appear

--- a/project.php
+++ b/project.php
@@ -46,17 +46,15 @@ $MAX_DETAIL_LEVEL = 4;
 $DEFAULT_DETAIL_LEVEL = 3;
 
 // Validate all the input
-$projectid      = validate_projectID('id', @$_GET['id']);
-$expected_state = get_enumerated_param($_GET, 'expected_state', null, $PROJECT_STATES_IN_ORDER, true);
-$detail_level   = get_integer_param($_GET, 'detail_level', $DEFAULT_DETAIL_LEVEL, $MIN_DETAIL_LEVEL, $MAX_DETAIL_LEVEL);
-
-// -----------------------------------------------------------------------------
-
 try
 {
+    $projectid = ex_validate_projectID('id', @$_GET['id']);
+    $expected_state = get_enumerated_param($_GET, 'expected_state', null, $PROJECT_STATES_IN_ORDER, true);
+    $detail_level   = get_integer_param($_GET, 'detail_level', $DEFAULT_DETAIL_LEVEL, $MIN_DETAIL_LEVEL, $MAX_DETAIL_LEVEL);
+
     $project = new Project( $projectid );
 }
-catch(NonexistentProjectException $exception)
+catch(Exception $exception)
 {
     die($exception->getMessage());
 }

--- a/project.php
+++ b/project.php
@@ -46,18 +46,11 @@ $MAX_DETAIL_LEVEL = 4;
 $DEFAULT_DETAIL_LEVEL = 3;
 
 // Validate all the input
-try
-{
-    $projectid = ex_validate_projectID('id', @$_GET['id']);
-    $expected_state = get_enumerated_param($_GET, 'expected_state', null, $PROJECT_STATES_IN_ORDER, true);
-    $detail_level   = get_integer_param($_GET, 'detail_level', $DEFAULT_DETAIL_LEVEL, $MIN_DETAIL_LEVEL, $MAX_DETAIL_LEVEL);
+$projectid = validate_projectID('id', @$_GET['id']);
+$expected_state = get_enumerated_param($_GET, 'expected_state', null, $PROJECT_STATES_IN_ORDER, true);
+$detail_level   = get_integer_param($_GET, 'detail_level', $DEFAULT_DETAIL_LEVEL, $MIN_DETAIL_LEVEL, $MAX_DETAIL_LEVEL);
 
-    $project = new Project( $projectid );
-}
-catch(Exception $exception)
-{
-    die($exception->getMessage());
-}
+$project = new Project( $projectid );
 
 // TRANSLATORS: this is the project page title.
 // In a tabbed browser, the page-title passed to output_header() will appear

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -46,8 +46,7 @@ if(!count($error_messages)) {
     }
     catch(NonexistentProjectException $exception)
     {
-        $error_messages[] = sprintf(_("no project with projectID '%s'"),
-            html_safe($projectid));
+        $error_messages[] = $exception->getMessage();
     }
 }
 

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -39,12 +39,12 @@ else
 {
     try
     {
-        $projectid = ex_validate_projectID('projectid', $projectid);
+        $projectid = validate_projectID('projectid', $projectid);
         $project = new Project($projectid);
     }
     catch(Exception $exception)
     {
-        $error_messages[] = $exception->getMessage();
+        $error_messages[] = html_safe($exception->getMessage());
     }
 }
 

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -31,20 +31,18 @@ if(isset($_GET["reset"])) {
 
 
 // If the projectID looks to be of roughly the right format, see if it exists.
-if($projectid=="") {
+if($projectid=="")
+{
     $error_messages[] = _("select a project");
-} elseif (!preg_match('/^projectID[0-9a-f]{13}$/', $projectid ) ) {
-    $error_messages[] = sprintf(_("projectID '%s' does not appear to be valid"),
-        html_safe($projectid));
 }
-
-// See if the projectID exists in the projects table
-if(!count($error_messages)) {
+else
+{
     try
     {
+        $projectid = ex_validate_projectID('projectid', $projectid);
         $project = new Project($projectid);
     }
-    catch(NonexistentProjectException $exception)
+    catch(Exception $exception)
     {
         $error_messages[] = $exception->getMessage();
     }

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -321,7 +321,8 @@ class ProjectInfoHolder
         }
         catch(NonexistentProjectException $exception)
         {
-            return sprintf(_("parameter '%s' is invalid"), 'project') . ": '$projectid'";
+            // should never get here because user_can_edit_project() catches PROJECT_DOES_NOT_EXIST
+            return $exception->getMessage();
         }
 
         $this->nameofwork       = $project->nameofwork;


### PR DESCRIPTION
The motivation for this is to avoid duplicating the projectID regex, and also to move any text output associated with handling errors up to the top level in order to facilitate eventual implementation of an api.