### PR TITLE
Increase size of 'subject' field for Random Rules

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -409,9 +409,10 @@ CREATE TABLE `rules` (
   `document` varchar(255) default NULL,
   `langcode` varchar(5) default NULL,
   `anchor` varchar(255) default NULL,
-  `subject` varchar(100) NOT NULL default '',
+  `subject` varchar(255) NOT NULL default '',
   `rule` text NOT NULL,
-  PRIMARY KEY  (`id`)
+  PRIMARY KEY  (`id`),
+  KEY `document_langcode` (`document`,`langcode`)
 ) DEFAULT CHARSET=latin1;
 # --------------------------------------------------------
 

--- a/SETUP/upgrade/14/20200322_alter_rules.php
+++ b/SETUP/upgrade/14/20200322_alter_rules.php
@@ -1,0 +1,36 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Increasing size of rules.subject...\n";
+
+$sql = "
+    ALTER TABLE rules MODIFY COLUMN subject VARCHAR(255)
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "Adding index (document, langcode) index to rules...\n";
+
+$sql = "
+    CREATE INDEX document_langcode
+        ON rules (document, langcode);
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/RandomRule.inc
+++ b/pinc/RandomRule.inc
@@ -263,6 +263,10 @@ class RandomRule
             $rule
         );
 
+        // prevent anchor and subject from being too big for their fields
+        $anchor = substr($anchor, 0, 255);
+        $subject = substr($subject, 0, 255);
+
         $sql = sprintf("
             INSERT INTO rules
             SET

--- a/pinc/RandomRule.md
+++ b/pinc/RandomRule.md
@@ -22,8 +22,8 @@ are located, as long as they are accessible by URL.
 Rules are parsed out of the raw HTML pages of the guildelines. In the HTML the
 parser looks for and pulls out the following pieces of information:
 
-* anchor - an HTML anchor for jumping to this rule on the page
-* subject - name of the rule to present to the user
+* anchor - an HTML anchor for jumping to this rule on the page; limited to 255 characters
+* subject - name of the rule to present to the user; limited to 255 characters
 * rule - the contents of the rule itself
 
 ### Code-based guidelines


### PR DESCRIPTION
Increase the size of the subject field for random rules and ensure that we don't try to add data into subject or anchor that are larger than the field.

Available in the [long-random-rule-subjects](https://www.pgdp.org/~cpeel/c.branch/long-random-rule-subjects) sandbox.