### PR TITLE
Return UTF-8 strings for MARCRecords

### DIFF
--- a/pinc/MARCRecord.inc
+++ b/pinc/MARCRecord.inc
@@ -1,21 +1,33 @@
 <?php
 include_once($relPath.'iso_lang_list.inc');
 include_once($relPath.'genres.inc'); // load_genre_translation_array
+include_once($relPath.'unicode.inc'); // guess_string_encoding()
 
 class MARCRecord
 {
     // MARC record in the yaz_search 'array' format
     private $record = array();
     private $literary_form_array = array("a" => "Art", "b" => "Biography", 3 => "Comedy", "c" => "Comic Strip", 4 => "Cooking", "d" => "Drama", "e" => "Essay", 1 => "Fiction", "g" => "Geography", 5 => "Historical", 6 => "History", 7 => "Humor", "i" => "Letter", "l" => "Linguistics", 8 => "Math", 9 => "Medicine", "m" => "Mixed Form", "v" => 'Music', 0 => "Non-Fiction", "f" => "Novel", "y" => "Periodical", "p" => "Poetry", "r" => "Romance", "z" => "Science", "h" => "Satire", "j" => "Short Story", "s" => "Speech", "u" => "Unknown", "|" => "Unknown");
+    private $force_utf8;
 
-    public function __construct()
+    public function __construct($force_utf8=True)
     {
+        $this->force_utf8 = $force_utf8;
     }
 
     public function __get($field)
     {
         $func = "get_$field";
-        return $this->{$func}();
+        $string = $this->{$func}();
+        if($this->force_utf8)
+        {
+            $encoding = guess_string_encoding($string);
+            if($encoding && $encoding != 'UTF-8')
+            {
+                $string = mb_convert_encoding($string, "UTF-8", $encoding);
+            }
+        }
+        return $string;
     }
 
     public function __set($field, $value)

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -110,7 +110,10 @@ function do_search_and_show_hits()
     }
 
     global $external_catalog_locator;
-    $id = yaz_connect($external_catalog_locator);
+    // We request UTF-8 character set, but according to the docs (and our testing)
+    // most servers ignore this and return ISO-8859-1 anyway. The strings get
+    // converted to UTF-8 via MARCRecord::__get() instead.
+    $id = yaz_connect($external_catalog_locator, [ "charset" => "UTF-8" ]);
     yaz_syntax($id, "usmarc");
     yaz_element($id, "F");
     yaz_search($id, "rpn", trim($fullquery));


### PR DESCRIPTION
Ensure that Z29.50 results are always returned in UTF-8. Servers seem to ignore our request, so convert the encodings when pulled from the MARCRecord.

This is available in my [fix-loc-utf8-lookups](https://www.pgdp.org/~cpeel/c.branch/fix-loc-utf8-lookups) sandbox.