### PR TITLE
fixes for two bugs and diagnostic die added

### DIFF
--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -309,7 +309,7 @@ class ProjectSearchForm
                 'type'       => 'select',
                 'options'    => $this->_get_options_genre(),
                 'can_be_multiple' => TRUE,
-                'q_contrib'  => array('genre', '='),
+                'q_contrib'  => array('projects.genre', '='),
             )),
             new ProjectSearchWidget( array(
                 'id'         => 'difficulty',

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -89,7 +89,6 @@ function display_project_filter_form($filter_type, $filter_label, $data, $state_
 
     if($display_fields["genre"])
     {
-        maybe_create_temporary_genre_translation_table();
         $genre_options = _load_project_filter_field_values("genre", $state_sql);
         echo _build_project_filter_select(_("Genre"), _("All Genres"), "genre", $genre_options, @$data["genre"], $td_width, TRUE);
     }
@@ -450,6 +449,7 @@ function _load_project_filter_field_values($field, $state_sql)
             $query = "SELECT distinct language FROM projects WHERE ($state_sql) ORDER BY language";
             break;
         case "genre":
+            maybe_create_temporary_genre_translation_table();
             $query = "SELECT distinct projects.genre, genre_translations.trans_genre FROM projects NATURAL JOIN genre_translations WHERE ($state_sql) ORDER BY trans_genre";
             $load_associative = TRUE;
             break;
@@ -477,7 +477,7 @@ function _load_project_filter_field_values($field, $state_sql)
 
     $return = array();
 
-    $result = mysqli_query(DPDatabase::get_connection(), $query);
+    $result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
     while ($a_res = @mysqli_fetch_row($result))
     {
         if($load_associative)

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -404,7 +404,7 @@ function show_project_listing(
     {
         echo_html_comment($query);
     }
-    $result = mysqli_query(DPDatabase::get_connection(), $query);
+    $result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
 
     if( is_a( $stage, 'Round' ) )
     {


### PR DESCRIPTION
Specify projects.genre in ProjectSearchForm.inc
to avoid ambiguous genre.
Move maybe_create_temporary_genre_translation_table() in
filter_project_list so never avoided.