### PR TITLE
Refactor and address bugs in PP notification

### DIFF
--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -18,3 +18,4 @@
 
 # monthly:
 50 0 1 * * URL=<<CODE_URL>>/crontab/notify_old_pp.php; <<URL_DUMP_PROGRAM>> $URL
+50 0 15 * * URL=<<CODE_URL>>/crontab/notify_old_pp.php; <<URL_DUMP_PROGRAM>> $URL

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -5,98 +5,100 @@ include_once($relPath.'project_states.inc');
 include_once($relPath.'maybe_mail.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'User.inc');
+include_once($relPath.'post_processing.inc'); // get_pp_projects_past_threshold
 
 // check that caller is localhost or bail
 if(!requester_is_localhost())
     die("You are not authorized to perform this request.");
 
-$old_date = time() - 7776000; // 90 days ago.
+$projects_by_PPer = get_pp_projects_past_threshold();
 
-// send reminder email to PPers with projects checked out for longer than
-// 90 days
+// now send them notifications
+foreach($projects_by_PPer as $PPer => $projects)
+{
+    send_pp_reminders($PPer, $projects);
+}
 
-//get projects that have been checked out longer than old_date
-$sql = "
-    SELECT
-        nameofwork,
-        checkedoutby,
-        projects.projectid,
-        authorsname,
-        DATE_FORMAT(FROM_UNIXTIME(user_project_info.t_latest_home_visit), '%e %M  %Y') as nicedate
-    FROM projects LEFT OUTER JOIN user_project_info ON
-        projects.projectid = user_project_info.projectid AND
-        projects.checkedoutby = user_project_info.username
-    WHERE state = '".PROJ_POST_FIRST_CHECKED_OUT."' AND
-        user_project_info.t_latest_home_visit <= $old_date
-    ORDER BY checkedoutby, user_project_info.t_latest_home_visit;
-";
-$result = mysqli_query(DPDatabase::get_connection(), $sql);
+//---------------------------------------------------------------------------
 
-$rownum = 0;
+function send_pp_reminders($PPer, $projects)
+{
+    global $code_url, $general_help_email_addr, $forums_url,
+           $site_name, $site_signoff, $site_abbreviation;
+    global $pp_alert_threshold_days;
 
-$PPinQuestion = "";
-$lastwork = "";
-$projectslist = "";
-$numprojs = 0;
-$urlbase = "$code_url/project.php?expected_state=proj_post_first_checked_out&id=";
+    $urlbase = "$code_url/project.php?id=";
 
-while ($row = mysqli_fetch_assoc($result)) {
+    $numprojs = count($projects);
 
-    $nameofwork = $row["nameofwork"];
-    $authorsname = $row["authorsname"];
-    $checkedoutby = $row["checkedoutby"];
-    $projectid = $row["projectid"];
-    $nicedate = $row["nicedate"];
+    $projects_list = "";
+    foreach($projects as $project)
+    {
+        $nameofwork = $project["nameofwork"];
+        $authorsname = $project["authorsname"];
+        $projectid = $project["projectid"];
+        $modifieddate = strftime("%e %B %Y", $project["modifieddate"]);
+        $lastvisitdate = strftime("%e %B %Y", $project["lastvisitdate"]);
 
-    if ($PPinQuestion != $checkedoutby) {
-        // have finished the last PPer. Send email to them
-        if ($rownum > 0) {
-
-            $user = new User($PPinQuestion);
-            $email = $user->email;
-
-            echo $PPinQuestion . "\n" . $projectslist ."\n\n";
-
-            if ($numprojs == 1) {
-                $message = "Hello $PPinQuestion,\n\nThis is an automated message.\n\n
-Our database indicates that you have had a PP project checked out for more than 90 days:\n\n
-$projectslist\n\n
-If you haven't yet finished and wish to continue working on this book, please log in to $site_url and visit $url . This will update the status of the project. If you need help please forward a copy of this email (quoting the information on the book, above) with a brief description of the status to $general_help_email_addr.\n\n
-If you have completed your work on the book, please log in to $site_url and visit $url. Select the 'Upload for verification' option and follow the prompts. You will be able to leave a message for the verifier during this process, if you have any special information or comments to pass on.\n\n
-If you are waiting on missing images or page scans, please add the details to the Missing Page Wiki at: $forums_url/viewtopic.php?t=7584\n\n
-If you no longer wish to have this text assigned to you please visit the $site_name website Post Processing section and select Return to Available for this book, or forward this email to $general_help_email_addr and state that you would no longer like to have the book in question assigned to you so that we may return it to the available pool for someone else to work on.\n\n
-$site_signoff";
-            } else {
-                $message = "Hello $PPinQuestion,\n\nThis is an automated message.\n\n
-Our database indicates that you have had $numprojs PP projects checked out for more than 90 days:\n\n
-$projectslist\n\n
-If you wish to continue working on some or all of these books, please log in to $site_url and visit each such project's home-page (copy the URL listed with the project above and paste it into your browser's address-field). Doing this will update the status of the project and let us know that you are still working on it. If you need help please forward this email, quoting the list of books, with a brief description of the status for each of the various books listed above that you need help with to $general_help_email_addr.\n\n
-If you have completed your work on any of these books, please log in to $site_url and visit each such project's home-page (copy the URL listed with the project above and paste it into your browser's address-field). Select the 'Upload for verification' option and follow the prompts. You will be able to leave a message for the verifier during this process, if you have any special information or comments to pass on.\n\n
-If you are waiting on missing images or page scans, please add the details to the Missing Page Wiki at: $forums_url/viewtopic.php?t=7584\n\n
-If you no longer wish to have some or all of these books assigned to you please visit the $site_name website Post Processing section and select Return to Available for the books in question or forward this email to $general_help_email_addr and state that you would no longer like to have the books in question assigned to you so that we may return them to the available pool for someone else to work on.\n\n
-$site_signoff";
-            }
-
-            maybe_mail("$email", "$subject","$message");
-
-            $projectslist = "";
-            $numprojs = 0;
-         }
-        $PPinQuestion = $checkedoutby;
+        $url = $urlbase . $projectid;
+        $work_details  = "$nameofwork by $authorsname ($projectid)";
+        $time_details = "[checked out since $modifieddate, project last visited $lastvisitdate]";
+        $projects_list .= "$work_details\n$time_details\n    $url\n\n";
     }
 
-    $numprojs++;
+    echo "\nNotifying $PPer about $numprojs project(s):\n$projects_list";
 
-    $url = $urlbase . $projectid;
+    $user = new User($PPer);
+    $email = $user->email;
 
-    $projectslist .= "$nameofwork by $authorsname ($projectid), out since $nicedate\n$url\n\n";
-    if ($numprojs == 1) {
-        $subject = "$site_abbreviation: Status update needed for 1 project checked out for PPing over 90 days";
-    } else {
-        $subject = "$site_abbreviation: Status updates needed for $numprojs projects checked out for PPing over 90 days";
+    if($numprojs == 1)
+    {
+        // only one project
+        $url = $urlbase . $projects[0]["projectid"];
+
+        $subject = "$site_abbreviation: Status update needed for 1 project checked out for PPing over $pp_alert_threshold_days days";
+
+        $message = <<<EOF
+Hello $PPer,
+
+Our database indicates that you have had a PP project checked out for more than $pp_alert_threshold_days days:
+
+$projects_list
+If you haven't yet finished and wish to continue working on this book, please visit $url. This will update the status of the project. If you need help please forward a copy of this email (quoting the information on the book, above) with a brief description of the status to $general_help_email_addr.
+
+If you have completed your work on the book, please visit $url. Select the 'Upload for verification' option and follow the prompts. You will be able to leave a message for the verifier during this process, if you have any special information or comments to pass on.
+
+If you are waiting on missing images or page scans, please add the details to the Missing Page Wiki at: $forums_url/viewtopic.php?t=7584
+
+If you no longer wish to have this text assigned to you please visit the $site_name website Post Processing section and select Return to Available for this book, or forward this email to $general_help_email_addr and state that you would no longer like to have the book in question assigned to you so that we may return it to the available pool for someone else to work on.
+
+$site_signoff
+EOF;
+    }
+    else
+    {
+        // more than one project
+        $subject = "$site_abbreviation: Status updates needed for $numprojs projects checked out for PPing over $pp_alert_threshold_days days";
+
+        $message = <<<EOF
+Hello $PPer,
+
+Our database indicates that you have had $numprojs PP projects checked out for more than $pp_alert_threshold_days days:
+
+$projects_list
+If you wish to continue working on some or all of these books, please visit each such project's home-page (copy the URL listed with the project above and paste it into your browser's address-field). Doing this will update the status of the project and let us know that you are still working on it. If you need help please forward this email, quoting the list of books, with a brief description of the status for each of the various books listed above that you need help with to $general_help_email_addr.
+
+If you have completed your work on any of these books, please visit each such project's home-page (copy the URL listed with the project above and paste it into your browser's address-field). Select the 'Upload for verification' option and follow the prompts. You will be able to leave a message for the verifier during this process, if you have any special information or comments to pass on.
+
+If you are waiting on missing images or page scans, please add the details to the Missing Page Wiki at: $forums_url/viewtopic.php?t=7584
+
+If you no longer wish to have some or all of these books assigned to you please visit the $site_name website Post Processing section and select Return to Available for the books in question or forward this email to $general_help_email_addr and state that you would no longer like to have the books in question assigned to you so that we may return them to the available pool for someone else to work on.
+
+$site_signoff
+EOF;
     }
 
-    $rownum++;
+    maybe_mail($email, $subject, $message);
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -98,7 +98,11 @@ $site_signoff
 EOF;
     }
 
