### PR TITLE
Don't update user_project_info on checkout/return

### DIFF
--- a/SETUP/upgrade/13/20190929_update_user_project_info.php
+++ b/SETUP/upgrade/13/20190929_update_user_project_info.php
@@ -1,0 +1,119 @@
+<?php
+
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+include($relPath.'udb_user.php'); // $archive_db_name
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Updating user_project_info to set t_latest_page_event=1 only for\n";
+echo "projects where the user has saved a page as done or in-progress...\n\n";
+
+// Load a list of all users
+$sql = "
+    SELECT username
+    FROM users
+    ORDER BY username
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql)
+    or die( mysqli_error(DPDatabase::get_connection()) );
+
+$users = [];
+while($row = mysqli_fetch_assoc($result))
+{
+    $users[] = $row['username'];
+}
+mysqli_free_result($result);
+
+// Loop though all users getting their user_project_info records to see what
+// projects they have "worked on" (ie: t_latest_page_event > 0)
+foreach($users as $username)
+{
+    echo "Processing $username...\n";
+
+    // load all projects this user has "worked on"
+    $sql = "
+        SELECT projectid
+        FROM user_project_info
+        WHERE
+            username='$username'
+            AND t_latest_page_event > 0
+    ";
+
+    $result = mysqli_query(DPDatabase::get_connection(), $sql)
+        or die( mysqli_error(DPDatabase::get_connection()) );
+
+    $projectids = [];
+    while($row = mysqli_fetch_assoc($result))
+    {
+        $projectids[] = $row['projectid'];
+    }
+    mysqli_free_result($result);
+
+    // For each project, get the distinct event_types from page_events, which
+    // indicates what the user did in that project. If neither the 'saveAsDone'
+    // or the 'saveAsInProgress' events are present then this is a case where
+    // the new code in pinc/DPage.inc would not have updated t_latest_page_event.
+    // For these projects, set user_project_info.t_latest_page_event=0 for this
+    // (username, projectid), to achieve the same effect retroactively.
+    foreach($projectids as $projectid)
+    {
+        // Process both the main page_events table and the archived
+        // page_events table.
+        $current_event_types = get_distinct_event_types("page_events", $username, $projectid);
+        $archived_event_types = get_distinct_event_types("$archive_db_name.page_events", $username, $projectid);
+        $event_types = array_unique(array_merge($current_event_types, $archived_event_types));
+
+        // see if the only event_types are checkout and returnToRound
+        if(in_array('saveAsDone', $event_types) ||
+            in_array('saveAsInProgress', $event_types))
+        {
+            continue;
+        }
+        else
+        {
+            echo "    setting t_latest_page_event=0 for project $projectid\n";
+            $sql = "
+                UPDATE user_project_info
+                SET t_latest_page_event=0
+                WHERE
+                    username='$username'
+                    AND projectid='$projectid';
+            ";
+            $result = mysqli_query(DPDatabase::get_connection(), $sql)
+                or die( mysqli_error(DPDatabase::get_connection()) );
+        }
+    }
+}
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// ------------------------------------------------------------
+
+function get_distinct_event_types($table, $username, $projectid)
+{
+    $sql = "
+        SELECT DISTINCT event_type
+        FROM $table
+        WHERE
+            username='$username'
+            AND projectid='$projectid'
+    ";
+    $result = mysqli_query(DPDatabase::get_connection(), $sql)
+        or die( mysqli_error(DPDatabase::get_connection()) );
+
+    $event_types = [];
+    while($row = mysqli_fetch_assoc($result))
+    {
+        $event_types[] = $row['event_type'];
+    }
+    mysqli_free_result($result);
+    return $event_types;
+}
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -133,7 +133,7 @@ function project_add_page(
     // If the INSERT raised an error, don't do the other stuff.
     if ($errs) return $errs;
 
-    _log_page_event( $projectid, $image_file_name, 'add', $user, NULL, FALSE );
+    _log_page_event( $projectid, $image_file_name, 'add', $user, NULL );
 
     _project_adjust_n_pages( $projectid, +1 );
     _project_adjust_n_available_pages( $projectid, +1 );
@@ -170,7 +170,7 @@ function Page_delete( $projectid, $image, $user )
     $sql = "DELETE FROM $projectid WHERE image = '$image'";
     mysqli_query(DPDatabase::get_connection(), $sql);
 
-    _log_page_event( $projectid, $image, 'delete', $user, NULL, FALSE );
+    _log_page_event( $projectid, $image, 'delete', $user, NULL );
 
     _project_adjust_n_pages( $projectid, -1 );
     if ($page_was_available)
@@ -188,7 +188,7 @@ function Page_replaceImage( $projectid, $image, $new_image, $user )
         image='$new_image'
     ");
 
-    _log_page_event( $projectid, $image, 'replaceImage', $user, NULL, FALSE ); // $new_image
+    _log_page_event( $projectid, $image, 'replaceImage', $user, NULL ); // $new_image
 }
 
 // -----------------------------------------------------------------------------
