### PR TITLE
Specify a font-family to fall back to

### DIFF
--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -166,6 +166,7 @@ function get_DifferenceEngine_css_files() {
 // Override default css for DP customizations
 function get_DifferenceEngine_css_data() {
     list($font_family, $font_size) = get_user_proofreading_font();
+    $font_family_fallback = get_proofreading_font_family_fallback();
     if($font_family != '')
         $font_family = "$font_family,";
     if($font_size != '')
@@ -180,7 +181,7 @@ function get_DifferenceEngine_css_data() {
 .diff-addedline,
 .diff-deletedline,
 .diff-context {
-    font-family: $font_family monospace;
+    font-family: $font_family $font_family_fallback;
     $font_size;
 }
 ";

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -1,10 +1,11 @@
 <?php
 define( 'BROWSER_DEFAULT_STR', _("Browser default") );
 
-# $proofreading_font_faces and $proofreading_font_sizes are used to
-# set the font family and size in the proofing interface. These strings
-# are both shown to the user *and* passed in the HTML to the browser
-# and thus must be valid values for font-family and font-size respectively.
+# The return values from get_available_proofreading_font_faces() and
+# get_available_proofreading_font_sizes() are used to set the font family
+# and size in the proofing interface. These strings are both shown to the
+# user *and* passed in the HTML to the browser and thus must be valid values
+# for font-family and font-size respectively.
 
 # Care should be taken when changing the following arrays. The user
 # preferences (stored in user_profiles) stores the array index
@@ -74,6 +75,12 @@ function get_user_proofreading_font()
     $font_style = $proofreading_font_faces[$font_style_i];
 
     return array($font_style, $font_size);
+}
+
+// This string is appended to the user's proofreading font for a fallback
+function get_proofreading_font_family_fallback()
+{
+    return "monospace";
 }
 
 // $u_n = show rank neighbors

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -15,12 +15,12 @@ if ($user_is_logged_in)
 {
     list($font_face, $font_size) = get_user_proofreading_font();
 
-    $font_settings = '';
+    $font_settings = 'font-family: ';
     if ( $font_face != '' )
     {
-        $font_settings .= "font-family: $font_face;";
-        $font_settings .= " ";
+        $font_settings .= "$font_face, ";
     }
+    $font_settings .= get_proofreading_font_family_fallback() . "; ";
     if ( $font_size != '' )
     {
         $font_settings .= "font-size: $font_size;";

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -253,12 +253,12 @@ elseif ($frame=="text") {
             id='text_data'
             cols='$n_cols'
             rows='$n_rows'
-            style='";
+            style='font-family: ";
         if ( $font_face != '' )
         {
-            echo "font-family: $font_face;";
-            echo " ";
+            echo "$font_face,";
         }
+        echo get_proofreading_font_family_fallback() . "; ";
         if ( $font_size != '' )
         {
             echo "font-size: $font_size;";

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -225,13 +225,13 @@ class PPage
             dir='".lang_direction($lang)."'
         ";
 
-        echo "style='";
+        echo "style='font-family: ";
         list($font_face, $font_size) = get_user_proofreading_font();
         if ( $font_face != '' )
         {
-            echo "font-family: $font_face;";
-            echo " ";
+            echo "$font_face,";
         }
+        echo get_proofreading_font_family_fallback() . "; ";
         if ( $font_size != '' )
         {
             echo "font-size: $font_size;";

--- a/tools/proofers/button_menu.inc
+++ b/tools/proofers/button_menu.inc
@@ -10,6 +10,7 @@ function echo_button_menu( $ppage )
     global $userP;
     $proofreading_font_faces = get_available_proofreading_font_faces();
     $proofreading_font_sizes = get_available_proofreading_font_sizes();
+    $font_family_fallback = get_proofreading_font_family_fallback();
 ?>
 <script>
 function refuseNonNumeric(event) {
@@ -37,7 +38,7 @@ HREF="#" accesskey="'" onfocus="scrollImage('up')" onclick="scrollImage('up')"><
 HREF="#" accesskey="/" onfocus="scrollImage('down')" onclick="scrollImage('down')"></A><select
 name="fntFace" ID="fntFace"  class="dropsmall" title="<?php 
     echo attr_safe(_("Change Font Face"));
-?>" onChange="top.changeFontFamily(this.options[this.selectedIndex].value, this.options[this.selectedIndex].text)"><?php
+?>" onChange="top.changeFontFamily(this.options[this.selectedIndex].value, this.options[this.selectedIndex].text, '<?php echo $font_family_fallback; ?>')"><?php
     list($current_font, $current_size) = get_user_proofreading_font();
     foreach($proofreading_font_faces as $index => $font)
     {

--- a/tools/proofers/dp_proof.js
+++ b/tools/proofers/dp_proof.js
@@ -48,12 +48,14 @@ function fixText()
     //}
 }
 
-function changeFontFamily(font_family_index, font_family)
+function changeFontFamily(font_index, font, fallback)
 {
     setText();
     // if the index is 0, we're to use the browser default
-    if (font_family_index == 0) {
-        font_family = null;
+    if (font_index == 0) {
+        font_family = fallback;
+    } else {
+        font_family = font + ", " + fallback;
     }
     docRef.editform.text_data.style.fontFamily = font_family;
     fixText();

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -48,6 +48,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
     // ok, at this point we have a finalized list of bad words.
     // start preparing the page
     list($font_style, $font_size) = get_user_proofreading_font();
+    $font_family_fallback = get_proofreading_font_family_fallback();
     if($font_size != '')
         $font_size = "font-size: $font_size";
     if($font_style != '')
@@ -55,7 +56,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
     // define the styles used for the interface (highlight for the punctuation, AW button, etc)
     $returnString.="<style type='text/css'>" .
                    " pre { $font_size }".
-                   "  .proofingfont { font-family: $font_style monospace; $font_size }" .
+                   "  .proofingfont { font-family: $font_style $font_family_fallback; $font_size }" .
                    "  .hl { background-color: yellow; color: black; }" .
                    "  img.aw { border: 0; margin-left: 5px; }" .
                    "  span.aw { background-color: white; color: black; }" .


### PR DESCRIPTION
If the browser doesn't have the specified font, fall back to something sensible.

This is most important for Safari and Chrome on macOS which don't show textareas in monospace fonts.