### PR TITLE
Add a sitemap; also add metadata to project pages

### DIFF
--- a/SETUP/apache2.conf.example
+++ b/SETUP/apache2.conf.example
@@ -29,6 +29,12 @@ DirectoryIndex index.php default.php index.html default.html
 
     ErrorLog ${APACHE_LOG_DIR}/error.log
 
+    <IfModule mod_rewrite.c>
+        # make the sitemap work with an .xml extension
+        RewriteEngine On
+        RewriteRule ^(.*)sitemap\.xml$ $1sitemap.php [R,L]
+    </IfModule>
+
     # Possible values include: debug, info, notice, warn, error, crit,
     # alert, emerg.
     LogLevel warn

--- a/project.php
+++ b/project.php
@@ -61,13 +61,33 @@ $title = sprintf( _("Project Page for '%s'"), $project->nameofwork );
 
 // -----------------------------------------------------------------------------
 
+// Include structured metadata in LD+JSON format for this book
+$ld_json_object = [
+    "@context" => "http://schema.org",
+    "@type" => "Book",
+    "name" => $project->nameofwork,
+    "author" => [
+        "@type" => "Person",
+        "name" => $project->authorsname,
+    ],
+    "inLanguage" => explode(" with ", $project->language)[0],
+    "genre" => $project->genre,
+];
+
+$extra_args = [
+    "head_data" => '<script type="application/ld+json">' .
+        json_encode($ld_json_object, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) .
+    '</script>',
+];
+
+output_header($title_for_theme, NO_STATSBAR, $extra_args);
+
+echo "<h1>$title</h1>\n";
+
+
 if ( !$user_is_logged_in )
 {
     // Guests see a reduced version of the project page.
-
-    output_header($title_for_theme, NO_STATSBAR);
-
-    echo "<h1>$title</h1>\n";
 
     list($top_blurb, $bottom_blurb) = decide_blurbs();
     do_blurb_box( $top_blurb );
@@ -86,10 +106,8 @@ if ( $user_is_logged_in )
         $pguser, $project->projectid, $project->t_retrieved );
 }
 
-output_header($title_for_theme, NO_STATSBAR);
 if ($detail_level==1)
 {
-    echo "<h1>$title</h1>\n";
 
     do_expected_state();
     do_detail_level_switch();
@@ -109,8 +127,6 @@ else
     // Detail level 2 should show the information
     // that is usually wanted by the people who usually work with
     // the project in its current state.
-
-    echo "<h1>$title</h1>\n";
 
     do_detail_level_switch();
     do_expected_state();

--- a/sitemap.php
+++ b/sitemap.php
@@ -1,0 +1,82 @@
+<?php
+$relPath = "pinc/";
+include_once($relPath."base.inc");
+include_once($relPath."project_states.inc");
+
+// fixed, non-project pages to include in the listing with their
+// change frequency
+$fixed_pages = [
+    "default.php" => "monthly",
+];
+
+header('Content-type: application/xml; charset=utf-8');
+
+// see https://en.wikipedia.org/wiki/Sitemaps#File_format
+echo <<<XML_HEADER
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+
+XML_HEADER;
+
+// sitemaps are limited to 50k URLs, so we need to keep track of how many
+// we output and stop when we get to that number
+$MAX_URLS = 50000;
+$url_count = 0;
+
+foreach($fixed_pages as $page => $frequency)
+{
+    if($url_count >= $MAX_URLS)
+        break;
+
+    $url = "$code_url/$page";
+    $lastmod = strftime("%Y-%m-%d", filemtime("$code_dir/$page"));
+    echo <<<URL
+    <url>
+        <loc>$url</loc>
+        <lastmod>$lastmod</lastmod>
+        <changefreq>$frequency</changefreq>
+        <priority>1.0</priority>
+    </url>
+
+URL;
+    $url_count += 1;
+}
+
+// now project pages
+
+// Order the projects in the order they go through the system. This is only
+// relevant if there are more than 50k of them, in which case we drop off
+// projects on the tail end (deleted projects get dropped first, posted ones
+// get dropped second, etc).
+$order_by = sql_collater_for_project_state("state");
+$sql = "
+    SELECT projectid, modifieddate
+    FROM projects
+    ORDER BY $order_by
+";
+$result = mysqli_query(DPDatabase::get_connection(), $sql);
+while($row = mysqli_fetch_assoc($result))
+{
+    if($url_count >= $MAX_URLS)
+        break;
+
+    $url = "$code_url/project.php?id=" . $row["projectid"];
+    $lastmod = strftime("%Y-%m-%d", $row["modifieddate"]);
+
+    echo <<<URL
+    <url>
+        <loc>$url</loc>
+        <lastmod>$lastmod</lastmod>
+        <priority>0.5</priority>
+    </url>
+
+URL;
+    $url_count += 1;
+}
+
+echo <<<XML_FOOTER
+</urlset>
+
+XML_FOOTER;


### PR DESCRIPTION
Add a sitemap we can submit to search engines so they can reasonably index our site. Note that most of our pages require a login, so mostly these are project pages.

On the project pages, include LD+JSON metadata so search engines can glean a bit more structured data about the page.