### PR TITLE
Validate codepoints in a charsuite are normalized

### DIFF
--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -9,6 +9,7 @@ all: less lint
 lint:
 	$(SELF_DIR)lint_php_files.sh $(SELF_DIR)..
 	$(SELF_DIR)lint_json_files.sh $(SELF_DIR)..
+	$(SELF_DIR)lint_charsuites.php $(SELF_DIR)..
 
 #----------------------------------------------------------------------------
 # CSS compilation

--- a/SETUP/lint_charsuites.php
+++ b/SETUP/lint_charsuites.php
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+$relPath="../pinc/";
+include_once($relPath."CharSuites.inc");
+
+foreach(CharSuites::get_all() as $charsuite)
+{
+    echo "Validating charsuite $charsuite->name...\n";
+    $nonnormalized_codepoints = $charsuite->get_nonnormalized_codepoints();
+    if($nonnormalized_codepoints)
+    {
+        echo "ERROR: codepoints are not normalized:\n";
+        foreach($nonnormalized_codepoints as $orig => $norm)
+        {
+            echo sprintf("    %s normalized is %s\n", $orig, $norm);
+        }
+        exit(1);
+    }
+}

--- a/SETUP/tests/UnicodeTest.php
+++ b/SETUP/tests/UnicodeTest.php
@@ -9,7 +9,6 @@ class UnicodeTests extends PHPUnit\Framework\TestCase
         'U+004E',  # N
         'U+004E>U+0305',  # N̅
         'U+004E>U+0306',  # N̆
-        'U+004E>U+0307',  # Ṅ
     ];
 
     public function testSubstrReplace()
@@ -24,6 +23,18 @@ class UnicodeTests extends PHPUnit\Framework\TestCase
         $codepoint = 'U+004E';  # N
         $char = utf8_combined_chr($codepoint);
         $this->assertEquals("N", $char);
+    }
+
+    public function testAreCodepointsNormalized()
+    {
+        $codepoints = [ 'U+004E>U+0305' ];  # N̅
+        $this->assertEquals(get_nonnormalized_codepoints($codepoints), []);
+    }
+
+    public function testAreCodepointsNormalizedFail()
+    {
+        $codepoints = [ 'U+004e>U+0307'];  # Ṅ but normalizes to U+1e44
+        $this->assertEquals(get_nonnormalized_codepoints($codepoints), [ "U+004e>U+0307" => "U+1e44" ]);
     }
 
     public function testUtf8CombinedChrCombined()
@@ -98,7 +109,7 @@ class UnicodeTests extends PHPUnit\Framework\TestCase
 
     public function testConvertCodepointsToCharactersCombined()
     {
-        $chars = ["N", "N̅", "N̆", "Ṅ"];
+        $chars = ["N", "N̅", "N̆"];
         $string = convert_codepoint_ranges_to_characters($this->combined_codepoints);
         $this->assertEquals($chars, $string);
     }

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -83,6 +83,11 @@ class CharSuite
         $enabled_sets = CharSuites::get_enabled();
         return in_array($this, $enabled_sets);
     }
+
+    public function get_nonnormalized_codepoints()
+    {
+        return get_nonnormalized_codepoints($this->codepoints);
+    }
 }
 
 class CharSuites

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -21,7 +21,28 @@ function utf8_normalize($string)
 function utf8_combined_chr($codepoint)
 {
     $codepoints = explode('>', $codepoint);
-    return utf8_normalize(implode('', array_map('utf8_chr', $codepoints)));
+    return implode('', array_map('utf8_chr', $codepoints));
+}
+
+# Get codepoints that are not normalized.
+# Returns an associative array where the key is the nonnormalized codepoint
+# and the value is the normalized version. If all codepoints are normalized
+# it returns an empty array.
+function get_nonnormalized_codepoints($codepoints)
+{
+    $characters = convert_codepoint_ranges_to_characters($codepoints);
+    $nonnorm_codepoints = [];
+    foreach($characters as $character)
+    {
+        $norm_character = utf8_normalize($character);
+        if($character != $norm_character)
+        {
+            $norm_codepoint = implode('>', array_map('utf8_chr_to_hex', utf8_split($norm_character)));
+            $orig_codepoint = implode('>', array_map('utf8_chr_to_hex', utf8_split($character)));
+            $nonnorm_codepoints[$orig_codepoint] = $norm_codepoint;
+        }
+    }
+    return $nonnorm_codepoints;
 }
 
 # Given a single character, or a combined character, return its name


### PR DESCRIPTION
This validates that all codepoints in a character suite are normalized to prevent non-normalized characters from being inserted into proofreading texts and confusing the user when validation fails, among other things.