### PR TITLE
Drop redundant indexes

### DIFF
--- a/SETUP/upgrade/13/20191228_alter_page_events.php
+++ b/SETUP/upgrade/13/20191228_alter_page_events.php
@@ -1,0 +1,24 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Dropping redundant keys on page_events...\n";
+$sql = "
+    ALTER TABLE page_events
+        DROP INDEX projectid,
+        DROP INDEX username_projectid_round_time;
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
past_tallies and page_events are the two largest tables on pgdp.net because they are constantly written to. Both contain indexes that are no longer used but are taking up disk space. For instance, the page_events index size is 2x the size of the data itself.

Drop the indexes on these tables that aren't used in queries against them as confirmed by explain plans.

This is done with an eye to the InnoDB conversion and later the Unicode conversion (although page_events is already InnoDB on PROD).