### PR TITLE
Fix wording about character picker in help

### DIFF
--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -670,16 +670,12 @@ Proofreading Guidelines for suggestions).
 
 <p>
 As an alternate option, the Proofreading interfaces have a tiled character
-picker section. Hovering over a character will show an enlarged view of it
-in the box on the left and a tooltip text will appear describing the
-character. Clicking on a character will insert it into the text.
-</p>
-
-<p>
-The top row shows the available character categories. The ones labeled
-A,E,I,O,U contain various accented versions, upper and lower case, of
-those respective characters. The one labeled "+" contains other special
-symbols, and accented versions of some consonants like Y, C, D, N etc.
+picker. At the top of the picker is a row of menu tiles. Hovering over a menu
+tile will show a tooltip containing a short description of what characters
+that menu contains. Clicking a menu tile will show a grid of characters below
+it. Hovering over a character will show an enlarged view of it in the box on
+the left and a tooltip text will appear describing the character. Clicking
+on a character will insert it into the text.
 </p>
 
 

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -90,31 +90,31 @@ class CharacterSelector
             [
                 [
                     "code" => "A",
-                    "title" => "A",
+                    "title" => _("A accents"),
                     "upper" => [0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6],
                     "lower" => [0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6],
                 ],
                 [
                     "code" => "E",
-                    "title" => "E",
+                    "title" => _("E accents"),
                     "upper" => [200, 201, 202, 203],
                     "lower" => [232, 233, 234, 235],
                 ],
                 [
                     "code" => "I",
-                    "title" => "I",
+                    "title" => _("I accents"),
                     "upper" => [204, 205, 206, 207],
                     "lower" => [236, 237, 238, 239],
                 ],
                 [
                     "code" => "O",
-                    "title" => "O",
+                    "title" => _("O accents"),
                     "upper" => [210, 211, 212, 213, 214, 216],
                     "lower" => [242, 243, 244, 245, 246, 248],
                 ],
                 [
                     "code" => "U",
-                    "title" => "U",
+                    "title" => _("U accents"),
                     "upper" => [217, 218, 219, 220],
                     "lower" => [249, 250, 251, 252],
                 ],


### PR DESCRIPTION
Remove outdated paragraph in the proofreading interface help that discusses the old character selection UI and try to clarify the new character picker interface.