### PR TITLE
Allow sites to define default character suites

### DIFF
--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -43,7 +43,7 @@ _ARCHIVE_DB_NAME=PICK_ANOTHER_DB_NAME
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-# File and URL locatios
+# File and URL locations
 # -----------------------------
 
 # We don't require a particular arrangement of directories configured in
@@ -74,7 +74,7 @@ _CODE_URL=$base_url/c
 _DYN_DIR=$base_dir/d
 _DYN_URL=$base_url/d
 # This directory houses two classes of DP-related files that must be
-# readable and writeable by the web server.
+# readable and writable by the web server.
 #
 # Optional user-supplied files:
 #     $_DYN_DIR/code_images/ stores files used by the DP code. They are
@@ -149,6 +149,22 @@ _PHPBB_TABLE_PREFIX=phpbb
 _FORUMS_DIR=$base_dir/phpBB3
 _FORUMS_URL=$base_url/phpBB3
 # Locations of the phpBB code via filesystem path and URL.
+
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Character suites
+# ----------------
+
+# To help provide better quality UTF-8 texts, the code requires project
+# managers to select which characters are valid for a project. These
+# characters are defined in a Character Suite. If you want all new
+# projects to have specific character suites selected upon creation,
+# specify them here using PHP array syntax within a string. An empty
+# array can be used to disable default character suites. All character
+# suites must be installed and enabled on the system.
+# See SETUP/UNICODE.md for more information.
+
+_DEFAULT_CHAR_SUITES='[ "basic-latin" ]'
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/SETUP/tests/travis-ci_configuration.sh
+++ b/SETUP/tests/travis-ci_configuration.sh
@@ -19,6 +19,8 @@ _PHPBB_TABLE_PREFIX=phpbb3.phpbb
 _FORUMS_DIR=$HOME/phpBB3
 _FORUMS_URL='http://localhost/phpBB3'
 
+_DEFAULT_CHAR_SUITES='[ "basic-latin" ]'
+
 _SITE_NAME='Travis-CI'
 _SITE_ABBREVIATION=TCI
 _SITE_SIGNOFF="Ciao!"

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -125,6 +125,7 @@ $auto_post_to_project_topic = <<AUTO_POST_TO_PROJECT_TOPIC>>;
 $ordinary_users_can_see_queue_settings = <<ORDINARY_USERS_CAN_SEE_QUEUE_SETTINGS>>;
 $external_catalog_locator = '<<EXTERNAL_CATALOG_LOCATOR>>';
 $charset = 'UTF-8';
+$default_project_char_suites = <<DEFAULT_CHAR_SUITES>>;
 
 $jpgraph_FF='<<JPGRAPH_FONT_FACE>>';
 $jpgraph_FS='<<JPGRAPH_FONT_STYLE>>';

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -154,15 +154,8 @@ else
 
 function get_default_character_suites()
 {
-    foreach(CharSuites::get_enabled() as $enabled_char_suite)
-    {
-        if ($enabled_char_suite->name == 'basic-latin')
-        {
-            return ['basic-latin'];
-        }
-    }
-
-    return [];
+    global $default_project_char_suites;
+    return $default_project_char_suites;
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
Instead of defaulting to basic-latin, allow sites to specify their own default character suites for new projects.

This seemed like a small but useful change for other sites. `SETUP/UNICODE.md` doesn't exist yet but will ... soon.