### PR TITLE
Picker fix 1

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -695,20 +695,22 @@ table.dirlist caption {
   font-size: 300%;
   width: 1.3em;
   margin: 0.1em;
+  text-align: center;
 }
 #toolbox .picker {
   margin-top: 1px;
   font-size: 1em;
-  padding: 0 1px 0 1px;
+  padding: 0 1px 0 0;
   vertical-align: middle;
   width: 100%;
   min-width: 1em;
+  max-width: 1.1em;
 }
 #toolbox .invisible {
   visibility: hidden;
 }
 #toolbox #char-selector {
-  min-width: 474px;
+  min-width: 430px;
 }
 /* ------------------------------------------------------------------------ */
 /* Special days tables */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -757,14 +757,16 @@ table.dirlist {
         font-size: 300%;
         width: 1.3em;
         margin: 0.1em;
+        text-align: center;
     }
     .picker {
         margin-top: 1px;
         font-size: 1em;
-        padding: 0 1px 0 1px;
+        padding: 0 1px 0 0;
         vertical-align: middle;
         width: 100%;
         min-width: 1em;
+        max-width: 1.1em;
     }
 
     .invisible {
@@ -773,7 +775,7 @@ table.dirlist {
 
     /* adjust so tools do not jump around with differnt character pickers */
     #char-selector {
-        min-width: 474px;
+        min-width: 430px;
     }
 }
 

--- a/tools/proofers/character_selector.js
+++ b/tools/proofers/character_selector.js
@@ -27,8 +27,8 @@ $(function () {
     });
 
     $(".picker", charSelector).click(function () {
-        top.insertCharacter(this.innerText);
+        top.insertCharacter(this.textContent);
     }).mouseover(function () {
-        largeChar.value = this.innerText;
+        largeChar.value = this.textContent;
     });
 });


### PR DESCRIPTION
This fixes two issues found on old browsers:
In Firefox 52 on windows XP the characters are very wide making the picker block too wide.
Firefox < 45 does not support innerText, using textContent instead which makes no difference in this context.