### PR TITLE
Tweak condition for skipping unrecognized filenames

### DIFF
--- a/crontab/import_pg_catalog.php
+++ b/crontab/import_pg_catalog.php
@@ -123,7 +123,7 @@ foreach (scandir($local_catalog_dir) as $filename)
 {
     if ($filename == '.' || $filename == '..') continue;
 
-    if(preg_match('/^pg(\d+)\.rdf$/', $filename, $matches) === FALSE)
+    if(! preg_match('/^pg(\d+)\.rdf$/', $filename, $matches))
     {
         echo "Skipping unrecognized PG RDF file: $filename\n";
         continue;


### PR DESCRIPTION
"preg_match() returns 1 if the pattern matches, 0 if it does not, or FALSE if an error occurred."

So by comparing the result to FALSE, we're only detecting when an error occurs (which is probably never), rather than detecting a simple failure of the pattern to match.
    
Instead, just check if the result is falsy (covering both 0 and FALSE).

[This tweak is already in place on pgdp.net.]