### PR TITLE
Remove symbols before preview and restore after

### DIFF
--- a/tools/proofers/mark_wrap.js
+++ b/tools/proofers/mark_wrap.js
@@ -14,6 +14,8 @@
 // will precede \n. If insering \n the caret will follow it.
 // doesn't work correctly in Internet explorer 9 or chrome 16
 
+var wrapControl = false;
+
 $(function () {
     "use strict";
     if (0 === lineWrap) {
@@ -69,6 +71,15 @@ $(function () {
         return txt.replace(reSymb, "");
     }
 
+    function cleanText() {
+        text1.val(removeAllSymbols(text1.val()));
+    }
+
+    wrapControl = {
+        cleanText: cleanText,
+        adjustSymbol: adjustSymbol
+    };
+
     text1.click(function () {
         // if at end of line move to left of symbol
         var cPos = text1[0].selectionStart;
@@ -97,7 +108,7 @@ $(function () {
 
     // remove symbols before saving
     $("#editform").submit(function () {
-        text1.val(removeAllSymbols(text1.val()));
+        cleanText();
     });
 
     text1.on("copy", function (ev) {

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -1,5 +1,5 @@
 /*global $ previewDemo, top, makePreview, window, alert, ieWarn
-document localStorage */
+document localStorage wrapControl*/
 /*
 This file controls the user interface functions. Initially nothing is displayed
 because "prevdiv" has diplay:none; which means it is not displayed and the page
@@ -260,6 +260,9 @@ function initPrev() {
         // restore the bottom frame
         proofFrameSet.setAttribute("rows", old_rows);
         proofDiv.style.display = "block";
+        if (wrapControl) {
+            wrapControl.adjustSymbol();
+        }
         leavePreview();
     }
 
@@ -318,6 +321,9 @@ function initPrev() {
             // make the bottom frame very small since it is not useful
             proofFrameSet.setAttribute("rows", "*,1");
             proofDiv.style.display = "none";
+            if (wrapControl) {
+                wrapControl.cleanText();
+            }
             enterPreview();
             font_size = parseFloat(window.getComputedStyle(txtarea, null).fontSize);
             this.reSizeText(1.0);


### PR DESCRIPTION
This fixes a problem with preview when the line-wrap symbols are shown.