### PR TITLE
#1837: Properly escape project nameofwork on output

### DIFF
--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -324,18 +324,18 @@ $help['Change Interface Layout'] = "
 </p>
 <p>
     <IMG SRC='../tools/proofers/gfx/bt4.png'
-	ALT='Change Interface Layout'
-	TITLE='Change Interface Layout'
-	WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
+    ALT='Change Interface Layout'
+    TITLE='Change Interface Layout'
+    WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
     When in horizontal mode,
     clicking this button will switch you to vertical mode
     (scanned image of page appears to the LEFT of the OCR text you are correcting).
 </p>
 <p>
     <IMG SRC='../tools/proofers/gfx/bt5.png'
-	ALT='Change Interface Layout'
-	TITLE='Change Interface Layout'
-	WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
+    ALT='Change Interface Layout'
+    TITLE='Change Interface Layout'
+    WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
     When in vertical mode,
     clicking this button will switch you to horizontal mode
     (scanned image of page appears ABOVE the OCR text you are correcting).
@@ -440,72 +440,72 @@ if ( $i_type == 0 )
     echo "<form>\n";
     echo "<dl>\n";
     foreach(
-	Array(
-	    "Save as 'In Progress'",
-	    "Save as 'Done' & Proofread Next Page",
-	    "Save as 'Done'",
-	    'Stop Proofreading',
-	    'Switch to Vertical/Horizontal',
-	    'Show All Text',
-	    'Return Page to Round',
-	    'Report Bad Page',
-	    'WordCheck',
-	    'Preview',
-	)
-	as $name )
+    Array(
+        "Save as 'In Progress'",
+        "Save as 'Done' & Proofread Next Page",
+        "Save as 'Done'",
+        'Stop Proofreading',
+        'Switch to Vertical/Horizontal',
+        'Show All Text',
+        'Return Page to Round',
+        'Report Bad Page',
+        'WordCheck',
+        'Preview',
+    )
+    as $name )
     {
-	echo "<dt>";
-	if ( $name == 'Switch to Vertical/Horizontal' )
-	{
-	    echo "<input type='button' value='Switch to Vertical'> / ";
-	    echo "<input type='button' value='Switch to Horizontal'>";
-	}
-	else
-	{
-	    echo "<input type='button' value=\"$name\">";
-	}
-	echo "</dt>\n";
-	echo "<dd>$help[$name]</dd>\n";
+    echo "<dt>";
+    if ( $name == 'Switch to Vertical/Horizontal' )
+    {
+        echo "<input type='button' value='Switch to Vertical'> / ";
+        echo "<input type='button' value='Switch to Horizontal'>";
+    }
+    else
+    {
+        echo "<input type='button' value=\"$name\">";
+    }
+    echo "</dt>\n";
+    echo "<dd>$help[$name]</dd>\n";
     }
 
     echo "
     <dt>Page number</dt>
     <dd>
     <p>
-	This shows the index number
-	of the files on our site that contain the information
-	(scanned image and OCR text)
-	for the page in the book you are proofreading.
-	It may vary from the printed page number of the book,
-	since some of the pages that get scanned
-	(such as introduction pages, some illustration pages)
-	have no ordinary page numbers in the book,
-	but still count as another page to be proofread on the site.
-	Also some books have numbered pages that are otherwise blank,
-	and sometimes these are not scanned,
-	further throwing out the correspondence
-	between the 'on site' page number and the 'printed' page number.
-	If the OCR text matches the text in the image,
-	then this is not a case of 'mismatched image/text',
-	even if the page that was scanned
-	was numbered, say, 10 in the book and
-	is numbered, say, 21 on our site.
+    This shows the index number
+    of the files on our site that contain the information
+    (scanned image and OCR text)
+    for the page in the book you are proofreading.
+    It may vary from the printed page number of the book,
+    since some of the pages that get scanned
+    (such as introduction pages, some illustration pages)
+    have no ordinary page numbers in the book,
+    but still count as another page to be proofread on the site.
+    Also some books have numbered pages that are otherwise blank,
+    and sometimes these are not scanned,
+    further throwing out the correspondence
+    between the 'on site' page number and the 'printed' page number.
+    If the OCR text matches the text in the image,
+    then this is not a case of 'mismatched image/text',
+    even if the page that was scanned
+    was numbered, say, 10 in the book and
+    is numbered, say, 21 on our site.
     </p>
     </dd>
 
     <dt>Proofread by:</dt>
     <dd>
     <p>
-	This appears only in the second round.
-	The name of the first-round proofreader
-	is a link to send them a private message
-	through the site's forum system.
-	It is shown for your convenience
-	should you wish to send the first-round proofreader
-	a comment or question,
-	(polite, constructive) criticism
-	or praise
-	on their proofreading of this page in the first round.
+    This appears only in the second round.
+    The name of the first-round proofreader
+    is a link to send them a private message
+    through the site's forum system.
+    It is shown for your convenience
+    should you wish to send the first-round proofreader
+    a comment or question,
+    (polite, constructive) criticism
+    or praise
+    on their proofreading of this page in the first round.
     </p>
     </dd>
 
@@ -517,27 +517,27 @@ if ( $i_type == 0 )
     <dt>View Image</dt>
     <dd>
     <p>
-	Opens a copy of the png image file
-	of the page you are proofreading in a new browser window.
-	In Internet Explorer,
-	if you hover your mouse over the image in this new window,
-	a 'show actual size' icon will appear in the lower right corner.
-	Clicking this will display the image in extreme close-up,
-	which can be useful sometimes.
+    Opens a copy of the png image file
+    of the page you are proofreading in a new browser window.
+    In Internet Explorer,
+    if you hover your mouse over the image in this new window,
+    a 'show actual size' icon will appear in the lower right corner.
+    Clicking this will display the image in extreme close-up,
+    which can be useful sometimes.
     </p>
     </dd>
 
     <dt>Image Resize:
-	<input type='button' value='-25%'>
-	<input type='button' value='+25%'>
-	<input type='button' value='Original'>
+    <input type='button' value='-25%'>
+    <input type='button' value='+25%'>
+    <input type='button' value='Original'>
     </dt>
     <dd>
     <p>
-	These three buttons change the zoom of
-	the image already loaded inside the main proofreading browser window.
-	They can be useful in making out small, faded or blurry type
-	in the scanned images.
+    These three buttons change the zoom of
+    the image already loaded inside the main proofreading browser window.
+    They can be useful in making out small, faded or blurry type
+    in the scanned images.
     </p>
     </dd>
     ";
@@ -575,14 +575,14 @@ function echo_row( $name, $tooltip, $button_image_base, $accelerator )
     $tooltip_esc = attr_safe($tooltip);
     foreach( explode('+', $button_image_base) as $bib )
     {
-	echo "<IMG SRC='../tools/proofers/gfx/{$bib}.png'
-	    ALT='$tooltip_esc' TITLE='$tooltip_esc'
-	    WIDTH='26' HEIGHT='26' BORDER='0'>\n";
+    echo "<IMG SRC='../tools/proofers/gfx/{$bib}.png'
+        ALT='$tooltip_esc' TITLE='$tooltip_esc'
+        WIDTH='26' HEIGHT='26' BORDER='0'>\n";
     }
     echo "</TD><TD><B>$name</B><BR>\n";
     if ( $accelerator != '' )
     {
-	echo "Accelerator key: <B>$accelerator</B><br>\n";
+    echo "Accelerator key: <B>$accelerator</B><br>\n";
     }
     echo "$help[$name]</TD></TR>\n";
 }
@@ -686,9 +686,9 @@ on a character will insert it into the text.
     We usually wish to transliterate Greek letters into Latin ones,
     and wrap the result in tags [Greek: ].
     So
-	<blockquote>
-	&beta;&iota;&beta;&lambda;&omicron;&sigmaf;
-	</blockquote>
+    <blockquote>
+    &beta;&iota;&beta;&lambda;&omicron;&sigmaf;
+    </blockquote>
     in the image is rendered
     <pre>
     [Greek: biblos]
@@ -817,8 +817,8 @@ since that is done in the formatting rounds.
 <dl>
 <dt>
     <img src='../tools/proofers/gfx/tags/help.png'
-	width='30' height='30' border='0'
-	alt='Help' title='Help'>
+    width='30' height='30' border='0'
+    alt='Help' title='Help'>
 </dt>
 <dd>
     <p>

--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -324,18 +324,18 @@ $help['Change Interface Layout'] = "
 </p>
 <p>
     <IMG SRC='../tools/proofers/gfx/bt4.png'
-    ALT='Change Interface Layout'
-    TITLE='Change Interface Layout'
-    WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
+	ALT='Change Interface Layout'
+	TITLE='Change Interface Layout'
+	WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
     When in horizontal mode,
     clicking this button will switch you to vertical mode
     (scanned image of page appears to the LEFT of the OCR text you are correcting).
 </p>
 <p>
     <IMG SRC='../tools/proofers/gfx/bt5.png'
