### PR TITLE
Daily Page Limits

### DIFF
--- a/SETUP/upgrade/09/01_daily_page_limits.php
+++ b/SETUP/upgrade/09/01_daily_page_limits.php
@@ -1,0 +1,39 @@
+<?php
+
+$relPath='../../../pinc/';
+include($relPath.'connect.inc');
+new dbConnect();
+
+header('Content-type: text/plain');
+
+
+echo "Creating 'daily_page_limits' table...\n";
+$sql = "
+    CREATE TABLE daily_page_limit
+    (
+        name             VARCHAR(50) NOT NULL,
+        project_selector VARCHAR(256) NOT NULL,
+        daily_limit      INT(8) NOT NULL,
+        PRIMARY KEY (name)
+    )
+";
+echo "$sql\n";
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+
+echo "Creating 'daily_page_limit_user_counts' table...\n";
+$sql = "
+    CREATE TABLE daily_page_limit_user_counts
+    (
+        limit_name    VARCHAR(50) NOT NULL,
+        username      VARCHAR(25) NOT NULL,
+        current_count INT(8) NOT NULL,
+        PRIMARY KEY (limit_name, username)
+    )
+";
+echo "$sql\n";
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/DailyPageLimit.inc
+++ b/pinc/DailyPageLimit.inc
@@ -1,0 +1,132 @@
+<?php
+include_once($relPath."Project.inc");
+include_once($relPath."misc.inc"); // functions that might be used in project_selector
+
+class DailyPageLimit
+{
+    function DailyPageLimit( $name, $project_selector, $daily_limit )
+    {
+        $this->name = $name;
+        $this->project_selector = $project_selector;
+        $this->daily_limit = $daily_limit;
+    }
+
+    function applies_to_project($project)
+    {
+        $str_to_eval = "return $this->project_selector;";
+        // echo "<br>\nevaluating: $str_to_eval<br>\n";
+        $result = eval($str_to_eval);
+        // echo "returns "; var_dump($result);
+        return $result;
+    }
+
+    function get_current_count_for_user($username)
+    {
+        $res = mysqli_query(DPDatabase::get_connection(), "
+            SELECT current_count
+            FROM daily_page_limit_user_counts
+            WHERE
+                limit_name = '$this->name'
+                AND
+                username = '$username'
+        ") or die(mysqli_error(DPDatabase::get_connection()));
+        if (mysqli_num_rows($res) == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            list($count) = mysqli_fetch_row($res);
+            return $count;
+        }
+    }
+
+    function user_count_has_reached_limit($username)
+    {
+        $user_count = $this->get_current_count_for_user($username);
+        return ($user_count >= $this->daily_limit);
+    }
+
+    function adjust_user_count($username, $adjustment)
+    {
+        $res = mysqli_query(DPDatabase::get_connection(), "
+            INSERT INTO daily_page_limit_user_counts
+            SET
+                limit_name = '$this->name',
+                username = '$username',
+                current_count = $adjustment
+            ON DUPLICATE KEY UPDATE
+                current_count = current_count + $adjustment
+        ") or die(mysqli_error(DPDatabase::get_connection()));
+        // $n_rows = mysqli_affected_rows($res);
+        // $n_rows == 0 means an existing row was set to its current values
+        // $n_rows == 1 means a new row was inserted
+        // $n_rows == 2 means an existing row was updated
+    }
+}
+
+// We assume that there will be very few DPLs in the system,
+// and a project will rarely if ever be targeted by more than one DPL.
+
+function dpls_get_all()
+{
+    static $all_dpls = NULL;
+    if (is_null($all_dpls))
+    {
+        // XXX get from DB
+        $all_dpls = array(
+            new DailyPageLimit('F1', '$project->state == "F1.proj_avail" && !startswith($project->nameofwork, "F1 self-evaluation")', 3)
+        );
+    }
+    return $all_dpls;
+}
+
+function dpls_get_applicable($project)
+// Return an array of DailyPageLimit objects,
+// one for each page limit that currently applies to this project.
+{
+    $all_dpls = dpls_get_all();
+
+    $applicable_dpls = array();
+    foreach ($all_dpls as $dpl)
+    {
+        if ($dpl->applies_to_project($project))
+        {
+            $applicable_dpls[] = $dpl;
+        }
+    }
+    return $applicable_dpls;
+}
+
+function dpls_reset_user_counts()
+{
+    mysqli_query(DPDatabase::get_connection(), "
+        TRUNCATE TABLE daily_page_limit_user_counts
+    ") or die( mysqli_error(DPDatabase::get_connection()) );
+}
+
+function dpls_check_user_count($project, $username)
+// Of the DPLs (if any) applicable to $project,
+// return those (if any) for which the user has reached the limit.
+{
+    $dpls_reached = array();
+    foreach ( dpls_get_applicable($project) as $dpl )
+    {
+        if ($dpl->user_count_has_reached_limit($username))
+        {
+            $dpls_reached[] = $dpl;
+        }
+    }
+    return $dpls_reached;
+}
+
+function dpls_adjust_user_count($project, $username, $adjustment)
+// Adjust the user's counts in all DPLs that apply to $project.
+{
+    foreach ( dpls_get_applicable($project) as $dpl )
+    {
+        $dpl->adjust_user_count($username, $adjustment);
+    }
+}
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -11,6 +11,7 @@ include_once($relPath.'page_tally.inc');
 include_once($relPath.'project_continuity.inc');
 include_once($relPath.'abort.inc');
 include_once($relPath.'maybe_mail.inc');
+include_once($relPath.'DailyPageLimit.inc'); // dpls_check_user_count, dpls_adjust_user_count
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -286,13 +287,26 @@ class LPage
         $this->reverting_to_orig = 0;
     }
 
-    function saveAsDone($text_data,$pguser)
+    function attemptSaveAsDone($text_data,$pguser)
+    // Return an array containing two values:
+    // a boolean indicating whether the page was saved,
+    // and a (possibly empty) array of DPLs for which the user has reached the limit.
     {
+        $project = new Project($this->projectid);
+        $dpls_reached = dpls_check_user_count($project, $pguser);
+        if ($dpls_reached)
+            // The user has already reached their limit of this kind of page.
+            return array(FALSE, $dpls_reached);
+
         $this->page_state =
             Page_saveAsDone( $this->projectid, $this->imagefile, $this->round, $pguser, $text_data );
 
         // add to user page count
         page_tallies_add( $this->round->id, $pguser, +1 );
+        dpls_adjust_user_count($project, $pguser, +1);
+
+        $dpls_reached = dpls_check_user_count($project, $pguser);
+        return array(TRUE, $dpls_reached);
     }
 
     function returnToRound($pguser)
@@ -369,6 +383,7 @@ the project will automatically be made unavailable.";
             // (Plugs a former page-count cheat.)
 
             page_tallies_add( $this->round->id, $pguser, -1 );
+            dpls_adjust_user_count(new Project($this->projectid), $pguser, -1);
         }
         else
         {

--- a/tools/project_manager/page_operations.inc
+++ b/tools/project_manager/page_operations.inc
@@ -68,6 +68,7 @@ function page_clear( $projectid, $image )
     // page will be cleared, so decrement page tallies for user & teams
 
     page_tallies_add( $round->id, $proofer, -1 );
+    dpls_adjust_user_count( $project, $proofer, -1 );
 
     // ------------------------------------------------
     // now clear the page

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -287,9 +287,9 @@ class PPage
         $this->lpage->saveAsInProgress( $page_text, $user );
     }
 
-    function saveAsDone( $page_text, $user )
+    function attemptSaveAsDone( $page_text, $user )
     {
-        $this->lpage->saveAsDone( $page_text, $user );
+        return $this->lpage->attemptSaveAsDone( $page_text, $user );
     }
 
     function can_be_reverted_to_last_save()

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -123,13 +123,13 @@ switch( $tbutton )
         break;
 
     case B_SAVE_AND_DO_ANOTHER:
-        $ppage->saveAsDone($text_data,$pguser);
+        attempt_to_save_as_done($ppage, $text_data, TRUE);
         $url = $ppage->url_for_do_another_page();
         metarefresh(1,$url,_("Save as 'Done' & Proofread Next Page"),_("Page Saved."));
         break;
 
     case B_SAVE_AND_QUIT:
-        $ppage->saveAsDone($text_data,$pguser);
+        attempt_to_save_as_done($ppage, $text_data, FALSE);
         leave_proofing_interface( _("Save as 'Done'") );
         break;
 
@@ -229,7 +229,7 @@ switch( $tbutton )
             $_POST["projectid"],$ppage->lpage->round->id,$page,$pguser,$accepted_words,array());
 
         // 2. Save the current page as done
