### PR TITLE
Prepare to cut the 201903 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -4,7 +4,7 @@ Major changes to this project are documented here. For minor changes,
 see the git history.
 
 
-## R??????
+## R201903
 Scripts supporting this upgrade are in `SETUP/upgrade/12`
 
 * Support Ubuntu 16.04 middleware (cpeel)
@@ -16,6 +16,15 @@ Scripts supporting this upgrade are in `SETUP/upgrade/12`
   language-specific subdirectories under `faq/` (cpeel)
 * Large file uploads in `remote_file_manager.php` (cpeel)
 * View page differences without formatting (70ray)
+* Cleanup of users table (cpeel)
+* Task Center updates (mlazaric)
+* RSS feed improvements (mlazaric)
+* Smooth Reading transition updates and notifications (mlazaric)
+* DPCustomMono2 available as a web font (cpeel)
+* Gravatar support (cpeel)
+* User registrations ask about how they found the site (cpeel)
+* Server time now displayed on PM page (70ray)
+* My Project links no longer reuse windows (70ray)
 
 
 _Usernames below this point refer to SourceForge usernames, rather than

--- a/SETUP/installation.txt
+++ b/SETUP/installation.txt
@@ -423,6 +423,7 @@ newer release of the DP code.
             c/SETUP/upgrade/09/
             c/SETUP/upgrade/10/
             c/SETUP/upgrade/11/
+            c/SETUP/upgrade/12/
         (in that order!)
 
     --- If your old installation was release 1.5:
@@ -433,6 +434,7 @@ newer release of the DP code.
             c/SETUP/upgrade/09/
             c/SETUP/upgrade/10/
             c/SETUP/upgrade/11/
+            c/SETUP/upgrade/12/
 
     --- If your old installation was release 1.6:
         You need to run the scripts in
@@ -441,6 +443,7 @@ newer release of the DP code.
             c/SETUP/upgrade/09/
             c/SETUP/upgrade/10/
             c/SETUP/upgrade/11/
+            c/SETUP/upgrade/12/
 
     --- If your old installation was release R200609
         You need to run the scripts in
@@ -448,21 +451,29 @@ newer release of the DP code.
             c/SETUP/upgrade/09/
             c/SETUP/upgrade/10/
             c/SETUP/upgrade/11/
+            c/SETUP/upgrade/12/
 
     --- If your old installation was release R201601
         You need to run the scripts in
             c/SETUP/upgrade/09/
             c/SETUP/upgrade/10/
             c/SETUP/upgrade/11/
+            c/SETUP/upgrade/12/
 
     --- If your old installation was release R201701
         You need to run the scripts in
             c/SETUP/upgrade/10/
             c/SETUP/upgrade/11/
+            c/SETUP/upgrade/12/
 
     --- If your old installation was release R201707
         You need to run the scripts in
             c/SETUP/upgrade/11/
+            c/SETUP/upgrade/12/
+
+    --- If your old installation was release R201802
+        You need to run the scripts in
+            c/SETUP/upgrade/12/
 
     To run the upgrade scripts, you must cd into the directory and invoke the
     scripts from there. E.g.:


### PR DESCRIPTION
Documentation updates for the 201903 release. I've confirmed that the DB schema upgrades are correct, we just need to update the docs and cut the release.