### PR TITLE
Enable diacritical markup conversion in quizes

### DIFF
--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -208,23 +208,11 @@ trait CharSuiteSet
     }
 }
 
-class QuizProject
-{
-    use CharSuiteSet;
-
-    public function get_charsuites()
-    {
-        $charsuites[] = CharSuites::get('basic-latin');
-        $charsuites[] = CharSuites::get('extended-european-latin');
-        return $charsuites;
-    }
-}
-
 function get_real_or_quiz_project($identifier=NULL)
 {
     if($identifier == "quiz")
     {
-        return new QuizProject();
+        return new QuizCharSuites();
     }
     else
     {

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -179,44 +179,55 @@ foreach($charsuite_files as $charsuite_file)
     include_once($charsuite_file);
 }
 
-function get_pickersets($charsuites)
+trait CharSuiteSet
 {
-    $pickersets = [];
-    foreach($charsuites as $charsuite)
+    public function get_pickersets()
     {
-        $pickersets[] = $charsuite->pickerset;
+        $pickersets = [];
+        foreach($this->get_charsuites() as $charsuite)
+        {
+            $pickersets[] = $charsuite->pickerset;
+        }
+        return $pickersets;
     }
-    return $pickersets;
-}
 
-function get_valid_codepoints($charsuites)
-{
-    # Codepoints applicable to all projects
-    $global_codepoints = [
-        'U+000A', # new lines
-        'U+000D', # carriage returns
-    ];
-
-    $codepoints = $global_codepoints;
-    foreach($charsuites as $charsuite)
+    public function get_valid_codepoints()
     {
-        $codepoints = array_merge($codepoints, $charsuite->codepoints);
-    }
-    return $codepoints;
-}
-
-function get_charsuites($identifier=NULL)
-{
-    try
-    {
-        $project = new Project($identifier);
-        return $project->get_charsuites();
-    }
-    catch (NonexistentProjectException $e)
-    {
-        return [
-            CharSuites::get('basic-latin'),
-            CharSuites::get('extended-european-latin'),
+        # Codepoints applicable to all projects
+        $global_codepoints = [
+            'U+000A', # new lines
+            'U+000D', # carriage returns
         ];
+
+        $codepoints = $global_codepoints;
+        foreach($this->get_charsuites() as $charsuite)
+        {
+            $codepoints = array_merge($codepoints, $charsuite->codepoints);
+        }
+        return $codepoints;
+    }
+}
+
+class QuizProject
+{
+    use CharSuiteSet;
+
+    public function get_charsuites()
+    {
+        $charsuites[] = CharSuites::get('basic-latin');
+        $charsuites[] = CharSuites::get('extended-european-latin');
+        return $charsuites;
+    }
+}
+
+function get_real_or_quiz_project($identifier=NULL)
+{
+    if($identifier == "quiz")
+    {
+        return new QuizProject();
+    }
+    else
+    {
+        return new Project($identifier);
     }
 }

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -178,3 +178,45 @@ foreach($charsuite_files as $charsuite_file)
 {
     include_once($charsuite_file);
 }
+
+function get_pickersets($charsuites)
+{
+    $pickersets = [];
+    foreach($charsuites as $charsuite)
+    {
+        $pickersets[] = $charsuite->pickerset;
+    }
+    return $pickersets;
+}
+
+function get_valid_codepoints($charsuites)
+{
+    # Codepoints applicable to all projects
+    $global_codepoints = [
+        'U+000A', # new lines
+        'U+000D', # carriage returns
+    ];
+
+    $codepoints = $global_codepoints;
+    foreach($charsuites as $charsuite)
+    {
+        $codepoints = array_merge($codepoints, $charsuite->codepoints);
+    }
+    return $codepoints;
+}
+
+function get_charsuites($identifier=NULL)
+{
+    try
+    {
+        $project = new Project($identifier);
+        return $project->get_charsuites();
+    }
+    catch (NonexistentProjectException $e)
+    {
+        return [
+            CharSuites::get('basic-latin'),
+            CharSuites::get('extended-european-latin'),
+        ];
+    }
+}

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -6,8 +6,8 @@ class CharacterSelector
 {
     function __construct ($projectid)
     {
-        // if in a quiz this will be a deliberately invalid projectid
-        $this->picker_sets = get_pickersets(get_charsuites($projectid));
+        $project = get_real_or_quiz_project($projectid);
+        $this->picker_sets = $project->get_pickersets();
     }
 
     function draw()

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -6,16 +6,8 @@ class CharacterSelector
 {
     function __construct ($projectid)
     {
-        // quizzes use a 'fake' project that still needs a pickerset
-        if($projectid == 'projectID0000000000000')
-        {
-            $this->picker_sets = [ CharSuites::get('basic-latin')->pickerset ];
-        }
-        else
-        {
-            $project = new Project($projectid);
-            $this->picker_sets = $project->get_pickersets();
-        }
+        // if in a quiz this will be a deliberately invalid projectid
+        $this->picker_sets = get_pickersets(get_charsuites($projectid));
     }
 
     function draw()

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -243,32 +243,6 @@ class Project
         return $charsuites;
     }
 
-    public function get_valid_codepoints()
-    {
-        # Codepoints applicable to all projects
-        $global_codepoints = [
-            'U+000A', # new lines
-            'U+000D', # carriage returns
-        ];
-
-        $codepoints = $global_codepoints;
-        foreach($this->get_charsuites() as $charsuite)
-        {
-            $codepoints = array_merge($codepoints, $charsuite->codepoints);
-        }
-        return $codepoints;
-    }
-
-    public function get_pickersets()
-    {
-        $pickersets = [];
-        foreach($this->get_charsuites() as $charsuite)
-        {
-            $pickersets[] = $charsuite->pickerset;
-        }
-        return $pickersets;
-    }
-
     // -------------------------------------------------------------------------
 
     private function _get_PPer()

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -16,6 +16,8 @@ class UTF8ConversionException extends Exception { }
 
 class Project
 {
+    use CharSuiteSet;
+
     function __construct( $arg )
     {
         if ( is_string($arg) )

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -3,6 +3,7 @@ include_once($relPath."base.inc");
 include_once($relPath."Stage.inc");
 include_once($relPath."stages.inc");
 include_once($relPath.'misc.inc'); // get_enumerated_param
+include_once($relPath.'CharSuites.inc'); // CharSuiteSet
 
 // for groups of quizzes that go together
 class QuizLevel
@@ -190,6 +191,18 @@ class Quiz
                 <tr><td colspan='$n_columns' style='background-color: $bgcolor; font-weight: bold; text-align: center;'>$text</td></tr>";
         }
         echo "</table>\n";
+    }
+}
+
+class QuizCharSuites
+{
+    use CharSuiteSet;
+
+    public function get_charsuites()
+    {
+        $charsuites[] = CharSuites::get('basic-latin');
+        $charsuites[] = CharSuites::get('extended-european-latin');
+        return $charsuites;
     }
 }
 

--- a/pinc/codepoint_validator.inc
+++ b/pinc/codepoint_validator.inc
@@ -20,6 +20,5 @@ END;
 
 function get_json_codepoints($projectid)
 {
-    $project = new Project($projectid);
-    return json_encode($project->get_valid_codepoints());
+    return json_encode(get_valid_codepoints(get_charsuites($projectid)));
 }

--- a/pinc/codepoint_validator.inc
+++ b/pinc/codepoint_validator.inc
@@ -20,5 +20,6 @@ END;
 
 function get_json_codepoints($projectid)
 {
-    return json_encode(get_valid_codepoints(get_charsuites($projectid)));
+    $project = get_real_or_quiz_project($projectid);
+    return json_encode($project->get_valid_codepoints());
 }

--- a/quiz/generic/main.php
+++ b/quiz/generic/main.php
@@ -25,5 +25,5 @@ slim_header_frameset(qp_full_browser_title(), $header_args);
 </frameset>
 <frame name="right" src="right.php?quiz_page_id=<?php echo $quiz_page_id;?>">
 </frameset>
-<frame name="menuframe" src="../../tools/proofers/ctrl_frame.php?round_id=<?php echo qp_round_id_for_pi_toolbox(); ?>&amp;projectid=projectID0000000000000" marginwidth="2" marginheight="2" frameborder="0">
+<frame name="menuframe" src="../../tools/proofers/ctrl_frame.php?round_id=<?php echo qp_round_id_for_pi_toolbox(); ?>" marginwidth="2" marginheight="2" frameborder="0">
 </frameset>

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -26,8 +26,7 @@ else
 {
     $font_settings = '';
 }
-
-// 'quiz' is a deliberately invalid projectid
+// 'quiz' will result in codepoints for quizes
 $json_code_points = get_json_codepoints("quiz");
 
 $header_args = array(

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -5,6 +5,7 @@ include_once($relPath.'slim_header.inc');
 include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'quizzes.inc'); // get_quiz_page_id_param
 include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
+include_once($relPath.'codepoint_validator.inc');
 
 $quiz_page_id = get_quiz_page_id_param($_REQUEST, 'quiz_page_id');
 
@@ -26,7 +27,17 @@ else
     $font_settings = '';
 }
 
+// 'quiz' is a deliberately invalid projectid
+$json_code_points = get_json_codepoints("quiz");
+
 $header_args = array(
+    "js_files" => array(
+        "$code_url/scripts/character_test.js",
+        "$code_url/tools/proofers/process_diacritcal_markup.js",
+        ),
+    "js_data" => "
+        var codePoints = $json_code_points;
+    ",
     'body_attributes' => "onload='top.initializeStuff(1)'",
 );
 

--- a/tools/proofers/ctrl_frame.php
+++ b/tools/proofers/ctrl_frame.php
@@ -8,11 +8,12 @@ include_once($relPath.'Project.inc'); // validate_projectID()
 include_once($relPath.'ProofreadingToolbox.inc');
 include_once($relPath.'Project.inc'); // validate_projectID()
 
-
-$projectid = validate_projectID($_GET, $_GET["projectid"]);
 $round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_));
 $round = get_Round_for_round_id($round_id);
