### PR TITLE
Text format

### DIFF
--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -141,6 +141,7 @@ function output_preview_div()
     <span class='ilb'>
       <label><input type="radio" name="viewSel" id="show_tags">$tags</label>
       <label><input type="radio" name="viewSel" id="no_tags">$no_tags</label>
+      <label><input type="radio" name="viewSel" id="flat">$flat</label>
     </span>
     <span class='ilb'>
     <label><input type="checkbox" id="re_wrap">$re_wrap</label>
@@ -193,7 +194,7 @@ function output_preview_div()
   <br><span class='ilb'>$initial_mode <select id="id_init_mode">
     <option value="show_tags">$tags</option>
     <option value="no_tags">$no_tags</option>
-    <option value="re_wrap">$re_wrap</option>
+    <option value="flat">$flat</option>
   </select></span>
   <div class="box2">
     <input type='button' onclick="previewControl.OKConfig()" value="$ok">

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -103,6 +103,7 @@ function output_preview_div()
     $font = html_safe(_("Font"));
     $tags = html_safe(_("Tags"));
     $no_tags = html_safe(_("No Tags"));
+    $flat = html_safe(_("Flat"));
     $re_wrap = html_safe(_("Re-wrap"));
     $issues = html_safe(_("Issues"));
     $poss_iss = html_safe(_("Poss. Issues"));
@@ -140,7 +141,9 @@ function output_preview_div()
     <span class='ilb'>
       <label><input type="radio" name="viewSel" id="show_tags">$tags</label>
       <label><input type="radio" name="viewSel" id="no_tags">$no_tags</label>
-      <label><input type="radio" name="viewSel" id="re_wrap">$re_wrap</label>
+    </span>
+    <span class='ilb'>
+    <label><input type="checkbox" id="re_wrap">$re_wrap</label>
     </span>
     <span class='ilb'>$issues <input type="text" id="id_iss" size="1" readonly></span>
     <span class='ilb'>$poss_iss <input type="text" id="id_poss_iss" size="1" readonly></span>

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -103,14 +103,12 @@ function output_preview_div()
     $font = html_safe(_("Font"));
     $tags = html_safe(_("Tags"));
     $no_tags = html_safe(_("No Tags"));
-    $flat = html_safe(_("Flat"));
     $re_wrap = html_safe(_("Re-wrap"));
     $issues = html_safe(_("Issues"));
     $poss_iss = html_safe(_("Poss. Issues"));
     $default = html_safe(_("Default"));
     $other_tags = html_safe(_("Other tags"));
     $ss = shared_strings("html_safe");
-    $text = html_safe(_("Text"));
     $background = html_safe(_("Background"));
     $allow_underine = html_safe(_("Allow <u> for underline"));
     $suppress_warnings = html_safe(_('Suppress warnings'));
@@ -141,7 +139,7 @@ function output_preview_div()
     <span class='ilb'>
       <label><input type="radio" name="viewSel" id="show_tags">$tags</label>
       <label><input type="radio" name="viewSel" id="no_tags">$no_tags</label>
-      <label><input type="radio" name="viewSel" id="flat">$flat</label>
+      <label><input type="radio" name="viewSel" id="flat">$text</label>
     </span>
     <span class='ilb'>
     <label><input type="checkbox" id="re_wrap">$re_wrap</label>
@@ -194,7 +192,7 @@ function output_preview_div()
   <br><span class='ilb'>$initial_mode <select id="id_init_mode">
     <option value="show_tags">$tags</option>
     <option value="no_tags">$no_tags</option>
-    <option value="flat">$flat</option>
+    <option value="flat">$text</option>
   </select></span>
   <div class="box2">
     <input type='button' onclick="previewControl.OKConfig()" value="$ok">

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -7,11 +7,11 @@ The external references are previewMessages which is loaded by the function
 output_preview_strings() defined in preview.inc, called in preview_strings.php
 and previewControl.adjustMargin() defined in previewControl.js
 txt is the text to analyse.
-viewMode determines if the inline tags are to be shown or hidden and whether to
-re-wrap the text.
+viewMode determines if the inline tags are to be shown or hidden
+wrapMode whether to re-wrap the text.
 styler is an object containing colour and font options.
 */
