### PR TITLE
Check combination

### DIFF
--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -716,11 +716,13 @@ function get_normalize_page_text_changes($text, $projectid)
 
     if($invalid_chars)
     {
-        // this will contain the characters and decomposed codepoint arrays.
+        // for each element in this array the key will be the character and
+        // the value will be an array of utf8 strings for each component
+        // if not printable the key is U+xxxx codepoint instead.
         $processed_invalid_chars = [];
         foreach(array_keys($invalid_chars) as $char)
         {
-            // find the components if it is an extended character
+            // find the components; maybe an extended character
             preg_match_all("/./u", $char, $matches);
             $char0 = $matches[0][0];
             // if not defined or is a control character or soft hyphen

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -716,23 +716,33 @@ function get_normalize_page_text_changes($text, $projectid)
 
     if($invalid_chars)
     {
-        $invalid_char_names = [];
+        // this will contain the characters and decomposed codepoint arrays.
+        $processed_invalid_chars = [];
         foreach(array_keys($invalid_chars) as $char)
         {
-            $name = IntlChar::charName($char);
-            # if it doesn't have a name it's a control character which can't
-            # be printed anyway, or if it's a soft hyphen
-            if(!$name || utf8_chr_to_hex($char) == 'U+00ad')
+            // find the components if it is an extended character
+            preg_match_all("/./u", $char, $matches);
+            $char0 = $matches[0][0];
+            // if not defined or is a control character or soft hyphen
+            if(!IntlChar::isdefined($char0) || IntlChar::iscntrl($char0) || ($char0 === "\x{ad}"))
             {
-                $name = utf8_chr_to_hex($char);
+                // put U+xxxx instead of utf8 string
+                $processed_invalid_chars[utf8_chr_to_hex($char0)] = $matches[0];
             }
             else
             {
-                $name = $char;
+                // extended characters will get here unless first component is caught above
+                $processed_invalid_chars[$char] = $matches[0];
             }
-            $invalid_char_names[] = $name;
         }
-        $invalid_char_string = implode(", ", $invalid_char_names);
+        // put the characters in spans with a title
+        $char_spans = [];
+        foreach($processed_invalid_chars as $char => $codepoints)
+        {
+            $title = make_title($codepoints);
+            $char_spans[] = "<span class='warning' title='$title'>$char</span>";
+        }
+        $invalid_char_string = implode(", ", $char_spans);
         $changes[] = sprintf(_("Invalid characters will be removed: <span class='mono'>%s</span>"), $invalid_char_string);
     }
 

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -898,9 +898,9 @@ function get_remarks_for_bad_byte_sequence($raw)
 
         $why_bad = "HTML numeric character reference";
     }
-    elseif(utf8_strlen($raw) == 1 && is_utf8($raw))
+    elseif(extended_strlen($raw) == 1 && is_utf8($raw))
     {
-        $why_bad = "Codepoint not valid for project";
+        $why_bad = "Character not valid for project";
         $intended_character = "";
     }
     else

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -423,8 +423,8 @@ function tds_for_bad_bytes($raw)
     $tds = "";
 
     $tds .= "<td>$raw</td>";
-
-    if (startswith($raw,'&'))
+var_dump($raw);
+    if (!is_extended($raw) && startswith($raw,'&'))
     {
         // It's a named or numeric character reference
         // so just show the reference itself,
@@ -433,7 +433,7 @@ function tds_for_bad_bytes($raw)
     }
     else
     {
-        $hex = utf8_chr_to_hex($raw);
+        $hex = extended_to_hex($raw);
         $tds .= "<td>$hex</td>";
     }
 

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -423,7 +423,7 @@ function tds_for_bad_bytes($raw)
     $tds = "";
 
     $tds .= "<td>$raw</td>";
-var_dump($raw);
+
     if (!is_extended($raw) && startswith($raw,'&'))
     {
         // It's a named or numeric character reference

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -61,6 +61,26 @@ function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement=""
     return preg_replace($pattern_string, $replacement, $string);
 }
 
+// make a string for use in a regular expression to match any of the characters
+// including the ranges
+function make_regex_string($characters)
+{
+    $char_class = "";
+    foreach($characters as $character)
+    {
+        if(strpos($character, '-') === False)
+        {
+            $char_class .= utf8_chr($character);
+        }
+        else
+        {
+            list($start, $end) = explode('-', $character);
+            $char_class .= utf8_chr($start) . '-' . utf8_chr($end);
+        }
+    }
+    return "[$char_class]";
+}
+
 # Take an array of Unicode codepoints (U+####), or codepoint ranges
 # (U+####-U+####) and return an array of unicode characters.
 function convert_codepoint_ranges_to_characters($codepoints)

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -25,7 +25,6 @@ function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement="")
         function ($matches) use($pattern_string)
         {
             $match = $matches[0];
-//            var_dump($match);
             if(1 === preg_match($pattern_string, $match))
             {
                 return $match;
@@ -49,7 +48,6 @@ function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement=""
         function ($matches) use($pattern_string)
         {
             $match = $matches[0];
-//            var_dump($match);
             if(1 === preg_match($pattern_string, $match))
             {
                 return "";
@@ -109,19 +107,25 @@ function convert_codepoint_ranges_to_characters($codepoints)
 # Return an array of invalid characters and their count
 function get_invalid_characters($string, $codepoints)
 {
-    $string = utf8_filter_out_codepoints($string, $codepoints);
+    $pattern_string = make_regex_string($codepoints);
+    $pattern_string = "/$pattern_string/u";
     $char_count = [];
     if($string)
     {
-        foreach(utf8_split($string) as $char)
+        // split into array of extended unicode characters
+        preg_match_all("/\X/u", $string, $matches);
+        foreach($matches[0] as $char)
         {
-            if(!isset($char_count[$char]))
+            if(0 === preg_match($pattern_string, $char))
             {
-                $char_count[$char] = 1;
-            }
-            else
-            {
-                $char_count[$char]++;
+                if(!isset($char_count[$char]))
+                {
+                    $char_count[$char] = 1;
+                }
+                else
+                {
+                    $char_count[$char]++;
+                }
             }
         }
     }
@@ -188,4 +192,44 @@ function guess_string_encoding($text)
 
     # Give up and return ISO-8859-1
     return 'ISO-8859-1';
+}
+
+function make_title($character)
+{
+    // make title from array of codepoint and possible combining marks
+    $title = IntlChar::charName($character[0]);
+    $count = count($character);
+    if($count > 1)
+    {
+        $title .= " with " . IntlChar::charName($character[1]);
+    }
+    for($index = 2; $index < $count; $index++)
+    {
+        $title .= " and " . IntlChar::charName($character[$index]);
+    }
+    return $title;
+}
+
+function extended_to_hex($char)
+{
+    // find the components of extended character
+    $codepoints = [];
+    preg_match_all("/./u", $char, $matches);
+    foreach($matches[0] as $match)
+    {
+        $codepoints[] = str_pad(dechex(IntlChar::ord($match)), 4, "0", STR_PAD_LEFT);
+    }
+    return implode(" ", $codepoints);
+}
+
+function extended_strlen($string)
+{
+    // how many 'extended Unicode sequences'?
+    return preg_match_all("/\X/u", $string);
+}
+
+function is_extended($string)
+{
+    // do any combining codepoints follow?
+    return preg_match("/^\PM\pM/u", $string);
 }

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -18,47 +18,45 @@ function utf8_normalize($string)
 # Filter to only characters in $string that are in $valid_codepoints.
 function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement="")
 {
-    $char_class = "";
-    foreach($valid_codepoints as $codepoint)
-    {
-        if(strpos($codepoint, '-') === False)
+    $pattern_string = make_regex_string($valid_codepoints);
+    $pattern_string = "/$pattern_string/u";
+    return preg_replace_callback(
+        "/\X/u",
+        function ($matches) use($pattern_string)
         {
-            $char_class .= utf8_chr($codepoint);
-        }
-        else
-        {
-            list($start, $end) = explode('-', $codepoint);
-            $char_class .= utf8_chr($start) . '-' . utf8_chr($end);
-        }
-    }
-    if(!$char_class)
-        return $string;
-
-    $pattern_string = "/[^$char_class]/u";
-    return preg_replace($pattern_string, $replacement, $string);
+            $match = $matches[0];
+//            var_dump($match);
+            if(1 === preg_match($pattern_string, $match))
+            {
+                return $match;
+            }
+            return "";
+        },
+        $string);
 }
 
 # Filter out any characters in $string that are in $remove_codepoints
 function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement="")
 {
-    $char_class = "";
-    foreach($remove_codepoints as $codepoint)
-    {
-        if(strpos($codepoint, '-') === False)
-        {
-            $char_class .= utf8_chr($codepoint);
-        }
-        else
-        {
-            list($start, $end) = explode('-', $codepoint);
-            $char_class .= utf8_chr($start) . '-' . utf8_chr($end);
-        }
-    }
-    if(!$char_class)
+    if(!$remove_codepoints)
         return $string;
 
-    $pattern_string = "/[$char_class]/u";
-    return preg_replace($pattern_string, $replacement, $string);
+    $pattern_string = make_regex_string($remove_codepoints);
+    $pattern_string = "/$pattern_string/u";
+    // find characters including those with combining diacritical marks
+    return preg_replace_callback(
+        "/\X/u",
+        function ($matches) use($pattern_string)
+        {
+            $match = $matches[0];
+//            var_dump($match);
+            if(1 === preg_match($pattern_string, $match))
+            {
+                return "";
+            }
+            return $match;
+        },
+        $string);
 }
 
 // make a string for use in a regular expression to match any of the characters
@@ -78,7 +76,8 @@ function make_regex_string($characters)
             $char_class .= utf8_chr($start) . '-' . utf8_chr($end);
         }
     }
