### PR TITLE
Standardize email footer

### DIFF
--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -166,13 +166,8 @@ _SITE_NAME=PICK_A_NAME
 # of each page ('%s: Welcome') and in the subject line of emails.
 _SITE_ABBREVIATION=PICK_AN_ABBREVIATION
 
-# Something like 'Thank you!\nThe Management' would be good. It will be
-# used in the footer of emails from the site. (Does not affect phpBB
-# emails; use the Administration Panel to change that.)
-_SITE_SIGNOFF="Thank you!\n$_SITE_NAME"
-
 # You can think of this as the "publishable" HTTP URL for the site.
-# So far, it's only used when generating credit lines.
+# So far, it's used in email footers and project credits.
 # -- It could be exactly the same as $_CODE_URL.
 # -- Or it might be a more memorable or more permanent URL that simply
 #    redirects to $_CODE_URL.

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -34,8 +34,7 @@ foreach($projects_by_PPer as $PPer => $projects)
 
 function send_pp_reminders($PPer, $projects, $which_message)
 {
-    global $code_url, $db_requests_email_addr,
-           $site_signoff, $site_abbreviation;
+    global $code_url, $db_requests_email_addr, $site_abbreviation, $site_name;
     global $pp_alert_threshold_days;
 
     $user = new User($PPer);
@@ -71,7 +70,6 @@ function send_pp_reminders($PPer, $projects, $which_message)
         $subject = sprintf(_("%s: Renew or Return Post-Processing Projects"), $site_abbreviation);
 
         $message[] = sprintf(_("Hello %s,"), $PPer);
-        $message[] = _("This is an automated message.");
         $message[] = sprintf(_("Our database system indicates that you have had one or more projects checked out for Post-Processing for more than %d days:"), $pp_alert_threshold_days);
         $message[] = $projects_list_string;
         $message[] = _("It is important that books don't get stuck in the Post-Processing process but keep moving towards being posted at Project Gutenberg. As a community, we have a lot vested in each project -- each represents many hours of volunteer work. We are all eager to see each book posted and there is also a risk that that work would be lost should other organizations produce and post a book before we finish.");
@@ -88,7 +86,7 @@ function send_pp_reminders($PPer, $projects, $which_message)
 
         $message[] = "==" . _("Are there any problems?") . "==";
         $message[] = sprintf(_("If any project is missing page images or illustrations, please contact the Project Manager (PM) for assistance. If the PM does not respond within a reasonable amount of time, please email %s and request help concerning any problems."), $db_requests_email_addr);
-        $message[] = $site_signoff;
+        $message[] = sprintf(_("Thank you for volunteering with %s!"), $site_name);
     }
     else
     {
@@ -99,7 +97,7 @@ function send_pp_reminders($PPer, $projects, $which_message)
         $message[] = _("An automated reminder was sent to you on the first of the month to ask whether you wished to renew the projects you have checked out for Post-Processing. You are receiving this second automated notice because you have not renewed or returned the projects.");
         $message[] = $projects_list_string;
         $message[] = sprintf(_("If you have already notified %s of an expected absence, you may safely ignore this message. Otherwise, any projects in your queue for which a previous notice has been sent may be reclaimed if you do not respond or renew within the next 7 days."), $db_requests_email_addr);
-        $message[] = $site_signoff;
+        $message[] = sprintf(_("Thank you for volunteering with %s!"), $site_name);
     }
 
     $email = $user->email;

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -469,17 +469,14 @@ EOS;
         $projectid = $this->projectid;
         $title = $this->nameofwork;
 
