### PR TITLE
Encode forum subjects when creating topics

### DIFF
--- a/SETUP/upgrade/13/20200127_fix_forum_topic_encoding.php
+++ b/SETUP/upgrade/13/20200127_fix_forum_topic_encoding.php
@@ -1,0 +1,143 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+# Force the DB connection into UTF8
+mysqli_set_charset(DPDatabase::get_connection(), "utf8");
+
+header('Content-type: text/plain');
+
+$topic_table_name = PHPBB_TABLE_PREFIX . "_topics";
+$forum_table_name = PHPBB_TABLE_PREFIX . "_forums";
+
+// ------------------------------------------------------------
+
+echo "Finding topics with unescaped HTML attributes in the title...\n";
+
+$sql = "
+    SELECT topic_id, topic_title
+    FROM $topic_table_name
+    WHERE
+        topic_title like '%& %' OR
+        topic_title like '%<%' OR
+        topic_title like '%>%' OR
+        topic_title like '%\"%'
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+echo "Updating topic titles...\n";
+
+while($row = mysqli_fetch_assoc($result))
+{
+    $topic_id = $row["topic_id"];
+    $subject_shorter = preg_replace("/\s+/", " ", $row["topic_title"]);
+    $subject_encoded = htmlspecialchars($subject_shorter, ENT_COMPAT, 'UTF-8', false);
+    if(!$subject_encoded)
+    {
+        echo "    ERROR: Failed to encode topic_title for topic $topic_id, likely the string wasn't in UTF-8\n";
+        echo "           $subject_shorter\n";
+        continue;
+    }
+    $subject_escaped = mysqli_real_escape_string(DPDatabase::get_connection(), $subject_encoded);
+    $sql = sprintf("
+        UPDATE $topic_table_name
+        SET topic_title = '%s'
+        WHERE topic_id = %d
+    ", $subject_escaped, $topic_id);
+    echo "    $sql\n";
+
+    mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+}
+
+echo "\n";
+
+// ------------------------------------------------------------
+
+echo "Finding topics with unescaped HTML attributes in the last post subject...\n";
+
+$sql = "
+    SELECT topic_id, topic_last_post_subject
+    FROM $topic_table_name
+    WHERE
+        topic_last_post_subject like '%& %' OR
+        topic_last_post_subject like '%<%' OR
+        topic_last_post_subject like '%>%' OR
+        topic_last_post_subject like '%\"%'
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+echo "Updating topic last post subjects...\n";
+
+while($row = mysqli_fetch_assoc($result))
+{
+    $topic_id = $row["topic_id"];
+    $subject_shorter = preg_replace("/\s+/", " ", $row["topic_last_post_subject"]);
+    $subject_encoded = htmlspecialchars($subject_shorter, ENT_COMPAT, 'UTF-8', false);
+    if(!$subject_encoded)
+    {
+        echo "    ERROR: Failed to encode topic_last_post_subject for topic $topic_id, likely the string wasn't in UTF-8\n";
+        echo "           $subject_shorter\n";
+        continue;
+    }
+    $subject_escaped = mysqli_real_escape_string(DPDatabase::get_connection(), $subject_encoded);
+    $sql = sprintf("
+        UPDATE $topic_table_name
+        SET topic_last_post_subject = '%s'
+        WHERE topic_id = %d
+    ", $subject_escaped, $topic_id);
+    echo "    $sql\n";
+
+    mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+}
+
+echo "\n";
+
+// ------------------------------------------------------------
+
+echo "Finding forums with unescaped HTML attributes in the last post subject...\n";
+
+$sql = "
+    SELECT forum_id, forum_last_post_subject
+    FROM $forum_table_name
+    WHERE
+        forum_last_post_subject like '%& %' OR
+        forum_last_post_subject like '%<%' OR
+        forum_last_post_subject like '%>%' OR
+        forum_last_post_subject like '%\"%'
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+echo "Updating forum last post subjects...\n";
+
+while($row = mysqli_fetch_assoc($result))
+{
+    $forum_id = $row["forum_id"];
+    $subject_shorter = preg_replace("/\s+/", " ", $row["forum_last_post_subject"]);
+    $subject_encoded = htmlspecialchars($subject_shorter, ENT_COMPAT, 'UTF-8', false);
+    if(!$subject_encoded)
+    {
+        echo "    ERROR: Failed to encode forum_last_post_subject for forum $forum_id, likely the string wasn't in UTF-8\n";
+        echo "           $subject_shorter\n";
+        continue;
+    }
+    $subject_escaped = mysqli_real_escape_string(DPDatabase::get_connection(), $subject_encoded);
+    $sql = sprintf("
+        UPDATE $forum_table_name
+        SET forum_last_post_subject = '%s'
+        WHERE forum_id = %d
+    ", $subject_escaped, $forum_id);
+    echo "    $sql\n";
+
+    mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+}
+
+echo "\n";
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -426,7 +426,7 @@ class Project
         // determine appropriate forum to create thread in
         $forum_id = get_forum_id_for_project_state($this->state);
 
-        $post_subject = "\"{$this->nameofwork}\"    by {$this->authorsname}";
+        $post_subject = "\"{$this->nameofwork}\" by {$this->authorsname}";
 
         global $code_url;
         $post_body = <<<EOS

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -235,6 +235,13 @@ function _insert_post(
     $subject = utf8_normalize_nfc($post_subject);
     $text    = utf8_normalize_nfc($post_text);
 
+    // phpBB encodes the subject (but not the body) using ENT_COMPAT, the chain is:
+    // phpBB3/posting.php
+    //   $request->variable() in phpBB3/phpbb/request/request.php
+    //     $type_cast_helper->recursive_set_var() in phpBB3/phpbb/request/type_cast_helper.php
+    //       $type_cast_helper->set_var() in phpBB3/phpbb/request/type_cast_helper.php
+    $subject = htmlspecialchars($subject, ENT_COMPAT, 'UTF-8', false);
+
     $poll = $uid = $bitfield = $options = '';
     generate_text_for_storage($text, $uid, $bitfield, $options, true, true, true);
 


### PR DESCRIPTION
phpBB encodes forum subjects before saving them to the database. We haven't been doing this since we moved over to phpBB3. Browsers appear to be forgiving the sin of not encoding the double quotes, but they draw the line at `>`s which breaks the rendering of project names with those in them.