### PR TITLE
Multi point

### DIFF
--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -786,24 +786,16 @@ define_bad_byte_sequences();
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function find_bad_byte_sequences_in_text($text, $projectid)
+function find_bad_byte_sequences_in_text($text)
 {
     global $_unanchored_bad_bytes_regex, $_bad_byte_sequences;
 
     $occurrences = array();
 
-    // find any characters in the text that are not valid for the project
     if(utf8_string_has_bom($text))
     {
         $occurrences['BOM'] = 1;
         $text = utf8_str_replace(utf8_bom(), '', $text);
-    }
-
-    $project = new Project($projectid);
-    $invalid_chars = get_invalid_characters($text, $project->get_valid_codepoints());
-    foreach($invalid_chars as $char => $num)
-    {
-        $occurrences[$char] = $num;
     }
 
     $n_matches = preg_match_all($_unanchored_bad_bytes_regex, $text, $matches);
@@ -898,30 +890,22 @@ function get_remarks_for_bad_byte_sequence($raw)
 
         $why_bad = "HTML numeric character reference";
     }
-    elseif(utf8_strlen($raw) == 1 && is_utf8($raw))
-    {
-        $why_bad = "Codepoint not valid for project";
-        $intended_character = "";
-    }
     else
     {
         list($code_point, $why_bad) = $_bad_byte_sequences[$raw];
     }
 
-    if(!isset($intended_character))
+    @$info = $_character_data[$code_point];
+    if ($info)
     {
-        @$info = $_character_data[$code_point];
-        if ($info)
-        {
-            $char_name = $info['name'];
-        }
-        else
-        {
-            // $_character_data doesn't have an entry for that code point
-            $char_name = '???';
-        }
-        $intended_character = sprintf("U+%04x %s", $code_point, $char_name);
+        $char_name = $info['name'];
     }
+    else
+    {
+        // $_character_data doesn't have an entry for that code point
+        $char_name = '???';
+    }
+    $intended_character = sprintf("U+%04x %s", $code_point, $char_name);
 
     return array($intended_character, $why_bad);
 }

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -788,6 +788,7 @@ define_bad_byte_sequences();
 
 define("BOM", "\u{feff}");
 
+// note that this can change $text
 function find_bad_byte_sequences_in_text(&$text)
 {
     global $_unanchored_bad_bytes_regex, $_bad_byte_sequences;
@@ -902,7 +903,7 @@ function get_remarks_for_bad_byte_sequence($raw)
         list($code_point, $why_bad) = $_bad_byte_sequences[$raw];
     }
 
