### PR TITLE
Genre translated and sorted

### DIFF
--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -210,6 +210,7 @@ class ProjectSearchForm
         global $relPath;
         include($relPath.'genres.inc');
 
+        asort($GENRES, SORT_LOCALE_STRING);
         return array_merge( array( '' => _('Any') ), $GENRES );
     }
 

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -9,6 +9,7 @@ include_once($relPath.'ProjectSearchResultsConfig.inc');
 include_once($relPath.'forum_interface.inc'); // get_topic_details() & get_url_to_view_topic()
 include_once($relPath.'misc.inc'); // array_get()
 include_once($relPath.'pg.inc'); // get_pg_catalog_url_for_etext
+include_once($relPath.'genre_table.inc');
 
 class Column
 {
@@ -217,7 +218,7 @@ class GenreColumn extends Column
             "easy"      => _("EASY"),
             "hard"      => _("HARD")
         );
-        $genre = $project->genre;
+        $genre = $project->trans_genre;
         $prefix = $diff_prefix[$project->difficulty];
         if($prefix != "")
             $genre = $prefix." ".$genre;
@@ -403,7 +404,7 @@ class ColumnData
             new Column("author", _('Author'), '', 'left-align', true, true, 'authorsname'),
             new Column("projectid", _('Project ID'), '', 'left-align', false, true, 'projectid'),
             new Column("language", _("Language"), '', 'left-align', false, true, 'language'),
-            new GenreColumn("genre", _("Genre"), '', 'left-align', true, true, 'genre'),
+            new GenreColumn("genre", _("Genre"), '', 'left-align', true, true, 'trans_genre'),
             new LinkColumn("project_manager", pgettext("project manager", "PM"), _('Project Manager'), 'left-align', true, true, 'username'),
             new LinkColumn("checkedoutby", _('Checked Out By'), '', 'left-align', false, true, 'checkedoutby'),
             // TRANSLATORS: Abbreviation for Post Processor
@@ -435,6 +436,8 @@ class ProjectSearchResults
     {
         global $pguser;
 
+        create_genre_table();
+
         assert(($search_origin === 'PM') || ($search_origin === 'PS'));
 
         $this->userSettings =& Settings::get_Settings($pguser);
@@ -459,7 +462,6 @@ class ProjectSearchResults
         }
         $this->get_sorting();
     }
