### PR TITLE
Allow for combined characters in project_quick_check and Add files

### DIFF
--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -719,18 +719,21 @@ function get_normalize_page_text_changes($text, $projectid)
         $invalid_char_names = [];
         foreach(array_keys($invalid_chars) as $char)
         {
-            $name = IntlChar::charName($char);
-            # if it doesn't have a name it's a control character which can't
-            # be printed anyway, or if it's a soft hyphen
-            if(!$name || utf8_chr_to_hex($char) == 'U+00ad')
+            // in case its a combined character
+            $codepoints = utf8_split($char);
+            $base_codepoint = $codepoints[0];
+            // if not defined or is a control character or soft hyphen
+            if(!IntlChar::isdefined($base_codepoint) || IntlChar::iscntrl($base_codepoint) || ($base_codepoint === "\x{ad}"))
             {
-                $name = utf8_chr_to_hex($char);
+                // put U+xxxx instead of utf8 string
+                $invalid_char_names[] = utf8_chr_to_hex($base_codepoint);
             }
             else
             {
-                $name = $char;
+                // combined characters will get here unless first component is caught above
+                $title = utf8_character_name($char);
+                $invalid_char_names[] = "<span title='$title'>$char</span>";
             }
-            $invalid_char_names[] = $name;
         }
         $invalid_char_string = implode(", ", $invalid_char_names);
         $changes[] = sprintf(_("Invalid characters will be removed: <span class='mono'>%s</span>"), $invalid_char_string);

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -786,24 +786,20 @@ define_bad_byte_sequences();
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function find_bad_byte_sequences_in_text($text, $projectid)
+define("BOM", "\u{feff}");
+
+// note that this can change $text
+function find_bad_byte_sequences_in_text(&$text)
 {
     global $_unanchored_bad_bytes_regex, $_bad_byte_sequences;
 
     $occurrences = array();
 
-    // find any characters in the text that are not valid for the project
     if(utf8_string_has_bom($text))
     {
-        $occurrences['BOM'] = 1;
+        $occurrences[BOM] = 1;
+        //remove it so not reported again as an invalid character
         $text = utf8_str_replace(utf8_bom(), '', $text);
-    }
-
-    $project = new Project($projectid);
-    $invalid_chars = get_invalid_characters($text, $project->get_valid_codepoints());
-    foreach($invalid_chars as $char => $num)
-    {
-        $occurrences[$char] = $num;
     }
 
     $n_matches = preg_match_all($_unanchored_bad_bytes_regex, $text, $matches);
@@ -881,6 +877,10 @@ function get_remarks_for_bad_byte_sequence($raw)
 {
     global $_bad_byte_sequences, $_character_data;
 
+    if(BOM === $raw)
+    {
+        return array("", "Byte Order Mark");
+    }
     if (startswith($raw, '&#'))
     {
         // This is a numeric character reference.
@@ -898,30 +898,22 @@ function get_remarks_for_bad_byte_sequence($raw)
 
         $why_bad = "HTML numeric character reference";
     }
-    elseif(utf8_strlen($raw) == 1 && is_utf8($raw))
-    {
-        $why_bad = "Codepoint not valid for project";
-        $intended_character = "";
-    }
     else
     {
         list($code_point, $why_bad) = $_bad_byte_sequences[$raw];
     }
 
-    if(!isset($intended_character))
+    $info = $_character_data[$code_point] ?? null;
+    if ($info)
     {
-        @$info = $_character_data[$code_point];
-        if ($info)
-        {
-            $char_name = $info['name'];
-        }
-        else
-        {
-            // $_character_data doesn't have an entry for that code point
-            $char_name = '???';
-        }
-        $intended_character = sprintf("U+%04x %s", $code_point, $char_name);
+        $char_name = $info['name'];
     }
+    else
+    {
+        // $_character_data doesn't have an entry for that code point
+        $char_name = '???';
+    }
+    $intended_character = sprintf("U+%04x %s", $code_point, $char_name);
 
     return array($intended_character, $why_bad);
 }

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -903,16 +903,8 @@ function get_remarks_for_bad_byte_sequence($raw)
         list($code_point, $why_bad) = $_bad_byte_sequences[$raw];
     }
 