-    ALT='Change Interface Layout'
-    TITLE='Change Interface Layout'
-    WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
+	ALT='Change Interface Layout'
+	TITLE='Change Interface Layout'
+	WIDTH='26' HEIGHT='26' BORDER='0' ALIGN='LEFT'>
     When in vertical mode,
     clicking this button will switch you to horizontal mode
     (scanned image of page appears ABOVE the OCR text you are correcting).
@@ -440,72 +440,72 @@ if ( $i_type == 0 )
     echo "<form>\n";
     echo "<dl>\n";
     foreach(
-    Array(
-        "Save as 'In Progress'",
-        "Save as 'Done' & Proofread Next Page",
-        "Save as 'Done'",
-        'Stop Proofreading',
-        'Switch to Vertical/Horizontal',
-        'Show All Text',
-        'Return Page to Round',
-        'Report Bad Page',
-        'WordCheck',
-        'Preview',
-    )
-    as $name )
+	Array(
+	    "Save as 'In Progress'",
+	    "Save as 'Done' & Proofread Next Page",
+	    "Save as 'Done'",
+	    'Stop Proofreading',
+	    'Switch to Vertical/Horizontal',
+	    'Show All Text',
+	    'Return Page to Round',
+	    'Report Bad Page',
+	    'WordCheck',
+	    'Preview',
+	)
+	as $name )
     {
-    echo "<dt>";
-    if ( $name == 'Switch to Vertical/Horizontal' )
-    {
-        echo "<input type='button' value='Switch to Vertical'> / ";
-        echo "<input type='button' value='Switch to Horizontal'>";
-    }
-    else
-    {
-        echo "<input type='button' value=\"$name\">";
-    }
-    echo "</dt>\n";
-    echo "<dd>$help[$name]</dd>\n";
+	echo "<dt>";
+	if ( $name == 'Switch to Vertical/Horizontal' )
+	{
+	    echo "<input type='button' value='Switch to Vertical'> / ";
+	    echo "<input type='button' value='Switch to Horizontal'>";
+	}
+	else
+	{
+	    echo "<input type='button' value=\"$name\">";
+	}
+	echo "</dt>\n";
+	echo "<dd>$help[$name]</dd>\n";
     }
 
     echo "
     <dt>Page number</dt>
     <dd>
     <p>
-    This shows the index number
-    of the files on our site that contain the information
-    (scanned image and OCR text)
-    for the page in the book you are proofreading.
-    It may vary from the printed page number of the book,
-    since some of the pages that get scanned
-    (such as introduction pages, some illustration pages)
-    have no ordinary page numbers in the book,
-    but still count as another page to be proofread on the site.
-    Also some books have numbered pages that are otherwise blank,
-    and sometimes these are not scanned,
-    further throwing out the correspondence
-    between the 'on site' page number and the 'printed' page number.
-    If the OCR text matches the text in the image,
-    then this is not a case of 'mismatched image/text',
-    even if the page that was scanned
-    was numbered, say, 10 in the book and
-    is numbered, say, 21 on our site.
+	This shows the index number
+	of the files on our site that contain the information
+	(scanned image and OCR text)
+	for the page in the book you are proofreading.
+	It may vary from the printed page number of the book,
+	since some of the pages that get scanned
+	(such as introduction pages, some illustration pages)
+	have no ordinary page numbers in the book,
+	but still count as another page to be proofread on the site.
+	Also some books have numbered pages that are otherwise blank,
+	and sometimes these are not scanned,
+	further throwing out the correspondence
+	between the 'on site' page number and the 'printed' page number.
+	If the OCR text matches the text in the image,
+	then this is not a case of 'mismatched image/text',
+	even if the page that was scanned
+	was numbered, say, 10 in the book and
+	is numbered, say, 21 on our site.
     </p>
     </dd>
 
     <dt>Proofread by:</dt>
     <dd>
     <p>
-    This appears only in the second round.
-    The name of the first-round proofreader
-    is a link to send them a private message
-    through the site's forum system.
-    It is shown for your convenience
-    should you wish to send the first-round proofreader
-    a comment or question,
-    (polite, constructive) criticism
-    or praise
-    on their proofreading of this page in the first round.
+	This appears only in the second round.
+	The name of the first-round proofreader
+	is a link to send them a private message
+	through the site's forum system.
+	It is shown for your convenience
+	should you wish to send the first-round proofreader
+	a comment or question,
+	(polite, constructive) criticism
+	or praise
+	on their proofreading of this page in the first round.
     </p>
     </dd>
 
@@ -517,27 +517,27 @@ if ( $i_type == 0 )
     <dt>View Image</dt>
     <dd>
     <p>
-    Opens a copy of the png image file
-    of the page you are proofreading in a new browser window.
-    In Internet Explorer,
-    if you hover your mouse over the image in this new window,
-    a 'show actual size' icon will appear in the lower right corner.
-    Clicking this will display the image in extreme close-up,
-    which can be useful sometimes.
+	Opens a copy of the png image file
+	of the page you are proofreading in a new browser window.
+	In Internet Explorer,
+	if you hover your mouse over the image in this new window,
+	a 'show actual size' icon will appear in the lower right corner.
+	Clicking this will display the image in extreme close-up,
+	which can be useful sometimes.
     </p>
     </dd>
 
     <dt>Image Resize:
-    <input type='button' value='-25%'>
-    <input type='button' value='+25%'>
-    <input type='button' value='Original'>
+	<input type='button' value='-25%'>
+	<input type='button' value='+25%'>
+	<input type='button' value='Original'>
     </dt>
     <dd>
     <p>
-    These three buttons change the zoom of
-    the image already loaded inside the main proofreading browser window.
-    They can be useful in making out small, faded or blurry type
-    in the scanned images.
+	These three buttons change the zoom of
+	the image already loaded inside the main proofreading browser window.
+	They can be useful in making out small, faded or blurry type
+	in the scanned images.
     </p>
     </dd>
     ";
@@ -575,14 +575,14 @@ function echo_row( $name, $tooltip, $button_image_base, $accelerator )
     $tooltip_esc = attr_safe($tooltip);
     foreach( explode('+', $button_image_base) as $bib )
     {
-    echo "<IMG SRC='../tools/proofers/gfx/{$bib}.png'
-        ALT='$tooltip_esc' TITLE='$tooltip_esc'
-        WIDTH='26' HEIGHT='26' BORDER='0'>\n";
+	echo "<IMG SRC='../tools/proofers/gfx/{$bib}.png'
+	    ALT='$tooltip_esc' TITLE='$tooltip_esc'
+	    WIDTH='26' HEIGHT='26' BORDER='0'>\n";
     }
     echo "</TD><TD><B>$name</B><BR>\n";
     if ( $accelerator != '' )
     {
-    echo "Accelerator key: <B>$accelerator</B><br>\n";
+	echo "Accelerator key: <B>$accelerator</B><br>\n";
     }
     echo "$help[$name]</TD></TR>\n";
 }
@@ -686,9 +686,9 @@ on a character will insert it into the text.
     We usually wish to transliterate Greek letters into Latin ones,
     and wrap the result in tags [Greek: ].
     So
-    <blockquote>
-    &beta;&iota;&beta;&lambda;&omicron;&sigmaf;
-    </blockquote>
+	<blockquote>
+	&beta;&iota;&beta;&lambda;&omicron;&sigmaf;
+	</blockquote>
     in the image is rendered
     <pre>
     [Greek: biblos]
@@ -817,8 +817,8 @@ since that is done in the formatting rounds.
 <dl>
 <dt>
     <img src='../tools/proofers/gfx/tags/help.png'
-    width='30' height='30' border='0'
-    alt='Help' title='Help'>
+	width='30' height='30' border='0'
+	alt='Help' title='Help'>
 </dt>
 <dd>
     <p>

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -8,7 +8,7 @@ include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'ProjectSearchResultsConfig.inc');
 include_once($relPath.'forum_interface.inc'); // get_topic_details() & get_url_to_view_topic()
 include_once($relPath.'misc.inc'); // array_get()
-include_once($relPath.'pg.inc'); // get_pg_catalog_url_for_etext
+include_once($relPath.'pg.inc'); // get_pg_catalog_url_for_etext, html_safe()
 include_once($relPath.'genres.inc');  // maybe_create_temporary_genre_translation_table()
 
 class Column
@@ -190,7 +190,7 @@ class TitleColumn extends Column
     public function print_cell_data($project)
     {
         global $code_url;
-        echo "<a href='$code_url/project.php?id=$project->projectid&amp;detail_level=3'>".html_safe($project->nameofwork)."</a>";
+        echo "<a href='$code_url/project.php?id=$project->projectid&amp;detail_level=3'>" . html_safe($project->nameofwork) . "</a>";
     }
 }
 

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -7,8 +7,8 @@ include_once($relPath.'forum_interface.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'ProjectSearchResultsConfig.inc');
 include_once($relPath.'forum_interface.inc'); // get_topic_details() & get_url_to_view_topic()
-include_once($relPath.'misc.inc'); // array_get()
-include_once($relPath.'pg.inc'); // get_pg_catalog_url_for_etext, html_safe()
+include_once($relPath.'misc.inc'); // array_get(), html_safe()
+include_once($relPath.'pg.inc'); // get_pg_catalog_url_for_etext
 include_once($relPath.'genres.inc');  // maybe_create_temporary_genre_translation_table()
 
 class Column

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -135,7 +135,7 @@ class Column
 
     public function print_cell_data($project)
     {
-        echo $project->{$this->db_column};
+        echo html_safe($project->{$this->db_column});
     }
 }
 