-$projectid = validate_projectID('projectid', @$_GET['projectid']);
+// if this is used in a quiz there will not be a projectid, 'quiz' will be used
+// for the MRU local storage prefix and the toolbox output will discover the
+// projectid is invalid and provide the quiz charsuites
+$projectid = array_get($_GET, 'projectid', 'quiz');
 $mru_title = javascript_safe(_("Most recently used"));
 // TRANSLATORS: This is an abbreviation for "Most recently used"
 $mru_abbreviation = javascript_safe(_("MRU"));

--- a/tools/proofers/ctrl_frame.php
+++ b/tools/proofers/ctrl_frame.php
@@ -10,10 +10,15 @@ include_once($relPath.'Project.inc'); // validate_projectID()
 
 $round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_));
 $round = get_Round_for_round_id($round_id);
-// if this is used in a quiz there will not be a projectid, 'quiz' will be used
-// for the MRU local storage prefix and the toolbox output will discover the
-// projectid is invalid and provide the quiz charsuites
+// if this is used in a quiz there will not be a real projectid, 'quiz' will be
+// used for the MRU local storage prefix and the character selector will
+// provide the quiz pickers
 $projectid = array_get($_GET, 'projectid', 'quiz');
+if($projectid != "quiz")
+{
+    $projectid = validate_projectID('projectid', $projectid);
+}
+
 $mru_title = javascript_safe(_("Most recently used"));
 // TRANSLATORS: This is an abbreviation for "Most recently used"
 $mru_abbreviation = javascript_safe(_("MRU"));


### PR DESCRIPTION
pickerset and valid_codepoint functions moved out of project.inc
so we can use them if there isn't a project.
New function to construct charsuites for quizes.