@@ -200,7 +200,7 @@ function Page_replaceText( $projectid, $image, $text_file_path, $user )
         master_text=$text_file_content_expr
     ");
 
-    _log_page_event( $projectid, $image, 'replaceText', $user, NULL, FALSE );
+    _log_page_event( $projectid, $image, 'replaceText', $user, NULL );
 }
 
 // -----------------------------------------------------------------------------
@@ -214,7 +214,7 @@ function Page_modifyText( $projectid, $image, $page_text, $text_column, $user )
 
     $round = get_Round_for_text_column_name($text_column);
 
-    _log_page_event( $projectid, $image, 'modifyText', $user, $round, FALSE );
+    _log_page_event( $projectid, $image, 'modifyText', $user, $round );
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -234,7 +234,7 @@ function Page_checkout( $projectid, $image, $round, $user )
         {$round->user_column_name}='$user'
     " );
 
-    _log_page_event( $projectid, $image, 'checkout', $user, $round, TRUE );
+    _log_page_event( $projectid, $image, 'checkout', $user, $round );
 
     _project_adjust_n_available_pages( $projectid, -1 );
 
@@ -260,7 +260,8 @@ function Page_saveAsInProgress( $projectid, $image, $round, $user, $page_text )
         {$round->text_column_name}='%s'
     ", mysqli_real_escape_string(DPDatabase::get_connection(), $page_text)));
 
-    _log_page_event( $projectid, $image, 'saveAsInProgress', $user, $round, TRUE );
+    _log_page_event( $projectid, $image, 'saveAsInProgress', $user, $round );
+    upi_set_t_latest_page_event( $user, $projectid, 'UNIX_TIMESTAMP()' );
 
     return $round->page_temp_state;
 }
@@ -284,7 +285,8 @@ function Page_saveAsDone( $projectid, $image, $round, $user, $page_text )
         {$round->text_column_name}='%s'
     ", mysqli_real_escape_string(DPDatabase::get_connection(), $page_text)));
 
-    _log_page_event( $projectid, $image, 'saveAsDone', $user, $round, TRUE );
+    _log_page_event( $projectid, $image, 'saveAsDone', $user, $round );
+    upi_set_t_latest_page_event( $user, $projectid, 'UNIX_TIMESTAMP()' );
 
     _project_set_t_last_page_done( $projectid, $timestamp );
 
@@ -308,7 +310,7 @@ function Page_reopen( $projectid, $image, $round, $user )
         {$round->user_column_name}='$user'
     " );
 
-    _log_page_event( $projectid, $image, 'reopen', $user, $round, TRUE );
+    _log_page_event( $projectid, $image, 'reopen', $user, $round );
 
     return $round->page_temp_state;
 }
@@ -330,7 +332,7 @@ function Page_returnToRound( $projectid, $image, $round, $user )
         {$round->user_column_name}='$user'
     " );
 