@@ -190,7 +190,7 @@ class TitleColumn extends Column
     public function print_cell_data($project)
     {
         global $code_url;
-        echo "<a href='$code_url/project.php?id=$project->projectid&amp;detail_level=3'>$project->nameofwork</a>";
+        echo "<a href='$code_url/project.php?id=$project->projectid&amp;detail_level=3'>".html_safe($project->nameofwork)."</a>";
     }
 }
 

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -21,8 +21,8 @@ function list_projects_tersely( $where_condition, $order_clause, $limit_clause )
     {
         echo "<li><span class='title-listing'>";
 
-        echo "<span class='book-title'>", '"', $title, '"', "</span>";
-        echo "&mdash;$author ($language)";
+        echo "<span class='book-title'>", '"', html_safe($title), '"', "</span>";
+        echo "&mdash;".html_safe($author)." ($language)";
         if ( !is_null($postednum) )
         {
             echo "<br>", get_pg_catalog_link_for_etext($postednum);

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -22,7 +22,7 @@ function list_projects_tersely( $where_condition, $order_clause, $limit_clause )
         echo "<li><span class='title-listing'>";
 
         echo "<span class='book-title'>", '"', html_safe($title), '"', "</span>";
-        echo "&mdash;".html_safe($author)." ($language)";
+        echo "&mdash;" . html_safe($author) . " ($language)";
         if ( !is_null($postednum) )
         {
             echo "<br>", get_pg_catalog_link_for_etext($postednum);
@@ -139,7 +139,7 @@ function list_projects( $where_condition, $order_clause, $url_base, $per_page = 
         {
             echo "\"<a style=\"font-weight: bold;text-decoration:none\" href=\"$code_url/project.php?id=$projectid\">$title</a>\"";
         } else {
-            echo "\"<span style=\"font-weight: bold;color:#444444\">".html_safe($title)."</span>\"";
+            echo "\"<span style=\"font-weight: bold;color:#444444\">" . html_safe($title) . "</span>\"";
         }
         // Author
         echo ", ", html_safe($author);

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -139,10 +139,10 @@ function list_projects( $where_condition, $order_clause, $url_base, $per_page = 
         {
             echo "\"<a style=\"font-weight: bold;text-decoration:none\" href=\"$code_url/project.php?id=$projectid\">$title</a>\"";
         } else {
-            echo "\"<span style=\"font-weight: bold;color:#444444\">$title</span>\"";
+            echo "\"<span style=\"font-weight: bold;color:#444444\">".html_safe($title)."</span>\"";
         }
         // Author
-        echo ", ", $author;
+        echo ", ", html_safe($author);
         // Language
         echo " (", $language, ")";
         echo "<br>";

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -488,7 +488,7 @@ function _test_project_for_valid_clearance($projectid)
     $test_name = _("Clearance");
     $test_desc = _("This test checks if the project has a clearance in a valid form. This doesn't mean that the clearance itself is good, just that it looks like it could be.");
 
-    $details = "<p><b>" . _("Clearance Line") . "</b>: $clearance</p>";
+    $details = "<p><b>" . _("Clearance Line") . "</b>: " . html_safe($clearance) . "</p>";
 
     $valid_pattern_1 = '/^20[0-9]{12}[a-z]+\.?$/';
     $valid_pattern_2 = '/^gbn[0-9]/';

--- a/project.php
+++ b/project.php
@@ -67,7 +67,7 @@ if ( !$user_is_logged_in )
 
     output_header($title_for_theme, NO_STATSBAR);
 
-    echo "<h1>".html_safe($title)."</h1>\n";
+    echo "<h1>" . html_safe($title) . "</h1>\n";
 
     list($top_blurb, $bottom_blurb) = decide_blurbs();
     do_blurb_box( $top_blurb );
@@ -89,7 +89,7 @@ if ( $user_is_logged_in )
 output_header($title_for_theme, NO_STATSBAR);
 if ($detail_level==1)
 {
-    echo "<h1>".html_safe($title)."</h1>\n";
+    echo "<h1>" . html_safe($title) . "</h1>\n";
 
     do_expected_state();
     do_detail_level_switch();
@@ -110,7 +110,7 @@ else
     // that is usually wanted by the people who usually work with
     // the project in its current state.
 
-    echo "<h1>".html_safe($title)."</h1>\n";
+    echo "<h1>" . html_safe($title) . "</h1>\n";
 
     do_detail_level_switch();
     do_expected_state();

--- a/project.php
+++ b/project.php
@@ -67,7 +67,7 @@ if ( !$user_is_logged_in )
 
     output_header($title_for_theme, NO_STATSBAR);
 
-    echo "<h1>$title</h1>\n";
+    echo "<h1>".html_safe($title)."</h1>\n";
 
     list($top_blurb, $bottom_blurb) = decide_blurbs();
     do_blurb_box( $top_blurb );
@@ -89,7 +89,7 @@ if ( $user_is_logged_in )
 output_header($title_for_theme, NO_STATSBAR);
 if ($detail_level==1)
 {
-    echo "<h1>$title</h1>\n";
+    echo "<h1>".html_safe($title)."</h1>\n";
 
     do_expected_state();
     do_detail_level_switch();
@@ -110,7 +110,7 @@ else
     // that is usually wanted by the people who usually work with
     // the project in its current state.
 
-    echo "<h1>$title</h1>\n";
+    echo "<h1>".html_safe($title)."</h1>\n";
 
     do_detail_level_switch();
     do_expected_state();
@@ -185,7 +185,7 @@ function do_expected_state()
         echo "<p class='warning'>";
         echo sprintf(
             _('Warning: Project "%1$s" is no longer in state "%2$s"; it is now in state "%3$s".'),
-            $project->nameofwork,
+            html_safe($project->nameofwork),
             project_states_text($expected_state),
             project_states_text($project->state)
         );
@@ -395,8 +395,8 @@ function do_project_info_table()
         );
     }
 
-    echo_row_a( _("Title"),           $project->nameofwork );
-    echo_row_a( _("Author"),          $project->authorsname );
+    echo_row_a( _("Title"),           $project->nameofwork,  TRUE );
+    echo_row_a( _("Author"),          $project->authorsname, TRUE );
     echo_row_a( _("Language"),        $project->language );
     echo_row_a( _("Genre"),           _($project->genre) );
     echo_row_a( _("Difficulty"),      _($project->difficulty) );

--- a/stats/PPV_avail.php
+++ b/stats/PPV_avail.php
@@ -3,7 +3,7 @@ $relPath="../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 
@@ -80,7 +80,7 @@ while ( $project = mysqli_fetch_object( $result ) )
     echo "
         <tr>
         <td>$rownum</td>
-        <td>".html_safe($project->nameofwork)."</td>
+        <td>" . html_safe($project->nameofwork) . "</td>
         <td style='white-space: nowrap;'>$project->username</td>
         <td style='white-space: nowrap;'>$project->postproofer</td>
         <td style='white-space: nowrap;'>$datestamp</td>

--- a/stats/PPV_avail.php
+++ b/stats/PPV_avail.php
@@ -80,7 +80,7 @@ while ( $project = mysqli_fetch_object( $result ) )
     echo "
         <tr>
         <td>$rownum</td>
-        <td>$project->nameofwork</td>
+        <td>".html_safe($project->nameofwork)."</td>
         <td style='white-space: nowrap;'>$project->username</td>
         <td style='white-space: nowrap;'>$project->postproofer</td>
         <td style='white-space: nowrap;'>$datestamp</td>

--- a/stats/PP_unknown.php
+++ b/stats/PP_unknown.php
@@ -49,7 +49,7 @@ while ($row = mysqli_fetch_assoc($result)) {
 
     echo "<tr>";
     echo "<td>$rownum</td>";
-    echo "<td>$nameofwork</td>";
+    echo "<td>".html_safe($nameofwork)."</td>";
     echo "<td style='white-space: nowrap;'>$author</td>";
     echo "<td style='white-space: nowrap;'>$username</td>";
     echo "<td>$projectID</td>";

--- a/stats/PP_unknown.php
+++ b/stats/PP_unknown.php
@@ -3,7 +3,7 @@ $relPath="../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 
@@ -49,8 +49,8 @@ while ($row = mysqli_fetch_assoc($result)) {
 
     echo "<tr>";
     echo "<td>$rownum</td>";
-    echo "<td>".html_safe($nameofwork)."</td>";
-    echo "<td style='white-space: nowrap;'>".html_safe($author)."</td>";
+    echo "<td>" . html_safe($nameofwork) . "</td>";
+    echo "<td style='white-space: nowrap;'>" . html_safe($author) . "</td>";
     echo "<td style='white-space: nowrap;'>$username</td>";
     echo "<td>$projectID</td>";
     echo "<td style='white-space: nowrap;'>$modifieddate</td>";

--- a/stats/PP_unknown.php
+++ b/stats/PP_unknown.php
@@ -50,7 +50,7 @@ while ($row = mysqli_fetch_assoc($result)) {
     echo "<tr>";
     echo "<td>$rownum</td>";
     echo "<td>".html_safe($nameofwork)."</td>";
-    echo "<td style='white-space: nowrap;'>$author</td>";
+    echo "<td style='white-space: nowrap;'>".html_safe($author)."</td>";
     echo "<td style='white-space: nowrap;'>$username</td>";
     echo "<td>$projectID</td>";
     echo "<td style='white-space: nowrap;'>$modifieddate</td>";

--- a/stats/checkedout.php
+++ b/stats/checkedout.php
@@ -115,7 +115,7 @@ while ( $project = mysqli_fetch_object( $result ) )
     echo "
         <tr>
         <td>$rownum</td>
-        <td>$project->nameofwork</td>
+        <td>".html_safe($project->nameofwork)."</td>
       ";
      
       if (isset($inPPV)) { 

--- a/stats/checkedout.php
+++ b/stats/checkedout.php
@@ -3,7 +3,7 @@ $relPath="../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 
@@ -115,7 +115,7 @@ while ( $project = mysqli_fetch_object( $result ) )
     echo "
         <tr>
         <td>$rownum</td>
-        <td>".html_safe($project->nameofwork)."</td>
+        <td>" . html_safe($project->nameofwork) . "</td>
       ";
      
       if (isset($inPPV)) { 

--- a/stats/to_be_released.php
+++ b/stats/to_be_released.php
@@ -56,7 +56,7 @@ while ($row = mysqli_fetch_assoc($result)) {
 
     echo "<tr>";
     echo "<td>$rownum</td>";
-    echo "<td>".html_safe($nameofwork)."</td>";
+    echo "<td>" . html_safe($nameofwork) . "</td>";
     echo "<td style='white-space: nowrap;'>$username</td>";
     echo "<td style='white-space: nowrap;'>$datestamp</td>";
     echo "<td>$language</td>";

--- a/stats/to_be_released.php
+++ b/stats/to_be_released.php
@@ -56,7 +56,7 @@ while ($row = mysqli_fetch_assoc($result)) {
 
     echo "<tr>";
     echo "<td>$rownum</td>";
-    echo "<td>$nameofwork</td>";
+    echo "<td>".html_safe($nameofwork)."</td>";
     echo "<td style='white-space: nowrap;'>$username</td>";
     echo "<td style='white-space: nowrap;'>$datestamp</td>";
     echo "<td>$language</td>";

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -53,7 +53,7 @@ function fatal_error( $msg )
 
     echo "<pre>\n";
     echo _("You requested:") . "\n";
-    echo "    projectid  = $projectid ($project->nameofwork)\n";
+    echo "    projectid  = $projectid (".html_safe($project->nameofwork).")\n";
     echo "    curr_state = $curr_state\n";
     echo "    next_state = $next_state\n";
     echo "\n";
@@ -69,8 +69,8 @@ function fatal_error( $msg )
 if ( !is_null($transition->confirmation_question) && $confirmed != 'yes' )
 {
     echo "<p><b>" . _("Project ID") . ":</b> $projectid<br>\n";
-    echo "<b>" . _("Title") . ":</b> {$project->nameofwork}<br>\n";
-    echo "<b>" . _("Author") . ":</b> {$project->authorsname}</p>\n";
+    echo "<b>" . _("Title") . ":</b> ".html_safe($project->nameofwork)."<br>\n";
+    echo "<b>" . _("Author") . ":</b> ".html_safe($project->authorsname)."</p>\n";
     echo $transition->confirmation_question;
     echo "<br>
         <form action='changestate.php' method='POST'>

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -6,7 +6,7 @@ include_once($relPath.'project_trans.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'ProjectTransition.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 
@@ -53,7 +53,7 @@ function fatal_error( $msg )
 
     echo "<pre>\n";
     echo _("You requested:") . "\n";
-    echo "    projectid  = $projectid (".html_safe($project->nameofwork).")\n";
+    echo "    projectid  = $projectid (" . html_safe($project->nameofwork) . ")\n";
     echo "    curr_state = $curr_state\n";
     echo "    next_state = $next_state\n";
     echo "\n";
@@ -69,8 +69,8 @@ function fatal_error( $msg )
 if ( !is_null($transition->confirmation_question) && $confirmed != 'yes' )
 {
     echo "<p><b>" . _("Project ID") . ":</b> $projectid<br>\n";
-    echo "<b>" . _("Title") . ":</b> ".html_safe($project->nameofwork)."<br>\n";
-    echo "<b>" . _("Author") . ":</b> ".html_safe($project->authorsname)."</p>\n";
+    echo "<b>" . _("Title") . ":</b> " . html_safe($project->nameofwork) . "<br>\n";
+    echo "<b>" . _("Author") . ":</b> " . html_safe($project->authorsname) . "</p>\n";
     echo $transition->confirmation_question;
     echo "<br>
         <form action='changestate.php' method='POST'>

--- a/tools/extend_sr.php
+++ b/tools/extend_sr.php
@@ -51,7 +51,7 @@ catch(ActionException $e)
 {
     slim_header($title);
     echo "<h1>$title</h1>";
-    echo "<h2>", sprintf("Project: %s", $project->nameofwork), "</h2>";
+    echo "<h2>", sprintf("Project: %s", html_safe($project->nameofwork)), "</h2>";
     echo "<p class='error'>", $e->getMessage(), "</p>\n";
     echo "<a href='$back_url'>", _("Return to the Project Page"), "</a>";
 }

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -102,7 +102,7 @@ elseif ($frame=="top") {
         $myresult = mysqli_query(DPDatabase::get_connection(), sprintf("SELECT nameofwork FROM projects WHERE projectid = '%s'", mysqli_real_escape_string(DPDatabase::get_connection(), $projectid)));
         $row = mysqli_fetch_assoc($myresult);
         $project_name = $row['nameofwork'];
-        echo "<h3>".sprintf(_("Viewing %1\$s text for %2\$s in '%3\$s'"),$round_id,$page,$project_name)."</h3>\n";
+        echo "<h3>".sprintf(_("Viewing %1\$s text for %2\$s in '%3\$s'"),$round_id,$page,html_safe($project_name))."</h3>\n";
     } else {
         echo "<h3>"._("Choose a page image/text to view");
         echo " - " . implode("; ",$error_messages);

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -12,7 +12,7 @@ include_once($relPath.'project_trans.inc');
 include_once($relPath.'DPage.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'Project.inc'); // project_get_auto_PPer
-include_once($relPath.'misc.inc'); // requester_is_localhost()
+include_once($relPath.'misc.inc'); // requester_is_localhost(), html_safe()
 include_once('autorelease.inc');
 
 $one_project = validate_projectID('project', @$_GET['project'], true);
@@ -265,7 +265,7 @@ while ( $project = mysqli_fetch_assoc($allprojects) ) {
             }
 
             $state = $round->project_complete_state;
-            if ($verbose) echo "    Advancing \"".html_safe($nameofwork)."\" to $state\n";
+            if ($verbose) echo "    Advancing \"" . html_safe($nameofwork) . "\" to $state\n";
 
             $error_msg = project_transition( $projectid, $state, PT_AUTO );
             if ($error_msg)
@@ -306,7 +306,7 @@ while ( $project = mysqli_fetch_assoc($allprojects) ) {
         if ($verbose)
         {
             ensure_project_blurb( $project );
-            echo "    Promoting \"".html_safe($nameofwork)."\" to $new_state\n";
+            echo "    Promoting \"" . html_safe($nameofwork) . "\" to $new_state\n";
         }
 
         $error_msg = project_transition( $projectid, $new_state, PT_AUTO );

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -89,7 +89,7 @@ function ensure_project_blurb( $project )
         echo "\n";
         echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n";
         echo "projectid  = {$project['projectid']}\n";
-        echo "nameofwork = \"{$project['nameofwork']}\"\n";
+        echo "nameofwork = \"".html_safe($project['nameofwork'])."\"\n";
         echo "state      = {$project['state']}\n";
         echo "\n";
         $have_echoed_blurb_for_this_project = 1;
@@ -265,7 +265,7 @@ while ( $project = mysqli_fetch_assoc($allprojects) ) {
             }
 
             $state = $round->project_complete_state;
-            if ($verbose) echo "    Advancing \"$nameofwork\" to $state\n";
+            if ($verbose) echo "    Advancing \"".html_safe($nameofwork)."\" to $state\n";
 
             $error_msg = project_transition( $projectid, $state, PT_AUTO );
             if ($error_msg)
@@ -306,7 +306,7 @@ while ( $project = mysqli_fetch_assoc($allprojects) ) {
         if ($verbose)
         {
             ensure_project_blurb( $project );
-            echo "    Promoting \"$nameofwork\" to $new_state\n";
+            echo "    Promoting \"".html_safe($nameofwork)."\" to $new_state\n";
         }
 
         $error_msg = project_transition( $projectid, $new_state, PT_AUTO );

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -89,7 +89,7 @@ function ensure_project_blurb( $project )
         echo "\n";
         echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n";
         echo "projectid  = {$project['projectid']}\n";
-        echo "nameofwork = \"".html_safe($project['nameofwork'])."\"\n";
+        echo "nameofwork = \"" . html_safe($project['nameofwork']) . "\"\n";
         echo "state      = {$project['state']}\n";
         echo "\n";
         $have_echoed_blurb_for_this_project = 1;

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -77,7 +77,7 @@ while ($row = mysqli_fetch_assoc($res))
     echo "<td>" . html_safe($row['authorsname']) . "</td>";
     echo "<td>" . $row['username'] . "</td>";
     echo "<td>" . $row['state'] . "</td>";
-    echo "<td>" . $row['clearance'] . "</td>";
+    echo "<td>" . html_safe($row['clearance']) . "</td>";
     echo "</tr>";
 }
 echo "</table>";

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -73,8 +73,8 @@ while ($row = mysqli_fetch_assoc($res))
 {
     $projectid = $row['projectid'];
     echo "<tr>";
-    echo "<td><a href='$code_url/project.php?id=$projectid'>" . $row['nameofwork'] . "</a></td>";
-    echo "<td>" . $row['authorsname'] . "</td>";
+    echo "<td><a href='$code_url/project.php?id=$projectid'>" . html_safe($row['nameofwork']) . "</a></td>";
+    echo "<td>" . html_safe($row['authorsname']) . "</td>";
     echo "<td>" . $row['username'] . "</td>";
     echo "<td>" . $row['state'] . "</td>";
     echo "<td>" . $row['clearance'] . "</td>";

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -29,7 +29,7 @@ if (!$project->pages_table_exists)
     // But a user might have a bookmarked or otherwise saved a 'diff' URL.
     echo "<p>", _("Page details are not available for this project."), "</p>\n";
     echo "<p>", _("Project ID"), ": $projectid</p>\n";
-    echo "<p>", _("Title"), ":".html_safe($project_title)."</p>\n";
+    echo "<p>", _("Title"), ":" . html_safe($project_title) . "</p>\n";
     exit;
 }
 
@@ -112,7 +112,7 @@ $extra_args = array(
 );
 output_header("$title: $project_title", NO_STATSBAR, $extra_args);
 
-echo "<h1>".html_safe($project_title)."</h1>\n";
+echo "<h1>" . html_safe($project_title) . "</h1>\n";
 echo "<h2>$image_link</h2>\n";
 
 do_navigation($projectid, $image, $L_round_num, $R_round_num, 

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -29,7 +29,7 @@ if (!$project->pages_table_exists)
     // But a user might have a bookmarked or otherwise saved a 'diff' URL.
     echo "<p>", _("Page details are not available for this project."), "</p>\n";
     echo "<p>", _("Project ID"), ": $projectid</p>\n";
-    echo "<p>", _("Title"), ":$project_title</p>\n";
+    echo "<p>", _("Title"), ":".html_safe($project_title)."</p>\n";
     exit;
 }
 
@@ -112,7 +112,7 @@ $extra_args = array(
 );
 output_header("$title: $project_title", NO_STATSBAR, $extra_args);
 
-echo "<h1>$project_title</h1>\n";
+echo "<h1>".html_safe($project_title)."</h1>\n";
 echo "<h2>$image_link</h2>\n";
 
 do_navigation($projectid, $image, $L_round_num, $R_round_num, 

--- a/tools/project_manager/displayimage.php
+++ b/tools/project_manager/displayimage.php
@@ -89,7 +89,7 @@ prevnext_buttons();
 if($showreturnlink) {
     $project = new Project($projectid);
 
-    $label = sprintf(_("Return to Project Page for %s"), $project->nameofwork);
+    $label = sprintf(_("Return to Project Page for %s"), html_safe($project->nameofwork));
 
     echo "<br>\n";
     echo "<a href='$code_url/project.php?id=$projectid'>$label</a>";

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -318,7 +318,7 @@ class ProjectWordListHolder
         foreach($fields as $field => $label) {
             echo "<tr>";
             echo "<th class='label'>$label</th>";
-            echo "<td>" . $this->$field . "</td>";
+            echo "<td>" . html_safe($this->$field) . "</td>";
             echo "</tr>";
         }
 

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -8,7 +8,7 @@ include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'project_edit.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc');  // attr_safe()
+include_once($relPath.'misc.inc');  // attr_safe(), html_safe()
 include_once($relPath.'faq.inc');  // attr_safe()
 
 require_login();

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -559,7 +559,7 @@ class ProjectInfoHolder
             {
                 $errors .= sprintf(
                     _("Posted Number \"%s\" is not of the correct format."),
-                    $this->postednum) . "<br>";
+                    html_safe($this->postednum)) . "<br>";
                 // You'll sometimes see PG etext numbers with a 'C' appended.
                 // The 'C' is not part of the etext number
                 // (e.g., it does not appear in PG's RDF catalog),
@@ -1016,12 +1016,12 @@ class ProjectInfoHolder
         echo "<h2 id='preview'>", _("Preview Project"), "</h2>";
         echo "<p>", _("This is a preview of your project and roughly how it will look to the proofreaders."), "</p>\n";
         echo "<table class='basic'>";
-        echo "<tr><th>", _("Title"), "</th><td>$this->nameofwork</td></tr>\n";
-        echo "<tr><th>", _("Author"), "</th><td>$this->authorsname</td></tr>\n";
+        echo "<tr><th>", _("Title"), "</th><td>", html_safe($this->nameofwork), "</td></tr>\n";
+        echo "<tr><th>", _("Author"), "</th><td>", html_safe($this->authorsname), "</td></tr>\n";
         if (user_is_a_sitemanager())
         {
             // SAs are the only ones who can change this.
-            echo "<tr><th>", _("Project Manager"), "</th><td>$this->projectmanager</td></tr>\n";
+            echo "<tr><th>", _("Project Manager"), "</th><td>", html_safe($this->projectmanager), "</td></tr>\n";
         }
         echo "<tr><th>", _("Last Proofread"), "</th><td>$now</td></tr>\n";
         echo "<tr><th>", _("Forum"), "</th><td>", _("Start a discussion about this project"), "</td></tr>\n";
@@ -1031,7 +1031,7 @@ class ProjectInfoHolder
         echo "<br>$a<br>$b";
         echo "</th></tr>\n";
         echo "<tr><td colspan='2'>";
-        echo $comments;
+        echo html_safe($comments);
         echo "</td></tr>\n";
 
         echo "</table><br>";

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -1031,7 +1031,7 @@ class ProjectInfoHolder
         echo "<br>$a<br>$b";
         echo "</th></tr>\n";
         echo "<tr><td colspan='2'>";
-        echo html_safe($comments);
+        echo $comments;
         echo "</td></tr>\n";
 
         echo "</table><br>";

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -1021,7 +1021,7 @@ class ProjectInfoHolder
         if (user_is_a_sitemanager())
         {
             // SAs are the only ones who can change this.
-            echo "<tr><th>", _("Project Manager"), "</th><td>", html_safe($this->projectmanager), "</td></tr>\n";
+            echo "<tr><th>", _("Project Manager"), "</th><td>", $this->projectmanager, "</td></tr>\n";
         }
         echo "<tr><th>", _("Last Proofread"), "</th><td>$now</td></tr>\n";
         echo "<tr><th>", _("Forum"), "</th><td>", _("Start a discussion about this project"), "</td></tr>\n";

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param(), html_safe()
 include_once('./post_files.inc');
 
 require_login();
@@ -51,7 +51,7 @@ set_time_limit(0); // no time limit
 
 if ($save_files)
 {
-    echo "<p>generating files for $projectid (".html_safe($project->nameofwork).") ...</p>\n";
+    echo "<p>generating files for $projectid (" . html_safe($project->nameofwork) . ") ...</p>\n";
     flush();
     generate_post_files( $projectid, $round_id, $which_text, $include_proofers,  '' );
     flush();

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -51,7 +51,7 @@ set_time_limit(0); // no time limit
 
 if ($save_files)
 {
-    echo "<p>generating files for $projectid ($project->nameofwork) ...</p>\n";
+    echo "<p>generating files for $projectid (".html_safe($project->nameofwork).") ...</p>\n";
     flush();
     generate_post_files( $projectid, $round_id, $which_text, $include_proofers,  '' );
     flush();

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -78,7 +78,7 @@ if (!$resolution) {
     echo "<h1>$header</h1>";
 
     echo "<p>";
-    echo "<b>" . _("Project") . ":</b> {$project->nameofwork}<br>";
+    echo "<b>" . _("Project") . ":</b> ".html_safe($project->nameofwork)."<br>";
     echo "<b>" . _("Project ID") . ":</b> {$project->projectid}<br>";
     echo "<b>" . _("Project state") . ":</b> {$project->state}<br>";
     echo "<b>" . _("Page") . ":</b> $image<br>";

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -78,7 +78,7 @@ if (!$resolution) {
     echo "<h1>$header</h1>";
 
     echo "<p>";
-    echo "<b>" . _("Project") . ":</b> ".html_safe($project->nameofwork)."<br>";
+    echo "<b>" . _("Project") . ":</b> " . html_safe($project->nameofwork) . "<br>";
     echo "<b>" . _("Project ID") . ":</b> {$project->projectid}<br>";
     echo "<b>" . _("Project state") . ":</b> {$project->state}<br>";
     echo "<b>" . _("Page") . ":</b> $image<br>";

--- a/tools/project_manager/move_projects.php
+++ b/tools/project_manager/move_projects.php
@@ -55,13 +55,13 @@ foreach( $projectids as $projectid )
     $error_msg = project_transition( $projectid, $new_state, $pguser );
     if ( $error_msg )
     {
-        echo "    {$project->nameofwork}\n";
+        echo "    ".html_safe($project->nameofwork)."\n";
         echo "    $error_msg\n";
         continue;
     }
 
     // TRANSLATORS: %s is a project name
-    echo "    " . sprintf(_("%s successfully moved."), $project->nameofwork) . "\n";
+    echo "    " . sprintf(_("%s successfully moved."), html_safe($project->nameofwork)) . "\n";
 }
 
 echo "</pre>\n";

--- a/tools/project_manager/move_projects.php
+++ b/tools/project_manager/move_projects.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'project_edit.inc');
 include_once($relPath.'project_trans.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 include_once('projectmgr.inc');
 
 require_login();
@@ -55,7 +55,7 @@ foreach( $projectids as $projectid )
     $error_msg = project_transition( $projectid, $new_state, $pguser );
     if ( $error_msg )
     {
-        echo "    ".html_safe($project->nameofwork)."\n";
+        echo "    " . html_safe($project->nameofwork) . "\n";
         echo "    $error_msg\n";
         continue;
     }

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -43,7 +43,7 @@ class Comparator
         output_header("$title: $sub_title", NO_STATSBAR);
 
         echo "<h1>$title</h1>\n";
-        echo "<h2>".html_safe($sub_title)."</h2>\n";
+        echo "<h2>" . html_safe($sub_title) . "</h2>\n";
 
         $state = $this->project->state;
         $project_url = "$code_url/project.php?id=$this->projectid&amp;expected_state=$state";

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -43,7 +43,7 @@ class Comparator
         output_header("$title: $sub_title", NO_STATSBAR);
 
         echo "<h1>$title</h1>\n";
-        echo "<h2>$sub_title</h2>\n";
+        echo "<h2>".html_safe($sub_title)."</h2>\n";
 
         $state = $this->project->state;
         $project_url = "$code_url/project.php?id=$this->projectid&amp;expected_state=$state";

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -61,7 +61,7 @@ $page_details_str = _('Page Detail');
 
 output_header( "$page_details_str: $title", NO_STATSBAR);
 
-echo "<h1>$title</h1>\n";
+echo "<h1>".html_safe($title)."</h1>\n";
 echo "<h2>$page_details_str</h2>\n";
 
 $url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -61,7 +61,7 @@ $page_details_str = _('Page Detail');
 
 output_header( "$page_details_str: $title", NO_STATSBAR);
 
-echo "<h1>".html_safe($title)."</h1>\n";
+echo "<h1>" . html_safe($title) . "</h1>\n";
 echo "<h2>$page_details_str</h2>\n";
 
 $url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";

--- a/tools/project_manager/replace_image.php
+++ b/tools/project_manager/replace_image.php
@@ -30,7 +30,7 @@ $replace_image_str = _('Replace Image');
 
 output_header("$replace_image_str: {$project->nameofwork}");
 
-echo "<h1>{$project->nameofwork}</h1>\n";
+echo "<h1>".html_safe($project->nameofwork)."</h1>\n";
 echo "<h2>$replace_image_str: $image</h2>\n";
 
 if (!$project->can_be_managed_by_current_user)

--- a/tools/project_manager/replace_image.php
+++ b/tools/project_manager/replace_image.php
@@ -5,7 +5,7 @@ $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc'); // get_upload_err_msg, attr_safe
+include_once($relPath.'misc.inc'); // get_upload_err_msg, attr_safe, html_safe
 
 require_login();
 
@@ -30,7 +30,7 @@ $replace_image_str = _('Replace Image');
 
 output_header("$replace_image_str: {$project->nameofwork}");
 
-echo "<h1>".html_safe($project->nameofwork)."</h1>\n";
+echo "<h1>" . html_safe($project->nameofwork) . "</h1>\n";
 echo "<h2>$replace_image_str: $image</h2>\n";
 
 if (!$project->can_be_managed_by_current_user)

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -347,10 +347,10 @@ if (!isset($_GET['name']))
             echo "<tr>\n";
             echo "<td>";
             echo "<a href='$code_url/project.php?id=" .
-                $row['projectid'] . "'>" . $row['nameofwork'] . "</a>";
+                $row['projectid'] . "'>" . html_safe($row['nameofwork']) . "</a>";
             echo "</td>";
             echo "<td>";
-            echo $row['authorsname'];
+            echo html_safe($row['authorsname']);
             echo "</td>";
             echo "<td class='center-align'>";
             echo $row['genre'];

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -7,7 +7,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'dpsql.inc');
-include_once($relPath.'misc.inc'); // array_get()
+include_once($relPath.'misc.inc'); // array_get(), html_safe()
 include_once($relPath.'pg.inc');
 
 require_login();

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -3,7 +3,7 @@ include_once($relPath.'links.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'project_edit.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
+include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'faq.inc');
 
 // get_cutoff_string

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -236,7 +236,7 @@ function prep_numeric_keys_for_multisort(&$assocArray) {
 function echo_page_header($title,$projectid) {
     echo "<h1>$title</h1>";
 
-    $project_text = sprintf(_("Project: %s"),get_project_name($projectid));
+    $project_text = sprintf(_("Project: %s"),html_safe(get_project_name($projectid)));
     echo "<h2>$project_text</h2>\n";
 }
 

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -131,7 +131,7 @@ while ($proj =  mysqli_fetch_object($result))
     $proj_url = "$code_url/project.php?id=$proj->projectid";
     echo "<p>";
     // TRANSLATORS: format is <title> by <author>.
-    echo "<b>" . sprintf("%1\$s by %2\$s", "<a href='$proj_url'>".html_safe($proj->nameofwork)."</a>", $proj->authorsname) . "</b>";
+    echo "<b>" . sprintf("%1\$s by %2\$s", "<a href='$proj_url'>".html_safe($proj->nameofwork)."</a>", html_safe($proj->authorsname)) . "</b>";
     echo "</p>" ;
 
     dpsql_dump_query(page_summary_sql($mentored_round, $proj->projectid));

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -131,7 +131,7 @@ while ($proj =  mysqli_fetch_object($result))
     $proj_url = "$code_url/project.php?id=$proj->projectid";
     echo "<p>";
     // TRANSLATORS: format is <title> by <author>.
-    echo "<b>" . sprintf("%1\$s by %2\$s", "<a href='$proj_url'>$proj->nameofwork</a>", $proj->authorsname) . "</b>";
+    echo "<b>" . sprintf("%1\$s by %2\$s", "<a href='$proj_url'>".html_safe($proj->nameofwork)."</a>", $proj->authorsname) . "</b>";
     echo "</p>" ;
 
     dpsql_dump_query(page_summary_sql($mentored_round, $proj->projectid));

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -12,7 +12,7 @@ include_once($relPath.'prefs_options.inc');  // for PRIVACY_* constants
 include_once($relPath.'theme.inc');          // for page marginalia
 include_once($relPath.'project_states.inc'); // for PROJ_ declarations
 include_once($relPath.'TallyBoard.inc');     // for TallyBoard
-include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 
@@ -131,7 +131,7 @@ while ($proj =  mysqli_fetch_object($result))
     $proj_url = "$code_url/project.php?id=$proj->projectid";
     echo "<p>";
     // TRANSLATORS: format is <title> by <author>.
-    echo "<b>" . sprintf("%1\$s by %2\$s", "<a href='$proj_url'>".html_safe($proj->nameofwork)."</a>", html_safe($proj->authorsname)) . "</b>";
+    echo "<b>" . sprintf("%1\$s by %2\$s", "<a href='$proj_url'>" . html_safe($proj->nameofwork) . "</a>", html_safe($proj->authorsname)) . "</b>";
     echo "</p>" ;
 
     dpsql_dump_query(page_summary_sql($mentored_round, $proj->projectid));

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -22,7 +22,7 @@ if (is_null($zip_type))
 output_header("$image_index_str: {$project->nameofwork}");
 
 echo "
-    <h1>{$project->nameofwork}</h1>
+    <h1>".html_safe($project->nameofwork)."</h1>
     <p>$projectid</p>
     <p><a href='$code_url/project.php?id=$projectid'>", _('Return to Project Page'), "</a></p>
     <h2>$image_index_str</h2>

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -3,7 +3,7 @@ $relPath="./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 
@@ -22,7 +22,7 @@ if (is_null($zip_type))
 output_header("$image_index_str: {$project->nameofwork}");
 
 echo "
-    <h1>".html_safe($project->nameofwork)."</h1>
+    <h1>" . html_safe($project->nameofwork) . "</h1>
     <p>$projectid</p>
     <p><a href='$code_url/project.php?id=$projectid'>", _('Return to Project Page'), "</a></p>
     <h2>$image_index_str</h2>

--- a/tools/proofers/md_available.php
+++ b/tools/proofers/md_available.php
@@ -43,7 +43,7 @@ echo "<table class='themed theme_striped'>\n";
 
       echo "<tr>";
       echo "<td align='right'><a href = \"md_phase1.php?projectid=$projectid\">".html_safe($name)."</a></td>\n";
-      echo "<td align='right'>".html_safe($author)."</td>\n";
+      echo "<td align='right'>" . html_safe($author) . "</td>\n";
       echo "<td align='right'>$numpages</td>\n";
 //      echo "<td align='right'>#pages</td>\n";
 
@@ -87,7 +87,7 @@ echo "<br>";
 
       echo "<tr>";
       echo "<td align='right'><a href = \"md_phase2.php?projectid=$projectid\">".html_safe($name)."</a></td>\n";
-      echo "<td align='right'>".html_safe($author)."</td>\n";
+      echo "<td align='right'>" . html_safe($author) . "</td>\n";
       echo "<td align='right'>$numpages</td>\n";
       echo "<td align='right'>$availpages</td>\n";
 

--- a/tools/proofers/md_available.php
+++ b/tools/proofers/md_available.php
@@ -42,8 +42,8 @@ echo "<table class='themed theme_striped'>\n";
            $numpages = Project_getNumPages( $projectid );
 
       echo "<tr>";
-      echo "<td align='right'><a href = \"md_phase1.php?projectid=$projectid\">$name</a></td>\n";
-      echo "<td align='right'>$author</td>\n";
+      echo "<td align='right'><a href = \"md_phase1.php?projectid=$projectid\">".html_safe($name)."</a></td>\n";
+      echo "<td align='right'>".html_safe($author)."</td>\n";
       echo "<td align='right'>$numpages</td>\n";
 //      echo "<td align='right'>#pages</td>\n";
 
@@ -86,8 +86,8 @@ echo "<br>";
            $availpages = Project_getNumPagesInState( $projectid, 'avail_md_second');
 
       echo "<tr>";
-      echo "<td align='right'><a href = \"md_phase2.php?projectid=$projectid\">$name</a></td>\n";
-      echo "<td align='right'>$author</td>\n";
+      echo "<td align='right'><a href = \"md_phase2.php?projectid=$projectid\">".html_safe($name)."</a></td>\n";
+      echo "<td align='right'>".html_safe($author)."</td>\n";
       echo "<td align='right'>$numpages</td>\n";
       echo "<td align='right'>$availpages</td>\n";
 

--- a/tools/proofers/md_available.php
+++ b/tools/proofers/md_available.php
@@ -86,7 +86,7 @@ echo "<br>";
            $availpages = Project_getNumPagesInState( $projectid, 'avail_md_second');
 
       echo "<tr>";
-      echo "<td align='right'><a href = \"md_phase2.php?projectid=$projectid\">".html_safe($name)."</a></td>\n";
+      echo "<td align='right'><a href = \"md_phase2.php?projectid=$projectid\">" . html_safe($name) . "</a></td>\n";
       echo "<td align='right'>" . html_safe($author) . "</td>\n";
       echo "<td align='right'>$numpages</td>\n";
       echo "<td align='right'>$availpages</td>\n";

--- a/tools/proofers/md_available.php
+++ b/tools/proofers/md_available.php
@@ -42,7 +42,7 @@ echo "<table class='themed theme_striped'>\n";
            $numpages = Project_getNumPages( $projectid );
 
       echo "<tr>";
-      echo "<td align='right'><a href = \"md_phase1.php?projectid=$projectid\">".html_safe($name)."</a></td>\n";
+      echo "<td align='right'><a href = \"md_phase1.php?projectid=$projectid\">" . html_safe($name) . "</a></td>\n";
       echo "<td align='right'>" . html_safe($author) . "</td>\n";
       echo "<td align='right'>$numpages</td>\n";
 //      echo "<td align='right'>#pages</td>\n";

--- a/tools/proofers/md_phase1.php
+++ b/tools/proofers/md_phase1.php
@@ -102,7 +102,7 @@ output_header($title);
 echo "<h1>$title</h1>";
 
 echo "<p>";
-echo "<b>" . _("Project Name") . "</b>: $name<br>";
+echo "<b>" . _("Project Name") . "</b>: ".html_safe($name)."<br>";
 echo "<b>" . _("Total Number of Master Pages") . "</b>: $numpages<br>";
 echo "<b>" . _("Language") . "</b>: $language<br>";
 echo "</p>";

--- a/tools/proofers/md_phase1.php
+++ b/tools/proofers/md_phase1.php
@@ -5,7 +5,7 @@ include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'projectinfo.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
+include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'metarefresh.inc');
 
 require_login();
@@ -102,7 +102,7 @@ output_header($title);
 echo "<h1>$title</h1>";
 
 echo "<p>";
-echo "<b>" . _("Project Name") . "</b>: ".html_safe($name)."<br>";
+echo "<b>" . _("Project Name") . "</b>: " . html_safe($name) . "<br>";
 echo "<b>" . _("Total Number of Master Pages") . "</b>: $numpages<br>";
 echo "<b>" . _("Language") . "</b>: $language<br>";
 echo "</p>";

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -1,7 +1,7 @@
 <?php
 $relPath='../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // array_get(), surround_and_join()
+include_once($relPath.'misc.inc'); // array_get(), surround_and_join(), html_safe()
 include_once($relPath.'theme.inc');
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'stages.inc');
@@ -166,7 +166,7 @@ else
         }
         $url = "$code_url/project.php?id=$projectid";
         $onclick_attr = get_onclick_attr_for_link_to_project_page($url);
-        echo "<a href='$url' $onclick_attr>".html_safe($nameofwork)."</a>";
+        echo "<a href='$url' $onclick_attr>" . html_safe($nameofwork) . "</a>";
         echo "</td>\n";
 
         if(isset($colspecs['state']))
@@ -274,7 +274,7 @@ else
         echo "<tr>\n";
 
         echo "<td>";
-        echo "<a href='$code_url/project.php?id=$project->projectid'>".html_safe($project->nameofwork)."</a>";
+        echo "<a href='$code_url/project.php?id=$project->projectid'>" . html_safe($project->nameofwork) . "</a>";
         echo "</td>\n";
 
         echo "<td>";

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -162,11 +162,11 @@ else
         echo "<td>";
         if ($orig_nameofwork != '') {
             // say where this information came from
-            echo $orig_nameofwork . " <i>" .  _("merged into") . "</i> ";
+            echo html_safe($orig_nameofwork) . " <i>" .  _("merged into") . "</i> ";
         }
         $url = "$code_url/project.php?id=$projectid";
         $onclick_attr = get_onclick_attr_for_link_to_project_page($url);
-        echo "<a href='$url' $onclick_attr>$nameofwork</a>";
+        echo "<a href='$url' $onclick_attr>".html_safe($nameofwork)."</a>";
         echo "</td>\n";
 
         if(isset($colspecs['state']))
@@ -274,7 +274,7 @@ else
         echo "<tr>\n";
 
         echo "<td>";
-        echo "<a href='$code_url/project.php?id=$project->projectid'>$project->nameofwork</a>";
+        echo "<a href='$code_url/project.php?id=$project->projectid'>".html_safe($project->nameofwork)."</a>";
         echo "</td>\n";
 
         echo "<td>";

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -268,9 +268,9 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
         $state = $project->state;
         $nameofwork = $project->nameofwork;
         // OK, the information is now all for the project that the deleted one was merged into
-        $messages[] = array("<a href='$deleted_url'>".html_safe($deleted_nameofwork)."</a>",
+        $messages[] = array("<a href='$deleted_url'>" . html_safe($deleted_nameofwork) . "</a>",
                             $deleted_state,
-                            sprintf(_("Merged into %s"), "<a href='$url'>".html_safe($nameofwork)."</a>"),
+                            sprintf(_("Merged into %s"), "<a href='$url'>" . html_safe($nameofwork) . "</a>"),
                             MESSAGE_INFO);
     }
     // what do we do if it was merged but we haven't found a projectid? TODO
@@ -289,7 +289,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     if (!does_project_page_table_exist($projectid))
     {
         // table doesn't exist. We are not interested.
-        $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
+        $messages[] = array("<a href='$url'>" . html_safe($nameofwork) . "</a>",
                             $state,
                             _("Page information no longer available"),
                             MESSAGE_ERROR);
@@ -323,7 +323,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     mysqli_free_result($work_round_result);
     if (NULL == $max_done_timestamp) {
         // hasn't finished the work round. We are not interested.
-        $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
+        $messages[] = array("<a href='$url'>" . html_safe($nameofwork) . "</a>",
                             $state,
                             sprintf(_("Has not finished %s"), $work_round_id),
                             MESSAGE_INFO);
@@ -342,7 +342,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     mysqli_free_result($review_round_result);
     if (0 == $done_in_rround) {
         // hasn't been proofread in review round. We are not interested.
-        $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
+        $messages[] = array("<a href='$url'>" . html_safe($nameofwork) . "</a>",
                             $state,
                             sprintf(_('Has not been proofread in %1$s (%2$d pages worked on)'), $review_round_id, $pages_worked_in_review_round),
                             MESSAGE_INFO);
@@ -382,7 +382,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
         // Don't print a message in the Other Projects table to avoid confusion -- this will
         // need to be re-introduced once we limit the projects to ones that the user has
         // actually worked on in the work round
-        // $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
+        // $messages[] = array("<a href='$url'>" . html_safe($nameofwork) . "</a>",
         //                     $state,
         //                     sprintf(_("Has not been proofread in %s"), $review_round_id),
         //                     MESSAGE_INFO);
@@ -425,7 +425,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     $total_n_w_diff  += $n_with_diff;
 
     echo "<tr>";
-    echo "<td $n_latered_bg><a href='$url'>".html_safe($nameofwork)."</a></td>";
+    echo "<td $n_latered_bg><a href='$url'>" . html_safe($nameofwork) . "</a></td>";
     echo "<td nowrap>";
     echo get_medium_label_for_project_state( $state );
     echo "</td>";

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -268,9 +268,9 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
         $state = $project->state;
         $nameofwork = $project->nameofwork;
         // OK, the information is now all for the project that the deleted one was merged into
-        $messages[] = array("<a href='$deleted_url'>$deleted_nameofwork</a>",
+        $messages[] = array("<a href='$deleted_url'>".html_safe($deleted_nameofwork)."</a>",
                             $deleted_state,
-                            sprintf(_("Merged into %s"), "<a href='$url'>$nameofwork</a>"),
+                            sprintf(_("Merged into %s"), "<a href='$url'>".html_safe($nameofwork)."</a>"),
                             MESSAGE_INFO);
     }
     // what do we do if it was merged but we haven't found a projectid? TODO
@@ -289,7 +289,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     if (!does_project_page_table_exist($projectid))
     {
         // table doesn't exist. We are not interested.
-        $messages[] = array("<a href='$url'>$nameofwork</a>",
+        $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
                             $state,
                             _("Page information no longer available"),
                             MESSAGE_ERROR);
@@ -323,7 +323,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     mysqli_free_result($work_round_result);
     if (NULL == $max_done_timestamp) {
         // hasn't finished the work round. We are not interested.
-        $messages[] = array("<a href='$url'>$nameofwork</a>",
+        $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
                             $state,
                             sprintf(_("Has not finished %s"), $work_round_id),
                             MESSAGE_INFO);
@@ -342,7 +342,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     mysqli_free_result($review_round_result);
     if (0 == $done_in_rround) {
         // hasn't been proofread in review round. We are not interested.
-        $messages[] = array("<a href='$url'>$nameofwork</a>",
+        $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
                             $state,
                             sprintf(_('Has not been proofread in %1$s (%2$d pages worked on)'), $review_round_id, $pages_worked_in_review_round),
                             MESSAGE_INFO);
@@ -382,7 +382,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
         // Don't print a message in the Other Projects table to avoid confusion -- this will
         // need to be re-introduced once we limit the projects to ones that the user has
         // actually worked on in the work round
-        // $messages[] = array("<a href='$url'>$nameofwork</a>",
+        // $messages[] = array("<a href='$url'>".html_safe($nameofwork)."</a>",
         //                     $state,
         //                     sprintf(_("Has not been proofread in %s"), $review_round_id),
         //                     MESSAGE_INFO);
@@ -425,7 +425,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     $total_n_w_diff  += $n_with_diff;
 
     echo "<tr>";
-    echo "<td $n_latered_bg><a href='$url'>$nameofwork</a></td>";
+    echo "<td $n_latered_bg><a href='$url'>".html_safe($nameofwork)."</a></td>";
     echo "<td nowrap>";
     echo get_medium_label_for_project_state( $state );
     echo "</td>";

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -271,7 +271,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
 
         $project = new Project($projectid);
 
-        echo "<tr><th>" . _("Title") . ":</th><td>" . $project->nameofwork. "</td></tr>\n";
+        echo "<tr><th>" . _("Title") . ":</th><td>" . html_safe($project->nameofwork) . "</td></tr>\n";
 
         // ----------------------
 

--- a/tools/site_admin/proj_approvals.php
+++ b/tools/site_admin/proj_approvals.php
@@ -71,8 +71,8 @@ echo "<table class='themed'>\n";
 
         echo "
             <tr>
-            <td class='right-align'><a href='$code_url/project.php?id=$projectid'>$name</a></td>
-            <td class='right-align'>$author</td>
+            <td class='right-align'><a href='$code_url/project.php?id=$projectid'>".html_safe($name)."</a></td>
+            <td class='right-align'>".html_safe($author)."</td>
             <td><input type='text' size='67' name='clearance' value='$clearance'></td>
             <td>
                 <form action='proj_approvals.php?projectid=$projectid'>

--- a/tools/site_admin/proj_approvals.php
+++ b/tools/site_admin/proj_approvals.php
@@ -71,7 +71,7 @@ echo "<table class='themed'>\n";
 
         echo "
             <tr>
-            <td class='right-align'><a href='$code_url/project.php?id=$projectid'>".html_safe($name)."</a></td>
+            <td class='right-align'><a href='$code_url/project.php?id=$projectid'>" . html_safe($name) . "</a></td>
             <td class='right-align'>" . html_safe($author) . "</td>
             <td><input type='text' size='67' name='clearance' value='$clearance'></td>
             <td>

--- a/tools/site_admin/proj_approvals.php
+++ b/tools/site_admin/proj_approvals.php
@@ -72,7 +72,7 @@ echo "<table class='themed'>\n";
         echo "
             <tr>
             <td class='right-align'><a href='$code_url/project.php?id=$projectid'>".html_safe($name)."</a></td>
-            <td class='right-align'>".html_safe($author)."</td>
+            <td class='right-align'>" . html_safe($author) . "</td>
             <td><input type='text' size='67' name='clearance' value='$clearance'></td>
             <td>
                 <form action='proj_approvals.php?projectid=$projectid'>

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -41,7 +41,7 @@ $title = $project->nameofwork;
 
 echo "<pre>";
 echo "projectid: $projectid\n";
-echo "title    : ".html_safe($title)."\n";
+echo "title    : " . html_safe($title) . "\n";
 echo "</pre>\n";
 
 $res = mysqli_query(DPDatabase::get_connection(), "

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -41,7 +41,7 @@ $title = $project->nameofwork;
 
 echo "<pre>";
 echo "projectid: $projectid\n";
-echo "title    : $title\n";
+echo "title    : ".html_safe($title)."\n";
 echo "</pre>\n";
 
 $res = mysqli_query(DPDatabase::get_connection(), "

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -160,7 +160,7 @@ if (!isset($action))
     output_header($title, NO_STATSBAR, get_upload_args());
 
     echo "<h1>$title</h1>";
-    echo "<h2>" . sprintf("Project: %s", $project->nameofwork) . "</h2>";
+    echo "<h2>" . sprintf("Project: %s", html_safe($project->nameofwork)) . "</h2>";
 
     try
     {
@@ -225,7 +225,7 @@ else
 
     slim_header($title);
     echo "<h1>$title</h1>";
-    echo "<h2>", sprintf("Project: %s", $project->nameofwork), "</h2>";
+    echo "<h2>", sprintf("Project: %s", html_safe($project->nameofwork)), "</h2>";
 
     // if files have been uploaded, process them and mangle the postcomments
     $returning_to_pool = ('return_1' == $stage || 'return_2' == $stage);

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -8,7 +8,7 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), extract_zip_to(), return_bytes()
+include_once($relPath.'misc.inc'); // attr_safe(), extract_zip_to(), return_bytes(), html_safe()
 include_once($relPath.'smoothread.inc'); // handle_smooth_reading_change()
 include_once($relPath.'upload_file.inc'); // show_upload_form(), detect_too_large(), validate_uploaded_file
 


### PR DESCRIPTION
This was just a global search for the project name. I picked up author name when I ran into it as well. I noticed some other fields appear vulnerable in some contexts, however I did not get to all of those. I've deployed this to my sandbox, but don't know any accounts with permission to create a project:
https://www.pgdp.org/~chrismiceli/c/