### PR TITLE
Pass back phpBB login failure reason to DP login

### DIFF
--- a/accounts/login.php
+++ b/accounts/login.php
@@ -40,9 +40,21 @@ if ($userPW == '')
 }
 
 // Attempt to log into forum
-if (!login_forum_user($userNM, $userPW))
+list($success, $reason) = login_forum_user($userNM, $userPW);
+if(!$success)
 {
-    login_failure('auth_failure', $destination);
+    if($reason == 'unknown')
+    {
+        login_failure('unknown_failure', $destination);
+    }
+    elseif($reason == 'too_many_attempts')
+    {
+        login_failure('too_many_attempts', $destination);
+    }
+    else
+    {
+        login_failure('auth_failure', $destination);
+    }
 }
 
 // Look for user in 'users' table.

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -58,6 +58,13 @@ echo "<li>" . _("Caching set to off (or: refresh page every visit).") . "</li>\n
 echo "<li>" . _("Ensure your PC clock is set to the correct date &amp; time.") . "</li>\n";
 echo "</ol>";
 echo "<p>" . sprintf( _("If all of this fails, contact a <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr") . "</p>";
-echo "<p>" . sprintf( _("Note: If you have just registered, you will need to wait for the welcome mail to arrive to your mailbox. Once it does, please click the activation link to complete the registration (this is to prevent others from signing you up to the site without your knowledge). If you have waited for an hour or so and have still not received any mail from us (please check any spam filters!), it is likely that you misentered your email-address. Please contact a <a href='%s'>site manager</a> to solve the problem."), "mailto:$site_manager_email_addr") . "</p>";
+if($testing)
+{
+    echo "<p class='test_warning'>" . sprintf( _("Note: This is a testing site, and is not set up to send emails. If you have just registered, the page generated should have had an activation link on the page for you to copy and paste into a new browser tab. If you closed that page and can no longer access the information on it, please contact a <a href='%s'>site manager</a> to solve the problem."), "mailto:$site_manager_email_addr") . "</p>";
+}
+else
+{
+    echo "<p>" . sprintf( _("Note: If you have just registered, you will need to wait for the welcome mail to arrive to your mailbox. Once it does, please click the activation link to complete the registration (this is to prevent others from signing you up to the site without your knowledge). If you have waited for an hour or so and have still not received any mail from us (please check any spam filters!), it is likely that you misentered your email-address. Please contact a <a href='%s'>site manager</a> to solve the problem."), "mailto:$site_manager_email_addr") . "</p>";
+}
 
 // vim: sw=4 ts=4 expandtab

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -26,6 +26,8 @@ $login_failures = array(
     'no_username'      => _("You did not supply a username."),
     'no_password'      => _("You did not supply a password."),
     'auth_failure'     => _("Unable to authenticate. The username/password may be incorrect or your account may be locked."),
+    'unknown_failure'  => sprintf(_("An unexpected failure occurred, please contact the <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr"),
+    'too_many_attempts'=> sprintf(_("You exceeded the maxiumum number of failed logins. Go <a href='%s'>log into the forums</a> and answer the CAPTCHA. Once you have successfully logged in there, return here and try again."), "$forums_url/ucp.php?mode=login"),
     'reg_mismatch'     => sprintf(_("You are registered with the forum software, but not with %s."), $site_abbreviation),
 );
 
@@ -45,7 +47,7 @@ echo "<p>" . _("Please attempt again to log in above. If problems persist, revie
 echo "<ol>";
 if ($testing)
 {
-    echo "<li>" . _("Register! (Note that this is a test site, and has a separate database from the production site, so you need to register separately.)") . "</li>\n";
+    echo "<li class='test_warning'>" . _("Register! (Note that this is a test site, and has a separate database from the production site, so you need to register separately.)") . "</li>\n";
 }
 echo "<li>" . _("Type your username in the exact same way as when you registered.") . "</li>\n";
 echo "<li>" . sprintf( _("<a href='%s'>Reset</a> your password."), get_reset_password_url()) . "</li>\n";

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -26,7 +26,7 @@ $login_failures = array(
     'no_username'      => _("You did not supply a username."),
     'no_password'      => _("You did not supply a password."),
     'auth_failure'     => _("Unable to authenticate. The username/password may be incorrect or your account may be locked."),
-    'unknown_failure'  => sprintf(_("An unexpected failure occurred, please contact the <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr"),
+    'unknown_failure'  => sprintf(_("An unexpected failure occurred, please contact a <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr"),
     'too_many_attempts'=> sprintf(_("You exceeded the maxiumum number of failed logins. Go <a href='%s'>log into the forums</a> and answer the CAPTCHA. Once you have successfully logged in there, return here and try again."), "$forums_url/ucp.php?mode=login"),
     'reg_mismatch'     => sprintf(_("You are registered with the forum software, but not with %s."), $site_abbreviation),
 );
@@ -57,7 +57,7 @@ echo "<li>" . sprintf(_("Allow popup windows (at least from us at %s)."), $_SERV
 echo "<li>" . _("Caching set to off (or: refresh page every visit).") . "</li>\n";
 echo "<li>" . _("Ensure your PC clock is set to the correct date &amp; time.") . "</li>\n";
 echo "</ol>";
-echo "<p>" . sprintf( _("If all of this fails, contact the <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr") . "</p>";
-echo "<p>" . sprintf( _("Note: If you have just registered, you will need to wait for the welcome mail to arrive to your mailbox. Once it does, please click the activation link to complete the registration (this is to prevent others from signing you up to the site without your knowledge). If you have waited for an hour or so and have still not received any mail from us (please check any spam filters!), it is likely that you misentered your email-address. Please contact the <a href='%s'>site manager</a> to solve the problem."), "mailto:$site_manager_email_addr") . "</p>";
+echo "<p>" . sprintf( _("If all of this fails, contact a <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr") . "</p>";
+echo "<p>" . sprintf( _("Note: If you have just registered, you will need to wait for the welcome mail to arrive to your mailbox. Once it does, please click the activation link to complete the registration (this is to prevent others from signing you up to the site without your knowledge). If you have waited for an hour or so and have still not received any mail from us (please check any spam filters!), it is likely that you misentered your email-address. Please contact a <a href='%s'>site manager</a> to solve the problem."), "mailto:$site_manager_email_addr") . "</p>";
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/forum_interface.inc
+++ b/pinc/forum_interface.inc
@@ -132,8 +132,12 @@ function create_forum_user($username, $password, $email, $password_is_digested=F
 function login_forum_user($username, $password)
 // Log in the user to the forums.
 // Returns:
-//     TRUE  - user sucessfully logged in
-//     FALSE - login failed
+//     [TRUE, '']  - user sucessfully logged in
+//     [FALSE, $reason] - login failed and the reason why, valid $reasons:
+//         'incorrect_username'
+//         'incorrect_password'
+//         'too_many_attempts'
+//         'unknown'
 {
     global $forums_dir;
 
@@ -188,7 +192,28 @@ function login_forum_user($username, $password)
 
         define('IN_PHPBB', false);
 
-        return ($results["status"] == LOGIN_SUCCESS);
+        $success = $results["status"] == LOGIN_SUCCESS;
+        $reason = '';
+        switch($results["status"])
+        {
+            case LOGIN_SUCCESS:
+                $reason = '';
+                break;
+            case LOGIN_ERROR_USERNAME:
+                $reason = 'incorrect_username';
+                break;
+            case LOGIN_ERROR_PASSWORD:
+                $reason = 'incorrect_password';
+                break;
+            case LOGIN_ERROR_ATTEMPTS:
+                $reason = 'too_many_attempts';
+                break;
+            default:
+                $reason = 'unknown';
+                break;
+        }
+
+        return [$success, $reason];
     }
 }
 

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -88,7 +88,7 @@ function abort_if_cant_edit_project( $projectid )
             <P>
             "._("There appears to be no such project")." ($projectid).
             <P>
-            ", sprintf(_("If this message is an error, contact the <a href='%s'>site manager</a>"),
+            ", sprintf(_("If this message is an error, contact a <a href='%s'>site manager</a>"),
                 "mailto:$site_manager_email_addr"), "
             <P><a href=\"projectmgr.php\">"._("Back")."</a>";
         exit;
@@ -99,7 +99,7 @@ function abort_if_cant_edit_project( $projectid )
             <P>
             "._("You are not allowed to manage this project")." ($projectid).
             <P>
-            ", sprintf(_("If this message is an error, contact the <a href='%s'>site manager</a>"),
+            ", sprintf(_("If this message is an error, contact a <a href='%s'>site manager</a>"),
                 "mailto:$site_manager_email_addr"), "
             <P><a href=\"projectmgr.php\">"._("Back")."</a>";
         exit;

--- a/tools/project_manager/projectmgr.inc
+++ b/tools/project_manager/projectmgr.inc
@@ -10,7 +10,7 @@ function abort_if_not_manager()
     if ( !user_is_PM())
     {
         echo "<p>".sprintf(_("You are not listed as a project manager.
-            Please contact the <a href='%s'>site manager</a>
+            Please contact a <a href='%s'>site manager</a>
             about resolving this problem."),"mailto:$site_manager_email_addr")."
               </p><p>
               ".sprintf(_("Back to <a href='%s'>home page</a>"),"$code_url/default.php")."


### PR DESCRIPTION
Pass back the underlying phpBB failure reason to the DP login page.
Route the user to the forums if their maximum number of login attempts
were exceeded so they can log in through the CAPTCHA.

This is available for testing in the [phpbb3-login-improvements](https://www.pgdp.org/~cpeel/c.branch/phpbb3-login-improvements/) sandbox.