### PR TITLE
spaces after illustration etc. removed

### DIFF
--- a/pinc/PageUnformatter.inc
+++ b/pinc/PageUnformatter.inc
@@ -92,7 +92,7 @@ class PageUnformatter
     private function adjust_notes($text)
     {
         // Illustration with text, Sidenote, continuation Footnote without a ref.
-        $match = preg_match ("/\*\[Footnote: |\*?\[Sidenote: |\[Illustration: /", $text, $matches, PREG_OFFSET_CAPTURE);
+        $match = preg_match ("/\*\[Footnote:|\*?\[Sidenote:|\[Illustration:/", $text, $matches, PREG_OFFSET_CAPTURE);
         if(!$match) // if no match or error
         {
             return $text;


### PR DESCRIPTION
This fixes a problem where Illustration markup immediately followed by a newline as required for block quote markup is  not removed. See forum post [https://www.pgdp.net/phpBB3/viewtopic.php?p=1181037#p1181037]