### PR TITLE
Add WordCheck unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
 services:
     - mysql
 before_install:
+    - sudo apt-get update
+    - sudo apt-get install -y aspell aspell-en
     - mysql -e "CREATE DATABASE dp_db CHARACTER SET LATIN1;"
     - mysql -e "GRANT ALL ON dp_db.* TO dp_user@localhost IDENTIFIED BY 'dp_password';"
     - ./SETUP/configure ./SETUP/tests/travis-ci_configuration.sh .

--- a/SETUP/tests/phpunit_bootstrap.php
+++ b/SETUP/tests/phpunit_bootstrap.php
@@ -3,3 +3,4 @@ global $relPath;
 $relPath='../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
+include_once($relPath.'wordcheck_engine.inc');

--- a/SETUP/tests/pinc_WordCheckEngineTest.php
+++ b/SETUP/tests/pinc_WordCheckEngineTest.php
@@ -1,0 +1,172 @@
+<?php
+
+class WordCheckEngineTest extends PHPUnit\Framework\TestCase
+{
+
+    private $TEXT1 = <<<EOTEXT
+Not until the twenty-fourth day of August, 1819,
+when less than a hundred soldiers of the Fifth
+United States Infantry disembarked opposite the
+towering height where a few years later rose the
+white walls of Fort Snelling, did the nation which
+was to rule assert its power. The event was, indeed,
+epochal. It not only marked a change in the sovereignty
+over the vast region, but it also made possible
+the development of those factors which were to bring
+about the great transformation.
+
+"double quotes" "single quotes" hyphenated-words
+
+a1l 1st 33rd
+
+EOTEXT;
+
+    protected function setUp()
+    {
+        global $aspell_temp_dir;
+        if(!is_dir($aspell_temp_dir))
+            mkdir($aspell_temp_dir);
+    }
+
+    public function testGetAllWordsInTextNoOffsets()
+    {
+        $words = get_all_words_in_text($this->TEXT1);
+        $this->assertEquals($words[0], "Not");
+        $this->assertEquals($words[89], "words");
+    }
+
+    public function testGetAllWordsInTextWithOffsets()
+    {
+        $words = get_all_words_in_text($this->TEXT1, TRUE);
+        $this->assertEquals($words[0], "Not");
+        $this->assertEquals($words[530], "words");
+    }
+
+    public function testGetDistinctWordsInTextSmall()
+    {
+        $words = get_distinct_words_in_text($this->TEXT1);
+        $this->assertEquals($words["of"], 4);
+        $this->assertEquals($words["words"], 1);
+    }
+
+    public function testGetDistinctWordsInTextLarge()
+    {
+        // We need to make $text large enough that the function uses
+        // the too-big function.
+        $multiplier = 100;
+        $text = '';
+        for($i=0; $i<$multiplier; $i++)
+            $text .= $this->TEXT1;
+
+        $words = get_distinct_words_in_text($text);
+        $this->assertEquals($words["of"], 4 * $multiplier);
+        $this->assertEquals($words["words"], 1 * $multiplier);
+    }
+
+    public function testGetDistinctWordsInTextArray()
+    {
+        $array_size = 100;
+        $text_array = array();
+        for($i=0; $i<$array_size; $i++)
+            $text_array[] = $this->TEXT1;
+
+        $words = get_distinct_words_in_text($text_array);
+        $this->assertEquals($words["of"], 4 * $array_size);
+        $this->assertEquals($words["words"], 1 * $array_size);
+    }
+
+    public function testGetBadWordsViaPattern()
+    {
+        $languages = [ "English" ];
+
+        $words = get_distinct_words_in_text($this->TEXT1);
+        $bad_words = get_bad_words_via_pattern($words, $languages);
+        $this->assertEquals(count($bad_words), 1);
+        $this->assertEquals($bad_words[0], "a1l");
+    }
+
+    public function testGetBadWordsForTextNoWordLists()
+    {
+        $languages = [ "English" ];
+
+        list($input_words_w_freq, $bad_words, $messages) =
+            get_bad_words_for_text($this->TEXT1, $languages);
+
+        $this->assertEquals(count($messages), 0);
+        $this->assertEquals(count($bad_words), 2);
+        $this->assertEquals($bad_words["Snelling"], WC_WORLD);
+        $this->assertEquals($bad_words["a1l"], WC_SITE);
+    }
+
+    public function testGetBadWordsForTextSiteWordList()
+    {
+        $languages = [ "English" ];
+
+        $word_lists = [
+            "site_bad" => [ "disembarked" ],
+            "site_good" =>  [ "Snelling" ],
+        ];
+
+        list($input_words_w_freq, $bad_words, $messages) =
+            get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
+
+        $this->assertEquals(count($messages), 0);
+        $this->assertEquals(count($bad_words), 2);
+        $this->assertEquals($bad_words["disembarked"], WC_SITE);
+        $this->assertEquals($bad_words["a1l"], WC_SITE);
+    }
+
+    public function testGetBadWordsForTextProjectWordList()
+    {
+        $languages = [ "English" ];
+
+        $word_lists = [
+            "project_bad" => [ "disembarked" ],
+            "project_good" =>  [ "Snelling" ],
+        ];
+
+        list($input_words_w_freq, $bad_words, $messages) =
+            get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
+
+        $this->assertEquals(count($messages), 0);
+        $this->assertEquals(count($bad_words), 2);
+        $this->assertEquals($bad_words["disembarked"], WC_PROJECT);
+        $this->assertEquals($bad_words["a1l"], WC_SITE);
+    }
+
+    public function testGetBadWordsForTextSiteAndProjectWordList()
+    {
+        $languages = [ "English" ];
+
+        $word_lists = [
+            "site_bad" => [ "disembarked" ],
+            "site_good" =>  [ "Snelling" ],
+            "project_bad" => [ "opposite" ],
+        ];
+
+        list($input_words_w_freq, $bad_words, $messages) =
+            get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
+
+        $this->assertEquals(count($messages), 0);
+        $this->assertEquals(count($bad_words), 3);
+        $this->assertEquals($bad_words["disembarked"], WC_SITE);
+        $this->assertEquals($bad_words["opposite"], WC_PROJECT);
+        $this->assertEquals($bad_words["a1l"], WC_SITE);
+    }
+
+    public function testGetBadWordsForTextAdhocWordList()
+    {
+        $languages = [ "English" ];
+
+        $word_lists = [
+            "adhoc_good" =>  [ "Snelling" ],
+        ];
+
+        list($input_words_w_freq, $bad_words, $messages) =
+            get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
+
+        $this->assertEquals(count($messages), 0);
+        $this->assertEquals(count($bad_words), 1);
+        $this->assertEquals($bad_words["a1l"], WC_SITE);
+    }
+}

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -7,6 +7,9 @@ include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------
 
