### PR TITLE
Standardize on Smooth Reading

### DIFF
--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -48,11 +48,11 @@ function upi_set_t_latest_page_event( $username, $projectid, $timestamp )
 $subscribable_project_events = array(
     'round_available' => _("Project becomes available in a round"),
     'round_complete'  => _("Project finishes a round"),
-    'pp_enter'        => _("Project enters PP stage"),
-    'sr_available'    => _("Project becomes available for smooth-reading"),
-    'sr_reported'     => _("User has uploaded a smooth-reading report"),
-    'sr_complete'     => _("Project finishes smooth-reading"),
-    'ppv_enter'       => _("Project enters PPV stage"),
+    'pp_enter'        => _("Project enters Post-Processing stage"),
+    'sr_available'    => _("Project becomes available for Smooth Reading"),
+    'sr_reported'     => _("User has uploaded a Smooth Reading report"),
+    'sr_complete'     => _("Project finishes Smooth Reading"),
+    'ppv_enter'       => _("Project enters Post-Processing Verification stage"),
     'posted'          => _("Project posted to Project Gutenberg"),
 );
 
@@ -180,17 +180,17 @@ function notify_project_event_subscribers( $project, $event, $extras=array() )
 
         case 'sr_available':
             $msg_body .=
-                _("This project has become available for smooth-reading.");
+                _("This project has become available for Smooth Reading.");
             break;
 
         case 'sr_reported':
             $msg_body .=
-                _("A new smooth-reading report has been uploaded.");
+                _("A new Smooth Reading report has been uploaded.");
             break;
 
         case 'sr_complete':
             $msg_body .=
-                _("This project has finished smooth-reading.");
+                _("This project has finished Smooth Reading.");
             break;
 
         case 'ppv_enter':

--- a/project.php
+++ b/project.php
@@ -1180,7 +1180,7 @@ function do_history()
         "creation" => _("creation"),
         "deletion" => _("deletion"),
         "edit" => _("edit"),
-        "smooth-reading" => _("smoothreading"),
+        "smooth-reading" => _("smooth reading"),
         "transition" => _("transition"),
         "transition(s)" => _("transition(s)"),
         "add_holds" => _("add hold(s)"),

--- a/tools/change_sr_commitment.php
+++ b/tools/change_sr_commitment.php
@@ -38,7 +38,7 @@ case "commit":
 case "withdraw":
     sr_withdraw_commitment($projectid, $pguser);
     $title = _("Withdraw from SR");
-    $body = sprintf(_("%1\$s, you have withdrawn from smoothreading project %2\$s."),
+    $body = sprintf(_("%1\$s, you have withdrawn from Smooth Reading project %2\$s."),
         $pguser, $projectid);
     break;
 }

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -119,8 +119,8 @@ else if ($site_supports_corrections_after_posting && $stage == 'correct' )
 }
 else if ($stage == 'smooth_avail')
 {
-    $title = _("Upload file for smooth reading");
-    $intro_blurb = _("This page allows you to upload a fully post-processed file for smooth reading. Uploading another version will overwrite the previously uploaded file.");
+    $title = _("Upload file for Smooth Reading");
+    $intro_blurb = _("This page allows you to upload a fully post-processed file for Smooth Reading. Uploading another version will overwrite the previously uploaded file.");
     $submit_button = _("Upload file");
     $is_file_optional = FALSE;
     $indicator = "_smooth_avail";
@@ -427,8 +427,8 @@ function handle_smooth_reading_change($project, $postcomments, $days, $extend)
         $project->ensure_topic();
         topic_add_post(
             $project->topic_id,
-            "Project made available for smooth-reading",
-            "The project has just been made available for smooth-reading for $days days."
+            "Project made available for Smooth Reading",
+            "The project has just been made available for Smooth Reading for $days days."
                 . "\n\n"
                 . "(This post is automatically generated.)",
             '[Smooth Reading Monitor]',


### PR DESCRIPTION
Here are all of the user-facing instances of `smooth reading`, `smooth-reading`, and `smoothreading` (even `smooth read`) that I found in the code.

I do wonder if in some of these places we should use `smooth read(ing)` with lowercase as the verb and `Smooth Reading` as a stage/noun. The former seems to read better alongside `proofread`/`proofreading` on the main page, for instance.