### PR TITLE
Define wfDebug() for MediaWiki diff code

### DIFF
--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -148,6 +148,14 @@ if(!class_exists("Xml")) {
     }
 }
 
+// MW code references wfDebug() in some places
+if(!function_exists("wfDebug")) {
+    function wfDebug($text, $dest='all', array $context=[]) {
+        // don't log any debug messages
+        return;
+    }
+}
+
 // Return URL to main CSS file
 function get_DifferenceEngine_css_files() {
     global $code_url;


### PR DESCRIPTION
The updated MediaWiki diff code in 1fe084781 uses the `wfDebug()`
function so we need to define it.