### PR TITLE
Don't do strict checks on zips

### DIFF
--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -670,7 +670,7 @@ function is_valid_zip_file(string $file_path, bool $ignore_extension_check = fal
 
     $zip = new ZipArchive();
 
-    $result = $zip->open($file_path, ZipArchive::CHECKCONS);
+    $result = $zip->open($file_path);
 
     if ($result === true) {
         $zip->close();


### PR DESCRIPTION
Zip files with Mac resource forks (ie: __MACOSX directories) fail validation when ZipArchive::CHECKCONS is used. The files still extract correctly so let's err on the side of less rigid checks knowing we an accept these zips with are not infrequent.