### PR TITLE
Remove use of MAX_FILE_SIZE in form uploads

### DIFF
--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -424,7 +424,6 @@ function manage_form($locale)
     echo "<form action='$translate_url?func=upload' method='POST' enctype='multipart/form-data'>\n";
     echo "<input type='hidden' name='locale' value='$locale'>";
     echo _("Select a PO file to upload:") . " ";
-    echo "<input type='hidden' name='MAX_FILE_SIZE' value='5000000'>";
     echo "<input type='file' name='userfile'><br>\n";
     echo "<input type='submit' value='"
         . attr_safe(_("Upload file")) . "'> ";

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -212,7 +212,6 @@ if (!isset($action) && !$extend)
     echo "<input type='hidden' name='stage' value='$stage'>\n";
     echo "<input type='hidden' name='days' value='$days'>\n";
     echo "<input type='hidden' name='action' value='1'>\n";
-    echo "<input type='hidden' name='MAX_FILE_SIZE' value='25165824'>\n";
 
     echo "<p>" . _("Follow these steps:") . "</p>\n";
     echo "<ol>\n";


### PR DESCRIPTION
MAX_FILE_SIZE is relatively useless, as it isn't enforced on the browser side.

Ultimately it just leads to confusing messages. See also https://stackoverflow.com/questions/1381364/max-file-size-in-php-whats-the-point/1381422