-    @$info = $_character_data[$code_point];
+    $info = $_character_data[$code_point] ?? null;
     if ($info)
     {
         $char_name = $info['name'];

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -786,7 +786,9 @@ define_bad_byte_sequences();
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function find_bad_byte_sequences_in_text($text)
+define("BOM", "\u{feff}");
+
+function find_bad_byte_sequences_in_text(&$text)
 {
     global $_unanchored_bad_bytes_regex, $_bad_byte_sequences;
 
@@ -794,7 +796,8 @@ function find_bad_byte_sequences_in_text($text)
 
     if(utf8_string_has_bom($text))
     {
-        $occurrences['BOM'] = 1;
+        $occurrences[BOM] = 1;
+        //remove it so not reported again as an invalid character
         $text = utf8_str_replace(utf8_bom(), '', $text);
     }
 
@@ -873,6 +876,10 @@ function get_remarks_for_bad_byte_sequence($raw)
 {
     global $_bad_byte_sequences, $_character_data;
 
+    if(BOM === $raw)
+    {
+        return array("", "Byte Order Mark");
+    }
     if (startswith($raw, '&#'))
     {
         // This is a numeric character reference.

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -323,6 +323,7 @@ function _test_project_for_bad_bytes($projectid)
             <th>" . _("Text") . "</th>
             <th>" . _("#") . "</th>
             <th>" . _("Raw") . "</th>
+            <th>" . _("Codepoints") . "</th>
             <th>" . _("Bytes") . "</th>
             <th>" . _("Likely intended character") . "</th>
             <th>" . _("Why bad") . "</th>
@@ -431,12 +432,15 @@ function tds_for_bad_bytes($raw)
         // It's a named or numeric character reference
         // so just show the reference itself,
         // rather than converting it to hex.
-        $tds .= "<td>" . htmlspecialchars($raw) . "</td>";
+        $tds .= "<td colspan='2'>" . htmlspecialchars($raw) . "</td>";
     }
     else
     {
-        $hex = utf8_chr_to_hex($raw);
-        $tds .= "<td>$hex</td>";
+        $codepoints = combined_character_to_hex($raw);
+        $tds .= "<td>$codepoints</td>";
+
+        $bytes = string_to_hex($raw);
+        $tds .= "<td>$bytes</td>";
     }
 
     list($intended_character, $why_bad) = get_remarks_for_bad_byte_sequence($raw);

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -331,14 +331,18 @@ function _test_project_for_bad_bytes($projectid)
     ";
 
     $n_bad_pages = 0;
+    $valid_codepoints = $project->get_valid_codepoints();
+
     while (list($text, $imagename, $proofers) = page_info_fetch($pages_res))
     {
                 $text = "test 𐌄 file Β M̆  T̆  X̉̎ΔΗ &̇̇  &amp; &#161; \u{e2}\u{80}\u{94} \xe2\x80\x94";
 
         $round_num = get_round_num_from_proofers($proofers);
-        $occurrences = find_bad_byte_sequences_in_text($text, $projectid);
+        $occurrences = find_bad_byte_sequences_in_text($text);
+        $invalid_chars = get_invalid_characters($text, $valid_codepoints);
 
-        if (count($occurrences) == 0)
+        $number_bad_chars = count($occurrences) + count($invalid_chars);
+        if ($number_bad_chars == 0)
         {
             // Nothing bad on this page!
             continue;
@@ -354,7 +358,7 @@ function _test_project_for_bad_bytes($projectid)
         {
             if ($details_for_this_page == "")
             {
-                $rowspan = count($occurrences);
+                $rowspan = $number_bad_chars;
                 $img_url = "$code_url/tools/project_manager/displayimage.php?project=$projectid&imagefile=$imagename";
                 $text_url = "$code_url/tools/project_manager/downloadproofed.php?project=$projectid&amp;image=$imagename&amp;round_num=$round_num";
                 $details_for_this_page = "<tr>\n";
@@ -379,6 +383,15 @@ function _test_project_for_bad_bytes($projectid)
 
             $details_for_this_page .= tds_for_bad_bytes($raw);
 
+            $details_for_this_page .= "</tr>\n";
+        }
+
+        ksort($invalid_chars);
+        foreach ($invalid_chars as $raw => $n_occurrences)
+        {
+            $details_for_this_page .= "<tr>\n";
+            $details_for_this_page .= "<td class='right-align'>$n_occurrences</td>\n";
+            $details_for_this_page .= tds_for_invalid_chars($raw);
             $details_for_this_page .= "</tr>\n";
         }
 
@@ -448,6 +461,17 @@ function tds_for_bad_bytes($raw)
     $tds .= "<td>" . htmlspecialchars($intended_character) . "</td>";
 
     $tds .= "<td>" . htmlspecialchars($why_bad) . "</td>";
+
+    return $tds;
+}
+
+function tds_for_invalid_chars($raw)
+{
+    $tds = "<td>$raw</td>";
+    $tds .= "<td>" . combined_character_to_hex($raw) . "</td>"; // codepoints
+    $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
+    $tds .= "<td></td>"; // intended character
+    $tds .= "<td>" . "Codepoint not valid for project" . "</td>";
 
     return $tds;
 }

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -349,45 +349,41 @@ function _test_project_for_bad_bytes($projectid)
         // page had at least one bad byte-sequence
         $n_bad_pages += 1;
 
-        $details_for_this_page = "";
+        // write image and round columns
+        $rowspan = $number_bad_chars;
+        $img_url = "$code_url/tools/project_manager/displayimage.php?project=$projectid&imagefile=$imagename";
+        $text_url = "$code_url/tools/project_manager/downloadproofed.php?project=$projectid&amp;image=$imagename&amp;round_num=$round_num";
+        $details_for_this_page = "<tr>\n";
+        $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$img_url'>$imagename</a></td>\n";
+        if($round_num == 0)
+        {
+            $round_name = 'OCR';
+        }
+        else
+        {
+            $round = get_Round_for_round_number($round_num);
+            $round_name = $round->id;
+        }
+        $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$text_url'>$round_name</a></td>\n";
 
+        // on the first row <tr> is already written out with image and round
+        // columns so only write it on subsequent rows
+        $first_row = true;
+        // write bad bytes data
         ksort( $occurrences );
+
         foreach ($occurrences as $raw => $n_occurrences)
         {
-            if ($details_for_this_page == "")
-            {
-                $rowspan = $number_bad_chars;
-                $img_url = "$code_url/tools/project_manager/displayimage.php?project=$projectid&imagefile=$imagename";
-                $text_url = "$code_url/tools/project_manager/downloadproofed.php?project=$projectid&amp;image=$imagename&amp;round_num=$round_num";
-                $details_for_this_page = "<tr>\n";
-                $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$img_url'>$imagename</a></td>\n";
-                if($round_num == 0)
-                {
-                    $round_name = 'OCR';
-                }
-                else
-                {
-                    $round = get_Round_for_round_number($round_num);
-                    $round_name = $round->id;
-                }
-                $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$text_url'>$round_name</a></td>\n";
-            }
-            else
-            {
-                $details_for_this_page .= "<tr>\n";
-            }
-
+            $details_for_this_page .= write_row_start($first_row);
             $details_for_this_page .= "<td class='right-align'>$n_occurrences</td>\n";
-
             $details_for_this_page .= tds_for_bad_bytes($raw);
-
             $details_for_this_page .= "</tr>\n";
         }
 
         ksort($invalid_chars);
         foreach ($invalid_chars as $raw => $n_occurrences)
         {
-            $details_for_this_page .= "<tr>\n";
+            $details_for_this_page .= write_row_start($first_row);
             $details_for_this_page .= "<td class='right-align'>$n_occurrences</td>\n";
             $details_for_this_page .= tds_for_invalid_chars($raw);
             $details_for_this_page .= "</tr>\n";
@@ -412,6 +408,20 @@ function _test_project_for_bad_bytes($projectid)
     }
 
     return $r;
+}
+
+// write <tr> if not the first row
+function write_row_start(&$first_row)
+{
+    if($first_row)
+    {
+        $first_row = false;
+        return "";
+    }
+    else
+    {
+        return "<tr>\n";
+    }
 }
 
 // We can calculate what round number a page text was selected from by

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -447,11 +447,8 @@ function tds_for_bad_bytes($raw)
     }
     else
     {
-        $codepoints = combined_character_to_hex($raw);
-        $tds .= "<td>$codepoints</td>";
-
-        $bytes = string_to_hex($raw);
-        $tds .= "<td>$bytes</td>";
+        $tds .= "<td>" . codepoints_to_hex($raw) . "</td>"; // codepoints
+        $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
     }
 
     list($intended_character, $why_bad) = get_remarks_for_bad_byte_sequence($raw);
@@ -466,7 +463,7 @@ function tds_for_bad_bytes($raw)
 function tds_for_invalid_chars($raw)
 {
     $tds = "<td>$raw</td>";
-    $tds .= "<td>" . combined_character_to_hex($raw) . "</td>"; // codepoints
+    $tds .= "<td>" . codepoints_to_hex($raw) . "</td>"; // codepoints
     $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
     $tds .= "<td></td>"; // intended character
     $tds .= "<td>" . "Codepoint not valid for project" . "</td>";

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -323,8 +323,8 @@ function _test_project_for_bad_bytes($projectid)
             <th>" . _("Text") . "</th>
             <th>" . _("#") . "</th>
             <th>" . _("Raw") . "</th>
-            <th>" . _("Codepoints") . "</th>
             <th>" . _("Bytes") . "</th>
+            <th>" . _("Codepoints") . "</th>
             <th>" . _("Likely intended character") . "</th>
             <th>" . _("Why bad") . "</th>
         </tr>
@@ -336,6 +336,8 @@ function _test_project_for_bad_bytes($projectid)
     while (list($text, $imagename, $proofers) = page_info_fetch($pages_res))
     {
         $round_num = get_round_num_from_proofers($proofers);
+
+        // note that this can change $text
         $occurrences = find_bad_byte_sequences_in_text($text);
         $invalid_chars = get_invalid_characters($text, $valid_codepoints);
 
@@ -453,12 +455,12 @@ function tds_for_bad_bytes($raw)
         // It's a named or numeric character reference
         // so just show the reference itself,
         // rather than converting it to hex.
-        $tds .= "<td colspan='2'>" . htmlspecialchars($raw) . "</td>";
+        $tds .= "<td>" . htmlspecialchars($raw) . "</td><td></td>";
     }
     else
     {
-        $tds .= "<td>" . codepoints_to_hex($raw) . "</td>"; // codepoints
         $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
+        $tds .= "<td>" . string_to_codepoints($raw) . "</td>"; // codepoints
     }
 
     list($intended_character, $why_bad) = get_remarks_for_bad_byte_sequence($raw);
@@ -473,8 +475,8 @@ function tds_for_bad_bytes($raw)
 function tds_for_invalid_chars($raw)
 {
     $tds = "<td>$raw</td>";
-    $tds .= "<td>" . codepoints_to_hex($raw) . "</td>"; // codepoints
     $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
+    $tds .= "<td>" . string_to_codepoints($raw) . "</td>"; // codepoints
     $tds .= "<td></td>"; // intended character
     $tds .= "<td>" . "Codepoint not valid for project" . "</td>";
 

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -335,8 +335,6 @@ function _test_project_for_bad_bytes($projectid)
 
     while (list($text, $imagename, $proofers) = page_info_fetch($pages_res))
     {
-                $text = "test 𐌄 file Β M̆  T̆  X̉̎ΔΗ &̇̇  &amp; &#161; \u{e2}\u{80}\u{94} \xe2\x80\x94";
-
         $round_num = get_round_num_from_proofers($proofers);
         $occurrences = find_bad_byte_sequences_in_text($text);
         $invalid_chars = get_invalid_characters($text, $valid_codepoints);

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -332,6 +332,8 @@ function _test_project_for_bad_bytes($projectid)
     $n_bad_pages = 0;
     while (list($text, $imagename, $proofers) = page_info_fetch($pages_res))
     {
+                $text = "test 𐌄 file Β M̆  T̆  X̉̎ΔΗ &̇̇  &amp; &#161; \u{e2}\u{80}\u{94} \xe2\x80\x94";
+
         $round_num = get_round_num_from_proofers($proofers);
         $occurrences = find_bad_byte_sequences_in_text($text, $projectid);
 

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -171,11 +171,11 @@ function guess_string_encoding($text)
     return 'ISO-8859-1';
 }
 
-function combined_character_to_hex($char)
+function codepoints_to_hex($string)
 {
     // find the components of combined character as hex strings
     $codepoints = [];
-    preg_match_all("/./u", $char, $matches);
+    preg_match_all("/./u", $string, $matches);
     foreach($matches[0] as $match)
     {
         $codepoints[] = str_pad(dechex(IntlChar::ord($match)), 4, "0", STR_PAD_LEFT);

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -171,14 +171,7 @@ function guess_string_encoding($text)
     return 'ISO-8859-1';
 }
 
-function codepoints_to_hex($string)
+function string_to_codepoints($string)
 {
-    // find the components of combined character as hex strings
-    $codepoints = [];
-    preg_match_all("/./u", $string, $matches);
-    foreach($matches[0] as $match)
-    {
-        $codepoints[] = str_pad(dechex(IntlChar::ord($match)), 4, "0", STR_PAD_LEFT);
-    }
-    return implode(" ", $codepoints);
+    return implode(" ", utf8_codepoints($string, true));
 }

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -170,3 +170,15 @@ function guess_string_encoding($text)
     # Give up and return ISO-8859-1
     return 'ISO-8859-1';
 }
+
+function combined_character_to_hex($char)
+{
+    // find the components of combined character as hex strings
+    $codepoints = [];
+    preg_match_all("/./u", $char, $matches);
+    foreach($matches[0] as $match)
+    {
+        $codepoints[] = str_pad(dechex(IntlChar::ord($match)), 4, "0", STR_PAD_LEFT);
+    }
+    return implode(" ", $codepoints);
+}

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -153,8 +153,8 @@ function show_a_table_of_bads($desired_badness)
         <table class='basic striped'>
         <tr>
             <th>" . _("Raw") . "</th>
-            <th>" . _("Codepoints") . "</th>
             <th>" . _("Bytes") . "</th>
+            <th>" . _("Codepoints") . "</th>
             <th>" . _("Likely intended character") . "</th>
             <th>" . _("Why bad") . "</th>
         </tr>

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -50,10 +50,10 @@ output_header(_("Bad Bytes Explainer"), NO_STATSBAR);
         e.g., tab, no-break space, or soft hyphen.
     </li>
 
-    <li><b>Bytes</b>:
+    <li><b>Codepoints and Bytes</b>:
         If the byte-sequence is an HTML character-reference,
-        this column just shows the reference.
-        Otherwise, it shows the values of the bytes, written in hexadecimal.
+        these columns just show the reference.
+        Otherwise, they show the values of the unicode codepoints and bytes, written in hexadecimal.
     </li>
 
     <li><b>Likely intended character</b>:

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -153,6 +153,7 @@ function show_a_table_of_bads($desired_badness)
         <table class='basic striped'>
         <tr>
             <th>" . _("Raw") . "</th>
+            <th>" . _("Codepoints") . "</th>
             <th>" . _("Bytes") . "</th>
             <th>" . _("Likely intended character") . "</th>
             <th>" . _("Why bad") . "</th>


### PR DESCRIPTION
This shows multiple codepoints as well as bytes in the Bad Bytes tables.
Bad sequences are handled separately from invalid codepoints; this is to pre-empt a problem that would occur if considering combined characters rather than codepoints.
BOM handling is also improved.