### PR TITLE
Require transitions to P1.unavail to pass PQC

### DIFF
--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -2,8 +2,53 @@
 include_once('RoundDescriptor.inc'); // get_Round_for_round_number()
 include_once('wordcheck_engine.inc'); // get_file_info_object()
 include_once('links.inc'); // new_window_link()
+include_once('slim_header.inc'); // slim_header()
 include_once($relPath.'../tools/project_manager/post_files.inc'); // page_info_query page_info_fetch
 include_once('bad_bytes.inc');
+
+// Transition callback function to prevent a project state change if PQC
+// results return an error.
+function gate_on_pqc($projectid)
+{
+    global $code_url;
+
+    $results = get_pqc_test_results($projectid);
+
+    // loop thorugh results looking for errors
+    $found_error = FALSE;
+    foreach($results as $function => $test_result)
+    {
+        if($test_result["status"] == _("Error"))
+        {
+            $found_error = TRUE;
+            break;
+        }
+    }
+
+    if($found_error)
+    {
+        $title = _("Change Project State");
+        slim_header($title);
+        echo "<h1>$title</h1>";
+
+        echo "<p>";
+        echo sprintf(_("One or more errors were found when checking the project. Review the <a href='%s'>project quick check results</a>, address any problems found, and try the project transition again."), "$code_url/tools/project_manager/project_quick_check.php?projectid=$projectid");
+        echo "</p>";
+
+        echo "<p>";
+        echo _("If you believe these results are incorrect, please contact db-req for assistance.");
+        echo "</p>";
+
+        echo "<p>";
+        echo sprintf(_("Return to the <a %s>project page</a>"), "href='$code_url/project.php?id=$projectid'");
+        echo "</p>";
+
+        echo "<h2>" . _("Project Quick Check Summary") . "</h2>";
+        show_pqc_result_summary($results, FALSE);
+
+        exit();
+    }
+}
 
 function show_pqc_result_summary($results, $output_links = True)
 {
@@ -463,7 +508,7 @@ function _test_project_for_bad_bytes($projectid)
     }
     else
     {
-        $r['status'] = _('Warning');
+        $r['status'] = _('Error');
         $r['summary'] = sprintf(_("%d pages had bad characters, see detail."), $n_bad_pages);
         $r['details'] = $details_for_this_project;
     }

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -1,11 +1,81 @@
 <?php
-include_once('stages.inc'); // $Round_for_round_id_
-include_once('wordcheck_engine.inc'); // $word_characters $puncCharacters get_file_info_object()
+include_once('RoundDescriptor.inc'); // get_Round_for_round_number()
+include_once('wordcheck_engine.inc'); // get_file_info_object()
 include_once('links.inc'); // new_window_link()
 include_once($relPath.'../tools/project_manager/post_files.inc'); // page_info_query page_info_fetch
 include_once('bad_bytes.inc');
-include_once('wordcheck_engine.inc');
 
+function show_pqc_result_summary($results, $output_links = True)
+{
+    echo "<table class='basic striped'>";
+    echo "<tr>";
+    echo "<th>" . _("Test") . "</th>";
+    echo "<th>" . _("Status") . "</th>";
+    echo "<th>" . _("Summary") . "</th>";
+    echo "</tr>";
+    foreach($results as $function => $test_result)
+    {
+        echo "<tr>";
+        echo "<td>" . $test_result["name"] . "</td>";
+        echo "<td>";
+        if($output_links)
+            echo "<a href='#$function'>";
+        echo $test_result["status"];
+        if($output_links)
+            echo "</a>";
+        echo "</td>";
+        $css = get_css_for_pqc_status($test_result["status"]);
+        echo "<td $css>" . $test_result["summary"] . "</td>";
+        echo "</tr>";
+    }
+    echo "</table>";
+}
+
+function get_css_for_pqc_status($status)
+{
+    if($status == _("Warning"))
+        $css = "class='warning'";
+    elseif($status == _("Error"))
+        $css = "class='error'";
+    else
+        $css = '';
+    return $css;
+}
+
+function get_pqc_test_results($projectid)
+{
+    global $test_functions;
+
+    $result = array();
+    foreach($test_functions as $function)
+    {
+        $result[$function] = $function($projectid);
+    }
+    return $result;
+}
+
+// ---------------------------------------------------------------------------
+// Test functions
+
+// $test_functions, an array of function names, specifies the list of test
+// functions that will be applied to the project.
+//
+// Each test function:
+// - is declared later in this file
+// - by convention has a name that begins "_test_project_"
+// - is called with a single $projectid argument
+// - performs a particular kind of check on the given project
+// - returns an associative array of the form
+//    [
+//        "name" => $test_name,  # name of the test
+//        "description" => $test_desc,  # description of the test
+//        "status" => $status,  # overall result of the test
+//            # one of [ _("Success"), _("Warning"), _("Error"), _("Skipped") ]
+//        "summary" => $summary,  # result summary string (no HTML)
+//        "details" => $details,  # result details (can contain HTML)
+//    ]
+
+global $test_functions;
 $test_functions  = array(
     // Automatic tests
     "_test_project_has_all_page_images",
@@ -580,8 +650,5 @@ function _test_project_has_all_page_images($projectid)
         "details" => $details,
     );
 }
