### PR TITLE
Allow bypassing maint mode for upgrade scripts

### DIFF
--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -71,6 +71,15 @@ order is probably safest, as that's been tested the most.
 
 Each script will print 'Done!' if it completes without fatal errors.
 
+If you have placed the site into maintenance mode the scripts will bail out.
+To force the upgrade scripts to run while in maintenance mode, edit the ones
+you want to run and add the following line immediately after the opening
+`<?php` tag before `base.inc` is included.
+
+```php
+$maintenance_override = TRUE;
+```
+
 ### Upgrading from release 1.3 or earlier
 Sorry, there's no automated upgrade mechanism. If you post
 to the 'DP Site Code' forum, we might be able to help you.

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -72,7 +72,7 @@ if(DPDatabase::get_connection())
 
 configure_gettext($charset, get_desired_language(), $dyn_locales_dir, $system_locales_dir);
 
-if ($maintenance)
+if ($maintenance && !@$maintenance_override)
 {
     /*
     Including user_is.inc causes a perf impact because it includes


### PR DESCRIPTION
When maintenance mode is enabled the upgrade scripts won't run because `base.inc` will bail out. Allow scripts to override the maintenance check to enable upgrades to run.

I stumbled into this during the InnoDB conversion earlier in the year. This ensures that I don't have to hack this into the code again for the Unicode update.