### PR TITLE
Handle combining diacritical marks

### DIFF
--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -76,6 +76,7 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     // Global JS
     $js_files = array(
         "$code_url/pinc/3rdparty/jquery/jquery-3.3.1.js",
+        "$code_url/pinc/3rdparty/xregexp/xregexp-all.js",
     );
 
     // Per-page JS


### PR DESCRIPTION
This correctly highlights invalid characters with diacritical marks in the
validation view and removes them completely if required.
It also has code to enable use of valid glyphs with combining marks.