-        $ppage->saveAsDone($correct_text, $pguser);
+        attempt_to_save_as_done($ppage, $correct_text, TRUE);
 
         // Redirect to the next available page
         $url = $ppage->url_for_do_another_page();
@@ -304,6 +304,85 @@ function leave_spellcheck_mode( $ppage )
         // So generate the (normal-mode) image-and-text doc of the enh interface.
         echo_proof_frame($ppage);
     }
+}
+
+function attempt_to_save_as_done($ppage, $text_data, $and_do_another)
+// This is only an attempt, because a daily page limit might block the save,
+// or prevent further saves.
+// If there's a problem, this function does not return to the caller.
+{
+    global $code_url, $pguser, $projectid, $proj_state;
+
+    list($saved, $dpls_reached) = $ppage->attemptSaveAsDone($text_data, $pguser);
+
+    if (count($dpls_reached) == 0)
+    {
+        assert($saved);
+        return; // to let the caller do the appropriate normal thing
+    }
+
+    assert( count($dpls_reached) > 0 );
+
+    if ($saved)
+    {
+        $title = _("Saved, but at limit");
+        $sentence = _("Your page has been saved as 'Done'. However, you have now reached the following page limit(s):");
+    }
+    else
+    {
+        $ppage->saveAsInProgress($text_data, $pguser);
+        $title = _("Already at limit");
+        $sentence = _("Your page was saved as 'In Progress' rather than 'Done', because you have already reached the following page limit(s):");
+    }
+
+    $round = get_Round_for_project_state($proj_state);
+
+    slim_header( $title );
+
+    echo "<p>$sentence</p>\n";
+    
+    echo "<ul>\n";
+    foreach ($dpls_reached as $dpl)
+    {
+        echo "<li>"
+            .   "'{$dpl->name}'"
+            .   " "
+            .   sprintf(_("(daily limit = %s)"), $dpl->daily_limit)
+            . "</li>"
+            . "\n";
+    }
+    echo "</ul>\n";
+
+    echo "<p>"
+        . _("You will not be allowed to save any more such pages until the next server midnight.")
+        . "</p>\n";
+
+    echo "<ul>\n"
+        .   "<li>"
+        .     sprintf(
+                _("Return to <a %s>the Project Page</a>"),
+                "href='$code_url/project.php?id=$projectid' target='_top'"
+              )
+        .   "</li>\n"
+        .   "<li>"
+        .     sprintf(
+                _("Return to <a %s>round %s</a>"),
+                "href='round.php?round_id={$round->id}' target='_top'",
+                $round->id
+              )
+        .   "</li>\n"
+        .   "<li>"
+        .     sprintf(
+                _("Return to <a %s>the Activity Hub</a>"),
+                "href='$code_url/activity_hub.php' target='_top'"
+              )
+        .   "</li>\n"
+        . "</ul>\n"
+        ;
+
+    slim_footer();
+
+    exit;
 }
 
 function leave_proofing_interface( $title )


### PR DESCRIPTION
I developed this code about 4 years ago (yikes), and it received some testing, but I abandoned it when other things came up. I'm creating a draft pull request so that it exists somewhere other than my home repo, and can maybe get some discussion.

A lot of the code is production-ready, I think (modulo intervening changes in house style). The main unresolved question is how the system should represent limits. The upgrade script (`SETUP/upgrade/09/01_daily_page_limits.php`) creates a `daily_page_limit` table, but none of the other new code refers to it, because for testing purposes, it was easier to create a representative DailyPageLimit object "by hand". (See `dpls_get_all` in `pinc/DailyPageLimit.inc`.)