-    $info = $_character_data[$code_point] ?? null;
-    if ($info)
-    {
-        $char_name = $info['name'];
-    }
-    else
-    {
-        // $_character_data doesn't have an entry for that code point
-        $char_name = '???';
-    }
+    $char_name = $_character_data[$code_point]['name'] ?? '???';
+
     $intended_character = sprintf("U+%04x %s", $code_point, $char_name);
 
     return array($intended_character, $why_bad);

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -478,7 +478,7 @@ function tds_for_invalid_chars($raw)
     $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
     $tds .= "<td>" . string_to_codepoints_string($raw) . "</td>"; // codepoints
     $tds .= "<td></td>"; // intended character
-    $tds .= "<td>" . "Codepoint not valid for project" . "</td>";
+    $tds .= "<td>" . _("Codepoint not valid for project") . "</td>";
 
     return $tds;
 }

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -324,18 +324,25 @@ function _test_project_for_bad_bytes($projectid)
             <th>" . _("#") . "</th>
             <th>" . _("Raw") . "</th>
             <th>" . _("Bytes") . "</th>
+            <th>" . _("Codepoints") . "</th>
             <th>" . _("Likely intended character") . "</th>
             <th>" . _("Why bad") . "</th>
         </tr>
     ";
 
     $n_bad_pages = 0;
+    $valid_codepoints = $project->get_valid_codepoints();
+
     while (list($text, $imagename, $proofers) = page_info_fetch($pages_res))
     {
         $round_num = get_round_num_from_proofers($proofers);
-        $occurrences = find_bad_byte_sequences_in_text($text, $projectid);
 
-        if (count($occurrences) == 0)
+        // note that this can change $text
+        $occurrences = find_bad_byte_sequences_in_text($text);
+        $invalid_chars = get_invalid_characters($text, $valid_codepoints);
+
+        $number_bad_chars = count($occurrences) + count($invalid_chars);
+        if ($number_bad_chars == 0)
         {
             // Nothing bad on this page!
             continue;
@@ -344,38 +351,43 @@ function _test_project_for_bad_bytes($projectid)
         // page had at least one bad byte-sequence
         $n_bad_pages += 1;
 
-        $details_for_this_page = "";
+        // write image and round columns
+        $rowspan = $number_bad_chars;
+        $img_url = "$code_url/tools/project_manager/displayimage.php?project=$projectid&imagefile=$imagename";
+        $text_url = "$code_url/tools/project_manager/downloadproofed.php?project=$projectid&amp;image=$imagename&amp;round_num=$round_num";
+        $details_for_this_page = "<tr>\n";
+        $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$img_url'>$imagename</a></td>\n";
+        if($round_num == 0)
+        {
+            $round_name = 'OCR';
+        }
+        else
+        {
+            $round = get_Round_for_round_number($round_num);
+            $round_name = $round->id;
+        }
+        $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$text_url'>$round_name</a></td>\n";
 
+        // on the first row <tr> is already written out with image and round
+        // columns so only write it on subsequent rows
+        $first_row = true;
+        // write bad bytes data
         ksort( $occurrences );
+
         foreach ($occurrences as $raw => $n_occurrences)
         {
-            if ($details_for_this_page == "")
-            {
-                $rowspan = count($occurrences);
-                $img_url = "$code_url/tools/project_manager/displayimage.php?project=$projectid&imagefile=$imagename";
-                $text_url = "$code_url/tools/project_manager/downloadproofed.php?project=$projectid&amp;image=$imagename&amp;round_num=$round_num";
-                $details_for_this_page = "<tr>\n";
-                $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$img_url'>$imagename</a></td>\n";
-                if($round_num == 0)
-                {
-                    $round_name = 'OCR';
-                }
-                else
-                {
-                    $round = get_Round_for_round_number($round_num);
-                    $round_name = $round->id;
-                }
-                $details_for_this_page .= "<td class='top-align' rowspan='$rowspan'><a href='$text_url'>$round_name</a></td>\n";
-            }
-            else
-            {
-                $details_for_this_page .= "<tr>\n";
-            }
-
+            $details_for_this_page .= write_row_start($first_row);
             $details_for_this_page .= "<td class='right-align'>$n_occurrences</td>\n";
-
             $details_for_this_page .= tds_for_bad_bytes($raw);
+            $details_for_this_page .= "</tr>\n";
+        }
 
+        ksort($invalid_chars);
+        foreach ($invalid_chars as $raw => $n_occurrences)
+        {
+            $details_for_this_page .= write_row_start($first_row);
+            $details_for_this_page .= "<td class='right-align'>$n_occurrences</td>\n";
+            $details_for_this_page .= tds_for_invalid_chars($raw);
             $details_for_this_page .= "</tr>\n";
         }
 
@@ -398,6 +410,20 @@ function _test_project_for_bad_bytes($projectid)
     }
 
     return $r;
+}
+
+// write <tr> if not the first row
+function write_row_start(&$first_row)
+{
+    if($first_row)
+    {
+        $first_row = false;
+        return "";
+    }
+    else
+    {
+        return "<tr>\n";
+    }
 }
 
 // We can calculate what round number a page text was selected from by
