### PR TITLE
Enable character pickers to work in wordcheck

### DIFF
--- a/tools/proofers/dp_proof.js
+++ b/tools/proofers/dp_proof.js
@@ -167,8 +167,13 @@ function doBU()
 // apply tagOpen/tagClose to selection in textarea,
 function insertTags(tagOpen, tagClose, replace)
 {
-    "use strict";
-    var txtArea = docRef.editform.text_data;
+    var txtArea;
+    if(inFace < 2) {
+        txtArea = docRef.editform.text_data;
+    } else {
+        // we're in wordcheck
+        txtArea = docRef.getElementById("input_" + txtBoxID);
+    }
     var startPos = txtArea.selectionStart;
     var endPos = txtArea.selectionEnd;
 
@@ -226,6 +231,7 @@ function insertTags(tagOpen, tagClose, replace)
     var curPos = startPos + subst.length;
     txtArea.setSelectionRange(curPos, curPos);
     txtArea.focus();
+    $(txtArea).trigger("input");
 }
 
 function lc_common(str)

--- a/tools/proofers/dp_scroll.js
+++ b/tools/proofers/dp_scroll.js
@@ -288,7 +288,7 @@ function initializeStuff(wFace)
   else if (wFace==3)
     {
       // standard interface, spellcheck
-      docRef=top.proofframe.document;
+      docRef=top.proofframe.textframe.document;
     }
 
 

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -145,11 +145,11 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
                 // if the AW button is wanted, add the initial span
                 if($badWordHash[$word] == WC_WORLD ) {
                     $replaceString .= "<span id='$wordID'>";
-                    $onChange = " onBlur=\"disableAW('$wordID');\"";
-                    $onChange.= " onKeyup=\"disableAW('$wordID');\"";
+                    $onChange = " onBlur=\"markBox('$wordID');\"";
+                    $onChange.= " oninput=\"disableAW('$wordID');\"";
                 } else {
-                    $onChange = " onBlur=\"evaluateWordChange('$wordID');\"";
-                    $onChange.= " onKeyup=\"evaluateWordChange('$wordID');\"";
+                    $onChange = " onBlur=\"markBox('$wordID');\"";
+                    $onChange.= " oninput=\"evaluateWordChange('$wordID');\"";
                 }
 
                 // create the edit box
@@ -259,6 +259,11 @@ function spellcheck_get_js()
     function evaluateWordChange(wordID) {
         if (isWordChanged(wordID))
             markPageChanged();
+    }
+
+    // store wordID for char pickers to use
+    function markBox(wordID) {
+        top.txtBoxID = wordID;
     }
 
     // Disable a bad word's Unflag button


### PR DESCRIPTION
This implements task 1295 to enable the character pickers to work in the editable wordcheck boxes.