-    maybe_mail($email, $subject, $message);
+    $mail_accepted = maybe_mail($email, $subject, $message);
+    if(!$mail_accepted)
+    {
+        echo "WARNING: Email failed to send for $PPer <$email>\n";
+    }
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -107,7 +107,9 @@ function send_pp_reminders($PPer, $projects, $which_message)
     $email = $user->email;
     $message_string = implode("\n\n", $message);
 
-    $mail_accepted = maybe_mail($email, $subject, $message_string);
+    $headers = [ "Reply-To: $db_requests_email_addr" ];
+
+    $mail_accepted = maybe_mail($email, $subject, $message_string, $headers);
     if(!$mail_accepted)
     {
         echo "WARNING: Email failed to send for $PPer <$email>\n";

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -13,25 +13,32 @@ if(!requester_is_localhost())
 
 $projects_by_PPer = get_pp_projects_past_threshold();
 
+// if the script is run before the 14th of the month, send out the first email
+// otherwise send out the second one
+if(strftime("%d", time()) < 14)
+{
+    $which_message = "first";
+}
+else
+{
+    $which_message = "second";
+}
+
 // now send them notifications
 foreach($projects_by_PPer as $PPer => $projects)
 {
-    send_pp_reminders($PPer, $projects);
+    send_pp_reminders($PPer, $projects, $which_message);
 }
 
 //---------------------------------------------------------------------------
 
-function send_pp_reminders($PPer, $projects)
+function send_pp_reminders($PPer, $projects, $which_message)
 {
-    global $code_url, $general_help_email_addr, $forums_url,
-           $site_name, $site_signoff, $site_abbreviation;
+    global $code_url, $db_requests_email_addr,
+           $site_signoff, $site_abbreviation;
     global $pp_alert_threshold_days;
 
-    $urlbase = "$code_url/project.php?id=";
-
-    $numprojs = count($projects);
-
-    $projects_list = "";
+    $projects_list = [];
     foreach($projects as $project)
     {
         $nameofwork = $project["nameofwork"];
@@ -40,65 +47,61 @@ function send_pp_reminders($PPer, $projects)
         $modifieddate = strftime("%e %B %Y", $project["modifieddate"]);
         $lastvisitdate = strftime("%e %B %Y", $project["lastvisitdate"]);
 
-        $url = $urlbase . $projectid;
         $work_details  = "$nameofwork by $authorsname ($projectid)";
         $time_details = "[checked out since $modifieddate, project last visited $lastvisitdate]";
-        $projects_list .= "$work_details\n$time_details\n    $url\n\n";
+        $projects_list[] = "$work_details\n$time_details\n    $code_url/project.php?id=$projectid";
     }
 
-    echo "\nNotifying $PPer about $numprojs project(s):\n$projects_list";
+    $projects_list_string = implode("\n\n", $projects_list);
+
+    $numprojs = count($projects);
+    echo "\nNotifying $PPer about $numprojs project(s):\n$projects_list_string\n\n";
 
     $user = new User($PPer);
     $email = $user->email;
 
-    if($numprojs == 1)
+
+    $message = [];
+    if($which_message == "first")
     {
-        // only one project
-        $url = $urlbase . $projects[0]["projectid"];
+        // TRANSLATORS: %s is the site abbreviation (eg: 'DP')
+        $subject = sprintf(_("%s: Renew or Return Post-Processing Projects"), $site_abbreviation);
 
-        $subject = "$site_abbreviation: Status update needed for 1 project checked out for PPing over $pp_alert_threshold_days days";
+        $message[] = sprintf(_("Hello %s,"), $PPer);
+        $message[] = _("This is an automated message.");
+        $message[] = sprintf(_("Our database system indicates that you have had one or more projects checked out for Post-Processing for more than %d days:"), $pp_alert_threshold_days);
+        $message[] = $projects_list_string;
+        $message[] = _("It is important that books don't get stuck in the Post-Processing process but keep moving towards being posted at Project Gutenberg. As a community, we have a lot vested in each project -- each represents many hours of volunteer work. We are all eager to see each book posted and there is also a risk that that work would be lost should other organizations produce and post a book before we finish.");
 
-        $message = <<<EOF
-Hello $PPer,
+        $message[] = '==' . _("Do you wish to continue or to stop working on these books?") . "==";
+        $message[] = _("If you haven't yet finished and wish to continue working on these books, please visit the project pages listed above. This will update the status of the projects.");
+        $message[] = _("If you no longer wish to have these projects assigned to you, please visit the project pages and select 'Return to Available', or reply to this email and state that you no longer wish to have the projects in question assigned to you so that we may return them to the pool for someone else to work on.");
 
-Our database indicates that you have had a PP project checked out for more than $pp_alert_threshold_days days:
+        $message[] = "==" . _("Have you completed your work?") . "==";
+        $message[] = _("If you have completed your post-processing work, please visit the appropriate link listed above, select the 'Upload for verification' option on the Project Page, and follow the prompts. If you have any special information or comments to pass on, you will be able to leave a message for the verifier during this process. If you have Direct Upload capability and no longer use Post-Processing Verification, please upload each completed project directly to PG.");
 
-$projects_list
-If you haven't yet finished and wish to continue working on this book, please visit $url. This will update the status of the project. If you need help please forward a copy of this email (quoting the information on the book, above) with a brief description of the status to $general_help_email_addr.
+        $message[] = "==" . _("Do you need help with a particular technical aspect of the book?") . "==";
+        $message[] = _("If you have questions about how to handle a difficult table or need some help tidying up awkward illustrations, remember that the DP Post-Processing forum is full of volunteers with a wide range of skills and interests who are able and willing to help.");
 
-If you have completed your work on the book, please visit $url. Select the 'Upload for verification' option and follow the prompts. You will be able to leave a message for the verifier during this process, if you have any special information or comments to pass on.
-
-If you are waiting on missing images or page scans, please add the details to the Missing Page Wiki at: $forums_url/viewtopic.php?t=7584
-
-If you no longer wish to have this text assigned to you please visit the $site_name website Post Processing section and select Return to Available for this book, or forward this email to $general_help_email_addr and state that you would no longer like to have the book in question assigned to you so that we may return it to the available pool for someone else to work on.
-
-$site_signoff
-EOF;
+        $message[] = "==" . _("Are there any problems?") . "==";
+        $message[] = sprintf(_("If any project is missing page images or illustrations, please contact the Project Manager (PM) for assistance. If the PM does not respond within a reasonable amount of time, please email %s and request help concerning any problems."), $db_requests_email_addr);
+        $message[] = $site_signoff;
     }
     else
     {
-        // more than one project
-        $subject = "$site_abbreviation: Status updates needed for $numprojs projects checked out for PPing over $pp_alert_threshold_days days";
+        // TRANSLATORS: %s is the site abbreviation (eg: 'DP')
+        $subject = sprintf(_("%s Second Notice: Renew or Return Post-Processing Projects"), $site_abbreviation);
 
-        $message = <<<EOF
-Hello $PPer,
-
-Our database indicates that you have had $numprojs PP projects checked out for more than $pp_alert_threshold_days days:
-
-$projects_list
-If you wish to continue working on some or all of these books, please visit each such project's home-page (copy the URL listed with the project above and paste it into your browser's address-field). Doing this will update the status of the project and let us know that you are still working on it. If you need help please forward this email, quoting the list of books, with a brief description of the status for each of the various books listed above that you need help with to $general_help_email_addr.
-
-If you have completed your work on any of these books, please visit each such project's home-page (copy the URL listed with the project above and paste it into your browser's address-field). Select the 'Upload for verification' option and follow the prompts. You will be able to leave a message for the verifier during this process, if you have any special information or comments to pass on.
-
-If you are waiting on missing images or page scans, please add the details to the Missing Page Wiki at: $forums_url/viewtopic.php?t=7584
-
-If you no longer wish to have some or all of these books assigned to you please visit the $site_name website Post Processing section and select Return to Available for the books in question or forward this email to $general_help_email_addr and state that you would no longer like to have the books in question assigned to you so that we may return them to the available pool for someone else to work on.
-
-$site_signoff
-EOF;
+        $message[] = sprintf(_("Hello %s,"), $PPer);
+        $message[] = _("An automated reminder was sent to you on the first of the month to ask whether you wished to renew the projects you have checked out for Post-Processing. You are receiving this second automated notice because you have not renewed or returned the projects.");
+        $message[] = $projects_list_string;
+        $message[] = sprintf(_("If you have already notified %s of an expected absence, you may safely ignore this message. Otherwise, any projects in your queue for which a previous notice has been sent may be reclaimed if you do not respond or renew within the next 7 days."), $db_requests_email_addr);
+        $message[] = $site_signoff;
     }
 
