### PR TITLE
Fix case where yaz_record() doesn't return array

### DIFF
--- a/pinc/MARCRecord.inc
+++ b/pinc/MARCRecord.inc
@@ -58,6 +58,10 @@ class MARCRecord
             $marc_title = $this->record[$title_key][1];
             $marc_title = trim(preg_replace("/\/$|:$/", "", $marc_title));
         }
+        else
+        {
+            $marc_title = '';
+        }
 
         $edition_key = $this->_key_search("250","a");
         if(isset($this->record[$edition_key]))
@@ -65,8 +69,15 @@ class MARCRecord
             $marc_edition = $this->record[$edition_key][1];
             $marc_edition = trim($marc_edition);
         }
+        else
+        {
+            $marc_edition = '';
+        }
 
-        if (isset($marc_edition)) { $marc_title = $marc_title.", ".$marc_edition; }
+        if($marc_title && $marc_edition)
+        {
+            $marc_title = "$marc_title, $marc_edition";
+        }
 
         // Task 849, strip all trailing comma/semicolon/colon from title.
         // Space is needed below as there is one at the end of $marc_title

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -164,6 +164,15 @@ function do_search_and_show_hits()
     while (($start <= yaz_hits($id) && $i <= $hits_per_page))
     {
         $rec = yaz_record($id, $start, "array");
+
+        // if $rec isn't an array, then yaz_record() failed and we should
+        // skip this record
+        if(!is_array($rec))
+        {
+            $start++;
+            continue;
+        }
+
         //if it's not a book don't display it.  we might want to uncomment in the future if there are too many records being returned - if (substr(yaz_record($id, $start, "raw"), 6, 1) != "a") { $start++; continue; }
         $marc_record = new MARCRecord();
         $marc_record->load_yaz_array($rec);


### PR DESCRIPTION
php_errors on PROD have shown some cases where yaz_record() isn't returning an array, making MARCRecord very sad. We should skip those errors at the source.

Also handle an edge case where $marc_title isn't set (which is really cropping up because of the above error, but it seems sensible to handle here too).