-var makePreview = function (txt, viewMode, styler) {
+var makePreview = function (txt, viewMode, wrapMode, styler) {
     "use strict";
     // 1 means a definite issue, 0 a possible issue
     var issueType = {
@@ -535,7 +535,7 @@ var makePreview = function (txt, viewMode, styler) {
         // out of line tags
         colorString0 = makeColourStyle('etc');
         colorString = colorString0 + '>$&</span>';
-        if ((viewMode !== "re_wrap") && styler.color) {    // not re-wrap and colouring
+        if (!wrapMode && styler.color) {    // not re-wrap and colouring
             txt = txt.replace(/\/\*|\*\/|\/#|#\/|&lt;tb&gt;/g, '<span' + colorString);
         }
         if (viewMode !== "show_tags") {
@@ -1022,7 +1022,7 @@ var makePreview = function (txt, viewMode, styler) {
     restoreCommentLines();
     if (ok) {
         showStyle();
-        if (viewMode === "re_wrap") {
+        if (wrapMode) {
             reWrap();
         }
     }

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -510,6 +510,15 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
 
         function spanStyle(match, p1, p2) {
             // p1 is "/" or "", p2 is the tag id
+            var tagMap = {
+                "i": "_",
+                "b": "=",
+                "f": "~",
+                "g": "*",
+                "sc": "$",
+                "u": "%"
+            };
+
             if (!p2) { // must be user note
                 return match;
             }
@@ -519,7 +528,7 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
                     tagMark = match;
                     break;
                 case "flat":
-                    tagMark = "_";
+                    tagMark = tagMap[p2];
                     break;
                 default: // no_tags
                     break;
@@ -527,7 +536,14 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
             if (p1 === '/') {   // end tag
                 return tagMark + endSpan;
             }
-            return '<span class="' + p2 + '"' + makeColourStyle(p2) + '>' + tagMark;
+            // if flat do not apply style (some change the width)
+            var styleClass;
+            if (viewMode === "flat") {
+                styleClass = " ";
+            } else {
+                styleClass = " class='" + p2 + "' ";
+            }
+            return "<span" + styleClass + makeColourStyle(p2) + '>' + tagMark;
         }
 
         // inline tags

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -514,8 +514,8 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
                 "i": "_",
                 "b": "=",
                 "f": "~",
-                "g": "*",
-                "sc": "$",
+                "g": "$",
+                "sc": "",
                 "u": "%"
             };
 
@@ -549,7 +549,9 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
         // inline tags
         // the way html treats small cap text is different to the dp convention
         // so if sc-marked text is all upper-case transform to lower
-        txt = txt.replace(sc_re, transformSC);
+        if (viewMode !== "flat") {
+            txt = txt.replace(sc_re, transformSC);
+        }
         // find user note or inline tag
         var reTag = new RegExp(noteStringOr + "&lt;(\\/?)(" + ILTags + ")&gt;", "g");
         txt = txt.replace(reTag, spanStyle);

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -509,22 +509,27 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
         }
 
         function spanStyle(match, p1, p2) {
-            // p1 is "/" or "", p2 is the tag
+            // p1 is "/" or "", p2 is the tag id
             if (!p2) { // must be user note
                 return match;
             }
+            var tagMark = "";
+            switch (viewMode) {
+                case "show_tags":
+                    tagMark = match;
+                    break;
+                case "flat":
+                    tagMark = "_";
+                    break;
+                default: // no_tags
+                    break;
+            }
             if (p1 === '/') {   // end tag
-                if (viewMode === "show_tags") {
-                    return match + endSpan;
-                }
-                return endSpan;
+                return tagMark + endSpan;
             }
-            var str = '<span class="' + p2 + '"' + makeColourStyle(p2) + '>';
-            if (viewMode === "show_tags") {
-                str += match;
-            }
-            return str;
+            return '<span class="' + p2 + '"' + makeColourStyle(p2) + '>' + tagMark;
         }
+
         // inline tags
         // the way html treats small cap text is different to the dp convention
         // so if sc-marked text is all upper-case transform to lower

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -487,7 +487,6 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
     // this works on text which has already had < and > encoded as &lt; &gt;
     function showStyle() {
         var colorString0, colorString; // for out-of-line tags, tb, sub- and super-scripts
-        var repstr2 = endSpan;
         var sc1 = "&lt;sc&gt;";
         var sc2 = "&lt;\/sc&gt;";
         var noteStringOr = "\\[\\*\\*[^\\]]*\\]|"; // a user note
@@ -510,14 +509,15 @@ var makePreview = function (txt, viewMode, wrapMode, styler) {
         }
 
         function spanStyle(match, p1, p2) {
+            // p1 is "/" or "", p2 is the tag
             if (!p2) { // must be user note
                 return match;
             }
             if (p1 === '/') {   // end tag
                 if (viewMode === "show_tags") {
-                    return match + repstr2;
+                    return match + endSpan;
                 }
-                return repstr2;
+                return endSpan;
             }
             var str = '<span class="' + p2 + '"' + makeColourStyle(p2) + '>';
             if (viewMode === "show_tags") {

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -52,6 +52,7 @@ function initPrev() {
 
     var selTag;
     var viewMode;
+    var wrapMode = false;
 
     var tempStyle = {}; // used during configure
 
@@ -91,9 +92,9 @@ function initPrev() {
 
     function writePreviewText() {
         // makePreview is defined in preview.js
-        preview = makePreview(txtarea.value, viewMode, previewStyles);
+        preview = makePreview(txtarea.value, viewMode, wrapMode, previewStyles);
         prevWin.style.whiteSpace = (
-            (preview.ok && (viewMode === "re_wrap"))
+            (preview.ok && wrapMode)
             ? "normal"
             : "pre"
         );
@@ -203,6 +204,11 @@ function initPrev() {
 
     $("[name='viewSel']").click(function () {
         viewMode = this.id;
+        writePreviewText();
+    });
+
+    $("#re_wrap").change(function () {
+        wrapMode = this.checked;
         writePreviewText();
     });
 

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -214,7 +214,7 @@ function initPrev() {
 
     // functions for setting up the configuration screen
     function testDraw() {
-        preview = makePreview(previewDemo, 'no_tags', tempStyle);
+        preview = makePreview(previewDemo, 'no_tags', false, tempStyle);
         testDiv.innerHTML = preview.txtout;
     }
 


### PR DESCRIPTION
This adds a "text" mode where inline markup (i, b, f g,u)  is replaced by a single character to show how text will appear in the "plain text" version of the book to get correct alignment of tables etc. Small caps markup is not marked in this way. "Wrap" is now a checkbox so that the Text mode can be used with or without re-wrapping.