### PR TITLE
Daily Page Limit Per Round

### DIFF
--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -286,13 +286,35 @@ class LPage
         $this->reverting_to_orig = 0;
     }
 
-    function saveAsDone($text_data,$pguser)
+    function attemptSaveAsDone($text_data,$pguser)
+    // Return an array containing two values:
+    // a boolean indicating whether the page was saved,
+    // and a boolean indicating whether user has reached the round's daily page limit.
+    //
+    // (Note that (FALSE, FALSE) is currently impossible:
+    // if this function says that the page was not saved,
+    // it can only be because the user already reached the DPL.)
     {
+        if ($this->round->has_a_daily_page_limit())
+        {
+            $pre_save_dpl_count = $this->round->get_dpl_count_for_user($pguser);
+            if ($pre_save_dpl_count >= $this->round->daily_page_limit)
+                // The user has already reached their limit of this kind of page.
+                return array(FALSE, TRUE);
+        }
+
         $this->page_state =
             Page_saveAsDone( $this->projectid, $this->imagefile, $this->round, $pguser, $text_data );
 
         // add to user page count
         page_tallies_add( $this->round->id, $pguser, +1 );
+
+        $dpl_has_now_been_reached = (
+            $this->round->has_a_daily_page_limit()
+            &&
+            ($pre_save_dpl_count + 1 >= $this->round->daily_page_limit)
+        );
+        return array(TRUE, $dpl_has_now_been_reached);
     }
 
     function returnToRound($pguser)

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -11,6 +11,7 @@ include_once($relPath.'page_tally.inc');
 include_once($relPath.'project_continuity.inc');
 include_once($relPath.'abort.inc');
 include_once($relPath.'maybe_mail.inc');
+include_once($relPath.'daily_page_limit.inc'); // get_dpl_count_for_user_in_round
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -297,7 +298,7 @@ class LPage
     {
         if ($this->round->has_a_daily_page_limit())
         {
-            $pre_save_dpl_count = $this->round->get_dpl_count_for_user($pguser);
+            $pre_save_dpl_count = get_dpl_count_for_user_in_round($pguser, $this->round);
             if ($pre_save_dpl_count >= $this->round->daily_page_limit)
                 // The user has already reached their limit of this kind of page.
                 return array(FALSE, TRUE);

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -197,15 +197,8 @@ class Round extends Stage
         $round_tallyboard = new TallyBoard($this->id, 'U');
 
         $user = new User($username);
-        $u_id = $user->u_id;
 
-        $current_tally = $round_tallyboard->get_current_tally($u_id);
-        $snapshot_info = $round_tallyboard->get_info_from_latest_snapshot($u_id);
-        $latest_snapshot_tally = $snapshot_info['tally_value'];
-        $tally_delta_since_snapshot = $current_tally - $latest_snapshot_tally;
-        // (Alternatively, could extract it from the result of 'get_vitals')
-
-        return $tally_delta_since_snapshot;
+        return $round_tallyboard->get_delta_since_latest_snapshot($user->u_id);
     }
 
     // -----------

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -187,20 +187,6 @@ class Round extends Stage
         return !is_null($this->daily_page_limit);
     }
 
-    // XXX This probably doesn't belong here, but I'm not sure where it does.
-    function get_dpl_count_for_user($username)
-    // The current "dpl count" for a user (in a given round)
-    // is the delta in their page-tally for that round
-    // since the last snapshot.
-    // (i.e., the net number of save-as-dones in that round today.)
-    {
-        $round_tallyboard = new TallyBoard($this->id, 'U');
-
-        $user = new User($username);
-
-        return $round_tallyboard->get_delta_since_latest_snapshot($user->u_id);
-    }
-
     // -----------
 
     function get_honorific_for_page_tally( $page_tally )

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -53,6 +53,10 @@ class Round extends Stage
             // See pinc/ProofreadingToolbox.inc for which tools are avaialble
             // and their names.
 
+        $daily_page_limit,
+            // This is either NULL (indicating no daily page limit for this round)
+            // or a non-negative (though likely positive) integer.
+
         $other_rounds_with_visible_usernames,
             // An array of round_ids.
             // If user X worked on a page in this round, they can see the
