### PR TITLE
Update doc refs to old character drop-down menu

### DIFF
--- a/faq/proofreading_guidelines.php
+++ b/faq/proofreading_guidelines.php
@@ -844,7 +844,7 @@ output_header('Proofreading Guidelines', NO_STATSBAR, $theme_args);
 <p>Note that when some of these marks appear on some characters (mainly vowels) our standard
    Latin-1 character set already includes that character with the diacritical mark. <b>In those
    cases, use the Latin-1 character (see <a href="#a_chars">here</a>), available from the
-   drop-down lists in the proofreading interface.</b>
+   character picker in the proofreading interface.</b>
 </p>
 <!-- END RR -->
 
@@ -2163,7 +2163,7 @@ If you use one of these, be sure to insert only Latin-1 characters (those listed
   <li>You can use the Character Map program
      (Start: Run: charmap) to select an individual letter, and then cut &amp; paste.
   </li>
-  <li>The dropdown menus in the proofreading interface.
+  <li>The character picker in the proofreading interface.
   </li>
   <li>Or you can type the Alt+NumberPad shortcut codes listed below for these characters.
           This is faster than using cut &amp; paste, once you get used to the codes.
@@ -2369,7 +2369,7 @@ If you use one of these, be sure to insert only Latin-1 characters (those listed
       pane. Ensure that "Show input menu in menu bar" is checked. In the spreadsheet view, check the box
       for "Keyboard Viewer" in addition to any input locales you use.
   </li>
-  <li>The dropdown menus in the proofreading interface.
+  <li>The character picker in the proofreading interface.
   </li>
   <li>Or you can type the Apple Opt- shortcut codes list below for these characters.
       <br>This is a lot faster than using cut &amp; paste, once you get used to the codes.
@@ -2558,7 +2558,7 @@ If you use one of these, be sure to insert only Latin-1 characters (those listed
    Comments</a>, please do not use the fraction symbols, but instead use the guidelines for
    <a href="#fract_s">Fractions</a>. (1/2, 1/4, 3/4, etc.)
 </p>
-<p>&Dagger;&nbsp;Note: No equivalent shortcut; use drop-down menus if needed.
+<p>&Dagger;&nbsp;Note: No equivalent shortcut; use the character picker if needed.
 </p>
 <p class="backtotop"><a href="#top">Back to top</a></p>
 

--- a/pinc/templates/comment_files/eets.txt
+++ b/pinc/templates/comment_files/eets.txt
@@ -2,7 +2,7 @@
 
 <p>There are several special characters in these works. So far:<br>
 <br>
-The eth (/) and thorn (/) are found in the drop-down boxes.<br>
+The eth (/) and thorn (/) are found in the character picker.<br>
 [gh] for the yogh and [Gh] for the capital yogh (it looks like a three),<br>
 [l~l] for ll with a tilde through them,<br>
 [h-] for the h with a line through the top,<br>

--- a/quiz/generic/data/qd_p_mod1_5.inc
+++ b/quiz/generic/data/qd_p_mod1_5.inc
@@ -9,7 +9,7 @@ $initial_text                 = "when she discovered a new suitor, she had\nreco
 $solutions                    = array("when she discovered a new suitor, she had\nrecourse to a Rákshasa, who swallowed that\nunhappy suitor whole[b]. So Natabhrúkutí\nlooked towards the city wall, and she saw\nAja. And at the very first glance, she fell so\nviolently in love with him[c] that she could\n\nb This method of disposing of objectionable suitors\nis unfortunately not available in Europe.\n\nc Who ever loved that loved not at first sight?\nEvery Oriental would side with Shakspeare in\nthis matter: love, in the East, is not love, unless");
 if(!$utf8_site) {
     $parting_message          = "<h3>" . _("Handy Fact") . "</h3>\n" .
-                                    "<p>" . _("Where possible we use the same characters as in the original book, so we use <tt>&eacute;</tt> rather than <tt>[/e]</tt>.  You should only use the bracket notation for characters like <tt>[/r]</tt> that are not available in the drop-down menus at the bottom of the proofreading interface.") . "</p>";
+                                    "<p>" . _("Where possible we use the same characters as in the original book, so we use <tt>&eacute;</tt> rather than <tt>[/e]</tt>. You should only use the bracket notation for characters like <tt>[/r]</tt> that are not available in the character picker at the bottom of the proofreading interface.") . "</p>";
 }
 
 

--- a/quiz/generic/data/qd_p_thorn.inc
+++ b/quiz/generic/data/qd_p_thorn.inc
@@ -58,7 +58,7 @@ if($utf8_site) {
 }
 $messages["thorn"] = array(
     "message_title" => _("Thorn incorrectly proofread"),
-    "message_body" => _("The capital and lower case thorns (&THORN; and &thorn;) often appear in Old and Middle English texts.  These characters are available in the \"+\" drop-down menu at the bottom of the screen."),
+    "message_body" => _("The capital and lower case thorns (&THORN; and &thorn;) often appear in Old and Middle English texts. These characters are available in the character picker at the bottom of the screen."),
     "wiki_ref" => sprintf(_("See the <a href='%s' target='_blank'>Thorn</a> wiki page for details."), $thorn_url),
 );
 $messages["thorncase"] = array(

--- a/quiz/generic/quiz_defaults.inc
+++ b/quiz/generic/quiz_defaults.inc
@@ -62,7 +62,7 @@ if(!$utf8_site)
 {
     $messages["P_accentbracket"] = array(
         "message_title" => _("Accent"),
-        "message_body" => _("Where possible, proofread accented letters using the actual characters, like <tt>&aacute;</tt>. You can insert accented letters using the drop-down menus below, labelled \"A\" \"E\" \"I\" \"O\" \"U\" \"+\".  Only use brackets, such as <tt>['n]</tt>, when it is not available as a single character."),
+        "message_body" => _("Where possible, proofread accented letters using the actual characters, like <tt>&aacute;</tt>. You can insert accented letters using the character picker below. Only use brackets, such as <tt>['n]</tt>, when it is not available as a single character."),
         "guideline" => "a_chars"
     );
     $messages["P_oe"] = array(
@@ -85,12 +85,12 @@ else
 {
     $messages["P_accentbracket"] = array(
         "message_title" => _("Accent"),
-        "message_body" => _("Where possible, proofread accented letters using the actual characters, like <tt>&aacute;</tt>. You can insert accented letters using the drop-down menus below, labelled \"A\" \"E\" \"I\" \"O\" \"U\" \"+\"."),
+        "message_body" => _("Where possible, proofread accented letters using the actual characters, like <tt>&aacute;</tt>. You can insert accented letters using the character picker below."),
         "guideline" => "a_chars"
     );
     $messages["P_oe"] = array(
         "message_title" => _("Ligature"),
-        "message_body" => _("Proofread the 'oe' ligature (&oelig;) using the symbol directly, not as <tt>oe</tt> or <tt>[oe]</tt>.  You can insert the symbol using the \"O\" drop-down menu below."),
+        "message_body" => _("Proofread the 'oe' ligature (&oelig;) using the symbol directly, not as <tt>oe</tt> or <tt>[oe]</tt>. You can insert the symbol using the character picker below."),
         "guideline" => "a_chars"
     );
     $messages["P_macron"] = array(
@@ -102,12 +102,12 @@ else
 
 $messages["P_aebracket"] = array(
     "message_title" => _("Ligature"),
-    "message_body" => _("Proofread the 'ae' ligature (<tt>&aelig;</tt>) using the symbol directly; brackets are not necessary for this character.  You can insert the symbol using the \"A\" drop-down menu below."),
+    "message_body" => _("Proofread the 'ae' ligature (<tt>&aelig;</tt>) using the symbol directly; brackets are not necessary for this character. You can insert the symbol using the character picker below."),
     "guideline" => "a_chars"
 );
 $messages["P_ae"] = array(
     "message_title" => _("Ligature"),
-    "message_body" => _("Proofread the 'ae' ligature (&aelig;) using the symbol directly, not as <tt>ae</tt> or <tt>[ae]</tt>.  You can insert the symbol using the \"A\" drop-down menu below."),
+    "message_body" => _("Proofread the 'ae' ligature (&aelig;) using the symbol directly, not as <tt>ae</tt> or <tt>[ae]</tt>. You can insert the symbol using the character picker below."),
     "guideline" => "a_chars"
 );
 $messages["P_oelig"] = array(

--- a/quiz/tuts/tut_p_aeoe_1.php
+++ b/quiz/tuts/tut_p_aeoe_1.php
@@ -16,7 +16,7 @@ if(!$utf8_site)
 {
     echo "<p>" . _("The &aelig; ligature is in Latin-1 (the character set that we use for proofreading), so we normally proofread it using the symbol directly.  On the other hand, the &oelig; ligature is not, so we proofread it with brackets like this: <tt>[oe]</tt>") . "</p>\n";
 } else {
-    echo "<p>" . sprintf(_("You can insert each of these characters using the drop-down menus in the proofreading interface or using keyboard shortcuts. Tables for <a href='%1\$s' target='_blank'>Windows</a> and <a href='%2\$s' target='_blank'>Macintosh</a> which list these shortcuts are in the Proofreading Guidelines."), "../../faq/proofreading_guidelines.php#a_chars_win", "../../faq/proofreading_guidelines.php#a_chars_mac") . "</p>\n";
+    echo "<p>" . sprintf(_("You can insert each of these characters using the character picker in the proofreading interface or using keyboard shortcuts. Tables for <a href='%1\$s' target='_blank'>Windows</a> and <a href='%2\$s' target='_blank'>Macintosh</a> which list these shortcuts are in the Proofreading Guidelines."), "../../faq/proofreading_guidelines.php#a_chars_win", "../../faq/proofreading_guidelines.php#a_chars_mac") . "</p>\n";
 }
 
 echo "<p><a href='../generic/main.php?quiz_page_id=p_aeoe_1'>" . _("Continue to quiz") . "</a></p>\n";

--- a/quiz/tuts/tut_p_thorn.php
+++ b/quiz/tuts/tut_p_thorn.php
@@ -28,7 +28,7 @@ if(!$utf8_site)
 {
     echo " " . sprintf(_("The capital and lower case thorns, &THORN; and &thorn;, are available in Latin-1 (the character set used at %s), so we can use these symbols directly when proofreading."), $site_abbreviation);
 }
-echo " " . _("You can insert them using the \"+\" drop-down menu at the bottom of the Proofreading Interface.") . "</p>\n";
+echo " " . _("You can insert them using the character picker at the bottom of the Proofreading Interface.") . "</p>\n";
 
 echo "<p><a href='../generic/main.php?quiz_page_id=p_thorn'>" . _("Continue to quiz") . "</a></p>\n";
 


### PR DESCRIPTION
The new character picker has replaced the character drop-down menus, but
we neglected to update all of the documentation.