### PR TITLE
Set minimum PHP version to 7.0

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -4,6 +4,12 @@ Major changes to this project are documented here. For minor changes,
 see the git history.
 
 
+## R??????
+Scripts supporting this upgrade are in `SETUP/upgrade/13`
+
+* Updated minimum PHP version to 7.0 (cpeel)
+
+
 ## R201903
 Scripts supporting this upgrade are in `SETUP/upgrade/12`
 

--- a/SETUP/installation.txt
+++ b/SETUP/installation.txt
@@ -17,14 +17,11 @@ The following lists supported versions for the four primary middleware
 components.
 
 PHP
-    PHP version 5.3.2 is the minimum version supported, although any
-    version >= 5.3.2 should work.
-
-    PHP version 7.0 is supported. 7.1 and later should work but have
-    not been tested.
+    PHP version 7.0 is the minimum supported version. 7.1 and later should
+    work but have not been tested.
 
 MySQL
-    MySQL version 5.5 and later is recommended.
+    MySQL version 5.5 or later is recommended.
     Versions 5.1 and later may work but are untested.
 
     MariaDB version 5.5 and later should also work but has not been tested.
@@ -50,11 +47,11 @@ jpgraph
 
 
 These middleware components match the following major distribution releases:
-* Ubuntu 12.04, Precise
-* Ubuntu 14.04, Trusty
+* Ubuntu 14.04, Trusty (with PHP 7.0 upgrade)
 * Ubuntu 16.04, Xenial
-* RHEL / CentOS 6.x family
-* RHEL / CentOS 7.x family
+* Ubuntu 18.04, Bionic
+* RHEL / CentOS 6.x family (with PHP 7.0 upgrade)
+* RHEL / CentOS 7.x family (with PHP 7.0 upgrade)
 
 =======================================================================
 Installing from scratch

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -28,8 +28,6 @@ include_once($relPath.'site_vars.php');
 // Register autoloader
 spl_autoload_register('dp_class_autoloader');
 
-undo_all_magic_quotes();
-
 // If we're not testing, whitewash any uncaught exceptions
 if(!$testing)
 {
@@ -136,51 +134,6 @@ function dp_class_autoloader($class)
     {
         include_once($relPath.$class."Class.inc");
     }
-}
-
-function undo_all_magic_quotes()
-// Detect if magic_quotes_gpc is enabled, and if so strip the slashes from
-// all magic-quoted variables to return them to their pre-escaped form.
-//
-// NOTE: Using this function requires you to do appropriate escaping when
-// outputting variables in SQL and HTML. ie:
-// Code like the following relies on magic_quotes_gpc being on:
-//    $x = $_GET['x'];
-//    $res = mysqli_query(DPDatabase::get_connection(), "... WHERE x = '$x'");
-// Whereas the following works the same regardless of how magic_quotes_gpc
-// is set...
-//    undo_all_magic_quotes();
-//    $x = $_GET['x'];
-//    $res = mysqli_query(DPDatabase::get_connection(),
-//               sprintf("... WHERE x = '%s'", mysqli_real_escape_string(DPDatabase::get_connection(), $x))
-//    );
-{
-    static $already_undone = FALSE;
-
-    if (!$already_undone && get_magic_quotes_gpc())
-    {
-        stripslashes_arr_inplace($_GET);
-        stripslashes_arr_inplace($_POST);
-        stripslashes_arr_inplace($_COOKIE);
-        stripslashes_arr_inplace($_REQUEST);
-        // Also the deprecated $HTTP_* vars, but we don't use them.
-        // In PHP 4, $_ENV too, but we don't use it.
-    }
-
-    $already_undone = TRUE;
-}
-
-function stripslashes_arr_inplace(&$value, $key = NULL)
-// Run stripslashes on an array that may contain other arrays.
-// For space efficiency it changes the values in-place by taking the
-// first param as a reference.
-{
-    if(is_array($value))
-        array_walk($value, 'stripslashes_arr_inplace');
-    else
-        $value = stripslashes($value);
-
-    // no need to return $value as it was passed by reference
 }
 
 // vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
The new minimum PHP version going forward is 7.0. This obviates the need for `undo_all_magic_quotes()` since magic quotes do not function after PHP 5.3.

Tagging all active developers to make sure everyone is aware of this change.