### PR TITLE
Update tests to work with phpunit >=5.7 and <8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: php
+php:
+    # Test on a wide array of PHP versions. 7.3 and later can't be added until
+    # the phpunit tests are updated and a more recent version of phpunit is
+    # specified below.
+    - 7.0
+    - 7.1
+    - 7.2
 services:
     - mysql
 before_install:
@@ -10,6 +17,12 @@ install:
     - cd SETUP
     - php install_db.php
     - cd ..
+before_script:
+    # our phpunit tests won't work with phpunit8 (see SETUP/tests/README.md)
+    # so specify a version that works with php 7.0, 7.1, 7.2 (see
+    # https://phpunit.de/supported-versions.html)
+    - curl -sSfL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-6.phar
+    - phpunit --version
 script:
     # linting is SUCH a low bar, but it is a bar!
     - ./SETUP/lint_php_files.sh

--- a/SETUP/tests/MARCRecordTest.php
+++ b/SETUP/tests/MARCRecordTest.php
@@ -3,7 +3,7 @@
 /**
  * @backupGlobals disabled
  */
-class MARCRecordTest extends PHPUnit_Framework_TestCase
+class MARCRecordTest extends PHPUnit\Framework\TestCase
 {
     private $YAZ_ARRAY = NULL;
     private $YAZ_ARRAY_STR = NULL;
@@ -27,11 +27,13 @@ class MARCRecordTest extends PHPUnit_Framework_TestCase
     public function testEmptyConstructor()
     {
         $marc_record = new MARCRecord();
+        $this->assertEquals($marc_record->get_yaz_array(), array());
     }
 
     public function testLoadYazArray()
     {
         $marc_record = $this->_load_record();
+        $this->assertEquals($marc_record->get_yaz_array(), $this->YAZ_ARRAY);
     }
 
     public function testGetTitle()

--- a/SETUP/tests/NonactivatedUserTest.php
+++ b/SETUP/tests/NonactivatedUserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class NonactivatedUserTest extends PHPUnit_Framework_TestCase
+class NonactivatedUserTest extends PHPUnit\Framework\TestCase
 {
     private $TEST_USERNAME = "NonactivatedUserTest_php";
     private $createdRecords = array();
@@ -36,11 +36,13 @@ class NonactivatedUserTest extends PHPUnit_Framework_TestCase
     public function testEmptyConstructor()
     {
         $user = new NonactivatedUser();
+        $this->assertFalse(isset($user->id));
     }
 
     public function testCreateRegistration()
     {
-        $this->createNonactivatedUser($this->TEST_USERNAME);
+        $user = $this->createNonactivatedUser($this->TEST_USERNAME);
+        $this->assertEquals($user->username, $this->TEST_USERNAME);
     }
 
     public function testLoadRegistration()

--- a/SETUP/tests/PageCompareTest.php
+++ b/SETUP/tests/PageCompareTest.php
@@ -2,13 +2,8 @@
 $relPath='../../pinc/';
 include_once($relPath."PageUnformatter.inc"); // PageUnformatter()
 
-class PageCompareTest extends PHPUnit_Framework_TestCase
+class PageCompareTest extends PHPUnit\Framework\TestCase
 {
-    public function testEmptyConstructor()
-    {
-        $un_formatter = new PageUnformatter();
-    }
-
     /**
      * @dataProvider textProvider
      */

--- a/SETUP/tests/README.md
+++ b/SETUP/tests/README.md
@@ -1,7 +1,23 @@
+# Unit tests
+
 These are phpunit tests.
 
-To run them, use the phpunit_bootstrap.php file:
+## Version requirements
+
+The phpunit tests, as-coded, will work with phpunit 5.7, 6.x, and 7.x. They
+will not work in 8.x or later because the setUp() and tearDown() functions
+do not specify void return types. (See the
+[phpunit8 release notes](https://phpunit.de/announcements/phpunit-8.html).)
+That capability isn't available until PHP 7.1, which the DP code will
+nominally work with, but isn't available on the TEST server or in many
+modern distros.
+
+## Running tests
+
+To run them, use the `phpunit_bootstrap.php` file to pull in pre-requisits.
+
     phpunit --bootstrap phpunit_bootstrap.php --verbose .
 
 To run the page compare test only:
+
     phpunit PageCompareTest.php

--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SettingsTest extends PHPUnit_Framework_TestCase
+class SettingsTest extends PHPUnit\Framework\TestCase
 {
     private $TEST_USERNAME = 'SettingsTest_php';
     private $PREFIX = 'STU_';
@@ -145,12 +145,14 @@ class SettingsTest extends PHPUnit_Framework_TestCase
     {
         // Note: calling get_value() on a multi-valued setting use to result
         // in a RuntimeException being thrown, but commit 68ecf5 changed that.
+        // Instead we return one of them.
 
         $settings = new Settings($this->TEST_USERNAME);
         $settings->add_value($this->PREFIX . "multi_value", "value1");
         $settings->add_value($this->PREFIX . "multi_value", "value2");
 
-        $settings->get_value($this->PREFIX . "multi_value");
+        $values = $settings->get_value($this->PREFIX . "multi_value");
+        $this->assertTrue(in_array($values, array("value1", "value2")));
     }
 
     public function testSetMultivaluedSettingAsSingle()

--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserTest extends PHPUnit_Framework_TestCase
+class UserTest extends PHPUnit\Framework\TestCase
 {
     private $TEST_USERNAME = "UserTest_php";
     private $NONTEST_USERNAME = 'blahblahblah';
@@ -53,11 +53,13 @@ class UserTest extends PHPUnit_Framework_TestCase
     public function testEmptyConstructor()
     {
         $user = new User();
+        $this->assertTrue(!isset($user->username));
     }
 
     public function testNonemptyConstructor()
     {
         $user = new User($this->TEST_USERNAME);
+        $this->assertTrue(isset($user->username));
     }
 
     public function testValidateValidUserStrict()
@@ -145,12 +147,14 @@ class UserTest extends PHPUnit_Framework_TestCase
     {
         $user = new User();
         $user->team_1 = 1;
+        $this->assertEquals($user->team_1, 1);
     }
 
     public function testSetNewImmutable()
     {
         $user = new User();
         $user->username = "blah";
+        $this->assertEquals($user->username, "blah");
     }
 
     /**

--- a/SETUP/tests/misc_ParamValidatorTest.php
+++ b/SETUP/tests/misc_ParamValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ParamValidatorTest extends PHPUnit_Framework_TestCase
+class ParamValidatorTest extends PHPUnit\Framework\TestCase
 {
     private $GET = array(
         "enum" => "a",
@@ -145,6 +145,7 @@ class ParamValidatorTest extends PHPUnit_Framework_TestCase
         $min = 0;
         $max = 100;
         $result = get_float_param($this->GET, 'i10', $default, $min, $max);
+        $this->assertEquals($this->GET['i10'], $result);
     }
 
     public function testFloatDefault()


### PR DESCRIPTION
Our phpunit tests were created against phpunit4. phpunit6 introduced an updated, and backwards-incompatiable, namespace which was backported to phpunit5.7 (the last phpunit release to support PHP 5.x). This commit updates our tests to work with phpunit 5.7, 6.x, and 7.x.

phpunit6 also started flagging tests that did not do useful asserts as "risky", which they are since tests should assert that something useful was validated.

As part of this, I've updated the version of phpunit on the TEST server in `/usr/bin/phpunit` to be phpunit6 (was phpunit4). phpunit6 is the last to support PHP 7.0 which is what the TEST server is running. And if you are getting a headache trying to keep all of this in your head, you're not alone.