### PR TITLE
Point to round where PQC pulled the text

### DIFF
--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -330,6 +330,7 @@ function _test_project_for_bad_bytes($projectid)
     $n_bad_pages = 0;
     while (list($text, $imagename, $proofers) = page_info_fetch($pages_res))
     {
+        $round_num = get_round_num_from_proofers($proofers);
         $occurrences = find_bad_byte_sequences_in_text($text);
 
         if (count($occurrences) == 0)
@@ -350,10 +351,19 @@ function _test_project_for_bad_bytes($projectid)
             {
                 $rowspan = count($occurrences);
                 $img_url = "$code_url/tools/project_manager/displayimage.php?project=$projectid&imagefile=$imagename";
-                $text_url = "$code_url/tools/project_manager/downloadproofed.php?project=$projectid&amp;image=$imagename&amp;round_num=0";
+                $text_url = "$code_url/tools/project_manager/downloadproofed.php?project=$projectid&amp;image=$imagename&amp;round_num=$round_num";
                 $details_for_this_page = "<tr>\n";
                 $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$img_url'>$imagename</a></td>\n";
-                $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$text_url'>ocr</a></td>\n";
+                if($round_num == 0)
+                {
+                    $round_name = 'OCR';
+                }
+                else
+                {
+                    $round = get_Round_for_round_number($round_num);
+                    $round_name = $round->id;
+                }
+                $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$text_url'>$round_name</a></td>\n";
             }
             else
             {
@@ -386,6 +396,21 @@ function _test_project_for_bad_bytes($projectid)
     }
 
     return $r;
+}
+
+// We can calculate what round number a page text was selected from by
+// the number of proofers that has touched it.
+function get_round_num_from_proofers($proofers)
+{
+    $round_num = 0;
+    foreach($proofers as $proofer)
+    {
+        if($proofer == '')
+            break;
+        $round_num++;
+    }
+
+    return $round_num;
 }
 
 function tds_for_bad_bytes($raw)

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -27,13 +27,8 @@ output_header(_("Bad Bytes Explainer"), NO_STATSBAR);
     </li>
 
     <li><b>Text</b>:
-        The link will take you to the OCR text,
-        regardless of the round from which the page-text was taken.
-        To see the text from subsequent rounds,
-        <!--
-        If the bad bytes were introduced in proofing rounds,
-        -->
-        you will need to increment the round_num= parameter in the URL.
+        The link will take you to the text for the round where
+        page-text was taken and the bad byte-sequences were found.
     </li>
 
     <li><b>#</b>:


### PR DESCRIPTION
For the bad-bytes check, point to the round where the page text was pulled from, rather than just the OCR.

I suspect this will become more important later when we're using Unicode.

Task 1790