### PR TITLE
Normalise whitespace characters in searches

### DIFF
--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -140,6 +140,8 @@ class ProjectSearchWidget
             }
             elseif ( $comparator == 'LIKE' )
             {
+                $value = normalize_whitespace($value);
+
                 $contribution = "$column_name LIKE '%$value%'";
             }
         }

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -446,6 +446,27 @@ function javascript_safe($str, $encoding=NULL)
 
 // -----------------------------------------------------------------------------
 
+function normalize_whitespace($str)
+// Return a string with normalized whitespace characters.
+//
+// Example usage:
+//   echo normalize_whitespace("William  Shakespeare");
+//   echo normalize_whitespace("William Shakespeare ");
+//   echo normalize_whitespace(" William Shakespeare");
+//   echo normalize_whitespace("\tWilliam\tShakespeare\t");
+//
+//   They all return "William Shakespeare".
+//
+//
+// Replaces each run of whitespace characters with a single space and
+//   strips the resulting string.
+{
+    return trim(preg_replace('/\s+/', ' ', $str));
+}
+
+
+// -----------------------------------------------------------------------------
+
 // Safely encode a string for use in an XML document.
 function xmlencode($string)
 {

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -28,7 +28,7 @@ if (!empty($uname)) {
     {
         $where_clause = sprintf("
             WHERE username LIKE '%%%s%%'
-        ", addcslashes(mysqli_real_escape_string(DPDatabase::get_connection(), $uname), "%_"));
+        ", addcslashes(mysqli_real_escape_string(DPDatabase::get_connection(), normalize_whitespace($uname)), "%_"));
     }
 
     $mResult = mysqli_query(DPDatabase::get_connection(), "

--- a/stats/teams/tlist.php
+++ b/stats/teams/tlist.php
@@ -16,15 +16,15 @@ $texact = array_get($_REQUEST, 'texact', null);
 $tstart = get_integer_param( $_GET, 'tstart', 0, 0, null );
 
 if ($tname) {
-    if ($texact)
+    if ($texact == 'yes')
     {
         $where_body = sprintf("teamname='%s'",
-            mysqli_real_escape_string(DPDatabase::get_connection(), $tname));
+            mysqli_real_escape_string(DPDatabase::get_connection(), normalize_whitespace($tname)));
     }
     else
     {
         $where_body = sprintf("teamname LIKE '%%%s%%'",
-            mysqli_real_escape_string(DPDatabase::get_connection(), $tname));
+            mysqli_real_escape_string(DPDatabase::get_connection(), normalize_whitespace($tname)));
     }
 
     $tResult = select_from_teams($where_body, "ORDER BY $order $direction LIMIT $tstart,20");

--- a/tasks.php
+++ b/tasks.php
@@ -364,7 +364,7 @@ function SearchParams_get_sql_condition($request_params)
     $condition = "1";
     if(isset($request_params['search_text']))
     {
-        $search_text = $request_params['search_text'];
+        $search_text = normalize_whitespace($request_params['search_text']);
         if ($testing)
             echo_html_comment("\$request_params['search_text'] = $search_text");
 


### PR DESCRIPTION
Creates a new `search_safe` function that replaces each run of whitespace characters with a single space. It normalises tabs to a single space, multiple spaces to a single space etc.

## Testing

Code is live here: https://www.pgdp.org/~mlazaric/c/

#### Member Search
 - Uses `search_safe` when exact search is not checked: 
https://www.pgdp.org/~mlazaric/c/stats/members/mbr_list.php?uname=+++++test+++&uexact=no
 - Doesn't use `search_safe` when exact search is checked: 
https://www.pgdp.org/~mlazaric/c/stats/members/mbr_list.php?uname=+++++test+++&uexact=yes

#### Team Search
 - Always uses `search_safe`: 
https://www.pgdp.org/~mlazaric/c/stats/teams/tlist.php?tname=+++++test+++&texact=no
https://www.pgdp.org/~mlazaric/c/stats/teams/tlist.php?tname=+++++test+++&texact=yes
https://www.pgdp.org/~mlazaric/c/stats/teams/tlist.php?tname=+++++Aussies+++&texact=yes

#### Task Search
 - Always uses `search_safe`: 
https://www.pgdp.org/~mlazaric/c/tasks.php?action=search&search_text=+++++test+++

#### Project Search
 - Always uses `search_safe`:
https://www.pgdp.org/~mlazaric/c/tools/search.php?show=search&title=+++++test+++
https://www.pgdp.org/~mlazaric/c/tools/search.php?show=search&author=+++++test+++
https://www.pgdp.org/~mlazaric/c/tools/search.php?show=search&project_manager=+++++test+++
https://www.pgdp.org/~mlazaric/c/tools/search.php?show=search&checkedoutby=+++++test+++
https://www.pgdp.org/~mlazaric/c/tools/search.php?show=search&pp_er=+++++srj+++
https://www.pgdp.org/~mlazaric/c/tools/search.php?show=search&ppv_er=+++++e+++

## Related task:
  - https://www.pgdp.net/c/tasks.php?task_id=828