### PR TITLE
Don't save proofer names in CTF by default

### DIFF
--- a/SETUP/apache2.conf.example
+++ b/SETUP/apache2.conf.example
@@ -99,6 +99,13 @@ DirectoryIndex index.php default.php index.html default.html
         ExpiresByType image/jpg  "access plus 10 minutes"
         ExpiresByType image/jpeg "access plus 10 minutes"
 
+        # Cache .zip files and .txt files for a _very_ short period of time
+        # to ensure that if they are regenerated the user gets the new copy.
+        # Without setting an explicit cache on these, browsers tend to
+        # aggressively cache them, which isn't good.
+        ExpiresByType application/zip "access plus 10 seconds"
+        ExpiresByType text/plain "access plus 10 seconds"
+
         # Don't Vary image content at all.
         # This allows caching proxies to cache the images once and serve
         # it to all browsers. Note we can't include css/js content in case
@@ -107,11 +114,11 @@ DirectoryIndex index.php default.php index.html default.html
         # against Accept-Encoding, we just need to not override it.
         # Caching proxies will still cache css/js content but will cache
         # two or more copies and serve them accordingly.
-        SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|ico)$ dont-vary
+        SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|ico|zip)$ dont-vary
         Header unset Vary env=dont-vary
 
         # Explicitly set the Cache-Control to public for *all* cacheable content
-        SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|ico|css|js)$ cache-public
+        SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|ico|css|js|zip|txt)$ cache-public
         Header append Cache-Control "public" env=cache-public
     </LocationMatch>
 </IfModule>

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -924,7 +924,7 @@ function round_to_PP_avail_collateral( $old_project, $project, $transition, $who
 {
     global $site_abbreviation;
     $from_round = get_Round_for_project_state($transition->from_state);
-    generate_post_files( $project->projectid, $from_round->id, 'LE', 'Y', '' );
+    generate_post_files( $project->projectid, $from_round->id, 'LE', False, '' );
 
     // Always notify the PM
     $body_blurb =
@@ -967,7 +967,7 @@ function round_to_PP_out_collateral( $old_project, $project, $transition, $who )
 {
     global $site_abbreviation, $site_signoff;
     $from_round = get_Round_for_project_state($transition->from_state);
-    generate_post_files( $project->projectid, $from_round->id, 'LE', 'Y', '' );
+    generate_post_files( $project->projectid, $from_round->id, 'LE', False, '' );
 
     // The project has been checked out to someone for PPing.
     // We want to notify the PPer and the PM,

--- a/project.php
+++ b/project.php
@@ -1646,9 +1646,9 @@ function do_post_downloads()
     if ( $project->names_can_be_seen_by_current_user )
     {
         echo _("Include usernames?"), " &nbsp;&nbsp; ";
-        echo "<input type='radio' name='include_proofers' value='1' CHECKED>";
+        echo "<input type='radio' name='include_proofers' value='1'>";
         echo _("Yes"), " &nbsp;&nbsp; ";
-        echo "<input type='radio' name='include_proofers' value='0'>";
+        echo "<input type='radio' name='include_proofers' value='0' CHECKED>";
         echo _("No"), "<br>\n";
     }
     else


### PR DESCRIPTION
For better privacy, don't save proofer's names in the CTF by default.
PMs and PPs can still access a CTF with proofer's names manually.
This also changes the final CTF to not include the proofer's names.

[Task 1806](https://www.pgdp.net/c/tasks.php?action=show&task_id=1806)

In the [ctf-default-no-usernames](https://www.pgdp.org/~cpeel/c.branch/ctf-default-no-usernames/) sandbox.