### PR TITLE
Add checks to ensure project tables are UTF-8

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -396,6 +396,7 @@ class Project
     var $CBP_PROJECT_NOT_AVAILABLE        = 2;
     var $CBP_REQUESTOR_NOT_LOGGED_IN      = 3;
     var $CBP_USER_NOT_QUALIFIED_FOR_ROUND = 4;
+    var $CBP_PROJECT_REQUIRES_MAINTENANCE = 5;
 
     function can_be_proofed_by_current_user()
     // (where "proofed" means "worked on in a round, right now".)
@@ -414,6 +415,15 @@ class Project
             return array(
                 $this->CBP_PROJECT_NOT_IN_ROUND,
                 _('The project is not in a round.')
+            );
+        }
+
+        if (!$this->is_utf8)
+        {
+            // Project has not been converted to UTF-8 yet
+            return array(
+                $this->CBP_PROJECT_REQUIRES_MAINTENANCE,
+                _('The project requires maintenance.') . ' ' . _("Project table is not UTF-8.")
             );
         }
 

--- a/project.php
+++ b/project.php
@@ -552,6 +552,11 @@ function do_project_info_table()
         echo_row_a( _("Word Lists"), $links );
     }
 
+    if(!$project->is_utf8)
+    {
+        echo_row_a(_("Encoding"), "<span class='error'>" . _("Project table is not UTF-8.") . "</span>");
+    }
+
     $project_charsuites = [];
     foreach($project->get_charsuites() as $charsuite)
     {

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -31,6 +31,17 @@ abort_if_cant_edit_project( $projectid );
 
 echo "<h1>$title</h1>";
 
+$project = new Project($projectid);
+if(!$project->is_utf8)
+{
+    echo "<p>"
+        . _("Pages cannot be added to the project in its current state.")
+        . " "
+        . _("Project table is not UTF-8.")
+        . "</p>";
+    exit();
+}
+
 if(!user_can_add_project_pages($projectid, $loading_tpnv == 1 ? "tp&v" : "normal"))
 {
     // abort if a load_disabled user is trying to load normal pages into an empty project 

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -27,6 +27,14 @@ if(user_can_edit_project($projectid) != USER_CAN_EDIT_PROJECT)
     die("You are not authorized to manage this project.");
 }
 
+$project = new Project($projectid);
+
+// prevent changes to the project table if it isn't UTF-8
+if(!$project->is_utf8)
+{
+    die(_("Project table is not UTF-8."));
+}
+
 // If the user hit a cancel button, return them to the starting form
 if($cancel)
     $modify = '';
@@ -39,8 +47,6 @@ if (!$resolution) {
     $b_User = $page['b_user'];
     $b_Code = $page['b_code'];
 
-    $project = new Project($projectid);
-    
     $round = get_Round_for_page_state($state);
     $current_round_num = $round->round_number;
 

--- a/tools/site_admin/convert_project_table_utf8.php
+++ b/tools/site_admin/convert_project_table_utf8.php
@@ -1,0 +1,52 @@
+<?php
+$relPath='../../pinc/';
+include_once($relPath.'base.inc');
+include_once($relPath.'Project.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath.'user_is.inc');
+
+require_login();
+
+if ( !user_is_a_sitemanager() )
+{
+    die( "You are not allowed to run this script." );
+}
+
+$title = _("Convert Project Table to UTF-8");
+output_header($title, NO_STATSBAR);
+
+echo "<h1>$title</h1>";
+
+echo "<p>" . _("This tool will convert individual project tables to UTF-8 if they are not already. If the project table is already UTF-8 no changes will happen.") . "</p>";
+
+$projectid = validate_projectID('projectid', @$_REQUEST['projectid'], true);
+
+if ( !$projectid )
+{
+    echo "<form method='GET'>";
+    echo "Project: ";
+    echo "<input type='text' name='projectid' size='23' required>";
+    echo "<input type='submit' value='Go'>";
+    echo "</form>\n";
+    exit;
+}
+
+$project = new Project($projectid);
+$title = $project->nameofwork;
+
+echo "<pre>";
+echo "projectid: $projectid\n";
+echo "title    : $title\n";
+echo "</pre>\n";
+
+if($project->is_utf8)
+{
+    echo "<p>" . _("Project table is already UTF-8.") . "</p>";
+}
+else
+{
+    echo "<p>" . _("Project tabie is not UTF-8.") . "<p>";
+    echo "<p>" . _("Converting project table...") . "</p>";
+    $project->convert_to_utf8();
+    echo "<p>" . _("Done") . "</p>";
+}

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -233,6 +233,14 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
 
     foreach ( array( 'from', 'to' ) as $which )
     {
+        $projectid = $projectid_[$which];
+        $project = new Project($projectid);
+
+        if(!$project->is_utf8)
+        {
+            die("Project table $projectid is not UTF-8.");
+        }
+
         $res= mysqli_query(DPDatabase::get_connection(),
             sprintf("DESCRIBE %s",
             mysqli_real_escape_string(DPDatabase::get_connection(), $projectid_[$which]))
@@ -249,6 +257,9 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
 
     foreach ( array( 'from', 'to' ) as $which )
     {
+        $projectid = $projectid_[$which];
+        $project = new Project($projectid);
+
         // clever use of $which above means we need label uses translated
         // separately, which is convenient, since 'to/from' could be mistaken
         // as indicating a range.
@@ -265,11 +276,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
 
         echo "<table class='copy'>";
 
-        $projectid = $projectid_[$which];
-
         echo "<tr><th>" . _("Project ID") . ":</th><td>" . $projectid . "</td></tr>\n";
-
-        $project = new Project($projectid);
 
         echo "<tr><th>" . _("Title") . ":</th><td>" . $project->nameofwork. "</td></tr>\n";
 

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -30,6 +30,7 @@ $sections = array(
         "delete_pages.php" => _("Delete Pages"),
         "rename_pages.php" => _("Rename Pages"),
         "../project_manager/clearance_check.php?username=" => _("Questionable Clearances"),
+        "convert_project_table_utf8.php" => _("Convert Project Table to UTF-8"),
     ),
     _("Site") => array(
         "sitenews.php" => _("Manage Site News"),


### PR DESCRIPTION
Prevent changes to project tables that have not yet been converted to
UTF-8. This is mostly for the rare circumstances where projects created
before the conversion are unarchived. For these tables, provide an admin
tool to convert the table.

You can see how this works with the [Aspazio project](https://www.pgdp.org/~cpeel/c.branch/project-table-encoding-checks/project.php?id=projectID4fd62bf9ac045&detail_level=3) in my [project-table-encoding-checks](https://www.pgdp.org/~cpeel/c.branch/project-table-encoding-checks) sandbox.