@@ -87,6 +91,7 @@ class Round extends Stage
         $this->round_number       = $n_rounds;
 
         $this->pi_tools = $pi_tools;
+        $this->daily_page_limit = $daily_page_limit;
         $this->other_rounds_with_visible_usernames = $other_rounds_with_visible_usernames;
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
@@ -174,6 +179,36 @@ class Round extends Stage
 
     function is_a_mentee_round() { return !is_null($this->mentor_round); }
     function is_a_mentor_round() { return !is_null($this->mentee_round); }
+
+    // -----------
+
+    function has_a_daily_page_limit()
+    {
+        return !is_null($this->daily_page_limit);
+    }
+
+    // XXX This probably doesn't belong here, but I'm not sure where it does.
+    function get_dpl_count_for_user($username)
+    // The current "dpl count" for a user (in a given round)
+    // is the delta in their page-tally for that round
+    // since the last snapshot.
+    // (i.e., the net number of save-as-dones in that round today.)
+    {
+        $round_tallyboard = new TallyBoard($this->id, 'U');
+
+        $user = new User($username);
+        $u_id = $user->u_id;
+
+        $current_tally = $round_tallyboard->get_current_tally($u_id);
+        $snapshot_info = $round_tallyboard->get_info_from_latest_snapshot($u_id);
+        $latest_snapshot_tally = $snapshot_info['tally_value'];
+        $tally_delta_since_snapshot = $current_tally - $latest_snapshot_tally;
+        // (Alternatively, could extract it from the result of 'get_vitals')
+
+        return $tally_delta_since_snapshot;
+    }
+
+    // -----------
 
     function get_honorific_for_page_tally( $page_tally )
     {

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -629,6 +629,14 @@ class TallyBoard
 
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+    function get_delta_since_latest_snapshot( $holder_id )
+    {
+        $current_tally = $this->get_current_tally($holder_id);
+        $snapshot_info = $this->get_info_from_latest_snapshot($holder_id);
+        $latest_snapshot_tally = $snapshot_info['tally_value'];
+        return ($current_tally - $latest_snapshot_tally);
+    }
+
     function get_vitals( $holder_id )
     // Return an object whose members are various useful quantities
     // from this tallyboard for the given holder.

--- a/pinc/daily_page_limit.inc
+++ b/pinc/daily_page_limit.inc
@@ -1,4 +1,26 @@
 <?php
+
+// This include file is dedicated to the "Daily Page Limit" (DPL) feature:
+// each round can optionally impose a daily limit on the 
+// number of pages that each user can save-as-done in a server day.
+//
+// (More precisely, the limit is on the *net* number of pages saved-as-done;
+// reopens and clears decrement the count. This is the same quantity tracked
+// by the page-tally system, so we just consult it for the user's "dpl count".)
+
+// There's only one function here because the rest of the implementation
+// of the feature fits fairly well elsewhere.
+//
+// Limits are set in invocations of the Round constructor in stages.inc.
+//
+// Limits are consulted and imposed at 2 points:
+// - on the project page:
+//   See decide_blurbs() in project.php.
+//
+// - in the proofing interface:
+//   See LPage::attemptSaveAsDone() in LPage.inc
+//   and PPage::attempt_to_save_as_done() in PPage.inc
+
 include_once($relPath.'User.inc');
 include_once($relPath.'TallyBoard.inc');
 

--- a/pinc/daily_page_limit.inc
+++ b/pinc/daily_page_limit.inc
@@ -1,0 +1,18 @@
+<?php
+include_once($relPath.'User.inc');
+include_once($relPath.'TallyBoard.inc');
+
+function get_dpl_count_for_user_in_round($username, $round)
+// The current "dpl count" for a user in a given round
+// is the delta in their page-tally for that round
+// since the last snapshot.
+// (i.e., the net number of save-as-dones in that round today.)
+{
+    $user = new User($username);
+
+    $round_tallyboard = new TallyBoard($round->id, 'U');
+
+    return $round_tallyboard->get_delta_since_latest_snapshot($user->u_id);
+}
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -92,6 +92,7 @@ new Round(
         1 => '#FFF8DC', // cornsilk
     ),
     $pi_tools_for_P,
+    NULL, /* daily_page_limit */
     array(),
     array(
              0 => _('Novice'),
@@ -136,6 +137,7 @@ new Round(
         1 => '#FFF8DC', // cornsilk
     ),
     $pi_tools_for_P,
+    NULL, /* daily_page_limit */
     array( 'P1' ),
     array(
              0 => _('Precise Proofreader'),
@@ -180,6 +182,7 @@ new Round(
         1 => '#D8BFD8', // thistle
     ),
     $pi_tools_for_P,
+    NULL, /* daily_page_limit */
     array( 'P1', 'P2' ),
     array(
              0 => _('Specialist Proofreader'),
@@ -224,6 +227,7 @@ new Round(
         1 => '#FFF8DC', // cornsilk
     ),
     $pi_tools_for_F,
+    NULL, /* daily_page_limit */
     array(),
     array(
              0 => _('Formatting Neophyte'),
@@ -268,6 +272,7 @@ new Round(
         1 => '#D8BFD8', // thistle
     ),
     $pi_tools_for_F,
+    NULL, /* daily_page_limit */
     array( 'F1' ),
     array(
              0 => _('Refurbisher of Texts'),

--- a/project.php
+++ b/project.php
@@ -267,10 +267,10 @@ function decide_blurbs()
                 $round->daily_page_limit
             );
         }
-        else
+        elseif ($user_dpl_count >= 0.9 * $round->daily_page_limit)
         {
             // User hasn't reached this round's DPL,
-            // but they should be warned that there *is* a DPL for this round?
+            // but they should be warned that there *is* a DPL for this round.
             $msg = sprintf(
                 _("Warning: This project contributes to the '%s' limit of %d page-saves per day. Since server midnight, your current count is <b>%d</b>."),
                 $round->id,
@@ -278,6 +278,11 @@ function decide_blurbs()
                 $user_dpl_count
             );
             $page_limit_warning = "<br>\n$msg\n";
+        }
+        else
+        {
+            // They're not that close to reaching the DPL,
+            // so don't bother warning them about it.
         }
     }
     if ($blocked_by_limit_message)

--- a/project.php
+++ b/project.php
@@ -260,11 +260,12 @@ function decide_blurbs()
         if ($user_dpl_count >= $round->daily_page_limit)
         {
             // User has reached this round's DPL.
-            $blocked_by_limit_message = sprintf(
+            $msg = sprintf(
                 _("This project contributes to the '%s' limit of %d page-saves per day, and you have already reached that limit today."),
                 $round->id,
                 $round->daily_page_limit
             );
+            $blocked_by_limit_message = "<span class='warning'>$msg</span>";
             return array($blocked_by_limit_message, $blocked_by_limit_message);
         }
         elseif ($user_dpl_count >= 0.9 * $round->daily_page_limit)
@@ -272,12 +273,12 @@ function decide_blurbs()
             // User hasn't reached this round's DPL,
             // but they should be warned that there *is* a DPL for this round.
             $msg = sprintf(
-                _("Warning: This project contributes to the '%s' limit of %d page-saves per day. Since server midnight, your current count is <b>%d</b>."),
+                _("This project contributes to the '%s' limit of %d page-saves per day. Since server midnight, your current count is <b>%d</b>."),
                 $round->id,
                 $round->daily_page_limit,
                 $user_dpl_count
             );
-            $page_limit_warning = "<br>\n$msg\n";
+            $page_limit_warning = "<br>\n<span class='warning'>$msg</span>\n";
         }
         else
         {

--- a/project.php
+++ b/project.php
@@ -253,7 +253,6 @@ function decide_blurbs()
     // but we also want to produce a warning (when the project is covered by a DPL)
     // even when the user *isn't* blocked, which you can't really expect of that function.
     //
-    $blocked_by_limit_message = "";
     $page_limit_warning = "";
     if ($round->has_a_daily_page_limit())
     {
@@ -266,6 +265,7 @@ function decide_blurbs()
                 $round->id,
                 $round->daily_page_limit
             );
+            return array($blocked_by_limit_message, $blocked_by_limit_message);
         }
         elseif ($user_dpl_count >= 0.9 * $round->daily_page_limit)
         {
@@ -284,10 +284,6 @@ function decide_blurbs()
             // They're not that close to reaching the DPL,
             // so don't bother warning them about it.
         }
-    }
-    if ($blocked_by_limit_message)
-    {
-        return array($blocked_by_limit_message, $blocked_by_limit_message);
     }
 
     {

--- a/project.php
+++ b/project.php
@@ -261,7 +261,7 @@ function decide_blurbs()
         {
             // User has reached this round's DPL.
             $msg = sprintf(
-                _("This project contributes to the '%s' limit of %d page-saves per day, and you have already reached that limit today."),
+                _('%1$s limits you to %2$d page-saves per day, and you have already reached that limit today.'),
                 $round->id,
                 $round->daily_page_limit
             );
@@ -273,9 +273,9 @@ function decide_blurbs()
             // User hasn't reached this round's DPL,
             // but they should be warned that there *is* a DPL for this round.
             $msg = sprintf(
-                _("This project contributes to the '%s' limit of %d page-saves per day. Since server midnight, your current count is <b>%d</b>."),
-                $round->id,
+                _('You may save up to %1$d pages in %2$s before server midnight. Your current count is <b>%3$d</b>.'),
                 $round->daily_page_limit,
+                $round->id,
                 $user_dpl_count
             );
             $page_limit_warning = "<br>\n<span class='warning'>$msg</span>\n";

--- a/project.php
+++ b/project.php
@@ -22,6 +22,7 @@ include_once($relPath.'project_edit.inc'); // check_user_can_load_projects
 include_once($relPath.'forum_interface.inc'); // get_last_post_time_in_topic & get_url_*()
 include_once($relPath.'misc.inc'); // html_safe(), get_enumerated_param(), get_integer_param(), array_get(), humanize_bytes()
 include_once($relPath.'faq.inc');
+include_once($relPath.'daily_page_limit.inc'); // get_dpl_count_for_user_in_round
 
 // If the requestor is not logged in, we refer to them as a "guest".
 
@@ -256,7 +257,7 @@ function decide_blurbs()
     $page_limit_warning = "";
     if ($round->has_a_daily_page_limit())
     {
-        $user_dpl_count = $round->get_dpl_count_for_user($pguser);
+        $user_dpl_count = get_dpl_count_for_user_in_round($pguser, $round);
         if ($user_dpl_count >= $round->daily_page_limit)
         {
             // User has reached this round's DPL.

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -260,6 +260,84 @@ class PPage
 
     // -------------------------------------------------------------------------
 
+    function attempt_to_save_as_done($text_data)
+    // This is only an attempt, because a daily page limit might block the save,
+    // or prevent further saves.
+    // If there's a problem, this function does not return to the caller.
+    {
+        global $code_url, $pguser;
+
+        $projectid = $this->lpage->projectid;
+        $round = $this->lpage->round;
+
+        list($saved, $dpl_reached) = $this->attemptSaveAsDone($text_data, $pguser);
+
+        if (!$dpl_reached)
+        {
+            assert($saved);
+            return; // to let the caller do the appropriate normal thing
+        }
+
+        assert($dpl_reached);
+
+        if ($saved)
+        {
+            $title = _("Saved, but at limit");
+            $sentence = sprintf(
+                _("Your page has been saved as 'Done'. However, you have now reached the daily page limit for %s."),
+                $round->id
+            );
+        }
+        else
+        {
+            $this->saveAsInProgress($text_data, $pguser);
+            $title = _("Already at limit");
+            $sentence = sprintf(
+                _("Your page was saved as 'In Progress' rather than 'Done', because you have already reached the daily page limit for %s."),
+                $round->id
+            );
+        }
+
+        slim_header( $title );
+
+        echo "<p>$sentence</p>\n";
+        
+        echo "<p>"
+            . sprintf(
+                _("You will not be allowed to save any more pages in %s until the next server midnight."),
+                $round->id
+              )
+            . "</p>\n";
+
+        echo "<ul>\n"
+            .   "<li>"
+            .     sprintf(
+                    _("Return to the <a %s>project page</a>"),
+                    "href='$code_url/project.php?id=$projectid' target='_top'"
+                  )
+            .   "</li>\n"
+            .   "<li>"
+            .     sprintf(
+                    _("Return to <a %s>round %s</a>"),
+                    "href='round.php?round_id={$round->id}' target='_top'",
+                    $round->id
+                  )
+            .   "</li>\n"
+            .   "<li>"
+            .     sprintf(
+                    _("Return to the <a %s>Activity Hub</a>."),
+                    "href='$code_url/activity_hub.php' target='_top'"
+                  )
+            .   "</li>\n"
+            . "</ul>\n"
+            ;
+
+        // Do not return to caller.
+        exit;
+    }
+
+    // -------------------------------------------------------------------------
+
     // The remaining functions just delegate to $this->lpage...
 
     function revertToOriginal()

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -304,7 +304,7 @@ class PPage
         
         echo "<p>"
             . sprintf(
-                _("You will not be allowed to save any more pages in %s until the next server midnight."),
+                _("You will be able to save more pages in %s after server midnight."),
                 $round->id
               )
             . "</p>\n";

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -287,9 +287,9 @@ class PPage
         $this->lpage->saveAsInProgress( $page_text, $user );
     }
 
-    function saveAsDone( $page_text, $user )
+    function attemptSaveAsDone( $page_text, $user )
     {
-        $this->lpage->saveAsDone( $page_text, $user );
+        return $this->lpage->attemptSaveAsDone( $page_text, $user );
     }
 
     function can_be_reverted_to_last_save()

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -357,7 +357,7 @@ function attempt_to_save_as_done($ppage, $text_data, $and_do_another)
     echo "<ul>\n"
         .   "<li>"
         .     sprintf(
-                _("Return to <a %s>the Project Page</a>"),
+                _("Return to the <a %s>project page</a>"),
                 "href='$code_url/project.php?id=$projectid' target='_top'"
               )
         .   "</li>\n"
@@ -370,7 +370,7 @@ function attempt_to_save_as_done($ppage, $text_data, $and_do_another)
         .   "</li>\n"
         .   "<li>"
         .     sprintf(
-                _("Return to <a %s>the Activity Hub</a>"),
+                _("Return to the <a %s>Activity Hub</a>."),
                 "href='$code_url/activity_hub.php' target='_top'"
               )
         .   "</li>\n"

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -123,13 +123,13 @@ switch( $tbutton )
         break;
 
     case B_SAVE_AND_DO_ANOTHER:
-        attempt_to_save_as_done($ppage, $text_data, TRUE);
+        attempt_to_save_as_done($ppage, $text_data);
         $url = $ppage->url_for_do_another_page();
         metarefresh(1,$url,_("Save as 'Done' & Proofread Next Page"),_("Page Saved."));
         break;
 
     case B_SAVE_AND_QUIT:
-        attempt_to_save_as_done($ppage, $text_data, FALSE);
+        attempt_to_save_as_done($ppage, $text_data);
         leave_proofing_interface( _("Save as 'Done'") );
         break;
 
@@ -229,7 +229,7 @@ switch( $tbutton )
             $_POST["projectid"],$ppage->lpage->round->id,$page,$pguser,$accepted_words,array());
 
         // 2. Save the current page as done
-        attempt_to_save_as_done($ppage, $correct_text, TRUE);
+        attempt_to_save_as_done($ppage, $correct_text);
 
         // Redirect to the next available page
         $url = $ppage->url_for_do_another_page();
@@ -306,7 +306,7 @@ function leave_spellcheck_mode( $ppage )
     }
 }
 
-function attempt_to_save_as_done($ppage, $text_data, $and_do_another)
+function attempt_to_save_as_done($ppage, $text_data)
 // This is only an attempt, because a daily page limit might block the save,
 // or prevent further saves.
 // If there's a problem, this function does not return to the caller.

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -377,8 +377,7 @@ function attempt_to_save_as_done($ppage, $text_data, $and_do_another)
         . "</ul>\n"
         ;
 
-    slim_footer();
-
+    // Do not return to caller.
     exit;
 }
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -123,13 +123,13 @@ switch( $tbutton )
         break;
 
     case B_SAVE_AND_DO_ANOTHER:
-        attempt_to_save_as_done($ppage, $text_data);
+        $ppage->attempt_to_save_as_done($text_data);
         $url = $ppage->url_for_do_another_page();
         metarefresh(1,$url,_("Save as 'Done' & Proofread Next Page"),_("Page Saved."));
         break;
 
     case B_SAVE_AND_QUIT:
-        attempt_to_save_as_done($ppage, $text_data);
+        $ppage->attempt_to_save_as_done($text_data);
         leave_proofing_interface( _("Save as 'Done'") );
         break;
 
@@ -229,7 +229,7 @@ switch( $tbutton )
             $_POST["projectid"],$ppage->lpage->round->id,$page,$pguser,$accepted_words,array());
 
         // 2. Save the current page as done
