### PR TITLE
Rename invalid filenames upon upload

### DIFF
--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -391,24 +391,13 @@ function handle_file_upload($file_info)
     // we don't have to worry about weird characters in $temporary_path.
 
     // Verify that what was uploaded is actually a zip archive
-    $zip_test_result = array();
-    $zip_retval = 0;
-
-    // /usr/bin/file
-    // -b: brief output
-    // -i: input file
-    // --: don't parse any further arguments starting with -/-- as options
-    $cmd = "/usr/bin/file -b -i -- " . escapeshellcmd($temporary_path);
-    exec($cmd, $zip_test_result, $zip_retval);
-    list($file_type) = explode(';', $zip_test_result[0], 2);
-    if ($file_type == 'application/x-zip' ||
-        $file_type == 'application/zip') {
+    // ensure that it's a valid zip
+    exec("zipinfo -1 " . escapeshellcmd($temporary_path), $zipinfo_output, $return_code);
+    if($return_code == 0) {
         show_message('info', _("OK: Valid zip file."));
     } else {
         fatal_error( _("File is not a valid zip file: removing it.") );
     }
-    // XXX /usr/bin/file only looks at the first few bytes of the file.
-    // Maybe we should check the whole file's integrity with 'unzip -t'.
 
     // if an antivirus scanner is installed and configured, scan the file
     if($antivirus_executable) {

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -374,9 +374,11 @@ function handle_file_upload($file_info)
     }
 
     if (!is_valid_filename($file_info['name'], "zip")) {
-        fatal_error( sprintf(_("Invalid filename: %s."), $file_info['name']) );
-        // (Alternatively, we could construct a name that *was* okay,
-        // and use that instead.)
+        // create a valid filename re-using the extension provided
+        $old_filename = $file_info['name'];
+        $path_parts = pathinfo($old_filename);
+        $file_info['name'] = preg_replace('/[^a-zA-Z0-9_-]/', '_', $path_parts['filename']) . "." . $path_parts["extension"];
+        echo "<p class='warning'>" . sprintf(_('File was renamed to "%1$s" because "%2$s" is not a valid filename'), $file_info['name'], $old_filename) . "</p>";
     }
 
     // Okay so far, now let's run some tests on the content of the file.
@@ -1369,7 +1371,7 @@ function is_valid_filename($filename, $restrict_extension=False)
     } else {
         // If we want to restrict filename extensions, '.'s aren't allowed in the
         // body of the filename, and the filename must end with '.ext'
-        $regexp = '/^[a-zA-Z_0-9][a-zA-Z_0-9-]{0,200}\.' . $restrict_extension . '$/';
+        $regexp = '/^[a-zA-Z_0-9][a-zA-Z_0-9-]{0,200}\.' . $restrict_extension . '$/i';
     }
 
     // The filename is valid if the regexp matches exactly once.


### PR DESCRIPTION
When using Remote File Manager to do uploads, rather than aborting an upload due to an invalid filename let's create a valid one instead. This fixes task 1662.

This PR also changes to `zipinfo` to validate that the file uploaded was a valid zip file. We use this in other places in the codebase already and it is more robust than `file`.