### PR TITLE
Move the target-changing code into codepont_validator.js

### DIFF
--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -116,11 +116,7 @@ function echo_button( $button_id, $which_interface )
                 'name'      => "button8",
                 $label      => attr_safe(_("Revert to Original Document")),
                 'title'     => attr_safe(_("Revert to Original Document")),
-                'onclick'   => "return(confirm('"
-                    . javascript_safe(_("Are you sure you want to revert to the original text for this round?"), $charset)
-                    . "'));",
                 'src'       => "gfx/bt8.png",
-                'class'     => "check_button",
             );
             break;
 

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -58,11 +58,7 @@ function echo_button( $button_id, $which_interface )
                 'name'      => "button4",
                 $label      => attr_safe(sprintf(_("Switch to %s"), $horvert)),
                 'title'     => attr_safe(sprintf(_("Save and Switch to %s Layout"), $horvert)),
-                'onclick'   => "return(confirm('" 
-                    . javascript_safe(_("Are you sure you want to change layout & save the current document?"), $charset)
-                    . "'));",
                 'src'       => "gfx/bt$n.png",
-                'class'     => "check_button",
             );
             break;
 
@@ -187,15 +183,7 @@ function echo_button( $button_id, $which_interface )
                 $label      => attr_safe(_("WordCheck")),
                 'title'     => attr_safe(_("Run WordCheck")),
                 'src'       => "gfx/bt16.png",
-                'class'     => "check_button",
             );
-            if ($userP['i_type']==0)
-            {
-                // standard interface:
-                // Direct the (text-only) spellcheck doc to 'textframe'
-                // (rather than 'proofframe', the statically defined target).
-                $attrs['onclick']="document.getElementById('editform').target='textframe'; return 1;";
-            }
             break;
 
         case CONVERT_UTF8:

--- a/tools/proofers/codepoint_validator.js
+++ b/tools/proofers/codepoint_validator.js
@@ -1,4 +1,4 @@
-/*global $ codePoints */
+/*global $ codePoints standardInterface switchConfirm */
 
 // this function is copied from dp_proof.js
 // could put it in another file misc.js
