### PR TITLE
Add warning for images larger than 100 kibibytes.

### DIFF
--- a/pinc/image_check.inc
+++ b/pinc/image_check.inc
@@ -1,0 +1,15 @@
+<?php
+
+$page_image_size_limit = 100; // kb
+
+function get_image_size_error($imageSize)
+{
+    global $page_image_size_limit;
+    $result = NULL;
+
+    if($imageSize > ($page_image_size_limit * 1024))
+    {
+        $result = sprintf(_("Image > %dkb: %dkb"), $page_image_size_limit, $imageSize / 1024);
+    }
+    return $result;
+}

--- a/pinc/image_check.inc
+++ b/pinc/image_check.inc
@@ -2,14 +2,14 @@
 
 $page_image_size_limit = 100; // kb
 
-function get_image_size_error($imageSize)
+function get_image_size_error($image_size)
 {
     global $page_image_size_limit;
     $result = NULL;
 
-    if($imageSize > ($page_image_size_limit * 1024))
+    if($image_size > ($page_image_size_limit * 1024))
     {
-        $result = sprintf(_("Image > %dkb: %dkb"), $page_image_size_limit, $imageSize / 1024);
+        $result = sprintf(_("Image > %dkb: %dkb"), $page_image_size_limit, $image_size / 1024);
     }
     return $result;
 }

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -5,6 +5,7 @@ include_once('links.inc'); // new_window_link()
 include_once($relPath.'../tools/project_manager/post_files.inc'); // page_info_query page_info_fetch
 include_once('bad_bytes.inc');
 include_once('wordcheck_engine.inc');
+include_once('image_check.inc');
 
 $test_functions  = array(
     // Automatic tests
@@ -41,19 +42,18 @@ function _test_project_for_large_page_images($projectid)
         $details .= "<th>" . _("Size") . "</th>";
         $details .= "</tr>";
 
-        $page_image_size_limit = 100; // kb
-
         $num_large_images = 0;
         while(list($image) = mysqli_fetch_row($result_res)) {
             // the the file's info
             $file_info = get_file_info_object($image,"$projects_dir/$projectid","$projects_url/$projectid");
 
-            // check to see if the file is > $page_image_size_limit kb
-            if($file_info->size > ($page_image_size_limit * 1024))
+            // check to see if the file is > size limit
+            $error = get_image_size_error($file_info->size);
+            if(isset($error))
             {
                 $details .= "<tr>";
                 $details .= "<td><a href='{$file_info->abs_url}'>$image</a></td>";
-                $details .= "<td>" . sprintf(_("Image > %dkb: %dkb"), $page_image_size_limit, $file_info->size / 1024) . "</td>";
+                $details .= "<td>" . $error . "</td>";
                 $details .= "</tr>";
     
                 $num_large_images++;
@@ -63,6 +63,7 @@ function _test_project_for_large_page_images($projectid)
         mysqli_free_result($result_res);
 
         $details .= "</table>";
+        global $page_image_size_limit;
 
         if($num_large_images==0)
         {

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -26,6 +26,7 @@ function _test_project_for_large_page_images($projectid)
 {
     global $projects_dir;
     global $projects_url;
+    global $page_image_size_limit;
 
     $test_name = _("Large Page Image Files");
     $test_desc = _("This test checks to see if there are any unusually large image files within a project.");
@@ -63,7 +64,6 @@ function _test_project_for_large_page_images($projectid)
         mysqli_free_result($result_res);
 
         $details .= "</table>";
-        global $page_image_size_limit;
 
         if($num_large_images==0)
         {

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -9,6 +9,7 @@ include_once($relPath.'Project.inc');
 include_once($relPath.'projectinfo.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'prefs_options.inc');
+include_once($relPath.'image_check.inc');
 
 require_login();
 
@@ -382,7 +383,7 @@ class Loader
         {
             $row =& $this->page_file_table[$base];
 
-            $error_msgs = '';
+            $error_msgs = array();
             $warning_msgs = array();
 
             foreach ( array('text','image') as $toi )
@@ -397,7 +398,7 @@ class Loader
                 if ( $action == 'error' )
                 {
                     $this->n_errors++;
-                    $error_msgs .= "$error_msg\n";
+                    array_push($error_msgs, $error_msg);
                 }
             }
 
@@ -413,10 +414,11 @@ class Loader
             if (isset($row['image']['src'][0]))
             {
                 $image_filename = $base . $row['image']['src'][0];
-                if (filesize($image_filename) > 204800 /* 200 Kibibytes */)
+                $warning_msg = get_image_size_error(filesize($image_filename));
+                if (isset($warning_msg))
                 {
                     $this->n_warnings += 1;
-                    array_push($warning_msgs, pgettext("image too large", "Image may be larger than necessary."));
+                    array_push($warning_msgs, $warning_msg);
                 }
             }
 
@@ -468,7 +470,7 @@ class Loader
                     case 'add|':
                         $this->n_errors++;
                         $row['image']['action'] = 'error';
-                        $error_msgs .= _('Adding text without image') . "\n";
+                        array_push($error_msgs, _('Adding text without image'));
                         break;
 
                     case '|':
@@ -827,7 +829,7 @@ class Loader
                 $warning_msgs = nl2br(implode("\n", $row['warning_msgs']));
                 echo "<td>$warning_msgs</td>";
 
-                $error_msgs = nl2br($row['error_msgs']);
+                $error_msgs = nl2br(implode("\n", $row['error_msgs']));
                 echo "<td>$error_msgs</td>";
 
                 echo "</tr>\n";


### PR DESCRIPTION
Example where I forced every warning for > 50 bytes (so every image). It shows off rows with multiple warnings as well.
![image](https://user-images.githubusercontent.com/1526781/74003835-992c4400-4939-11ea-8036-579f8fb8fa82.png)
