### PR TITLE
Use default engine when creating tables

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -8,6 +8,9 @@ see the git history.
 Scripts supporting this upgrade are in `SETUP/upgrade/13`
 
 * Updated minimum PHP version to 7.0 (cpeel)
+* Create non-project database tables using default engine; for
+  MySQL 5.5 and higher that is InnoDB. Project tables are still created
+  using the MyISAM engine (cpeel)
 
 
 ## R201903

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -27,7 +27,14 @@ Ubuntu system package names.
 * zip - php-zip
 
 ### MySQL
-MySQL version 5.5 or later is recommended.
+MySQL version 5.6.6 or later is recommended with `innodb_file_per_table=ON`
+and using InnoDB as the default engine (which are the defaults for that
+version and later). Non-project tables will be created with the default engine
+and InnoDB tables are easier to manage in their own files.
+
+Version 5.5 will also work but consider setting your default engine to MyISAM
+rather than have all of the InnoDB tables created in your system tablespace.
+
 Versions below 5.5, down to 5.1, may work but are untested.
 
 MariaDB version 5.5 and later should also work but has not been tested.

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE `access_log` (
   `action` varchar(16) NOT NULL default '',
   `activity` varchar(32) NOT NULL default '',
   KEY `subject_username` (`subject_username`,`timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -38,7 +38,7 @@ CREATE TABLE `authors` (
   `enabled` tinytext NOT NULL,
   `last_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY  (`author_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -55,7 +55,7 @@ CREATE TABLE `best_tally_rank` (
   `best_rank` int(6) NOT NULL default '0',
   `best_rank_timestamp` int(10) unsigned NOT NULL default '0',
   PRIMARY KEY  (`tally_name`,`holder_type`,`holder_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -71,7 +71,7 @@ CREATE TABLE `biographies` (
   `bio` text NOT NULL,
   `last_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY  (`bio_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 COMMENT='Contains biographies (see authors)';
+) DEFAULT CHARSET=latin1 COMMENT='Contains biographies (see authors)';
 # --------------------------------------------------------
 
 #
@@ -87,7 +87,7 @@ CREATE TABLE `current_tallies` (
   `holder_id` int(6) unsigned NOT NULL default '0',
   `tally_value` int(8) NOT NULL default '0',
   PRIMARY KEY  (`tally_name`,`holder_type`,`holder_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -111,7 +111,7 @@ CREATE TABLE `image_sources` (
   `internal_comment` text,
   UNIQUE KEY `code_name` (`code_name`),
   UNIQUE KEY `display_name` (`display_name`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -126,7 +126,7 @@ CREATE TABLE `job_logs` (
   `tracetime` int(12) unsigned NOT NULL default '0',
   `event` varchar(20) NOT NULL default ''' ''',
   `comments` varchar(255) default NULL
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -141,7 +141,7 @@ CREATE TABLE `marc_records` (
   `original_array` text NOT NULL,
   `updated_array` text NOT NULL,
   PRIMARY KEY  (`projectid`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -161,7 +161,7 @@ CREATE TABLE `news_items` (
   `locale` varchar(8) NOT NULL DEFAULT '',
   PRIMARY KEY  (`id`),
   KEY `pageid_locale` (`news_page_id`,`locale`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -175,7 +175,7 @@ CREATE TABLE `news_pages` (
   `news_page_id` varchar(8) NOT NULL default '',
   `t_last_change` int(11) NOT NULL default '0',
   PRIMARY KEY  (`news_page_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -197,7 +197,7 @@ CREATE TABLE `non_activated_users` (
   `u_intlang` varchar(25) default '',
   `user_password` varchar(128) NOT NULL default '',
   PRIMARY KEY  (`username`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 COMMENT='Each row represents a not-yet-activated user, user_password ';
+) DEFAULT CHARSET=latin1 COMMENT='Each row represents a not-yet-activated user, user_password ';
 # --------------------------------------------------------
 
 #
@@ -220,7 +220,7 @@ CREATE TABLE `page_events` (
   KEY `username` (`username`,`round_id`),
   KEY `projectid_username` (`projectid`,`username`),
   KEY `username_projectid_round_time` (`username`,`projectid`,`round_id`,`timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -239,7 +239,7 @@ CREATE TABLE `past_tallies` (
   `tally_value` int(8) NOT NULL default '0',
   PRIMARY KEY  (`tally_name`,`holder_type`,`holder_id`,`timestamp`),
   KEY `tallyboard_time` (`tally_name`,`holder_type`,`timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -253,7 +253,7 @@ CREATE TABLE `pg_books` (
   `etext_number` int(10) unsigned NOT NULL,
   `formats` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY  (`etext_number`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 COMMENT='Each row represents a different PG etext';
+) DEFAULT CHARSET=latin1 COMMENT='Each row represents a different PG etext';
 # --------------------------------------------------------
 
 #
@@ -275,7 +275,7 @@ CREATE TABLE `project_events` (
   PRIMARY KEY  (`event_id`),
   KEY `project` (`projectid`),
   KEY `timestamp` (`timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -289,7 +289,7 @@ CREATE TABLE `project_holds` (
   `projectid` varchar(22) NOT NULL,
   `state` varchar(50) NOT NULL,
   PRIMARY KEY (`projectid`,`state`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -307,7 +307,7 @@ CREATE TABLE `project_state_stats` (
   `comments` varchar(255) default NULL,
   KEY `date` (`date`),
   KEY `state` (`state`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -358,7 +358,7 @@ CREATE TABLE `projects` (
   KEY `special_code` (`special_code`),
   KEY `projectid_archived_state` (`projectid`,`archived`,`state`),
   KEY `state_moddate` (`state`,`modifieddate`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -378,7 +378,7 @@ CREATE TABLE `queue_defns` (
   `comment` text,
   UNIQUE KEY `ordering` (`round_id`,`ordering`),
   UNIQUE KEY `name` (`round_id`,`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -394,7 +394,7 @@ CREATE TABLE `quiz_passes` (
   `quiz_page` varchar(15) NOT NULL default '',
   `result` varchar(10) NOT NULL default '',
   KEY `username` (`username`,`quiz_page`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -411,7 +411,7 @@ CREATE TABLE `rules` (
   `subject` varchar(100) NOT NULL default '',
   `rule` text NOT NULL,
   PRIMARY KEY  (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -427,7 +427,7 @@ CREATE TABLE `sessions` (
   `value` text NOT NULL,
   PRIMARY KEY  (`sid`),
   KEY `expiration` (`expiration`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -442,7 +442,7 @@ CREATE TABLE `site_tally_goals` (
   `tally_name` char(2) NOT NULL default '',
   `goal` int(6) NOT NULL default '0',
   PRIMARY KEY  (`date`,`tally_name`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -458,7 +458,7 @@ CREATE TABLE `smoothread` (
   `committed` tinyint(4) NOT NULL default '0',
   PRIMARY KEY  (`projectid`,`user`),
   KEY `user` (`user`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 COMMENT='Each row represents an association between a user and a proj';
+) DEFAULT CHARSET=latin1 COMMENT='Each row represents an association between a user and a proj';
 # --------------------------------------------------------
 
 #
@@ -482,7 +482,7 @@ CREATE TABLE `special_days` (
   `info_url` varchar(255) default NULL,
   `image_url` varchar(255) default NULL,
   UNIQUE KEY `spec_code` (`spec_code`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 COMMENT='definitions of SPECIAL days';
+) DEFAULT CHARSET=latin1 COMMENT='definitions of SPECIAL days';
 # --------------------------------------------------------
 
 #
@@ -516,7 +516,7 @@ CREATE TABLE `tasks` (
   `related_tasks` mediumtext NOT NULL,
   `related_postings` mediumtext NOT NULL,
   KEY `task_id` (`task_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -532,7 +532,7 @@ CREATE TABLE `tasks_comments` (
   `comment_date` int(11) NOT NULL default '0',
   `comment` mediumtext NOT NULL,
   PRIMARY KEY (`task_id`,`u_id`,`comment_date`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -550,7 +550,7 @@ CREATE TABLE `tasks_votes` (
   `vote_browser` tinyint(1) NOT NULL default '0',
   UNIQUE KEY `id` (`id`),
   KEY `task_id` (`task_id`,`u_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -566,7 +566,7 @@ CREATE TABLE `themes` (
   `unixname` varchar(100) NOT NULL default '',
   `created_by` varchar(25) NOT NULL default '',
   KEY `theme_id` (`theme_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -600,7 +600,7 @@ CREATE TABLE `uber_projects` (
   `d_text_preparer` varchar(25) default NULL,
   `d_extra_credits` tinytext,
   PRIMARY KEY  (`up_projectid`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -626,7 +626,7 @@ CREATE TABLE `user_active_log` (
   `A_4wks` mediumint(8) unsigned default NULL,
   `comments` varchar(255) default NULL,
   KEY `timestamp_ndx` (`time_stamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -641,7 +641,7 @@ CREATE TABLE `user_filters` (
   `filtertype` varchar(25) NOT NULL default '',
   `value` text NOT NULL,
   PRIMARY KEY  (`username`,`filtertype`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -679,7 +679,7 @@ CREATE TABLE `user_profiles` (
   `h_twrap` tinyint(1) default '0',
   PRIMARY KEY  (`id`),
   KEY `u_ref` (`u_ref`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -704,7 +704,7 @@ CREATE TABLE `user_project_info` (
   `iste_sr_reported` tinyint(1) NOT NULL default '0',
   PRIMARY KEY  (`username`,`projectid`),
   KEY `projectid` (`projectid`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -731,7 +731,7 @@ CREATE TABLE `user_teams` (
   `latestUser` mediumint(9) NOT NULL default '0',
   PRIMARY KEY  (`id`),
   UNIQUE KEY `teamname` (`teamname`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -769,7 +769,7 @@ CREATE TABLE `users` (
   KEY `u_id` (`u_id`),
   KEY `last_login` (`last_login`),
   KEY `t_last_activity` (`t_last_activity`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -786,7 +786,7 @@ CREATE TABLE `usersettings` (
   KEY `username_setting_val` (`username`,`setting`,`value`),
   KEY `setting` (`setting`,`value`),
   KEY `value` (`value`,`setting`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 
 #
@@ -807,6 +807,6 @@ CREATE TABLE `wordcheck_events` (
   `corrections` text,
   PRIMARY KEY  (`check_id`),
   KEY `pc_compound` (`projectid`,`timestamp`,`image`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 

--- a/SETUP/upgrade/13/20191230_convert_to_innodb.php
+++ b/SETUP/upgrade/13/20191230_convert_to_innodb.php
@@ -1,0 +1,117 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+// We need to include udb_user to get the database name ($db_name)
+// We require() it instead of include_once() since it may also be
+// loaded elsewhere and we can't continue without it.
+require($relPath.'udb_user.php');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo <<<EOF
+This script will convert all non-project DP tables to InnoDB.
+This is only recommended on MySQL 5.6.6 and later with innodb_file_per_table
+enabled.
+
+If you wish to continue with this, edit the script and remove the die()
+statement.
+
+EOF;
+
+die();
+
+// Get all of the non-project tables to iterate over that are still MyISAM
+
+$sql = "
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE
+        table_schema='$db_name' AND
+        engine = 'MyISAM' AND
+        table_name NOT LIKE 'projectID%'
+    ORDER BY table_name;
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+$myisam_tables = array();
+while($row = mysqli_fetch_assoc($result))
+{
+    $myisam_tables[] = $row['table_name'];
+}
+
+$stop_file = '/tmp/innodb_conversion';
+
+echo <<<EOF
+This will now start converting all of the non-project MyISAM tables in
+$db_name to InnoDB. This will likely take a while.
+To stop the process gracefully create $stop_file
+(eg: touch $stop_file) and it will stop after it
+finishes the table it is working on.
+
+EOF;
+
+echo count($myisam_tables) . " tables to evaluate.\n";
+
+$schema_tables = get_db_schema_tables();
+$non_schema_tables = [];
+
+foreach($myisam_tables as $table)
+{
+    if(file_exists($stop_file))
+    {
+        echo "\n\n";
+        echo "Detected stop file ($stop_file), so stopping before starting $table.\n";
+        echo "Delete this file and restart to continue.\n";
+        exit();
+    }
+
+    if(!in_array($table, $schema_tables))
+    {
+        $non_schema_tables[] = $table;
+        continue;
+    }
+
+    $sql = "
+        ALTER TABLE $table ENGINE = InnoDB;
+    ";
+
+    echo "Converting $table...\n";
+    mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+}
+
+if($non_schema_tables)
+{
+    echo "\n\n";
+    echo "The following tables were found in $db_name but are not part\n";
+    echo "of the standard DP schema and were not converted:\n";
+    foreach($non_schema_tables as $table)
+    {
+        echo "    $table\n";
+    }
+}
+
+echo "\n";
+
+// ------------------------------------------------------------
+
+function get_db_schema_tables()
+{
+    $tables = [];
+    foreach(explode("\n", file_get_contents("../../db_schema.sql")) as $line)
+    {
+        if(preg_match('/create table `(\w+)`/i', $line, $matches))
+        {
+            $tables[] = $matches[1];
+        }
+    }
+    return $tables;
+}
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -26,6 +26,15 @@ function project_allow_pages( $projectid )
         ";
     }
 
+    // While the rest of the DP tables use the MySQL default engine type,
+    // usually InnoDB with MySQL 5.5 and later, we still explicitly create
+    // project tables as MyISAM. This is primarily because InnoDB versions of
+    // project tables are often 3x the size of the MyISAM versions. If you opt
+    // to use InnoDB, consider using the ROW_FORMAT=COMPRESSED option which
+    // makes project tables only 2x the size of the MyISAM versions, i.e.
+    //     $engine = "ENGINE=InnoDB ROW_FORMAT=COMPRESSED";
+    $engine = "ENGINE=MyISAM";
+
     $res = mysqli_query(DPDatabase::get_connection(), "
         CREATE TABLE $projectid
         (
@@ -43,7 +52,7 @@ function project_allow_pages( $projectid )
                 'abbreviation', 'division', 'epigraph', 'footnote', 'illustration', 'letter', 'list', 'math', 'poetry', 'sidenote', 'verse', 'table',
                 'appendix', 'afterword', 'biblio', 'colophon', 'endnote', 'epilogue', 'index'
                 ) NOT NULL default ''
-        ) ENGINE = MYISAM
+        ) $engine
     ");
     return ( $res ? '' : mysqli_error(DPDatabase::get_connection()) );
 }


### PR DESCRIPTION
Create all non-project tables using the MySQL default engine. In MySQL 5.5 and later that changed to InnoDB. This also provides a script to convert tables to InnoDB.