### PR TITLE
Fix resumable upload buttons for Chrome 80

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -71,11 +71,17 @@
   display: flex;
 }
 .button {
-  -webkit-appearance: button;
-  -moz-appearance: button;
-  appearance: button;
+  /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+  border: solid 1px lightgray;
+  border-radius: 5px;
   font-size: 0.7rem;
   padding: 2px 6px;
+  cursor: default;
 }
 .nodisp {
   display: none;

--- a/styles/global.less
+++ b/styles/global.less
@@ -101,11 +101,17 @@
 }
 
 .button {
-    -webkit-appearance: button;
-    -moz-appearance: button;
-    appearance: button;
+    /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+    border: solid 1px lightgray;
+    border-radius: 5px;
     font-size: 0.7rem;
     padding: 2px 6px;
+    cursor: default;
 }
 
 .nodisp {


### PR DESCRIPTION
Chrome 80 removed the 'appearance' attribute for <span>s:
 https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
making the buttons just regular text on a screen.

The resumable.js docs say that we should use spans, however:
 https://github.com/23/resumable.js#how-can-i-use-it
so we make our own "button like" styling. This, sadly, won't match any button for anyone in pretty much any browser on any OS because they all render them slightly differently, but at least it looks like a button.

Example screenshot:
![screenshot](https://www.pgdp.org/~cpeel/forumPosts/custom-button.png)