+global $n_rounds, $Round_for_round_id_, $Round_for_round_number_,
+    $Round_for_project_state_, $Round_for_page_state_, $PAGE_STATES_IN_ORDER;
+
 $n_rounds = 0;
 $Round_for_round_id_      = array();
 $Round_for_round_number_  = array();

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -46,9 +46,8 @@ define('WC_PAGE',    4);
 //          This can be a string or an array of strings. If the latter, the
 //          strings are conceptually separated by whitespace.  (So it's never
 //          the case that a word begins in one string and ends in the next.)
-//   projectid - id of project, needed for temp filename
+//   projectid - id of project, needed for project languages
 //               and to load the custom dictionaries
-//   imagefile - image filename, needed for temp filename
 //   aux_languages - auxiliary language to check against
 //   adhoc_good_words - array of words to treat as good for this invocation only.
 //
@@ -63,7 +62,7 @@ define('WC_PAGE',    4);
 //         (if $which_result_values is 'LEVELS')
 //  -- an array: each value is the name of a language that was used
 //  -- an array: each value is a warning/error.
-function get_bad_words_for_text($text, $projectid, $imagefile, $aux_language, $adhoc_good_words, $which_result_values)
+function get_bad_words_for_text($text, $projectid, $aux_language, $adhoc_good_words, $which_result_values)
 {
     // Get the list of languages that we'll use.
     {
@@ -90,8 +89,7 @@ function get_bad_words_for_text($text, $projectid, $imagefile, $aux_language, $a
     // The world
     {
         list($external_bad_words, $messages) =
-            get_bad_words_via_external_checker(
-                $input_words_w_freq, $projectid, $imagefile, $languages);
+            get_bad_words_via_external_checker($input_words_w_freq, $languages);
         $acc->messages += $messages;
         $acc->add_bad_words($external_bad_words, WC_WORLD);
     }
@@ -217,9 +215,6 @@ class BadWordAccumulator
 // this implementation passes the text to aspell
 // Arguments:
 //   input_words_w_freq - an array whose keys are the distinct words of the input text
-//   projectid - id of projected, needed for temp filename
-//               and to load the custom dictionaries
-//   imagefile - image filename, needed for temp filename
 //   languages - array of languages, used to load aspell dictionary
 //               for those languages if available
 //
@@ -227,15 +222,14 @@ class BadWordAccumulator
 //       -- an array of misspelled words,
 //       -- an array of messages (errors/warnings)
 //
-function get_bad_words_via_external_checker($input_words_w_freq, $projectid, $imagefile, $languages)
+function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 {
     global $aspell_temp_dir;
     global $aspell_executable, $aspell_prefix, $charset;
 
     $messages = array();
 
-    $tmp_file_name = $projectid . $imagefile . ".txt";
-    $tmp_file_path = "$aspell_temp_dir/$tmp_file_name";
+    $tmp_file_path = tempnam($aspell_temp_dir, "pagetext-");
 
     $tmp_file_text = implode("\n", array_keys($input_words_w_freq));
     $wasWritten = file_put_contents($tmp_file_path, $tmp_file_text);

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -275,7 +275,7 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
                 //echo "<!-- aspell command: $aspell_command -->\n"; // Very useful for debugging
                 // run aspell
                 // "asr" stands for "aspell result"
-                $asr_text = `$aspell_command`;
+                $asr_text = trim(shell_exec($aspell_command));
                 $asr_text = str_replace(array("\r","\n"), array('',"[lf]"), $asr_text);
                 // build our list of possible misspellings
                 $misspellings[$langcode] = explode("[lf]", $asr_text);

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -378,27 +378,34 @@ function get_bad_words_via_pattern($input_words_w_freq, $langcode3s)
 
 // -----------------------------------------------------------------------------
 
-function load_site_good_words($langcode3)
+function load_site_good_words($langcode3s)
 {
-    $fileObject = get_site_word_file($langcode3, "good");
-
-    return load_word_list($fileObject->abs_path);
+    return _load_site_words("good", $langcode3s);
 }
 
-function load_site_bad_words($langcode3)
+function load_site_bad_words($langcode3s)
 {
-    $fileObject = get_site_word_file($langcode3, "bad");
-
-    return load_word_list($fileObject->abs_path);
+    return _load_site_words("bad", $langcode3s);
 }
 
-// -----------------------------------------------------------------------------
-
-function load_site_possible_bad_words($langcode3)
+function load_site_possible_bad_words($langcode3s)
 {
-    $fileObject = get_site_word_file($langcode3, "possible_bad");
+    return _load_site_words("possible_bad", $langcode3s);
+}
 
-    return load_word_list($fileObject->abs_path);
+function _load_site_words($type, $langcode3s)
+{
+    if(!is_array($langcode3s))
+        $langcode3s = array($langcode3s);
+
+    $words = [];
+    foreach($langcode3s as $langcode3)
+    {
+        $fileObject = get_site_word_file($langcode3, $type);
+        $words = array_merge($words, load_word_list($fileObject->abs_path));
+    }
+
+    return array_unique($words);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -612,52 +619,23 @@ function load_project_good_word_suggestions($projectid, $start_time=0)
 
 function load_site_good_words_given_project($projectid)
 {
-    // load project languages
-    $languages = array_unique(array_values(get_project_languages($projectid)));
-
-    // load site word lists for project languages
-    $words = array();
-    foreach($languages as $language) {
-        $langcode3 = langcode3_for_langname($language);
-        $words = array_merge($words, load_site_good_words($langcode3));
-    }
-    $words = array_unique($words);
-
-    return $words;
+    $languages = array_values(get_project_languages($projectid));
+    list($langcode3s, $messages) = get_langcode3s_for_languages($languages);
+    return load_site_good_words($langcode3s);
 }
 
 function load_site_bad_words_given_project($projectid)
 {
-    // load project languages
-    $languages = array_unique(array_values(get_project_languages($projectid)));
-
-    // load site word lists for project languages
-    $words = array();
-    foreach($languages as $language) {
-        $langcode3 = langcode3_for_langname($language);
-        $words = array_merge($words, load_site_bad_words($langcode3));
-    }
-    $words = array_unique($words);
-
-    return $words;
+    $languages = array_values(get_project_languages($projectid));
+    list($langcode3s, $messages) = get_langcode3s_for_languages($languages);
+    return load_site_bad_words($langcode3s);
 }
-
-// -----------------------------------------------------------------------------
 
 function load_site_possible_bad_words_given_project($projectid)
 {
-    // load project languages
-    $languages = array_unique(array_values(get_project_languages($projectid)));
-
-    // load site word lists for project languages
-    $words = array();
-    foreach($languages as $language) {
-        $langcode3 = langcode3_for_langname($language);
-        $words = array_merge($words, load_site_possible_bad_words($langcode3));
-    }
-    $words = array_unique($words);
-
-    return $words;
+    $languages = array_values(get_project_languages($projectid));
+    list($langcode3s, $messages) = get_langcode3s_for_languages($languages);
+    return load_site_possible_bad_words($langcode3s);
 }
 
 // -----------------------------------------------------------------------------
@@ -813,7 +791,7 @@ function save_word_list($path, $words)
 
 // Returns an associative array of all languages for a project
 //   $array[$langcode]=$language;
-function get_project_languages($projectid)
+function get_project_languages($projectid, $aux_language=NULL)
 {
     $returnArray = array();
 
@@ -826,6 +804,8 @@ function get_project_languages($projectid)
         return $returnArray;
     }
     $languages = preg_split('/ with /', $project->language);
+    if($aux_language)
+        $languages[] = $aux_language;
 
     foreach($languages as $language) {
         $langcode = proj_lang_code($language, "primary");
@@ -834,7 +814,7 @@ function get_project_languages($projectid)
         }
     }
 
-    return $returnArray;
+    return array_unique($returnArray);
 }
 
 
@@ -1014,6 +994,31 @@ function generate_frequencies($wordList)
     return $wordCount;
 }
 
+// Given an array of language names, return a list of valid langcode3s.
+// Arguments:
+//      languages - array of language names
+// Returns an array of:
+//      array of langcode3s
+//      array of zero or more error/warning messages
+function get_langcode3s_for_languages($languages)
+{
+    $messages = [];
+    $langcode3s = array();
+    foreach($languages as $language)
+    {
+        $langcode3 = langcode3_for_langname($language);
+        if(is_null($langcode3))
+        {
+            $messages[] = sprintf(_("Warning: unknown language '%s'"), $language);
+        }
+        else
+        {
+            $langcode3s[] = $langcode3;
+        }
+    }
+
+    return array($langcode3s, $messages);
+}
 
 // function for comparing words similar to strnatcasecmp
 // but deterministicly; without the strnatcmp() call

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -1,9 +1,9 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'Project.inc');
-include_once($relPath.'languages.inc');
+include_once($relPath.'languages.inc'); // proj_lang_code
 include_once($relPath.'iso_lang_list.inc'); // langcode3_for_langname
-include_once($relPath.'misc.inc'); // str_contains
+include_once($relPath.'misc.inc'); // str_contains, array_get
 
 // regex of word characters
 // This is used when splitting a text into words.
@@ -41,7 +41,22 @@ define('WC_SITE',    2);
 define('WC_PROJECT', 3);
 define('WC_PAGE',    4);
 
+
+// Wrapper functions for _get_bad_words_for_project_text() that abstract if
+// the function returns FREQS or LEVELS. See that function for arguments
+// and return values.
+function get_bad_word_freqs_for_project_text($text, $projectid, $aux_language='', $adhoc_good_words=[])
+{
+    return _get_bad_words_for_project_text('FREQS', $text, $projectid, $aux_language, $adhoc_good_words);
+}
+
+function get_bad_word_levels_for_project_text($text, $projectid, $aux_language='', $adhoc_good_words=[])
+{
+    return _get_bad_words_for_project_text('LEVELS', $text, $projectid, $aux_language, $adhoc_good_words);
+}
+
 // Arguments:
+//   which_result_values - select either the bad word FREQS or LEVELS
 //   text - the text for which bad words are sought
 //          This can be a string or an array of strings. If the latter, the
 //          strings are conceptually separated by whitespace.  (So it's never
@@ -62,22 +77,73 @@ define('WC_PAGE',    4);
 //         (if $which_result_values is 'LEVELS')
 //  -- an array: each value is the name of a language that was used
 //  -- an array: each value is a warning/error.
-function get_bad_words_for_text($text, $projectid, $aux_language, $adhoc_good_words, $which_result_values)
+function _get_bad_words_for_project_text($which_result_values, $text, $projectid, $aux_language, $adhoc_good_words)
 {
+    $messages = [];
+
     // Get the list of languages that we'll use.
+    $languages = array_values(get_project_languages($projectid, $aux_language));
+
+    // And the langcode3s for those languages
+    list($langcode3s, $new_messages) = get_langcode3s_for_languages($languages);
+    $messages += $new_messages;
+
+    $word_lists = array(
+        "adhoc_good" => $adhoc_good_words,
+        "site_good" => load_site_good_words($langcode3s),
+        "site_bad" => load_site_bad_words($langcode3s),
+        "project_good" => load_project_good_words($projectid),
+        "project_bad" => load_project_bad_words($projectid)
+    );
+
+    list($input_words_w_freq, $bad_words, $new_messages) =
+        get_bad_words_for_text($text, $languages, $word_lists);
+    $messages += $new_messages;
+
+    // At this point, we have two arrays whose keys are words:
+    // $input_words_w_freq (words in the text, that may or may not be bad)
+    // $acc->words (words that are bad, that may or may not be in the text)
+    // The key-intersection of these two arrays will give us the set of words
+    // that are both in the text and bad.
+    // But the way we do the intersection determines the values that are
+    // associated with those words.
+    //
+    if($which_result_values == 'FREQS')
     {
-        $languages = array_values(get_project_languages($projectid));
-
-        // add the aux_language if supplied
-        if ($aux_language != "")
-        {
-            $languages[] = $aux_language;
-        }
-
-        // unique the array, no point in checking one language more than once
-        $languages = array_unique($languages);
+        // Associate each bad word with its frequency in the text.
+        $bad_words_in_text = array_intersect_key($input_words_w_freq, $bad_words);
+    }
+    elseif($which_result_values == 'LEVELS')
+    {
+        // Associate each bad word with the most specific level at which it was deemed bad.
+        $bad_words_in_text = array_intersect_key($bad_words, $input_words_w_freq);
+    }
+    else
+    {
+        assert(FALSE);
     }
 
+    return array($bad_words_in_text, $languages, $messages);
+}
+
+
+// Returns a list of bad words from a given text using the specified
+// languages to run the spellchecker and a set of word lists
+// Arguments:
+//      text - string or array of strings
+//      languages - array of language names
+//      word_lists - array with the keys:
+//          site_good - array of site good words
+//          site_bad  - array of site bad words
+//          project_good - array of good words from project
+//          project_bad - array of bad words from project
+//          adhoc_good - array of adhoc good words
+// Returns an array that includes:
+//      - array of text words with frequency
+//      - array of bad words
+//      - array of possible warning/error messages
+function get_bad_words_for_text($text, $languages, $word_lists=[])
+{
     $input_words_w_freq = get_distinct_words_in_text($text);
 
     $acc = new BadWordAccumulator();
@@ -96,70 +162,26 @@ function get_bad_words_for_text($text, $projectid, $aux_language, $adhoc_good_wo
 
     // The site
     {
-        $langcode3s = array();
-        foreach($languages as $language)
-        {
-            $langcode3 = langcode3_for_langname($language);
-            if(is_null($langcode3))
-            {
-                $acc->messages[] = sprintf(_("Warning: unknown language '%s'"), $language);
-            }
-            else
-            {
-                $langcode3s[] = $langcode3;
-            }
-        }
+        $acc->remove_good_words(array_get($word_lists, "site_good", array()));
+        $acc->add_bad_words(array_get($word_lists, "site_bad", array()), WC_SITE);
 
-        foreach($langcode3s as $langcode3)
-        {
-            $acc->remove_good_words(load_site_good_words($langcode3));
-        }
-
-        foreach($langcode3s as $langcode3)
-        {
-            $acc->add_bad_words(load_site_bad_words($langcode3), WC_SITE);
-        }
-
-         $acc->add_bad_words(
-             get_bad_words_via_pattern($input_words_w_freq, $langcode3s), WC_SITE);
+        $acc->add_bad_words(
+            get_bad_words_via_pattern($input_words_w_freq, $languages), WC_SITE);
     }
 
     // The project
     {
-        $acc->remove_good_words(load_project_good_words($projectid));
+        $acc->remove_good_words(array_get($word_lists, "project_good", array()));
 
-        $acc->add_bad_words(load_project_bad_words($projectid), WC_PROJECT);
+        $acc->add_bad_words(array_get($word_lists, "project_bad", array()), WC_PROJECT);
     }
 
     // The page
     {
-        $acc->remove_good_words($adhoc_good_words);
+        $acc->remove_good_words(array_get($word_lists, "adhoc_good", array()));
     }
 
-    // At this point, we have two arrays whose keys are words:
-    // $input_words_w_freq (words in the text, that may or may not be bad)
-    // $acc->words (words that are bad, that may or may not be in the text)
-    // The key-intersection of these two arrays will give us the set of words
-    // that are both in the text and bad.
-    // But the way we do the intersection determines the values that are
-    // associated with those words.
-    //
-    if($which_result_values == 'FREQS')
-    {
-        // Associate each bad word with its frequency in the text.
-        $bad_words_in_text = array_intersect_key($input_words_w_freq, $acc->words);
-    }
-    elseif($which_result_values == 'LEVELS')
-    {
-        // Associate each bad word with the most specific level at which it was deemed bad.
-        $bad_words_in_text = array_intersect_key($acc->words, $input_words_w_freq);
-    }
-    else
-    {
-        assert(FALSE);
-    }
-
-    return array($bad_words_in_text, $languages, $acc->messages);
+    return array($input_words_w_freq, $acc->words, $acc->messages);
 }
 
 // -----------------------------------------------------------------------------
@@ -332,14 +354,16 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 // returns a list of 'bad' words in a text based on some pattern
 // Arguments:
 //   input_words_w_freq - an array whose keys are the distinct words of the input text
-//   langcode3s - codes for languages to check against
+//   languages - array of languages to check against
 //
 // Returns:
 //       -- an array of bad words
 //
-function get_bad_words_via_pattern($input_words_w_freq, $langcode3s)
+function get_bad_words_via_pattern($input_words_w_freq, $languages)
 {
     global $word_letters;
+
+    list($langcode3s, $messages) = get_langcode3s_for_languages($languages);
 
     $badWords = array();
 

--- a/tools/project_manager/show_current_flagged_words.php
+++ b/tools/project_manager/show_current_flagged_words.php
@@ -143,7 +143,7 @@ function _get_word_list($projectid) {
 
     // now run it through WordCheck
     list($bad_words_w_freq,$languages,$messages) =
-    get_bad_words_for_text($page_texts,$projectid,'',array(),'FREQS');
+    get_bad_word_freqs_for_project_text($page_texts, $projectid);
 
     // multisort screws up all-numeric words so we need to preprocess first
     prep_numeric_keys_for_multisort($bad_words_w_freq);

--- a/tools/project_manager/show_current_flagged_words.php
+++ b/tools/project_manager/show_current_flagged_words.php
@@ -143,7 +143,7 @@ function _get_word_list($projectid) {
 
     // now run it through WordCheck
     list($bad_words_w_freq,$languages,$messages) =
-    get_bad_words_for_text($page_texts,$projectid,'all','',array(),'FREQS');
+    get_bad_words_for_text($page_texts,$projectid,'',array(),'FREQS');
 
     // multisort screws up all-numeric words so we need to preprocess first
     prep_numeric_keys_for_multisort($bad_words_w_freq);

--- a/tools/project_manager/show_project_stealth_scannos.php
+++ b/tools/project_manager/show_project_stealth_scannos.php
@@ -278,7 +278,7 @@ function _get_word_list($projectid) {
 
     // run the list through WordCheck to see which it would flag
     list($possible_scannos_via_wordcheck,$languages,$messages) =
-        get_bad_words_for_text($text_to_check,$projectid,'all','',array(),'FREQS');
+        get_bad_words_for_text($text_to_check,$projectid,'',array(),'FREQS');
 
     // load site words
     $site_bad_words = load_site_bad_words_given_project($projectid);

--- a/tools/project_manager/show_project_stealth_scannos.php
+++ b/tools/project_manager/show_project_stealth_scannos.php
@@ -278,7 +278,7 @@ function _get_word_list($projectid) {
 
     // run the list through WordCheck to see which it would flag
     list($possible_scannos_via_wordcheck,$languages,$messages) =
-        get_bad_words_for_text($text_to_check,$projectid,'',array(),'FREQS');
+        get_bad_word_freqs_for_project_text($text_to_check, $projectid);
 
     // load site words
     $site_bad_words = load_site_bad_words_given_project($projectid);

--- a/tools/project_manager/show_project_wordcheck_stats.php
+++ b/tools/project_manager/show_project_wordcheck_stats.php
@@ -42,7 +42,7 @@ mysqli_free_result($pages_res);
 
 // now run it through WordCheck
 list($bad_words_w_freq,$languages,$messages) =
-    get_bad_words_for_text($page_texts,$projectid,'',array(),'FREQS');
+    get_bad_word_freqs_for_project_text($page_texts, $projectid);
 
 // see how many of the words are on the site and project bad word list
 $total["proj_bad_words"]=0;

--- a/tools/project_manager/show_project_wordcheck_stats.php
+++ b/tools/project_manager/show_project_wordcheck_stats.php
@@ -42,7 +42,7 @@ mysqli_free_result($pages_res);
 
 // now run it through WordCheck
 list($bad_words_w_freq,$languages,$messages) =
-    get_bad_words_for_text($page_texts,$projectid,'all','',array(),'FREQS');
+    get_bad_words_for_text($page_texts,$projectid,'',array(),'FREQS');
 
 // see how many of the words are on the site and project bad word list
 $total["proj_bad_words"]=0;

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -43,7 +43,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
     if ( $aux_language == _("Language") ) $aux_language = '';
 
     list($badWordHash,$languages,$messages) =
-        get_bad_words_for_text( $orig_text, $projectid, $imagefile, $aux_language, $accepted_words, 'LEVELS' );
+        get_bad_words_for_text( $orig_text, $projectid, $aux_language, $accepted_words, 'LEVELS' );
 
     // ok, at this point we have a finalized list of bad words.
     // start preparing the page

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -43,7 +43,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
     if ( $aux_language == _("Language") ) $aux_language = '';
 
     list($badWordHash,$languages,$messages) =
-        get_bad_words_for_text( $orig_text, $projectid, $aux_language, $accepted_words, 'LEVELS' );
+        get_bad_word_levels_for_project_text($orig_text, $projectid, $aux_language, $accepted_words);
 
     // ok, at this point we have a finalized list of bad words.
     // start preparing the page


### PR DESCRIPTION
As part of updating WordCheck to support UTF-8 I realized that there are no unit tests for WordCheck. I stepped back to add some and realized that some of the WordCheck functions, notably `get_bad_words_for_text()` was not unit-testable.

This series of commits reorganizes some of the WordCheck functions such that they are testable and then ultimately actually tests them.