### PR TITLE
Use DejaVu Sans Mono for character picker font

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -758,20 +758,21 @@ table.dirlist caption {
 #toolbox .char_box {
   padding-top: 1px;
 }
+#toolbox .big_text,
+#toolbox .picker {
+  font-family: DejaVu Sans Mono;
+  vertical-align: middle;
+  text-align: center;
+  width: 1.1em;
+}
 #toolbox .big_text {
   font-size: 300%;
-  width: 1.3em;
   margin: 2px;
-  text-align: center;
 }
 #toolbox .picker {
-  margin-top: 1px;
   font-size: 1em;
+  margin-top: 1px;
   padding: 0 1px 0 0;
-  vertical-align: middle;
-  width: 100%;
-  min-width: 1em;
-  max-width: 1.1em;
 }
 #toolbox .invisible {
   visibility: hidden;

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -775,20 +775,22 @@ table.dirlist {
         padding-top: 1px;
     }
 
+    .big_text, .picker {
+        font-family: DejaVu Sans Mono;
+        vertical-align: middle;
+        text-align: center;
+        width: 1.1em;
+    }
+
     .big_text {
         font-size: 300%;
-        width: 1.3em;
         margin: 2px;
-        text-align: center;
     }
+
     .picker {
-        margin-top: 1px;
         font-size: 1em;
+        margin-top: 1px;
         padding: 0 1px 0 0;
-        vertical-align: middle;
-        width: 100%;
-        min-width: 1em;
-        max-width: 1.1em;
     }
 
     .invisible {

--- a/tools/proofers/proof.php
+++ b/tools/proofers/proof.php
@@ -82,7 +82,7 @@ slim_header_frameset($nameofwork." - "._("Proofreading Interface"), $header_args
 
 $frameGet="?" . $_SERVER['QUERY_STRING'];
 ?>
-<frameset id="proof_frames" rows="*,73">
+<frameset id="proof_frames" rows="*,85">
 <frame name="proofframe" src="<?php echo "$code_url/tools/proofers/proof_frame.php{$frameGet}";?>" marginwidth="2" marginheight="2" frameborder="0">
 <frame name="menuframe" src="ctrl_frame.php?projectid=<?php echo $projectid; ?>&amp;round_id=<?php echo $round->id; ?>" marginwidth="2" marginheight="2" frameborder="0">
 </frameset>


### PR DESCRIPTION
Wide characters are currently getting cut off in the character picker (particularly in Firefox and Safari). Changing this to DejaVu Sans Mono ensures that they will all fit into the box and makes the characters look more like what they will look like in the monospace proofreading box.

I also tweaked the frameset for the proofreading toolbox so the entire picker shows up. I tested this on Chrome, Safari, and Firefox. This is available in the [dvsm-picker](https://www.pgdp.org/~cpeel/c.branch/dvsm-picker) sandbox.