### PR TITLE
Auto-commit DP updates

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -28,6 +28,9 @@ final class DPDatabase
         $sql = "SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));";
         if(!mysqli_query(self::$_connection, $sql))
             throw new DBConnectionError("Unable to set sql_mode");
+
+        // Autocommit DB updates
+        mysqli_autocommit(self::$_connection, TRUE);
     }
 
     static public function close()


### PR DESCRIPTION
The DP code doesn't (currently) use transactions. For systems that have moved to use MySQL engine backends that support transactions (i.e. InnoDB) we should auto commit updates.

This change improves updates on PROD since we have moved some tables (like page_events and user_project_info) to InnoDB tables.