### PR TITLE
Centralize proofreading font logic

### DIFF
--- a/faq/font_sample.php
+++ b/faq/font_sample.php
@@ -14,7 +14,7 @@ output_header($title, NO_STATSBAR);
 // (for comparison to DPCustomMono2)
 // from the following list:
 $selectable_fonts = array();
-foreach($proofreading_font_faces as $index => $font)
+foreach(get_available_proofreading_font_faces() as $index => $font)
 {
     if (!is_file(get_sample_image_for_font($font)))
         // We don't have a sample image file for this font,
@@ -32,17 +32,7 @@ foreach($proofreading_font_faces as $index => $font)
 sort($selectable_fonts);
 
 // determine user's current proofreading font, if any and use that as the compare_font
-$proofreading_font="";
-if ($userP['i_layout']==1)
-{
-    $proofreading_fonti = $userP['v_fntf'];
-    $proofreading_font = $proofreading_font_faces[$proofreading_fonti];
-}
-else if ((count($userP) > 0) and ($userP['i_layout']==0))
-{
-    $proofreading_fonti = $userP['h_fntf'];
-    $proofreading_font = $proofreading_font_faces[$proofreading_fonti];
-}
+list($proofreading_font, ) = get_user_proofreading_font();
 
 // set the default compare_font to the user's proofreading font
 // if it is selectable

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -16,40 +16,48 @@ define( 'BROWSER_DEFAULT_STR', _("Browser default") );
 # empty and replaced with BROWSER_DEFAULT_STR before displaying to the
 # user.
 
-$proofreading_font_faces = array(
-    0 => '', // browser default
-    5 => 'monospace',
-    3 => 'Arial',
-    1 => 'Courier',
-    6 => 'DPCustomMono2',
-    4 => 'Lucida',
-    7 => 'Lucida Console',
-    8 => 'Monaco',
-    2 => 'Times',
-);
+function get_available_proofreading_font_faces()
+{
+    return [
+        0 => '', // browser default
+        5 => 'monospace',
+        3 => 'Arial',
+        1 => 'Courier',
+        6 => 'DPCustomMono2',
+        4 => 'Lucida',
+        7 => 'Lucida Console',
+        8 => 'Monaco',
+        2 => 'Times',
+    ];
+}
 
-$proofreading_font_sizes = array (
-     0 => '', // browser default
-     1 => '11px',
-     2 => '12px',
-     3 => '13px',
-    12 => '14px',
-     4 => '15px',
-     5 => '16px',
-     6 => '17px',
-    13 => '18px',
-     7 => '19px',
-    14 => '20px',
-     8 => '21px',
-     9 => '22px',
-    10 => '24px',
-    11 => '26px',
-);
+function get_available_proofreading_font_sizes()
+{
+    return [
+         0 => '', // browser default
+         1 => '11px',
+         2 => '12px',
+         3 => '13px',
+        12 => '14px',
+         4 => '15px',
+         5 => '16px',
+         6 => '17px',
+        13 => '18px',
+         7 => '19px',
+        14 => '20px',
+         8 => '21px',
+         9 => '22px',
+        10 => '24px',
+        11 => '26px',
+    ];
+}
 
 // And a function to return user's current proofreading font
 function get_user_proofreading_font()
 {
-    global $userP, $proofreading_font_sizes, $proofreading_font_faces;
+    global $userP;
+    $proofreading_font_faces = get_available_proofreading_font_faces();
+    $proofreading_font_sizes = get_available_proofreading_font_sizes();
 
     if ( $userP['i_layout']==1 )   // "vertical"
     {

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'quizzes.inc'); // get_quiz_page_id_param
-include_once($relPath.'prefs_options.inc'); // $proofreading_font_*
+include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 
 $quiz_page_id = get_quiz_page_id_param($_REQUEST, 'quiz_page_id');
 
@@ -13,22 +13,7 @@ include "./quiz_page.inc"; // qp_initial_page_text qp_sample_solution
 // Figure out what font to use
 if ($user_is_logged_in)
 {
-    // Use the font prefs for the user's default interface layout, 
-    // since they're more likely to have set those prefs
-    global $userP;
-
-    if ( $userP['i_layout']==1 )
-    {
-        $font_face_i = $userP['v_fntf'];
-        $font_size_i = $userP['v_fnts'];    
-    }
-    else
-    {
-        $font_face_i = $userP['h_fntf'];
-        $font_size_i = $userP['h_fnts'];
-    }
-    $font_face = $proofreading_font_faces[$font_face_i];
-    $font_size = $proofreading_font_sizes[$font_size_i];
+    list($font_face, $font_size) = get_user_proofreading_font();
 
     $font_settings = '';
     if ( $font_face != '' )

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -237,16 +237,11 @@ elseif ($frame=="text") {
         // Use the font and wrap prefs for the user's default interface layout, 
         // since they're more likely to have set those prefs
         if ( $userP['i_layout']==1 ) {
-            $font_face_i = $userP['v_fntf'];
-            $font_size_i = $userP['v_fnts'];
             $line_wrap   = $userP['v_twrap'];
         } else {
-            $font_face_i = $userP['h_fntf'];
-            $font_size_i = $userP['h_fnts'];
             $line_wrap   = $userP['h_twrap'];
         }
-        $font_face = $proofreading_font_faces[$font_face_i];
-        $font_size = $proofreading_font_sizes[$font_size_i];
+        list($font_face, $font_size) = get_user_proofreading_font();
 
         // Since this page doesn't have a vertical layout version, 
         // we'll use their horizontal prefs for textarea size

--- a/tools/proofers/button_menu.inc
+++ b/tools/proofers/button_menu.inc
@@ -8,7 +8,8 @@ include_once('PPage.inc');
 function echo_button_menu( $ppage )
 {
     global $userP;
-    global $proofreading_font_faces, $proofreading_font_sizes;
+    $proofreading_font_faces = get_available_proofreading_font_faces();
+    $proofreading_font_sizes = get_available_proofreading_font_sizes();
 ?>
 <script>
 function refuseNonNumeric(event) {
@@ -37,14 +38,14 @@ HREF="#" accesskey="/" onfocus="scrollImage('down')" onclick="scrollImage('down'
 name="fntFace" ID="fntFace"  class="dropsmall" title="<?php 
     echo attr_safe(_("Change Font Face"));
 ?>" onChange="top.changeFontFamily(this.options[this.selectedIndex].value, this.options[this.selectedIndex].text)"><?php
-    $current_font_i = $userP['i_layout']==1 ? $userP['v_fntf'] : $userP['h_fntf'];
+    list($current_font, $current_size) = get_user_proofreading_font();
     foreach($proofreading_font_faces as $index => $font)
     {
         if($font == '')
             $font = BROWSER_DEFAULT_STR;
 
         $optP = "<option \r\n value=\"$index\"";
-        if($index == $current_font_i)
+        if($font == $current_font)
             $optP .= " selected";
         $optP .= ">" . $font . "</option>";
         echo $optP;
@@ -53,14 +54,13 @@ name="fntFace" ID="fntFace"  class="dropsmall" title="<?php
 name="fntSize" ID="fntSize"  class="dropsmall" title="<?php 
     echo attr_safe(_("Change Font Size"));
 ?>" onChange="top.changeFontSize(this.options[this.selectedIndex].value, this.options[this.selectedIndex].text)"><?php
-    $current_size_i = $userP['i_layout']==1 ? $userP['v_fnts'] : $userP['h_fnts'];
     foreach($proofreading_font_sizes as $index => $size)
     {
         if($size == '')
             $size = BROWSER_DEFAULT_STR;
 
         $optP = "<option \r\n value=\"$index\"";
-        if($index == $current_size_i)
+        if($size == $current_size)
             $optP .= " selected";
         $optP .= ">$size</option>";
         echo $optP;

--- a/userprefs.php
+++ b/userprefs.php
@@ -394,7 +394,6 @@ function save_general_tab() {
 function echo_proofreading_tab() {
     global $userP;
     global $i_resolutions;
-    global $proofreading_font_faces, $proofreading_font_sizes;
     global $userSettings;
 
     // see if they already have 10 profiles, etc.
@@ -500,6 +499,7 @@ function echo_proofreading_tab() {
     td_pophelp( 'horzprefs' );
     echo "</tr>\n";
 
+    $proofreading_font_faces = get_available_proofreading_font_faces();
     echo "<tr>\n";
     $proofreading_font_faces[0] = BROWSER_DEFAULT_STR;
     show_preference(
@@ -516,6 +516,7 @@ function echo_proofreading_tab() {
     );
     echo "</tr>\n";
 
+    $proofreading_font_sizes = get_available_proofreading_font_sizes();
     echo "<tr>\n";
     $proofreading_font_sizes[0] = BROWSER_DEFAULT_STR;
     show_preference(


### PR DESCRIPTION
This centralizes code that returns the current proofreading font
style and size. This is in preparation for providing sane proofreading
font fallbacks.