-
 
     private function results_navigator($numrows, $num_found_rows, $results_offset)
     {
@@ -557,9 +559,10 @@ class ProjectSearchResults
     {
         global $testing;
         $sql = "
-            SELECT SQL_CALC_FOUND_ROWS projects.*,
+            SELECT SQL_CALC_FOUND_ROWS projects.*, genres.trans_genre,
             project_holds.projectid IS NOT NULL AS hold
             FROM projects
+            JOIN genres ON projects.genre = genres.genre
             LEFT JOIN project_holds
             USING (projectid, state)
             WHERE $where_condition

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -90,7 +90,7 @@ function display_project_filter_form($filter_type, $filter_label, $data, $state_
     if($display_fields["genre"])
     {
         $genre_options = _load_project_filter_field_values("genre", $state_sql);
-        echo _build_project_filter_select(_("Genre"), _("All Genres"), "genre", $genre_options, @$data["genre"], $td_width);
+        echo _build_project_filter_select(_("Genre"), _("All Genres"), "genre", $genre_options, @$data["genre"], $td_width, TRUE);
     }
 
     if($display_fields["username"])
@@ -208,7 +208,7 @@ function maybe_update_project_filter($username, $filter_type, $data, $state_sql)
 
         // associative arrays are handled differently from non-associative ones
         $is_associative=FALSE;
-        if($field == "special_code" || $field=="difficulty")
+        if($field == "special_code" || $field=="difficulty" || $field=="genre")
             $is_associative=TRUE;
 
         $filter_segments=array();
@@ -449,7 +449,8 @@ function _load_project_filter_field_values($field, $state_sql)
             $query = "SELECT distinct language FROM projects WHERE ($state_sql) ORDER BY language";
             break;
         case "genre":
-            $query = "SELECT distinct genre FROM projects WHERE ($state_sql) ORDER BY genre";
+            $query = "SELECT distinct projects.genre, genres.trans_genre FROM projects NATURAL JOIN genres WHERE ($state_sql) ORDER BY trans_genre";
+            $load_associative = TRUE;
             break;
         case "special_code":
             $query = "

--- a/pinc/genre_table.inc
+++ b/pinc/genre_table.inc
@@ -1,0 +1,28 @@
+<?php
+include_once($relPath.'genres.inc');
+
+function create_genre_table()
+{
+    $sql = "
+    CREATE TEMPORARY TABLE genres
+    (
+        genre VARCHAR(25) NOT NULL,
+        trans_genre VARCHAR(50) NOT NULL,
+
+        PRIMARY KEY (genre)
+    )
+    ";
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    $link = DPDatabase::get_connection();
+    mysqli_query($link, $sql);
+
+    global $GENRES;
+    foreach($GENRES as $key => $value)
+    {
+        $key = mysqli_real_escape_string($link, $key);
+        $value = mysqli_real_escape_string($link, $value);
+        $sql = "INSERT INTO genres SET genre = '$key', trans_genre = '$value'";
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+        mysqli_query($link, $sql);
+    }
+}

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -381,10 +381,12 @@ function show_project_listing(
 
     // Build and execute the query against the projects table.
     $query = "
-        SELECT *,
+        SELECT nameofwork, authorsname, language, username, projects.projectid,
+            special_code, state, genres.trans_genre AS genre, difficulty,
+            checkedoutby, n_pages, n_available_pages, postproofer, correctedby,
             (unix_timestamp()    - modifieddate    )/(24 * 60 * 60) AS days_avail,
             (smoothread_deadline - unix_timestamp())/(24 * 60 * 60) AS days_left
-        FROM projects
+        FROM projects NATURAL JOIN genres
         $optional_join_clause
         WHERE
             $filtered_project_selector
@@ -392,6 +394,7 @@ function show_project_listing(
             $presort
             $curr_sql_orderclause
     ";
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
     $result = mysqli_query(DPDatabase::get_connection(), $query);
 
     if( is_a( $stage, 'Round' ) )

--- a/tools/pool.php
+++ b/tools/pool.php
@@ -8,8 +8,12 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'site_news.inc');
 include_once($relPath.'showavailablebooks.inc');
 include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'genre_table.inc'); // create_genre_table()
 
 require_login();
+
+// for translating and sorting genres
+create_genre_table();
 
 $pool_id = get_enumerated_param($_GET, 'pool_id', null, array_keys($Pool_for_id_));
 

--- a/tools/post_proofers/smooth_reading.php
+++ b/tools/post_proofers/smooth_reading.php
@@ -7,8 +7,12 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'site_news.inc');
 include_once($relPath.'showavailablebooks.inc');
+include_once($relPath.'genre_table.inc'); // create_genre_table()
 
 // ---------------------------------------
+// for translating and sorting genres
+create_genre_table();
+
 //Page construction varies with whether the user is logged in or out
 if (isset($GLOBALS['pguser'])) { $logged_in = TRUE;} else { $logged_in = FALSE;}
 

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -14,8 +14,12 @@ include_once($relPath.'site_news.inc');
 include_once($relPath.'mentorbanner.inc');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'faq.inc');
+include_once($relPath.'genre_table.inc'); // create_genre_table()
 
 require_login();
+
+// for translating and sorting genres
+create_genre_table();
 
 $round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_));
 $round = get_Round_for_round_id($round_id);


### PR DESCRIPTION
in PM, project search, round, pool and SR pages
using temporay genre translation table.
It was necessary to create a genre table to get the sorting right in the sql queries. I've used a temporary table but perhaps it would be better to make permanent tables and use the appropriate one.
In the project search the 'trans_genre' result is used directly, but in 'showavailablebooks' it seemed difficult to disentangle how the word 'genre' was being used so I aliased the translated result to 'genre' which meant having to write in the result fields expicitly instead of using *.