-        attempt_to_save_as_done($ppage, $correct_text);
+        $ppage->attempt_to_save_as_done($correct_text);
 
         // Redirect to the next available page
         $url = $ppage->url_for_do_another_page();
@@ -304,82 +304,6 @@ function leave_spellcheck_mode( $ppage )
         // So generate the (normal-mode) image-and-text doc of the enh interface.
         echo_proof_frame($ppage);
     }
-}
-
-function attempt_to_save_as_done($ppage, $text_data)
-// This is only an attempt, because a daily page limit might block the save,
-// or prevent further saves.
-// If there's a problem, this function does not return to the caller.
-{
-    global $code_url, $pguser;
-
-    $projectid = $ppage->lpage->projectid;
-    $round = $ppage->lpage->round;
-
-    list($saved, $dpl_reached) = $ppage->attemptSaveAsDone($text_data, $pguser);
-
-    if (!$dpl_reached)
-    {
-        assert($saved);
-        return; // to let the caller do the appropriate normal thing
-    }
-
-    assert($dpl_reached);
-
-    if ($saved)
-    {
-        $title = _("Saved, but at limit");
-        $sentence = sprintf(
-            _("Your page has been saved as 'Done'. However, you have now reached the daily page limit for %s."),
-            $round->id
-        );
-    }
-    else
-    {
-        $ppage->saveAsInProgress($text_data, $pguser);
-        $title = _("Already at limit");
-        $sentence = sprintf(
-            _("Your page was saved as 'In Progress' rather than 'Done', because you have already reached the daily page limit for %s."),
-            $round->id
-        );
-    }
-
-    slim_header( $title );
-
-    echo "<p>$sentence</p>\n";
-    
-    echo "<p>"
-        . sprintf(
-            _("You will not be allowed to save any more pages in %s until the next server midnight."),
-            $round->id
-          )
-        . "</p>\n";
-
-    echo "<ul>\n"
-        .   "<li>"
-        .     sprintf(
-                _("Return to the <a %s>project page</a>"),
-                "href='$code_url/project.php?id=$projectid' target='_top'"
-              )
-        .   "</li>\n"
-        .   "<li>"
-        .     sprintf(
-                _("Return to <a %s>round %s</a>"),
-                "href='round.php?round_id={$round->id}' target='_top'",
-                $round->id
-              )
-        .   "</li>\n"
-        .   "<li>"
-        .     sprintf(
-                _("Return to the <a %s>Activity Hub</a>."),
-                "href='$code_url/activity_hub.php' target='_top'"
-              )
-        .   "</li>\n"
-        . "</ul>\n"
-        ;
-
-    // Do not return to caller.
-    exit;
 }
 
 function leave_proofing_interface( $title )

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -311,9 +311,10 @@ function attempt_to_save_as_done($ppage, $text_data, $and_do_another)
 // or prevent further saves.
 // If there's a problem, this function does not return to the caller.
 {
-    global $code_url, $pguser, $projectid, $proj_state;
+    global $code_url, $pguser;
 
-    $round = get_Round_for_project_state($proj_state);
+    $projectid = $ppage->lpage->projectid;
+    $round = $ppage->lpage->round;
 
     list($saved, $dpl_reached) = $ppage->attemptSaveAsDone($text_data, $pguser);
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -123,13 +123,13 @@ switch( $tbutton )
         break;
 
     case B_SAVE_AND_DO_ANOTHER:
-        $ppage->saveAsDone($text_data,$pguser);
+        attempt_to_save_as_done($ppage, $text_data, TRUE);
         $url = $ppage->url_for_do_another_page();
         metarefresh(1,$url,_("Save as 'Done' & Proofread Next Page"),_("Page Saved."));
         break;
 
     case B_SAVE_AND_QUIT:
-        $ppage->saveAsDone($text_data,$pguser);
+        attempt_to_save_as_done($ppage, $text_data, FALSE);
         leave_proofing_interface( _("Save as 'Done'") );
         break;
 
@@ -229,7 +229,7 @@ switch( $tbutton )
             $_POST["projectid"],$ppage->lpage->round->id,$page,$pguser,$accepted_words,array());
 
         // 2. Save the current page as done
