### PR TITLE
Add a button to remove bad characters.

### DIFF
--- a/tools/proofers/codepoint_validator.inc
+++ b/tools/proofers/codepoint_validator.inc
@@ -5,6 +5,7 @@ function render_validator()
 {
     $bad_char_message = _("The text contains characters which are not enabled for this project");
     $quit_text = _("Quit");
+    $remove_text = _("Remove bad characters and quit");
     echo <<<END
 <div class='flex_container nodisp' id='checker'>
 <div class='stretchbox ws-pre' id='check-text'>
@@ -12,6 +13,7 @@ function render_validator()
 <div class='fixedbox'>
 $bad_char_message
 &nbsp;<button type='button' id='cc-quit'>$quit_text</button>
+&nbsp;<button type='button' id='cc-remove'>$remove_text</button>
 </div>
 </div>
 END;

--- a/tools/proofers/codepoint_validator.js
+++ b/tools/proofers/codepoint_validator.js
@@ -56,4 +56,11 @@ $(function () {
         $("#checker").hide();
         $("#proofdiv").show();
     });
+
+    $("#cc-remove").click(function () {
+        let textarea = $("#text_data");
+        textarea.val(textarea.val().replace(pattern , ""));
+        $("#checker").hide();
+        $("#proofdiv").show();
+    });
 });


### PR DESCRIPTION
Suppose the user insert a combining diacritical mark. The text will
be normalised. 3 cases:
1, a good character results -- ok
2, a bad character results and will be marked.
3,  no more normal form exists and the diacritical itsef is marked
This is invisible so the user may not know what the bad character is.
This feature allows him to proceed.
Interestingly in php regexes \X matches a composed glyph but this
is not available in JS regex.
It would be possible to do this functionally but seems a lot of
work for little return.