### PR TITLE
Fix WikiHiero to work with PHP 7.0

### DIFF
--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -126,24 +126,27 @@ If wdiff is not installed this one tool will fail but the rest of
 WordCheck will operate correctly.
 
 ### Install WikiHiero (optional)
-Install it somewhere in server's document hierarchy.
+To enable the hieroglyph transliteration tool, download
+[WikiHiero](http://aoineko.free.fr/) and extract it somewhere in your web
+server's document hierarchy. WikiHiero 0.2.13 needs to be patched with
+`wikihiero-0.2.13.patch` to make it work with PHP 7.0.
 
 For example:
 ```bash
+# Download and extract
 wget http://aoineko.free.fr/wikihiero.zip
-unzip -d wikihiero wikihiero.zip
+unzip -d /var/www/htdocs/wikihiero wikihiero.zip
 rm wikihiero.zip
 
-vim wikihiero/wikihiero.php
-# On line 59, for definition of WH_IMG_DIR,
-# change "$wgScriptPath/extensions/wikihiero/img/"
-# to just "img/"
-
-vim wikihiero/wh_language.php
-# The file begins with three bytes (EF BB BF), which
-# constitute the Unicode Byte Order Mark encoded in UTF-8.
-# Delete those bytes?
+# Patch
+cd /var/www/htdocs/wikihiero
+dos2unix wikihiero.php
+patch -p1 < /path/to/wikihiero-0.2.13.patch
+unix2dos wikihiero.php
 ```
+
+Then set `_WIKIHIERO_DIR` and `_WIKIHIERO_URL` in your `configuration.sh` file
+discussed below.
 
 ### Configure MySQL
 Choose names for various MySQL items:

--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -331,13 +331,13 @@ _ASPELL_TEMP_DIR=/tmp/sp_check
 
 # ----------------------------------------------------------------------
 
-_WIKIHIERO_DIR=$base_dir/wikihiero
-_WIKIHIERO_URL=$base_url/wikihiero
+_WIKIHIERO_DIR=
+_WIKIHIERO_URL=
 
 # If you're dealing with text containing Egyptian hieroglyphs, you may
 # want to install wikihiero to help with the transcription. If so, set
 # these variables to the location you installed it, and a link will
-# appear in the proofreading interface.
+# appear in the proofreading interface. See INSTALL.md for more info.
 # If you haven't installed wikihiero, leave them empty.
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/SETUP/wikihiero-0.2.13.patch
+++ b/SETUP/wikihiero-0.2.13.patch
@@ -1,0 +1,47 @@
+Common subdirectories: wikihiero.orig/img and wikihiero/img
+diff -u wikihiero.orig/wikihiero.php wikihiero/wikihiero.php
+--- wikihiero.orig/wikihiero.php	2004-04-15 23:19:22.000000000 +0000
++++ wikihiero/wikihiero.php	2019-12-31 04:55:27.148715030 +0000
+@@ -56,7 +56,7 @@
+   define("WH_VER_MED",       2);
+   define("WH_VER_MIN",       12);
+ 
+-  define("WH_IMG_DIR",       "$wgScriptPath/extensions/wikihiero/img/" ); //"img/"); //
++  define("WH_IMG_DIR",       "img/");
+   define("WH_IMG_PRE",       "hiero_");
+   define("WH_IMG_EXT",       "png");
+ 
+@@ -614,7 +614,7 @@
+     {
+       $code = $wh_phonemes[$glyph];
+       if(array_key_exists($code, $wh_files))
+-        return "<img style='margin:".WH_IMG_MARGIN."px;' $option src='".htmlspecialchars(WH_IMG_DIR.WH_IMG_PRE."{$code}.".WH_IMG_EXT)."' title='".htmlspecialchars($code[$glyph])."' alt='".htmlspecialchars($glyph)."' />";
++        return "<img style='margin:".WH_IMG_MARGIN."px;' $option src='".htmlspecialchars(WH_IMG_DIR.WH_IMG_PRE."{$code}.".WH_IMG_EXT)."' title='".htmlspecialchars($code)."' alt='".htmlspecialchars($glyph)."' />";
+       else
+         return "<font title='".htmlspecialchars($code)."'>".htmlspecialchars($glyph)."</font>";
+     }
+@@ -809,7 +809,7 @@
+         $block[$block_id][$item_id] = $hiero[$char];
+         $type = WH_TYPE_END;
+       }
+-      else if(ereg("[*:()]", $hiero[$char]))
++      else if(preg_match("/[*:()]/", $hiero[$char]))
+       {
+           if($type == WH_TYPE_GLYPH || $type == WH_TYPE_CODE)
+           {
+@@ -897,7 +897,7 @@
+         $temp = "";
+         foreach($code as $t)
+         {
+-          if(ereg("[*:!()]", $t[0]))
++          if(preg_match("/[*:!()]/", $t[0]))
+             $temp .= "&";
+           else
+             $temp .= $t;
+@@ -1002,4 +1002,4 @@
+ 		$html .= "Hieroglyph credit: S. Rosmorduc, G. Watson, J. Hirst (under GFDL).\n";
+     return $html;
+   }
+-?>
+\ No newline at end of file
++?>

--- a/tools/proofers/hiero/index.php
+++ b/tools/proofers/hiero/index.php
@@ -5,7 +5,7 @@ include_once($relPath.'slim_header.inc');
 
 require_login();
 
-slim_header_frameset();
+slim_header_frameset(_("Hieroglyphs"));
 ?>
 <frameset rows="*,*">
 <frame name="hierodisplay" src="display.php">


### PR DESCRIPTION
Add a patch file to make WikiHiero work with PHP 7.0 and update
the INSTALL.md file accordingly. Also change configuration.sh so
that it defaults to WikiHiero not being installed since it is an
optional tool.