### PR TITLE
Validate pickersets

### DIFF
--- a/SETUP/lint_charsuites.php
+++ b/SETUP/lint_charsuites.php
@@ -6,6 +6,8 @@ include_once($relPath."CharSuites.inc");
 foreach(CharSuites::get_all() as $charsuite)
 {
     echo "Validating charsuite $charsuite->name...\n";
+
+    // Validate that the character suite only contains normalized codepoints
     $nonnormalized_codepoints = $charsuite->get_nonnormalized_codepoints();
     if($nonnormalized_codepoints)
     {
@@ -15,5 +17,24 @@ foreach(CharSuites::get_all() as $charsuite)
             echo sprintf("    %s normalized is %s\n", $orig, $norm);
         }
         exit(1);
+    }
+
+    // Validate pickersets only contain characters within the suite
+    foreach($charsuite->pickerset->get_subsets() as $title => $picker_subset)
+    {
+        foreach($picker_subset as $codepoints)
+        {
+            $string = implode("", convert_codepoint_ranges_to_characters($codepoints));
+            $invalid_chars = get_invalid_characters($string, $charsuite->codepoints);
+            if($invalid_chars)
+            {
+                echo "ERROR: pickerset $title has codepoints not in charsuite:\n";
+                foreach($invalid_chars as $char => $count)
+                {
+                    echo sprintf("    %s: %s\n", $char, utf8_chr_to_hex($char));
+                }
+                exit(1);
+            }
+        }
     }
 }

--- a/pinc/charsuite-extended-european-latin.inc
+++ b/pinc/charsuite-extended-european-latin.inc
@@ -29,9 +29,9 @@ $pickerset->add_subset(utf8_chr("\u011C"), [
 # L-O with diacriticals
 $pickerset->add_subset(utf8_chr("\u0139"), [
     [ 'U+0139', 'U+013b', 'U+013d', 'U+013f', 'U+0141', 'U+0143', 'U+0145',
-      'U+0147', 'U+0149', 'U+014a', 'U+014c', 'U+014e', 'U+0150', 'U+0152'  ],
+      'U+0147', 'U+014a', 'U+014c', 'U+014e', 'U+0150', 'U+0152'  ],
     [ 'U+013a', 'U+013c', 'U+013e', 'U+0140', 'U+0142', 'U+0144', 'U+0146',
-      'U+0148', 'U+014a', 'U+014b', 'U+014d', 'U+014f', 'U+0151', 'U+0153' ],
+      'U+0148', 'U+014b', 'U+014d', 'U+014f', 'U+0151', 'U+0153' ],
 ]);
 # R-T with diacriticals
 $pickerset->add_subset(utf8_chr("\u0154"), [


### PR DESCRIPTION
Tony Browne discovered that we had a deprecated character in the Extended Latin pickerset. Worst yet we didn't have it in the character suite! This removes it and adds validation to ensure pickersets only contain characters within the character suite.

I confirmed this correctly failed before I fixed the Extended Latin charsuite.