-    _log_page_event( $projectid, $image, 'returnToRound', $user, $round, TRUE );
+    _log_page_event( $projectid, $image, 'returnToRound', $user, $round );
 
     _project_adjust_n_available_pages( $projectid, +1 );
 
@@ -351,7 +353,7 @@ function Page_reclaim( $projectid, $image, $round, $user )
         {$round->time_column_name}=0
     " );
 
-    _log_page_event( $projectid, $image, 'reclaim', $user, $round, FALSE );
+    _log_page_event( $projectid, $image, 'reclaim', $user, $round );
 
     _project_adjust_n_available_pages( $projectid, +1 );
 }
@@ -372,7 +374,7 @@ function Page_clearRound( $projectid, $image, $round, $user )
         {$round->text_column_name}=''
     ");
 
-    _log_page_event( $projectid, $image, 'clearRound', $user, $round, FALSE );
+    _log_page_event( $projectid, $image, 'clearRound', $user, $round );
 
     _project_adjust_n_available_pages( $projectid, +1 );
 }
@@ -402,7 +404,7 @@ function Page_markAsBad( $projectid, $image, $round, $user, $reason )
         {$round->text_column_name}={$round->prevtext_column_name}
     " );
 
-    _log_page_event( $projectid, $image, 'markAsBad', $user, $round, TRUE );
+    _log_page_event( $projectid, $image, 'markAsBad', $user, $round );
 }
 
 // -----------------------------------------------------------------------------
@@ -421,7 +423,7 @@ function Page_eraseBadMark( $projectid, $image, $round, $user )
         {$round->user_column_name}=''
     " );
 
-    _log_page_event( $projectid, $image, 'eraseBadMark', $user, $round, FALSE );
+    _log_page_event( $projectid, $image, 'eraseBadMark', $user, $round );
 
     _project_adjust_n_available_pages( $projectid, +1 );
 }
@@ -540,7 +542,7 @@ function _normalize_page_text( $page_text )
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function _log_page_event( $projectid, $image, $event_type, $username, $round, $is_prooferly )
+function _log_page_event( $projectid, $image, $event_type, $username, $round )
 {
     assert( strlen($event_type) <= 16 );
 
@@ -556,11 +558,6 @@ function _log_page_event( $projectid, $image, $event_type, $username, $round, $i
             username     = '$username',
             round_id     = $round_id_setting
     ") or die(mysqli_error(DPDatabase::get_connection()));
-
-    if ( $is_prooferly ) // as opposed to a PM-ish or Auto event
-    {
-        upi_set_t_latest_page_event( $username, $projectid, 'UNIX_TIMESTAMP()' );
-    }
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -3,6 +3,20 @@ include_once($relPath.'pg.inc'); // get_pg_catalog_url_for_etext
 include_once($relPath.'maybe_mail.inc');
 include_once($relPath.'forum_interface.inc'); // get_forum_email_address()
 
+/*
+The user_project_info table captures information that pertains specifically
+to the (username, projectid) tuple. This includes things like project
+subscriptions in addition to two timestamp fields that the site uses in
+various places:
+
+* t_latest_home_visit - timestamp of the last page visit (see project.php)
+* t_latest_page_event - timestamp of the last page saved in the project
+                        (see DPage.inc). Originally this recorded the last
+                        proofer-initiated page event and was later changed
+                        to only be updated on page save events and the
+                        database updated to reflect that.
+*/
+
 function upi_set_t_latest_home_visit( $username, $projectid, $timestamp )
 {
     mysqli_query(DPDatabase::get_connection(), "


### PR DESCRIPTION
Don't update user_project_info.t_latest_page_event upon page checkout
or return to round. This allows a user to "try out" a page in a project
and return it without it being added to their My Projects page.

[Task 1208](https://www.pgdp.net/c/tasks.php?action=show&task_id=1208)