### PR TITLE
Prompt the user to upload .zip files

### DIFF
--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -293,7 +293,7 @@ function do_showupload()
     $form_content .= "<div id='old_uploader'>";
     $form_content .= $submit_blurb;
     $form_content .= _("File to upload") . ":&nbsp;";
-    $form_content .= "<input type='file' name='the_file' size='50' maxsize='50'>";
+    $form_content .= "<input type='file' accept='.zip' name='the_file' size='50' maxsize='50'>";
     $form_content .= "</div>";
 
     $form_content .= "<div id='resumable_uploader' style='display: none;'>";

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -215,7 +215,7 @@ if (!isset($action))
         echo _("Select a zipped file to upload:");
     }
     echo "<br>\n";
-    echo "<input type='file' name='uploaded_file' size='25' maxsize='50'>\n";
+    echo "<input type='file' accept='.zip' name='uploaded_file' size='25' maxsize='50'>\n";
     echo "<p>$standard_blurb</p>";
     echo "<p>$big_upload_blurb</p>\n";
     echo "</li>\n";


### PR DESCRIPTION
For zip file uploads, tell the browser that we accept .zip files
to prevent the user from selecting a file that isn't a .zip file
(assumimg the browser supports it).