### PR TITLE
Bad character warning area now scrolls correctly in all cases

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -182,7 +182,7 @@ class Project
     {
         return [
             Glyphsets::get_glyphset("Basic Latin"),
-            Glyphsets::get_glyphset("Extended European Latin"),
+//            Glyphsets::get_glyphset("Extended European Latin"),
         ];
     }
 

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -902,17 +902,17 @@ table.search-column tr th {
 /* ------------------------------------------------------------------------ */
 /* Codepoint Validator */
 .flex_container {
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }
 .fixedbox {
-  flex: 0 0 auto;
+  flex: auto;
   background-color: #CDC0B0;
   padding: 2px;
 }
 .stretchbox {
-  flex: 1 1 100vh;
+  flex: auto;
   min-height: 10px;
   overflow: auto;
   background-color: HoneyDew;

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -982,19 +982,19 @@ table.search-column {
 /* Codepoint Validator */
 
 .flex_container {
-    height: 100vh;
+    height: 100%;
     display: flex;
     flex-direction: column;
 }
 
 .fixedbox {
-    flex:0 0 auto;
+    flex: auto;
     background-color: #CDC0B0;
     padding: 2px;
 }
 
 .stretchbox {
-    flex: 1 1 100vh;
+    flex: auto;
     min-height: 10px;
     overflow: auto;
     background-color: HoneyDew;

--- a/tools/proofers/codepoint_validator.inc
+++ b/tools/proofers/codepoint_validator.inc
@@ -3,7 +3,7 @@ include_once($relPath."Project.inc");
 
 function render_validator()
 {
-    $bad_char_message = _("The text contains characters which are not enabled for this project");
+    $bad_char_message = _("The text contains invalid characters <span class='bad-char'>highlighted</span>");
     $quit_text = _("Quit");
     $remove_text = _("Remove bad characters and quit");
     echo <<<END

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -30,6 +30,7 @@ function echo_text_frame_std( $ppage )
     slim_header(_("Text Frame"), $header_args);
     ?>
     <form name="editform" id="editform" method="post" action="processtext.php" target="proofframe">
+    <div style = 'height: 100vh'>
     <?php
     output_preview_div();
     render_validator(); ?>
@@ -80,6 +81,7 @@ function echo_text_frame_std( $ppage )
         <input title="<?php echo attr_safe(_("Zoom to Original Size")); ?>" type="button" value="<?php echo attr_safe(_("Original")); ?>" onclick="top.reSizeRelative(-1); document.getElementById('zoomout_button').disabled=false;">
 
       </div> <!-- proofdiv -->
+    </div>
     </form>
     <?php
 }


### PR DESCRIPTION
and message improved with highlighting.
The important part is changing the height of the flex container to 100% instead of 100vh which makes it work correctly in the enhanced interface.
Had to add an extra div with height 100vh in the standard interface for it to work there also.