### PR TITLE
Remove R* references from the code

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -15,12 +15,6 @@ $ACCESS_CRITERIA = array(
     'quiz/p_mod2'    => sprintf(_('<a href="%1$s">moderate proofreading quiz %2$d</a> pass'),"$code_url/quiz/start.php?show_level=P_MOD", 2),
     'quiz/f_only'    => sprintf(_("<a href='%s'>formatting quiz</a> pass"),"$code_url/quiz/start.php?show_only=format"),
 );
-if ( TRUE )
-{
-    // kludge
-    // TRANSLATORS: %s is a round ID, such as P1 or P1+P2
-    $ACCESS_CRITERIA['R*+P1'] = sprintf( _("'%s' pages completed"), 'R1+R2+P1' );
-}
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -290,17 +284,6 @@ function get_user_scores($username)
 
 function get_user_score( $user_obj, $criterion_code )
 {
-    $terms = explode( '+', $criterion_code );
-    if ( count($terms) > 1 )
-    {
-        $sum = 0;
-        foreach ( $terms as $term )
-        {
-            $sum += get_user_score( $user_obj, $term );
-        }
-        return $sum;
-    }
-
     if ( $criterion_code == 'days since reg' )
     {
         $user_score = round( ( time() - $user_obj->date_created ) / 86400, 1 );

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -17,15 +17,9 @@ function get_pages_proofed_maybe_simulated()
 // to pretend to have a different number of pages,
 // as long as it's less than their actual number.
 {
-    global $pguser, $userP;
+    global $pguser;
 
     $pagesproofed = user_get_ELR_page_tally( $pguser );
-    if ( TRUE )
-    {
-        $ru_tallyboard = new TallyBoard('R*', 'U');
-        $pagesproofed += $ru_tallyboard->get_current_tally( $userP['u_id'] );
-    }
-
     $pagesproofed = get_integer_param($_GET, 'numofpages', $pagesproofed, 0, $pagesproofed);
 
     return $pagesproofed;

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -109,7 +109,7 @@ function user_get_ELR_page_tally( $username )
         return 0;
     }
 
-    return $row[0];
+    return (int)$row[0];
 }
 
 // -----------------------------------------------------------------------------

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -121,7 +121,7 @@ new Round(
 new Round(
     'P2',
     _('Proofreading Round 2'),
-    array( 'R*+P1' => 300, 'days since reg' => 21, 'quiz/p_mod1' => 1 ),
+    array( 'P1' => 300, 'days since reg' => 21, 'quiz/p_mod1' => 1 ),
     'REQ-AUTO',
     '',
     _("The page-texts have already been proofread, and now need to have the text spellchecked and carefully compared to the image."),
@@ -207,7 +207,7 @@ new Round(
 new Round(
     'F1',
     _('Formatting Round 1'),
-    array( 'R*+P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1 ),
+    array( 'P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1 ),
     'REQ-AUTO',
     '',
     _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -192,15 +192,6 @@ function user_can_work_on_beginner_pages_in_round($round)
 
     global $pguser;
     $n_pages = user_get_ELR_page_tally( $pguser );
-    if ( TRUE )
-    {
-        // Augment user's ELR count with their R* count,
-        // so that old-timers don't do beginner projects.
-        global $userP;
-        $old_tallyboard = new TallyBoard( 'R*', 'U' );
-        $old_count = $old_tallyboard->get_current_tally( $userP['u_id'] );
-        $n_pages += $old_count;
-    }
     if ($round_number == 1)
         return $n_pages <= 40;
     else if ($round_number == 2)


### PR DESCRIPTION
This MR is broken out into 3 separate commits, depending on how much of the R* code we want to pull out.

* dde2ab9 does the minimum amount needed for [Task 1842: P2 and F1 requirements still have old R1 and R2 pages as objectives](https://www.pgdp.net/c/tasks.php?action=show&task_id=1842).
* 90de3dc goes one step further and removes the references from the R* rounds from the beginner project exclusion and the "how many pages have you done" exclusion. This one makes sense to pull in as well.
* aee25fc is the last and final step of removing all reference to the R* rounds from the code -- this pulls out all access to R* statistics. I'm dubious of how useful these stats are at this point, but I can see some arguments for keeping them in.