-
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -3,6 +3,7 @@ $relPath="../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'project_trans.inc');
+include_once($relPath.'slim_header.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'ProjectTransition.inc');
@@ -41,24 +42,25 @@ if ( !$transition->is_valid_for( $project, $pguser ) )
 
 if ($transition->why_disabled($project) == 'SR')
 {
-    $body = '<p>' . _("This function is disabled while the project is in the Smooth Reading Pool.")  . '</p>' .
-            '<p>' . _("If you believe this is an error, please contact db-req for assistance.")      . '</p>';
+    $body = _("This function is disabled while the project is in the Smooth Reading Pool.") . "<br>";
+            _("If you believe this is an error, please contact db-req for assistance.");
 
     fatal_error($body);
 }
 
 function fatal_error( $msg )
 {
-    global $projectid, $project, $curr_state, $next_state;
+    global $project, $curr_state, $next_state;
+
+    output_page_header();
 
     echo "<pre>\n";
     echo _("You requested:") . "\n";
-    echo "    projectid  = $projectid ($project->nameofwork)\n";
+    echo "    projectid  = $project->projectid ($project->nameofwork)\n";
     echo "    curr_state = $curr_state\n";
     echo "    next_state = $next_state\n";
-    echo "\n";
-    echo "$msg\n";
     echo "</pre>\n";
+    echo "<p class='error'>$msg</p>\n";
     exit;
 }
 
@@ -68,6 +70,8 @@ function fatal_error( $msg )
 // and we haven't just asked it, ask it now.
 if ( !is_null($transition->confirmation_question) && $confirmed != 'yes' )
 {
+    output_page_header();
+
     echo "<p><b>" . _("Project ID") . ":</b> $projectid<br>\n";
     echo "<b>" . _("Title") . ":</b> {$project->nameofwork}<br>\n";
     echo "<b>" . _("Author") . ":</b> {$project->authorsname}</p>\n";
@@ -121,10 +125,7 @@ if ( !empty($transition->detour) )
                 _("Something went wrong, and your request ('%s') has probably not been carried out."), 
                 $transition->action_name
             )
-            . "\n"
-            . _("Error") . ":"
-            . "\n"
-            . $error_msg
+            . "<br>" . _("Error") . ": $error_msg"
         );
     }
 }
@@ -149,6 +150,13 @@ function prepare_url( $url_template )
     $url .= "{$connector}return_uri=$encoded_return_uri";
 
     return $url;
+}
+
+function output_page_header()
+{
+    $title = _("Change Project State");
+    slim_header($title);
+    echo "<h1>$title</h1>";
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/project_manager/project_quick_check.php
+++ b/tools/project_manager/project_quick_check.php
@@ -82,50 +82,20 @@ if (!$project->user_can_do_quick_check())
 
 // -----------------------------------------------------------------------------
 
-$results = array();
-foreach($test_functions as $function)
-{
-    $result[$function] = $function($projectid);
-}
+$results = get_pqc_test_results($projectid);
 
 echo "<h1>" . _("Result Summary") . "</h1>";
-echo "<table class='basic striped'>";
-echo "<tr>";
-echo "<th>" . _("Test") . "</th>";
-echo "<th>" . _("Status") . "</th>";
-echo "<th>" . _("Summary") . "</th>";
-echo "</tr>";
-foreach($test_functions as $function)
-{
-    echo "<tr>";
-    echo "<td>" . $result[$function]["name"] . "</td>";
-    echo "<td><a href='#$function'>" . $result[$function]["status"] . "</a></td>";
-    $css = get_css_for_status($result[$function]["status"]);
-    echo "<td $css>" . $result[$function]["summary"] . "</td>";
-    echo "</tr>";
-}
-echo "</table>";
+show_pqc_result_summary($results);
 
 echo "<h1>" . _("Result Details") . "</h1>";
-foreach($test_functions as $function)
+foreach($results as $function => $test_result)
 {
     echo "<a name='$function'></a>";
-    echo "<h2>" . $result[$function]["name"] . "</h2>";
-    $css = get_css_for_status($result[$function]["status"]);
-    echo "<p $css>" . sprintf(_("Status: %s"), $result[$function]["status"]) . "</p>";
-    echo "<p>" . $result[$function]["description"] . "</p>";
-    echo $result[$function]["details"];
-}
-
-function get_css_for_status($status)
-{
-    if($status == _("Warning"))
-        $css = "class='warning'";
-    elseif($status == _("Error"))
-        $css = "class='error'";
-    else
-        $css = '';
-    return $css;
+    echo "<h2>" . $test_result["name"] . "</h2>";
+    $css = get_css_for_pqc_status($test_result["status"]);
+    echo "<p $css>" . sprintf(_("Status: %s"), $test_result["status"]) . "</p>";
+    echo "<p>" . $test_result["description"] . "</p>";
+    echo $test_result["details"];
 }
 
 // vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
Prevent projects from transitioning from NEW to P1.unavailable if PQC finds any errors.

This therefore changes the Bad Bytes check to output 'Error' instead of 'Warning'. This does involve a fair amount of out and back again redirecting using encoded URLs within encoded URLs and there is a nominal maximum URL length of ~2k characters. I don't think we're getting close to this limit but it is something I worry about.

This is available in the [pqc-in-transition](https://www.pgdp.org/~cpeel/c.branch/pqc-in-transition/) sandbox.