### PR TITLE
Don't duplicate site_abbreviation on quiz titles

### DIFF
--- a/quiz/generic/main.php
+++ b/quiz/generic/main.php
@@ -6,7 +6,7 @@ include_once($relPath.'quizzes.inc'); // get_quiz_page_id_param
 
 $quiz_page_id = get_quiz_page_id_param($_REQUEST, 'quiz_page_id');
 
-include "./quiz_page.inc"; // qp_full_browser_title qp_round_id_for_pi_toolbox
+include "./quiz_page.inc"; // qp_round_id_for_pi_toolbox
 
 $header_args = array(
     'js_files' => array(
@@ -15,7 +15,8 @@ $header_args = array(
     ),
 );
 
-slim_header_frameset(qp_full_browser_title(), $header_args);
+// $browser_title is from qd file which is included via quiz_page.inc
+slim_header_frameset($browser_title, $header_args);
 ?>
 <frameset rows="*,73">
 <frameset cols="60%,*">

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -63,17 +63,6 @@ $quiz_feedbacktext = sprintf($default_feedbacktext, $quiz_feedbackurl);
 
 // called by main.php:
 
-function qp_full_browser_title()
-{
-    global $site_abbreviation; // from site_vars.php
-    global $browser_title; // from the qd file
-
-    if (isset($browser_title))
-        return "$site_abbreviation: $browser_title";
-    else
-        return $site_abbreviation;
-}
-
 function qp_round_id_for_pi_toolbox()
 {
     global $quiz;


### PR DESCRIPTION
When the quizzes were refactored to use `slim_header_frameset()` we didn't account for it already prefixing `$site_abbreviation` and thus it is being prepended twice.