-        $ppage->saveAsDone($correct_text, $pguser);
+        attempt_to_save_as_done($ppage, $correct_text, TRUE);
 
         // Redirect to the next available page
         $url = $ppage->url_for_do_another_page();
@@ -304,6 +304,82 @@ function leave_spellcheck_mode( $ppage )
         // So generate the (normal-mode) image-and-text doc of the enh interface.
         echo_proof_frame($ppage);
     }
+}
+
+function attempt_to_save_as_done($ppage, $text_data, $and_do_another)
+// This is only an attempt, because a daily page limit might block the save,
+// or prevent further saves.
+// If there's a problem, this function does not return to the caller.
+{
+    global $code_url, $pguser, $projectid, $proj_state;
+
+    $round = get_Round_for_project_state($proj_state);
+
+    list($saved, $dpl_reached) = $ppage->attemptSaveAsDone($text_data, $pguser);
+
+    if (!$dpl_reached)
+    {
+        assert($saved);
+        return; // to let the caller do the appropriate normal thing
+    }
+
+    assert($dpl_reached);
+
+    if ($saved)
+    {
+        $title = _("Saved, but at limit");
+        $sentence = sprintf(
+            _("Your page has been saved as 'Done'. However, you have now reached the daily page limit for %s."),
+            $round->id
+        );
+    }
+    else
+    {
+        $ppage->saveAsInProgress($text_data, $pguser);
+        $title = _("Already at limit");
+        $sentence = sprintf(
+            _("Your page was saved as 'In Progress' rather than 'Done', because you have already reached the daily page limit for %s."),
+            $round->id
+        );
+    }
+
+    slim_header( $title );
+
+    echo "<p>$sentence</p>\n";
+    
+    echo "<p>"
+        . sprintf(
+            _("You will not be allowed to save any more pages in %s until the next server midnight."),
+            $round->id
+          )
+        . "</p>\n";
+
+    echo "<ul>\n"
+        .   "<li>"
+        .     sprintf(
+                _("Return to <a %s>the Project Page</a>"),
+                "href='$code_url/project.php?id=$projectid' target='_top'"
+              )
+        .   "</li>\n"
+        .   "<li>"
+        .     sprintf(
+                _("Return to <a %s>round %s</a>"),
+                "href='round.php?round_id={$round->id}' target='_top'",
+                $round->id
+              )
+        .   "</li>\n"
+        .   "<li>"
+        .     sprintf(
+                _("Return to <a %s>the Activity Hub</a>"),
+                "href='$code_url/activity_hub.php' target='_top'"
+              )
+        .   "</li>\n"
+        . "</ul>\n"
+        ;
+
+    slim_footer();
+
+    exit;
 }
 
 function leave_proofing_interface( $title )


### PR DESCRIPTION
Each round optionally gets a daily limit on the (net) number of pages saved-as-done in that round.

This is a simplified version of PR #204. There, each DPL defines the set of projects that it applies to, based on any project properties; here, the only option is for a DPL to apply to all the projects of a round. So the 'back-end' is simplified, but the 'front-end' is, in practice, pretty much identical.

The messages to the user could probably be made shorter. I'll leave it to the reviewers to suggest specific wording.