@@ -37,14 +37,14 @@ $(function () {
     var badPattern = new RegExp("[^" + charClass + "]", "ug");
     var textArea = document.getElementById("text_data");
 
-    $(".check_button").click(function(event) {
+    function validateText() {
         var text = textArea.value;
         text = text.normalize("NFC");
         textArea.value = text;
         badPattern.lastIndex = 0;
         if(!badPattern.test(text)) {
             // no bad characters found
-            return;
+            return true;
         }
         var replacement = "<span class='bad-char'>$&</span>";
         var markedText = htmlSafe(text).replace(badPattern , replacement);
@@ -52,7 +52,36 @@ $(function () {
         $("#checker").css("display", "flex");
         $("#proofdiv").hide();
         $("#check-text").html(markedText);
-        event.preventDefault();
+        return false;
+    }
+
+    // special handling for certain buttons
+    // switch layout - validate before confirm
+    $("#button4").click(function(event) {
+        if(validateText() && confirm(switchConfirm)) {
+            return;
+        } else {
+            event.preventDefault();
+        }
+    });
+
+    // word check -- for standard interface:
+    // Direct the (text-only) spellcheck doc to 'textframe'
+    // (rather than 'proofframe', the statically defined target).
+    $("#button10").click(function(event) {
+        if(!validateText()) {
+            event.preventDefault();
+            return;
+        }
+        if(standardInterface) {
+            document.getElementById('editform').target = 'textframe';
+        }
+    });
+
+    $(".check_button").click(function(event) {
+        if(!validateText()) {
+            event.preventDefault();
+        }
     });
 
     $("#cc-quit").click(function () {

--- a/tools/proofers/codepoint_validator.js
+++ b/tools/proofers/codepoint_validator.js
@@ -1,4 +1,4 @@
-/*global $ codePoints standardInterface switchConfirm */
+/*global $ codePoints standardInterface switchConfirm revertConfirm */
 
 // this function is copied from dp_proof.js
 // could put it in another file misc.js
@@ -59,6 +59,15 @@ $(function () {
     // switch layout - validate before confirm
     $("#button4").click(function(event) {
         if(validateText() && confirm(switchConfirm)) {
+            return;
+        } else {
+            event.preventDefault();
+        }
+    });
+
+    // revert to original - validate before confirm
+    $("#button8").click(function(event) {
+        if(validateText() && confirm(revertConfirm)) {
             return;
         } else {
             event.preventDefault();

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -13,7 +13,8 @@ function echo_proof_frame_enh( $ppage )
     global $code_url, $userP;
 
     $json_code_points = get_json_codepoints($ppage->projectid());
-    $switch_confirm = javascript_safe(_('Are you sure you want to change layout & save the current document?'));
+    $switch_confirm = javascript_safe(_('Are you sure you want to save the current page and change layout?'));
+    $revert_confirm = javascript_safe(_("Are you sure you want to save the current page and revert to the original text for this round?"));
 
     $header_args = array(
         "css_files" => array("$code_url/styles/preview.css"),
@@ -31,6 +32,7 @@ function echo_proof_frame_enh( $ppage )
         var codePoints = $json_code_points;
         var standardInterface = false;
         var switchConfirm = '$switch_confirm';
+        var revertConfirm = '$revert_confirm';
         ",
         "css_data" => ibe_get_styles(),
         "body_attributes" => 'id="enhanced_interface" onload="ldAll()" onresize="previewControl.adjustHeight()"',

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -13,6 +13,8 @@ function echo_proof_frame_enh( $ppage )
     global $code_url, $userP;
 
     $json_code_points = get_json_codepoints($ppage->projectid());
+    $switch_confirm = javascript_safe(_('Are you sure you want to change layout & save the current document?'));
+
     $header_args = array(
         "css_files" => array("$code_url/styles/preview.css"),
         "js_files" => array(
@@ -27,6 +29,8 @@ function echo_proof_frame_enh( $ppage )
             previewControl = initPrev();
         }
         var codePoints = $json_code_points;
+        var standardInterface = false;
+        var switchConfirm = '$switch_confirm';
         ",
         "css_data" => ibe_get_styles(),
         "body_attributes" => 'id="enhanced_interface" onload="ldAll()" onresize="previewControl.adjustHeight()"',

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -10,6 +10,8 @@ function echo_text_frame_std( $ppage )
     global $code_url;
     
     $json_code_points = get_json_codepoints($ppage->projectid());
+    $switch_confirm = javascript_safe(_('Are you sure you want to change layout & save the current document?'));
+
     $header_args = array(
         "css_files" => array("$code_url/styles/preview.css"),
         "js_files" => array(
@@ -24,6 +26,8 @@ function echo_text_frame_std( $ppage )
             previewControl = initPrev();
         }
         var codePoints = $json_code_points;
+        var standardInterface = true;
+        var switchConfirm = '$switch_confirm';
         ",
         "body_attributes" => "onload='ldAll()'  onresize='previewControl.adjustHeight()' class='no-margin'",
         );

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -10,7 +10,8 @@ function echo_text_frame_std( $ppage )
     global $code_url;
     
     $json_code_points = get_json_codepoints($ppage->projectid());
-    $switch_confirm = javascript_safe(_('Are you sure you want to change layout & save the current document?'));
+    $switch_confirm = javascript_safe(_('Are you sure you want to save the current page and change layout?'));
+    $revert_confirm = javascript_safe(_("Are you sure you want to save the current page and revert to the original text for this round?"));
 
     $header_args = array(
         "css_files" => array("$code_url/styles/preview.css"),
@@ -28,6 +29,7 @@ function echo_text_frame_std( $ppage )
         var codePoints = $json_code_points;
         var standardInterface = true;
         var switchConfirm = '$switch_confirm';
+        var revertConfirm = '$revert_confirm';
         ",
         "body_attributes" => "onload='ldAll()'  onresize='previewControl.adjustHeight()' class='no-margin'",
         );


### PR DESCRIPTION
This addresses task DPUT 2250 where next image and text loads into right pane. This was because the target-changing code is executed but then wordcheck is not actually run. This task only executes the code if the validator succeeds and we actually do
wordcheck. Also move the h-v switch confirm so we do the
validation first.