-    $mail_accepted = maybe_mail($email, $subject, $message);
+    $message_string = implode("\n\n", $message);
+
+    $mail_accepted = maybe_mail($email, $subject, $message_string);
     if(!$mail_accepted)
     {
         echo "WARNING: Email failed to send for $PPer <$email>\n";

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -48,13 +48,7 @@ function get_desired_language()
             $locale = $test_locale;
     }
 
-    // Fall back to en_US (English) if we weren't able to determine a locale
-    // or we don't have a translation for that locale.
-    if (!@$locale || !is_locale_translation_enabled($locale)) {
-        $locale = "en_US";
-    }
-
-    return $locale;
+    return get_valid_locale_for_translation($locale);
 }
 
 function configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_dir)

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -234,6 +234,16 @@ function is_locale_translation_enabled($locale)
     return in_array($locale, $enabled_locales);
 }
 
+function get_valid_locale_for_translation($locale)
+{
+    // Fall back to en_US (English) if locale isn't set
+    // or if we don't have a translation for that locale.
+    if (!@$locale || !is_locale_translation_enabled($locale)) {
+        $locale = "en_US";
+    }
+    return $locale;
+}
+
 function set_locale_translation_enabled($locale, $enable)
 {
     global $dyn_locales_dir;

--- a/pinc/maybe_mail.inc
+++ b/pinc/maybe_mail.inc
@@ -39,10 +39,12 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
         echo html_safe("$message\n");
         echo "</pre>\n";
         echo "<hr>\n";
+
+        return True;
     }
     else
     {
-        mail( $to, $subject, $message, $additional_headers );
+        return mail( $to, $subject, $message, $additional_headers );
     }
 }
 
