### PR TITLE
Remove duplicate fields from project_state_stats

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -438,7 +438,7 @@ CREATE TABLE `sessions` (
 #
 
 CREATE TABLE `site_tally_goals` (
-  `date` date NOT NULL default '0000-00-00',
+  `date` date NOT NULL default '2000-01-01',
   `tally_name` char(2) NOT NULL default '',
   `goal` int(6) NOT NULL default '0',
   PRIMARY KEY  (`date`,`tally_name`)

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -300,10 +300,7 @@ CREATE TABLE `project_holds` (
 #
 
 CREATE TABLE `project_state_stats` (
-  `year` smallint(4) NOT NULL default '2003',
-  `month` tinyint(2) NOT NULL default '0',
-  `day` tinyint(2) NOT NULL default '0',
-  `date` date NOT NULL default '2003-00-00',
+  `date` date NOT NULL default '2003-01-01',
   `state` varchar(50) NOT NULL default '0',
   `num_projects` int(12) NOT NULL default '0',
   `num_pages` int(12) NOT NULL default '0',

--- a/SETUP/upgrade/13/20191019_alter_project_state_stats.php
+++ b/SETUP/upgrade/13/20191019_alter_project_state_stats.php
@@ -1,0 +1,36 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Updating project_state_stats.date default value..\n";
+$sql = "
+    ALTER TABLE project_state_stats
+        MODIFY COLUMN date date NOT NULL DEFAULT '2003-01-01';
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+echo "Dropping columns from project_state_stats..\n";
+$sql = "
+    ALTER TABLE project_state_stats
+        DROP COLUMN day,
+        DROP COLUMN month,
+        DROP COLUMN year;
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/SETUP/upgrade/13/20191019_alter_site_tally_goals.php
+++ b/SETUP/upgrade/13/20191019_alter_site_tally_goals.php
@@ -1,0 +1,23 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Updating site_tally_goals.date default value..\n";
+$sql = "
+    ALTER TABLE site_tally_goals
+        MODIFY COLUMN date date NOT NULL DEFAULT '2000-01-01';
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/stats/jpgraph_files/cumulative_month_proj.php
+++ b/stats/jpgraph_files/cumulative_month_proj.php
@@ -28,11 +28,11 @@ $maxday = get_number_of_days_in_current_month();
 
 //query db and put results into arrays
 $result = mysqli_query(DPDatabase::get_connection(), "
-    SELECT day, SUM(num_projects)
+    SELECT DAYOFMONTH(date) as day, SUM(num_projects)
     FROM project_state_stats
-    WHERE month = '$month' AND year = '$year' AND ($psd->state_selector)
-    GROUP BY day
-    ORDER BY day
+    WHERE MONTH(date) = $month AND YEAR(date) = $year AND ($psd->state_selector)
+    GROUP BY DAYOFMONTH(date)
+    ORDER BY date
 ");
 
 list($datax,$y_num_projects) = dpsql_fetch_columns($result);

--- a/stats/jpgraph_files/curr_month_proj.php
+++ b/stats/jpgraph_files/curr_month_proj.php
@@ -29,11 +29,11 @@ $maxday = get_number_of_days_in_current_month();
 
 //query db and put results into arrays
 $result = mysqli_query(DPDatabase::get_connection(), "
-    SELECT day, SUM(num_projects)
+    SELECT DAYOFMONTH(date) as day, SUM(num_projects)
     FROM project_state_stats
-    WHERE month = '$month' AND year = '$year' AND ($psd->state_selector)
-    GROUP BY day
-    ORDER BY day
+    WHERE MONTH(date) = $month AND YEAR(date) = $year AND ($psd->state_selector)
+    GROUP BY DAYOFMONTH(date)
+    ORDER BY date
 ");
 
 list($datax,$y_cumulative) = dpsql_fetch_columns($result);


### PR DESCRIPTION
project_state_stats already includes a date column so there's no need to store additional year/month/day columns with the same data. Instead just use the right SQL in the stats queries.

Most importantly, use a valid default value for the date field.

I found this while working on Unicode conversion. MySQL got unhappy when it tried to update the encoding on this table with an invalid date default.