@@ -429,12 +455,12 @@ function tds_for_bad_bytes($raw)
         // It's a named or numeric character reference
         // so just show the reference itself,
         // rather than converting it to hex.
-        $tds .= "<td>" . htmlspecialchars($raw) . "</td>";
+        $tds .= "<td>" . htmlspecialchars($raw) . "</td><td></td>";
     }
     else
     {
-        $hex = utf8_chr_to_hex($raw);
-        $tds .= "<td>$hex</td>";
+        $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
+        $tds .= "<td>" . string_to_codepoints_string($raw) . "</td>"; // codepoints
     }
 
     list($intended_character, $why_bad) = get_remarks_for_bad_byte_sequence($raw);
@@ -442,6 +468,17 @@ function tds_for_bad_bytes($raw)
     $tds .= "<td>" . htmlspecialchars($intended_character) . "</td>";
 
     $tds .= "<td>" . htmlspecialchars($why_bad) . "</td>";
+
+    return $tds;
+}
+
+function tds_for_invalid_chars($raw)
+{
+    $tds = "<td>$raw</td>";
+    $tds .= "<td>" . string_to_hex($raw) . "</td>"; // bytes
+    $tds .= "<td>" . string_to_codepoints_string($raw) . "</td>"; // codepoints
+    $tds .= "<td></td>"; // intended character
+    $tds .= "<td>" . "Codepoint not valid for project" . "</td>";
 
     return $tds;
 }

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -3,7 +3,7 @@ $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // startswith str_contains
-include_once($relPath.'bad_bytes.inc'); // $_bad_byte_sequences string_to_hex
+include_once($relPath.'bad_bytes.inc'); // $_bad_byte_sequences
 include_once($relPath.'project_quick_check.inc'); // $css_for_bad_bytes_tables tds_for_bad_bytes
 
 output_header(_("Bad Bytes Explainer"), NO_STATSBAR);
@@ -154,6 +154,7 @@ function show_a_table_of_bads($desired_badness)
         <tr>
             <th>" . _("Raw") . "</th>
             <th>" . _("Bytes") . "</th>
+            <th>" . _("Codepoints") . "</th>
             <th>" . _("Likely intended character") . "</th>
             <th>" . _("Why bad") . "</th>
         </tr>


### PR DESCRIPTION
This is a re-make of a similar branch but using the new unicode functions.
It shows multiple codepoints as well as bytes in the Bad Bytes tables in PQC.
Bad sequences are handled separately from invalid codepoints; this simplifies distinguishing the nature of the badness.
For Add Page it shows complete combined characters if present and title names for the bad characters.
BOM handling is also improved.