-    return "[$char_class]";
+    // don't add /.../u yet so we can use it also in javascript
+    return "^[$char_class]$";
 }
 
 # Take an array of Unicode codepoints (U+####), or codepoint ranges

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -194,25 +194,25 @@ function guess_string_encoding($text)
     return 'ISO-8859-1';
 }
 
-function make_title($character)
+function make_title($codepoints)
 {
-    // make title from array of codepoint and possible combining marks
-    $title = IntlChar::charName($character[0]);
-    $count = count($character);
+    // make title from array of base codepoint and possible combining marks
+    $title = IntlChar::charName($codepoints[0]);
+    $count = count($codepoints);
     if($count > 1)
     {
-        $title .= " with " . IntlChar::charName($character[1]);
+        $title .= " with " . IntlChar::charName($codepoints[1]);
     }
     for($index = 2; $index < $count; $index++)
     {
-        $title .= " and " . IntlChar::charName($character[$index]);
+        $title .= " and " . IntlChar::charName($codepoints[$index]);
     }
     return $title;
 }
 
 function extended_to_hex($char)
 {
-    // find the components of extended character
+    // find the components of extended character as hex strings
     $codepoints = [];
     preg_match_all("/./u", $char, $matches);
     foreach($matches[0] as $match)


### PR DESCRIPTION
This addresses task 2260.
For adding files to a  project, if a file contains any extended characters (with combining diacritical marks) the whole character is shown in the list of bad characters and a title tooltip added to indicate what it is.
Similarly for Project Quick Check the bad character table shows the whole character and the hex codepoints from which it is composed.
This is running in the https://www.pgdp.org/~rp31/pm sandbox.
I made a bad project to test it projectID5c13a64918b30.
Perhaps we should make a project with a more comprehensive set of faults to give a better test if such a thing does not already exist.
bad_bytes.inc contains some reference to combining marks. I haven't investigated whether this will do anything in any circumstances.
