### PR TITLE
Use project load to indicate PPer activity when in PP

### DIFF
--- a/project.php
+++ b/project.php
@@ -155,9 +155,8 @@ else
 
 function do_update_pp_activity()
 {
-// If the project has been checked out for more than 90 days and
-// the pp-er loads the page, it's interpreted as a sign of
-// activity. Update the database accordingly.
+    // If the project is checked out and the PPer loads the page, it's
+    // interpreted as a sign of activity. Update the database accordingly.
 
     global $project;
 
@@ -165,17 +164,10 @@ function do_update_pp_activity()
 
     if (! $project->PPer_is_current_user) return;
 
-    // 7776000 = 90*24*60*60 seconds
-    if ($project->modifieddate < time()-7776000) {
-      // Modified more than 90 days ago. The PP-er,
-      // by loading this page, is reporting
-      // activity.
-
-      $projectid = $project->projectid;
-      $now = time();
-      mysqli_query(DPDatabase::get_connection(), "UPDATE projects SET modifieddate=$now WHERE projectid='$projectid'");
-      $project->modifieddate = $now;
-    }
+    $projectid = $project->projectid;
+    $now = time();
+    mysqli_query(DPDatabase::get_connection(), "UPDATE projects SET modifieddate=$now WHERE projectid='$projectid'");
+    $project->modifieddate = $now;
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
If a project is in PP, use the project page load by the PPer to indicate
activity rather than waiting until _after_ 90 days have passed. This
will reset the counter for the 90-day notification to the PPer thus
deferring the notification.

[Task 1764](https://www.pgdp.net/c/tasks.php?action=show&task_id=1764)