### PR TITLE
Simplify configuring gettext for user emails

### DIFF
--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -37,13 +37,11 @@ function send_pp_reminders($PPer, $projects, $which_message)
     global $code_url, $db_requests_email_addr,
            $site_signoff, $site_abbreviation;
     global $pp_alert_threshold_days;
-    global $charset, $dyn_locales_dir, $system_locales_dir;
 
     $user = new User($PPer);
-    $locale = get_valid_locale_for_translation($user->u_intlang);
 
     // configure gettext to translate user email
-    configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_dir);
+    configure_gettext_for_user($user);
 
     $projects_list = [];
     foreach($projects as $project)
@@ -114,6 +112,9 @@ function send_pp_reminders($PPer, $projects, $which_message)
     {
         echo "WARNING: Email failed to send for $PPer <$email>\n";
     }
+
+    // restore gettext to current user's locale
+    configure_gettext_for_user();
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/access_change_emails.inc
+++ b/pinc/access_change_emails.inc
@@ -4,16 +4,13 @@ include_once($relPath."maybe_mail.inc");
 function pp_access_change_email($user, $access_change)
 {
     global $site_name, $site_abbreviation, $site_signoff, $db_requests_email_addr;
-    global $charset, $dyn_locales_dir, $system_locales_dir;
 
     // only send emails on grant
     if($access_change != "grant")
         return;
 
-    $locale = get_valid_locale_for_translation($user->u_intlang);
-
     // configure gettext to translate user email
-    configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_dir);
+    configure_gettext_for_user($user);
 
     // TRANSLATORS: %s is the site abbreviation (eg: 'DP')
     $subject = sprintf(_("%s: Welcome to Post-Processing"), $site_abbreviation);
@@ -42,4 +39,7 @@ function pp_access_change_email($user, $access_change)
     $headers = [ "Reply-To: $db_requests_email_addr" ];
 
     $mail_accepted = maybe_mail($email, $subject, $message_string, $headers);
+
+    // restore gettext to current user's locale
+    configure_gettext_for_user();
 }

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -69,6 +69,28 @@ function configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_
     }
 }
 
+// Configure gettext for a specific user, useful for sending emails. $user
+// can be a User object or a username. If $user is NULL, the current user's
+// locale is configured.
+function configure_gettext_for_user($user=NULL)
+{
+    global $charset, $dyn_locales_dir, $system_locales_dir;
+
+    if(!$user)
+    {
+        $locale = get_desired_language();
+    }
+    else
+    {
+        if($user instanceof User == FALSE)
+        {
+            $user = new User($user);
+        }
+        $locale = get_valid_locale_for_translation($user->u_intlang);
+    }
+    configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_dir);
+}
+
 // If the gettext extension is compiled into PHP, then the function named '_'
 // (an alias for 'gettext') will be defined.
 // If it's not defined, define it to simply return its argument.


### PR DESCRIPTION
Rather than making every instance determine the desired user's locale and then setting it, create a wrapper function that does it as well as handle the global variables.

This then makes email composition something like:
```
 // switch to recipient's locale
 configure_gettext_for_user($username);
 
 // build the email
 $body = _("Hello fellow human!");
 maybe_email(... $body ...);
 
 // restore current user's locale for any future messages
 configure_gettext_for_user();
```