### PR TITLE
Encourage users to work in P2 where possible

### DIFF
--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -148,7 +148,7 @@ function encourage_p1_to_p2($round)
 
         echo "<div class='callout'>";
         echo "<div class='calloutheader'>";
-        echo _("Consider working on projects in $round_target!");
+        echo "Consider working on projects in $round_target!";
         echo "</div>";
 
         echo "<p>Please consider proofreading a project in $round_target rather than here in P1. With the large influx of new users, having eligible users working in <a href='$code_url/tools/proofers/round.php?round_id=$round_target'>$round_target</a> helps significantly.</p>";
@@ -164,7 +164,7 @@ function encourage_p1_to_p2($round)
     {
         echo "<div class='callout'>";
         echo "<div class='calloutheader'>";
-        echo _("You are eligible to work in P2!");
+        echo "You are eligible to work in P2!";
         echo "</div>";
 
         echo "<p>You are eligible to work on projects in P2! Simply <a href='$code_url/tools/proofers/round.php?round_id=P2#Entrance_Requirements'>request access</a> and find a <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a> project that interests you.</p>";
@@ -182,10 +182,10 @@ function encourage_p1_to_p2($round)
     {
         echo "<div class='callout'>";
         echo "<div class='calloutheader'>";
-        echo _("You are just a few quizzes away from P2!");
+        echo "You are just a few quizzes away from P2!";
         echo "</div>";
 
-        echo "<p>You are almost eligible to work in the P2 round! The only thing left is to pass the short <a href='$code_url/quiz/start.php?show_level=P_MOD'>moderate proofreading quizes</a>. After you pass them you can <a href='$code_url/tools/proofers/round.php?round_id=P2#Entrance_Requirements'>request access</a> and you'll be able to work on projects in <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a>.</p>";
+        echo "<p>You are almost eligible to work in the P2 round! The only thing left is to pass the short <a href='$code_url/quiz/start.php?show_level=P_MOD'>moderate proofreading quizzes</a>. After you pass them you can <a href='$code_url/tools/proofers/round.php?round_id=P2#Entrance_Requirements'>request access</a> and you'll be able to work on projects in <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a>.</p>";
         echo "<p>Please consider working on P2 projects rather than projects here in P1. With the large influx of new users, having eligible users working in <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a> helps significantly.</p>";
         echo "<p>Thank you!</p>";
         echo "</div>";

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -127,4 +127,70 @@ function maybe_output_new_proofer_message()
     }
 }
 
+function encourage_p1_to_p2($round)
+{
+    global $code_url, $pguser;
+
+    if($round != 'P1')
+        return;
+
+    // see if the user already has access to P3 or P2, if they do just
+    // encourage them to proof there instead
+    $userSettings =& Settings::get_Settings($pguser);
+    $p2_access = $userSettings->get_boolean("P2.access");
+    $p3_access = $userSettings->get_boolean("P3.access");
+    if($p2_access || $p3_access)
+    {
+        if($p3_access)
+            $round_target = "P3";
+        else
+            $round_target = "P2";
+
+        echo "<div class='callout'>";
+        echo "<div class='calloutheader'>";
+        echo _("Consider working on projects in $round_target!");
+        echo "</div>";
+
+        echo "<p>Please consider proofreading a project in $round_target rather than here in P1. With the large influx of new users, having eligible users working in <a href='$code_url/tools/proofers/round.php?round_id=$round_target'>$round_target</a> helps significantly.</p>";
+        echo "<p>Thank you!</p>";
+        echo "</div>";
+        return;
+    }
+
+    // if they are already eligible but have not requested access, tell them
+    $round = get_Round_for_round_id("P2");
+    $uao = $round->user_access($pguser);
+    if($uao->all_minima_satisfied)
+    {
+        echo "<div class='callout'>";
+        echo "<div class='calloutheader'>";
+        echo _("You are eligible to work in P2!");
+        echo "</div>";
+
+        echo "<p>You are eligible to work on projects in P2! Simply <a href='$code_url/tools/proofers/round.php?round_id=P2#Entrance_Requirements'>request access</a> and find a <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a> project that interests you.</p>";
+        echo "<p>Please consider working on P2 projects rather than projects here in P1. With the large influx of new users, having eligible users working in <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a> helps significantly.</p>";
+        echo "<p>Thank you!</p>";
+        echo "</div>";
+        return;
+    }
+
+    // they aren't yet eligible, but if they've been here for the required
+    // number of days and done the required number of pages and just need to
+    // take and pass the quiz, so nudge them along
+    $uao = $round->user_access($pguser);
+    if($uao->minima_table["P1"][3] && $uao->minima_table["days since reg"][3])
+    {
+        echo "<div class='callout'>";
+        echo "<div class='calloutheader'>";
+        echo _("You are just a few quizzes away from P2!");
+        echo "</div>";
+
+        echo "<p>You are almost eligible to work in the P2 round! The only thing left is to pass the short <a href='$code_url/quiz/start.php?show_level=P_MOD'>moderate proofreading quizes</a>. After you pass them you can <a href='$code_url/tools/proofers/round.php?round_id=P2#Entrance_Requirements'>request access</a> and you'll be able to work on projects in <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a>.</p>";
+        echo "<p>Please consider working on P2 projects rather than projects here in P1. With the large influx of new users, having eligible users working in <a href='$code_url/tools/proofers/round.php?round_id=P2'>P2</a> helps significantly.</p>";
+        echo "<p>Thank you!</p>";
+        echo "</div>";
+        return;
+    }
+}
+
 // vim: sw=4 ts=4 expandtab

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -41,6 +41,7 @@ alert_re_unread_messages( $pagesproofed );
 
 welcome_see_beginner_forum( $pagesproofed, $round->id );
 
+encourage_p1_to_p2($round->id);
 
 show_news_for_page($round_id);
 


### PR DESCRIPTION
_This code is up for review and feedback (particularly around wording) but is not intended to be, and will not be, merged._

With the crazy influx of new users, we want to really encourage people to work in P2 if they can. This hack shows a call-out box on the P1 page. It has 3 different messages:
1. If the user already has P3 or P2 access, it will encourage them to proof in those rounds instead.
2. If the user is already eligible to work in P2, but just haven't requested access, it will encourage them to do so and proof in P2.
3. If the user has done the minimum number of pages and been around long enough but not taken/passed the quiz it will encourage them to take/pass the quiz and work in P2.

This is available for testing in the [covid19-hacks](https://www.pgdp.org/~cpeel/c.branch/covid19-hacks) sandbox.

One oddity about the test site is that it reduces the minimum page and time criteria to get into the rounds (3 days and 10 pages rather than 21 days and 300 pages) -- but the gradual welcome messages are hard-coded at PROD-level numbers. This means that on TEST you may see two callouts (existing and the new) whereas on PROD you will only see one or the other.