### PR TITLE
Add 'if possible' and do not automatically remove invisible combining marks

### DIFF
--- a/pinc/codepoint_validator.inc
+++ b/pinc/codepoint_validator.inc
@@ -3,7 +3,7 @@ include_once($relPath."Project.inc");
 
 function render_validator()
 {
-    $bad_char_message = _("The text contains invalid characters <span class='bad-char'>highlighted</span> if possible");
+    $bad_char_message = _("The text contains invalid characters that will be <span class='bad-char'>highlighted</span> if possible");
     $quit_text = _("Quit");
     $remove_text = _("Remove bad characters and quit");
     echo <<<END

--- a/pinc/codepoint_validator.inc
+++ b/pinc/codepoint_validator.inc
@@ -3,7 +3,7 @@ include_once($relPath."Project.inc");
 
 function render_validator()
 {
-    $bad_char_message = _("The text contains invalid characters <span class='bad-char'>highlighted</span>");
+    $bad_char_message = _("The text contains invalid characters <span class='bad-char'>highlighted</span> if possible");
     $quit_text = _("Quit");
     $remove_text = _("Remove bad characters and quit");
     echo <<<END

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -25,9 +25,6 @@ function htmlSafe(str) {
 var validateText;
 
 $(function () {
-    // to remove combining chars at line start which are not markable
-    const linecheckRegex = XRegExp("^\\pM", "Amg");
-
     var textArea = document.getElementById("text_data");
 
     // check each character, if bad mark or remove it
@@ -52,7 +49,6 @@ $(function () {
     function _validateText() {
         var text = textArea.value;
         text = text.normalize("NFC");
-        text = text.replace(linecheckRegex, "");
         // replace the text with normalised version
         textArea.value = text;
         // convert any markup so does not get interpreted in the checker div


### PR DESCRIPTION
Since there are also other invisible characters such as zero-width space
there is little point in automatically removing just one category.
The 'Remove bad characters and quit' button will remove them.
Add 'if possible' so the user knows there could be invisible bad characters.