### PR TITLE
Add language redirect for walkthrough

### DIFF
--- a/default.php
+++ b/default.php
@@ -7,6 +7,7 @@ include_once($relPath.'site_specific.inc');
 include_once($relPath.'showstartexts.inc');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'site_news.inc');
+include_once($relPath.'walkthrough.inc');
 
 output_header(_("Welcome"), True);
 $etext_limit = 10;
@@ -81,17 +82,17 @@ echo "\n"
 echo "<p>"
     . sprintf(
         _("It's easy to volunteer at Distributed Proofreaders. Simply <a href='%s'>register as a volunteer</a>. Once you've confirmed your registration by e-mail, you'll receive an introductory e-mail with basic instructions on how to log in and use the site. Then, you're ready to sign in and start learning to proofread or visit the smooth reading page to pick an e-book to read! Wherever you go, you'll find lots of information to help you get started."),
-        "$code_url/accounts/addproofer.php")
-    .
-        (
-            is_file("$dyn_dir/walkthrough/00_Main.htm")
-            ?   " " .
-                sprintf(
-                    _("Please try our <a href='%s'>Walkthrough</a> for a preview of the steps involved when proofreading on this site."),
-                    "$dyn_url/walkthrough/00_Main.htm")
-            : ""
-        )
-    . "</p>"
+        "$code_url/accounts/addproofer.php");
+
+$walkthrough_url = get_walkthrough_url();
+if($walkthrough_url)
+{
+    echo " " . sprintf(
+        _("Please try our <a href='%s'>Walkthrough</a> for a preview of the steps involved when proofreading on this site."),
+        $walkthrough_url);
+}
+
+echo "</p>"
     . "\n";
 
 echo "<p>"

--- a/pinc/walkthrough.inc
+++ b/pinc/walkthrough.inc
@@ -1,0 +1,24 @@
+<?php
+
+// SITE-SPECIFIC
+// Functions that deal with the walkthrough housed in $dyn_dir
+
+function get_walkthrough_url($langcode=NULL)
+{
+    global $dyn_dir, $dyn_url;
+
+    // if no langcode was passed in, try to get the user's language
+    if(!$langcode)
+        $langcode = substr(get_desired_language(), 0, 2);
+
+    // first try $langcode, then English
+    foreach(array($langcode, "en") as $langcode)
+    {
+        if(is_dir("$dyn_dir/walkthrough/$langcode"))
+        {
+            return "$dyn_url/walkthrough/$langcode";
+        }
+    }
+
+    return "";
+}


### PR DESCRIPTION
Now that the walkthrough is available in French, lets do some smart language redirection and set up a consistent per-language structure for possible future expansion.