### PR TITLE
Make toolbox buttons at least 2ems wide

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -741,6 +741,7 @@ table.dirlist caption {
   margin: 1px 0px;
   cursor: pointer;
   font-size: 0.9em;
+  min-width: 2em;
 }
 #toolbox .key-block {
   display: none;

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -752,6 +752,7 @@ table.dirlist {
         margin: 1px 0px;
         cursor: pointer;
         font-size: 0.9em;
+        min-width: 2em;
     }
 
     .key-block {


### PR DESCRIPTION
Make the buttons in the proofreading toolbox at least 2ems wide. This most notably affects the italics button.

[Task 1840](https://www.pgdp.net/c/tasks.php?action=show&task_id=1840)