### PR TITLE
Redirect from homepage to Activity Hub on login

### DIFF
--- a/accounts/login.php
+++ b/accounts/login.php
@@ -100,8 +100,10 @@ dpsession_begin( $userNM );
 //   3. User is presented with an error message since $_POST has no login
 //      information.
 // To avoid this case we ignore $destination if it points to login_failure.php.
-// send them to the correct page
-if (!empty($destination) && !endswith($destination, "login_failure.php"))
+// send them to the correct page. We also ignore $destination if it is
+// default.php and intentionally redirect them to the Activity Hub.
+if (!empty($destination) && !endswith($destination, "login_failure.php") &&
+    !endswith($destination, "default.php"))
 {
     // They were heading to $destination (via a bookmark, say)
     // when we sidetracked them into the login pages.


### PR DESCRIPTION
When a user logs in from a page, we generally redirect them back to the
page they were on. Most new users will login from the home page and
get redirected back there -- which doesn't provide them with any good
links for where to go next. The Activity Hub, however, provides text
and links for new users to get them to the right place. The AH also
provides not-so-new users with useful News, so redirecting there from
the homepage for everyone is useful.