@@ -73,7 +75,7 @@ $site_signoff
 
     $user = new User($username);
 
-    maybe_mail($user->email, "$prefix: \"$nameofwork\"", $body);
+    return maybe_mail($user->email, "$prefix: \"$nameofwork\"", $body);
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/post_processing.inc
+++ b/pinc/post_processing.inc
@@ -1,0 +1,78 @@
+<?php
+include_once($relPath."project_states.inc"); // PROJ_POST_FIRST_CHECKED_OUT
+include_once($relPath."misc.inc"); // array_get
+
+// Global variable that specifies when we alert PPers about their
+// outstanding projects. Time is calculated as this many days prior
+// to midnight of the 1st of the current month.
+global $pp_alert_threshold_days;
+$pp_alert_threshold_days = 90;
+
+function count_pp_projects_past_threshold($PPer=NULL)
+{
+    $columns = [ "count(*) AS total" ];
+    $result = _run_pp_threshold_query_result($columns, $PPer);
+    
+    list($total) = mysqli_fetch_row($result);
+    return $total;
+}
+
+function get_pp_projects_past_threshold($PPer=NULL)
+{
+    $columns = [
+        "nameofwork",
+        "checkedoutby",
+        "projects.projectid",
+        "authorsname",
+        "modifieddate",
+        "user_project_info.t_latest_home_visit AS lastvisitdate",
+    ];
+
+    $ordering_criteria = "checkedoutby, modifieddate";
+
+    $result = _run_pp_threshold_query_result($columns, $PPer, $ordering_criteria);
+
+    $projects_grouped_by_PPer = [];
+
+    while($row = mysqli_fetch_assoc($result))
+    {
+        $row_PPer = $row["checkedoutby"];
+        if(!isset($projects_grouped_by_PPer[$row_PPer]))
+        {
+            $projects_grouped_by_PPer[$row_PPer] = [];
+        }
+        $projects_grouped_by_PPer[$row_PPer][] = $row;
+    }
+
+    if($PPer)
+        return array_get($projects_grouped_by_PPer, $PPer, []);
+    else
+        return $projects_grouped_by_PPer;
+}
+
+// internal function to avoid duplicating the SQL logic that determines
+// projects past the PP alert threshold
+function _run_pp_threshold_query_result($columns, $PPer, $ordering_criteria=NULL)
+{
+    global $pp_alert_threshold_days;
+
+    $column_selector = implode(", ", $columns);
+    $user_selector = $PPer ? "AND checkedoutby = '$PPer'" : "";
+    $order_by_clause = $ordering_criteria ? "ORDER BY $ordering_criteria" : "";
+
+    $cutoff_timestamp = strtotime("midnight first day of this month") -
+        ($pp_alert_threshold_days * 60 * 60 * 24);
+
+    $sql = "
+        SELECT
+            $column_selector
+        FROM projects LEFT OUTER JOIN user_project_info ON
+            projects.projectid = user_project_info.projectid AND
+            projects.checkedoutby = user_project_info.username
+        WHERE state = '".PROJ_POST_FIRST_CHECKED_OUT."' AND
+            user_project_info.t_latest_home_visit <= $cutoff_timestamp
+            $user_selector
+        $order_by_clause
+    ";
+    return mysqli_query(DPDatabase::get_connection(), $sql);
+}


### PR DESCRIPTION
This refactors the cumbersome logic used to collate old projects for a PP and notify them into two parts:
* a function to fetch results from the database and collate them to a PP
* a function to notify the PPer of their old projects

This fixes a bug where the last PPer in the DB query was not notified (identified by @jmdyck in https://github.com/DistributedProofreaders/dproofreaders/pull/121).

Given the refactor, it might be easiest to review the full code rather than the diff.