-        return
-            sprintf(
-                _("This is an automated message from the %s site regarding the following project:"),
-                // Should really be localized according to the preferences of the *recipient*.
-                $site_name
-            )
-            . "\n"
-            . "    \"$title\"\n"
-            . "    ($projectid)\n"
-            . "    $code_url/project.php?id=$projectid\n"
-            . "\n";
+        return implode("\n", [
+            // Should really be localized according to the preferences of the *recipient*.
+            _("This message is regarding the following project:"),
+            "",
+            "\"$title\"",
+            "    $code_url/project.php?id=$projectid",
+            "",
+        ]);
     }
 
     // -------------------------------------------------------------------------

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -936,7 +936,7 @@ function round_to_PP_avail_collateral( $old_project, $project, $transition, $who
     if ( !empty($old_project->checkedoutby))
     {
         $reserved_PPer = $old_project->checkedoutby;
-        global $site_manager_email_addr, $site_signoff;
+        global $site_manager_email_addr;
 
         $PPer = new User($reserved_PPer);
         $PPer_email_addr = $PPer->email;
@@ -948,8 +948,7 @@ function round_to_PP_avail_collateral( $old_project, $project, $transition, $who
              "It has not been checked out to you because you are not currently  \n" .
              "permitted to check projects out for PPing.\n" .
              "If you believe you are receiving this message in error, please contact\n" .
-             "a site manager by emailing $site_manager_email_addr.\n\n" .
-             "$site_signoff";
+             "a site manager by emailing $site_manager_email_addr.\n";
 
         maybe_mail(
             $PPer_email_addr,
@@ -962,7 +961,7 @@ function round_to_PP_avail_collateral( $old_project, $project, $transition, $who
 
 function round_to_PP_out_collateral( $old_project, $project, $transition, $who )
 {
-    global $site_abbreviation, $site_signoff;
+    global $site_abbreviation;
     $from_round = get_Round_for_project_state($transition->from_state);
     generate_post_files( $project->projectid, $from_round->id, 'LE', False, '' );
 
@@ -1006,8 +1005,7 @@ function round_to_PP_out_collateral( $old_project, $project, $transition, $who )
             $project->email_introduction().
             "This project, which is reserved for you to Post-Process,\n".
             "is now ready for you to work on, and should shortly appear in your list\n".
-            "of checked out projects.\n".
-            "$site_signoff";
+            "of checked out projects.\n";
 
         maybe_mail(
             $PPer_email_addr,

--- a/pinc/access_change_emails.inc
+++ b/pinc/access_change_emails.inc
@@ -3,7 +3,7 @@ include_once($relPath."maybe_mail.inc");
 
 function pp_access_change_email($user, $access_change)
 {
-    global $site_name, $site_abbreviation, $site_signoff, $db_requests_email_addr;
+    global $site_name, $site_abbreviation, $db_requests_email_addr;
 
     // only send emails on grant
     if($access_change != "grant")
@@ -16,7 +16,6 @@ function pp_access_change_email($user, $access_change)
     $subject = sprintf(_("%s: Welcome to Post-Processing"), $site_abbreviation);
 
     $message[] = sprintf(_("Hello %s,"), $user->username);
-    $message[] = _("This is an automated message.");
     // TRANSLATORS: %s is the site abbreviation (eg: 'DP')
     $message[] = sprintf(_("Congratulations! You are now eligible to learn to transform %s projects into their final formats, ready for upload to Project Gutenberg. If you're already familiar with HTML and CSS, it may make learning Post-Processing (PP) somewhat easier, but many prolific Post-Processors (PPers) knew no HTML or CSS when they first started, so if you aren't already familiar with them, don't be discouraged!"), $site_abbreviation);
     
@@ -31,7 +30,6 @@ function pp_access_change_email($user, $access_change)
     
     // TRANSLATORS: %s is the site name (eg: 'Distributed Proofreaders')
     $message[] = sprintf(_("Thank you for deciding to work as a Post-Processor! Although the work can be daunting at first, it can be the most rewarding and motivating activity here at %s."), $site_name);
-    $message[] = $site_signoff;
 
     $email = $user->email;
     $message_string = implode("\n\n", $message);

--- a/pinc/maybe_mail.inc
+++ b/pinc/maybe_mail.inc
@@ -8,7 +8,7 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
 // If this is for real, send the message.
 // If we're testing, just report what would have been sent.
 {
-    global $testing, $auto_email_addr;
+    global $testing, $auto_email_addr, $site_name, $site_url;
 
     assert(is_null($additional_headers) || is_array($additional_headers));
     if (empty($additional_headers))
@@ -16,6 +16,7 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
         $additional_headers = array();
     }
 
+    // Ensure that the From and Reply-To headers are set
     if (!preg_grep('/^From: /', $additional_headers))
     {
         array_unshift($additional_headers, "From: $auto_email_addr");
@@ -26,6 +27,23 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
     }
 
     $additional_headers = implode($additional_headers, "\r\n") . "\r\n";
+
+    // Append a standard footer to all emails sent out by the system.
+    // This replaces the $site_signoff in prior versions that was not
+    // translatable.
+    if(!endswith($message, "\n"))
+    {
+        $message .= "\n";
+    }
+
+    $message .= implode("\n", [
+        "",
+        "--",
+        $site_name,
+        $site_url,
+        "",
+        _("This is an automated message."),
+    ]);
 
     if ( $testing )
     {
@@ -51,24 +69,19 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
 
 function maybe_mail_project_manager( $project, $info, $prefix)
 {
-    global $code_url, $site_name, $site_signoff, $site_abbreviation;
+    global $code_url, $site_abbreviation, $site_name;
 
     $projectid = $project->projectid;
     $nameofwork = $project->nameofwork;
     $username = $project->username;
     configure_gettext_for_user($username);
 
-    $body =
-sprintf(_("Hello %s,"), $username) . "\n".
-sprintf(_("This is an automated message from the %s site."),$site_name)."
-
-" . sprintf(_("Regarding project \"%s\""), $nameofwork) . ":
-  $code_url/project.php?id=$projectid
-
-$info
-
-$site_signoff
-";
+    $body = implode("\n", [
+        sprintf(_("Hello %s,"), $username),
+        $project->email_introduction(),
+        $info,
+        sprintf(_("Thank you for volunteering with %s!"), $site_name),
+    ]);
 
     configure_gettext_for_user();
     $user = new User($username); 

--- a/pinc/maybe_mail.inc
+++ b/pinc/maybe_mail.inc
@@ -49,14 +49,14 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
     {
         echo "\n<hr>\n";
         echo "\$testing is $testing. If it were FALSE, the following mail would have been sent:\n";
-        echo "<pre>\n";
+        echo "<pre style='white-space: pre-wrap'>\n";
         echo html_safe("To: $to\n");
         echo html_safe("Subject: $subject\n");
         echo html_safe("$additional_headers");
         echo "</pre>";
-        echo "<span class='mono'>";
-        echo nl2br(html_safe("$message\n"));
-        echo "</span>\n";
+        echo "<pre style='white-space: pre-wrap'>";
+        echo html_safe("$message\n");
+        echo "</pre>\n";
         echo "<hr>\n";
 
         return True;

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -70,7 +70,6 @@ $teams_forum_idx                  = '<<FORUMS_TEAMS_IDX>>';
 
 $site_name = '<<SITE_NAME>>';
 $site_abbreviation = '<<SITE_ABBREVIATION>>';
-$site_signoff = "<<SITE_SIGNOFF>>";
 $site_url = '<<SITE_URL>>';
 
 $preceding_proofer_restriction = '<<PRECEDING_PROOFER_RESTRICTION>>';

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -139,8 +139,6 @@ function can_user_subscribe_to_project_event( $username, $projectid, $event )
 
 function notify_project_event_subscribers( $project, $event, $extras=array() )
 {
-    global $site_signoff;
-
     $event_label = get_label_for_event( $event );
 
     $projectid = $project->projectid;
@@ -201,8 +199,6 @@ function notify_project_event_subscribers( $project, $event, $extras=array() )
         default:
             assert(0);
     }
-
-    $msg_body .= "\n" . $site_signoff;
 
     $res1 = mysqli_query(DPDatabase::get_connection(), "
         SELECT username

--- a/tasks.php
+++ b/tasks.php
@@ -532,7 +532,7 @@ function create_task_from_form_submission($formsub)
         maybe_mail(
             $task_assignee_user->email,
             "$site_abbreviation Task Center: Task #$task_id has been assigned to you",
-            $task_assignee_user->username . ", you have been assigned task #$task_id.  Please visit this task at $tasks_url?action=show&task_id=$task_id.\n\nIf you do not want to accept this task please edit the task and change the assignee to 'Unassigned'.\n\n--\nDistributed Proofreaders\n$code_url\n\nThis is an automated message that you had requested please do not respond directly to this e-mail.\r\n"
+            $task_assignee_user->username . ", you have been assigned task #$task_id.  Please visit this task at $tasks_url?action=show&task_id=$task_id.\n\nIf you do not want to accept this task please edit the task and change the assignee to 'Unassigned'."
         );
     }
 
@@ -1562,11 +1562,7 @@ function NotificationMail($tid, $message, $new_task = false)
     $task_summary = $row['task_summary'];
 
     $subject = "$site_abbreviation Task #$tid: $task_summary";
-    $footer = "\n\n"
-        . "--\n"
-        . "$site_name\n"
-        . "$tasks_url?task_id=$tid\n\n"
-        . "This is an automated message, please do not respond directly to this e-mail.";
+    $footer  = "\n\n$tasks_url?task_id=$tid";
 
     if($new_task)
     {

--- a/tools/modify_access.php
+++ b/tools/modify_access.php
@@ -161,17 +161,18 @@ echo "Hit 'Back' to return to user's detail page. (And you may need to reload.)<
 
 function notify_user($user, $actions)
 {
-    global $site_name, $site_signoff;
+    global $site_name, $site_abbreviation;
+;
     if ((count($actions) == 1) && (array_search('grant',$actions) !== false))
     {
         // Special case: If the user has been granted access to
         // a single round, send a congratulations! email.
         list($activity_id) = array_keys($actions);
-        $subject = "DP: You have been granted access to $activity_id!";
-        $message = "Hello $user->username,\n\nThis is a message from the $site_name website.\n\n" .
+        $subject = "$site_abbreviation: You have been granted access to $activity_id!";
+        $message = "Hello $user->username,\n\n" .
                    "Congratulations, you have been granted access to $activity_id projects!\n" .
-                   "You can access this stage by following the link to it at the Activity Hub.\n\n" .
-                   "$site_signoff";
+                   "You can access this stage by following the link to it at the Activity Hub.\n";
+        $message .= sprintf(_("Thank you for volunteering with %s!"), $site_name);
         // XXX: Note that this wording works when the activity is a stage (round or pool),
         // but not otherwise.
         maybe_mail($user->email,$subject,$message);
@@ -179,19 +180,18 @@ function notify_user($user, $actions)
     }
     else
     {
-        $subject =  "DP: Your access has been modified";
-        $message =  "Hello $user->username,\n\nThis is a message from the $site_name website.\n\n" .
+        $subject =  "$site_abbreviation: Your access has been modified";
+        $message =  "Hello $user->username,\n\n" .
                     "The following modifications have been made to the stages in which you can work:\n";
         foreach ( $actions as $activity_id => $action_type )
         {
-            $message .= "\n";
-            $message .= "  $activity_id: ";
+            $message .= "* $activity_id: ";
             $message .=
                 ( $action_type == 'deny_request_for' ? 'Your request for access has not been approved. Please try again in a few weeks.' :
                 ( $action_type == 'grant' ? 'Access granted.' :
                 'Access revoked.' ) );
         }
-        $message .= "\n\n$site_signoff";
+        $message .= "\n";
         maybe_mail($user->email,$subject,$message);
         return "notified user.";
     }

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -813,8 +813,7 @@ else if ($action == HANDLE_ENTRY_FORM_SUBMISSION)
             "General comments"
         )
 
-        . "\n"
-        . "\n" . $site_signoff;
+        . "\n";
 
     echo _("Please check the information below to make sure everything is correct.
         To return to the form, simply use your browser's back button.") . "<br>\n";

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -473,7 +473,7 @@ class ImageSource
 
     function approve()
     {
-        global $pguser, $site_abbreviation, $site_signoff, $site_name;
+        global $pguser, $site_abbreviation, $site_name;
         $this->_set_field('is_active',1);
         $this->_set_field('info_page_visibility',1);
 
@@ -490,10 +490,9 @@ class ImageSource
             $subject = sprintf(_('%1$s: Image Source %2$s has been approved!'),$site_abbreviation,$this->display_name);
 
             $body = "Hello $username,\n\n" .
-                "This is a message from the $site_name website.\n\n".
                 "The Image Source that you proposed, $this->display_name, has been\n".
                 "approved by $pguser. You can select it, and apply it to projects, from\n".
-                "your project manager's page.\n\n$site_signoff";
+                "your project manager's page.\n";
 
             maybe_mail($user->email,$subject,$body);
         }
@@ -569,7 +568,7 @@ class ImageSource
 
     function log_request_for_approval($requestor_username)
     {
-        global $general_help_email_addr,$image_sources_manager_addr,$code_url,$site_abbreviation,$site_name,$site_signoff;
+        global $general_help_email_addr,$image_sources_manager_addr,$code_url,$site_abbreviation,$site_name;
 
         $userSettings =& Settings::get_Settings($requestor_username);
         $userSettings->add_value('is_approval_notify', $this->code_name);
@@ -582,7 +581,7 @@ class ImageSource
         "$requestor_username has proposed that $this->display_name be added\n".
         "to the list of Image Sources. To edit or approve this Image Source,\n".
         "visit\n    $code_url/tools/project_manager/manage_image_sources.php?action=show_sources#$this->code_name".
-        "\n\n$site_signoff";
+        "\n";
 
         maybe_mail($image_sources_manager_addr,$subject,$body);
     }


### PR DESCRIPTION
Standardize email footers, and statement about automated messages, across the codebase. For pgdp.net, the footer would look like:
```

--
Distributed Proofreaders
http://www.pgdp.net

This is an automated message.
```

This was in response to an SA conversion in Slack. You can test this out in the [tweak-mail-footer](https://www.pgdp.org/~cpeel/c.branch/tweak-mail-footer/) sandbox.