### PR TITLE
Add wordcheck status to diff page

### DIFF
--- a/tools/project_manager/page_table.inc
+++ b/tools/project_manager/page_table.inc
@@ -162,7 +162,7 @@ function echo_page_table(
 
     $path = "$projects_dir/$projectid/";
 
-    $fields_to_get = "image, length(master_text), state";
+    $fields_to_get = "$projectid.image, length(master_text), state";
     $tables = $projectid;
     $prev_text_column_name = 'master_text';
     foreach ( $rounds_to_display as $round )
@@ -178,11 +178,17 @@ function echo_page_table(
             $round->time_column_name,
             $round->user_column_name,
             $user_page_tally_column AS `$rn.user_page_tally`,
-            length($round->text_column_name)
+            length($round->text_column_name),
+            (wordcheck_events$rn.projectid IS NOT NULL) AS `wordcheck_status$rn`
         ";
         $tables .= "
             LEFT OUTER JOIN users AS users$rn
                 ON (users$rn.username = $round->user_column_name)
+            LEFT OUTER JOIN wordcheck_events AS wordcheck_events$rn
+                ON (wordcheck_events$rn.projectid = '$projectid' AND 
+                    wordcheck_events$rn.image = $projectid.image AND 
+                    wordcheck_events$rn.username = $round->user_column_name AND 
+                    wordcheck_events$rn.round_id = '$round->id')
             $joined_with_user_page_tallies
         ";
         $prev_text_column_name = $round->text_column_name;
@@ -228,7 +234,7 @@ function echo_page_table(
     }
 
     $res = mysqli_query(DPDatabase::get_connection(), "
-        SELECT $fields_to_get
+        SELECT DISTINCT $fields_to_get
         FROM $tables
         WHERE $where_condition
         ORDER BY image ASC
@@ -566,7 +572,14 @@ function echo_cells_for_round( $round_num, $diff_round_num, // <- These are the 
     {
         $R_pages_completed = $page_res["$round_num.user_page_tally"];
 
-        echo "<td $cell_class_attr>" . private_message_link($R_username,null) . " ($R_pages_completed)</td>\n";
+        $wordcheck_status = '<span title="' . _('This page was WordChecked.') . '">&check;</span>';
+
+        if (!$page_res["wordcheck_status$round_num"])
+        {
+            $wordcheck_status = '<span title="' . _('This page was not WordChecked.') . '">&#10008;</span>';
+        }
+
+        echo "<td $cell_class_attr>" . private_message_link($R_username,null) . " ($R_pages_completed) $wordcheck_status</td>\n";
     }
     else
     {


### PR DESCRIPTION
Adds an indicator to `/c/tools/project_manager/page_detail.php` of the WC status of each page. Useful for checking whether you ran wordcheck on each of your proofread pages.

 - Relevant task: https://www.pgdp.net/c/tasks.php?action=show&task_id=1174
 - Deployed at: https://www.pgdp.org/~mlazaric/c/

## Design

Currently it just prints `0` if it has not been wordchecked and `1` if it has:
![image](https://user-images.githubusercontent.com/3049847/74610108-6aa82900-50f0-11ea-94b2-935679917c22.png)

### Checkmarks and xs 

Alternatively we could add a &check; (`&check;`) or &times; (`&times;`):
![image](https://user-images.githubusercontent.com/3049847/74610274-0ede9f80-50f2-11ea-9cc5-893ea635715e.png)
![image](https://user-images.githubusercontent.com/3049847/74610315-7399fa00-50f2-11ea-8b70-809af3877186.png)

### Bold items which weren't wordchecked

We could bold the items which weren't wordchecked or the ones that were:
![image](https://user-images.githubusercontent.com/3049847/74610349-e4411680-50f2-11ea-82bf-6f43d6e05e21.png)

### New column in table

We could add a new column which contains the WC status:
![image](https://user-images.githubusercontent.com/3049847/74610550-83b2d900-50f4-11ea-8448-7eb38eb8fd8f.png)
![image](https://user-images.githubusercontent.com/3049847/74610598-d42a3680-50f4-11ea-927d-8f3b633e12e4.png)

**Note:** this would mean one additional WC column per round so it would bloat the table.

## Miscellaneous questions

 - Should we add the WC status to the recently proofed pages?

![image](https://user-images.githubusercontent.com/3049847/74610654-67fc0280-50f5-11ea-9b64-ada218be8362.png)

 - Should we treat it as a binary value (has been wordchecked / hasn't been wordchecked) or display the number of wordcheck events by the current user? 

 - Should we display it for formatting rounds?