### PR TITLE
Further WordCheck updates for Unicode

### DIFF
--- a/SETUP/tests/UnicodeTest.php
+++ b/SETUP/tests/UnicodeTest.php
@@ -170,4 +170,18 @@ class UnicodeTests extends PHPUnit\Framework\TestCase
         $invalid_chars = get_invalid_characters($string, $this->a_to_z_codepoints);
         $this->assertEquals($chars, $invalid_chars);
     }
+
+    public function testUtf8CharScript()
+    {
+        $char = 'a';
+        $script = utf8_char_script($char);
+        $this->assertEquals('Latin', $script);
+    }
+
+    public function testUtf8StringScripts()
+    {
+        $string = 'a.';
+        $scripts = utf8_string_scripts($string);
+        $this->assertEquals(['Latin', 'Common'], $scripts);
+    }
 }

--- a/SETUP/tests/pinc_WordCheckEngineTest.php
+++ b/SETUP/tests/pinc_WordCheckEngineTest.php
@@ -23,6 +23,8 @@ N̈oon
 
 Γreat
 
+b[oe]uf
+
 EOTEXT;
 
     protected function setUp()
@@ -80,6 +82,14 @@ EOTEXT;
         $this->assertEquals($words["words"], 1 * $array_size);
     }
 
+    public function testGetBadWordsWithDiacriticalMarkup()
+    {
+        $words = get_distinct_words_in_text($this->TEXT1);
+        $bad_words = get_bad_words_with_diacritical_markup($words);
+        $this->assertEquals(count($bad_words), 1);
+        $this->assertEquals($bad_words[0], "b[oe]uf");
+    }
+
     public function testGetBadWordsViaPattern()
     {
         $languages = [ "English" ];
@@ -106,8 +116,9 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 3);
+        $this->assertEquals(count($bad_words), 4);
         $this->assertEquals($bad_words["Snelling"], WC_WORLD);
+        $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
         $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
@@ -118,7 +129,7 @@ EOTEXT;
 
         $word_lists = [
             "site_bad" => [ "disembarked" ],
-            "site_good" =>  [ "Snelling" ],
+            "site_good" =>  [ "Snelling", "b[oe]uf" ],
         ];
 
         list($input_words_w_freq, $bad_words, $messages) =
@@ -144,7 +155,8 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 3);
+        $this->assertEquals(count($bad_words), 4);
+        $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["disembarked"], WC_PROJECT);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
         $this->assertEquals($bad_words["Γreat"], WC_SITE);
@@ -164,7 +176,8 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 4);
+        $this->assertEquals(count($bad_words), 5);
+        $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["disembarked"], WC_SITE);
         $this->assertEquals($bad_words["opposite"], WC_PROJECT);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
@@ -183,7 +196,8 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 2);
+        $this->assertEquals(count($bad_words), 3);
+        $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
         $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }

--- a/SETUP/tests/pinc_WordCheckEngineTest.php
+++ b/SETUP/tests/pinc_WordCheckEngineTest.php
@@ -19,6 +19,8 @@ about the great transformation.
 
 a1l 1st 33rd
 
+N̈oon
+
 EOTEXT;
 
     protected function setUp()
@@ -33,6 +35,7 @@ EOTEXT;
         $words = get_all_words_in_text($this->TEXT1);
         $this->assertEquals($words[0], "Not");
         $this->assertEquals($words[89], "words");
+        $this->assertEquals($words[93], "N̈oon");
     }
 
     public function testGetAllWordsInTextWithOffsets()

--- a/SETUP/tests/pinc_WordCheckEngineTest.php
+++ b/SETUP/tests/pinc_WordCheckEngineTest.php
@@ -21,6 +21,8 @@ a1l 1st 33rd
 
 N̈oon
 
+Γreat
+
 EOTEXT;
 
     protected function setUp()
@@ -88,6 +90,14 @@ EOTEXT;
         $this->assertEquals($bad_words[0], "a1l");
     }
 
+    public function testGetBadWordsWithMultiScripts()
+    {
+        $words = get_distinct_words_in_text($this->TEXT1);
+        $bad_words = get_bad_words_with_multi_scripts($words);
+        $this->assertEquals(count($bad_words), 1);
+        $this->assertEquals($bad_words[0], "Γreat");
+    }
+
     public function testGetBadWordsForTextNoWordLists()
     {
         $languages = [ "English" ];
@@ -96,9 +106,10 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 2);
+        $this->assertEquals(count($bad_words), 3);
         $this->assertEquals($bad_words["Snelling"], WC_WORLD);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
+        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextSiteWordList()
@@ -114,9 +125,10 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 2);
+        $this->assertEquals(count($bad_words), 3);
         $this->assertEquals($bad_words["disembarked"], WC_SITE);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
+        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextProjectWordList()
@@ -132,9 +144,10 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 2);
+        $this->assertEquals(count($bad_words), 3);
         $this->assertEquals($bad_words["disembarked"], WC_PROJECT);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
+        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextSiteAndProjectWordList()
@@ -151,10 +164,11 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 3);
+        $this->assertEquals(count($bad_words), 4);
         $this->assertEquals($bad_words["disembarked"], WC_SITE);
         $this->assertEquals($bad_words["opposite"], WC_PROJECT);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
+        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextAdhocWordList()
@@ -169,7 +183,8 @@ EOTEXT;
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 1);
+        $this->assertEquals(count($bad_words), 2);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
+        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 }

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -666,6 +666,9 @@ function get_normalize_page_text_changes($text, $projectid)
         $text = utf8_str_replace(utf8_bom(), '', $text);
     }
 
+    # normalize UTF-8 string
+    $text = utf8_normalize($text);
+
     $invalid_chars = get_invalid_characters($text, $project->get_valid_codepoints());
     if($invalid_chars)
     {

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -24,6 +24,46 @@ function utf8_combined_chr($codepoint)
     return implode('', array_map('utf8_chr', $codepoints));
 }
 
+# Given a character, return the Unicode script it belongs to
+function utf8_char_script($char)
+{
+    $enum = IntlChar::getIntPropertyValue($char, IntlChar::PROPERTY_SCRIPT);
+    return IntlChar::getPropertyValueName(IntlChar::PROPERTY_SCRIPT, $enum);
+}
+
+# Given a string, return an array of Unicode scripts used within the string.
+function utf8_string_scripts($string)
+{
+    $scripts = [];
+
+    // Reduce the string completely, or after 20 iterations in case PHP's
+    // PREG library doesn't have the complete set of Unicode scripts.
+    // Most strings will be through here in only as many Unicode scripts it
+    // contains, usually just one or two.
+    for($i = 0; $i < 20; $i++)
+    {
+        if(strlen($string) == 0)
+            break;
+
+        $char = utf8_substr($string, 0, 1);
+        $script_name = utf8_char_script($char);
+        $scripts[] = $script_name;
+        $string = preg_replace("/\p{".$script_name."}/u", "", $string);
+    }
+
+    // Fall back to character by character to make sure we have everything.
+    // Most cases will skip this.
+    if($string)
+    {
+        foreach(utf8_split($string) as $char)
+        {
+            $scripts[] = utf8_char_script($char);
+        }
+    }
+
+    return array_unique($scripts);
+}
+
 # Get codepoints that are not normalized.
 # Returns an associative array where the key is the nonnormalized codepoint
 # and the value is the normalized version. If all codepoints are normalized

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -15,7 +15,7 @@ $mark = '[=:.`\\\\\'/v)(~,^\\\\\*]'; // pattern for: diacritical mark
 $bracketed_character_pattern = "\\[(?:oe|OE|$mark$base|$base$mark)\\]";
 
 // This is used when splitting a text into words.
-$char_pattern = "(?:\w|$bracketed_character_pattern)";
+$char_pattern = "(?:\w\pM*|$bracketed_character_pattern)";
 $word_pattern = "!$char_pattern+(?:'$char_pattern+)*!uS";
 // (The pattern is delimited by exclamation marks rather than the usual slashes,
 // because slash is a character within the pattern.)

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -162,6 +162,9 @@ function get_bad_words_for_text($text, $languages, $word_lists=[])
 
         $acc->add_bad_words(
             get_bad_words_via_pattern($input_words_w_freq, $languages), WC_SITE);
+
+        $acc->add_bad_words(
+            get_bad_words_with_multi_scripts($input_words_w_freq), WC_SITE);
     }
 
     // The project
@@ -339,6 +342,11 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
         }
     }
 
+    // Finally, only return words that were in our original set. This ensures
+    // that aspell hasn't parsed words differently than we did and we then
+    // return partial words that aren't actually in the list.
+    $finalMisspellings = array_intersect($finalMisspellings, array_keys($input_words_w_freq));
+
     return array($finalMisspellings, $messages);
 }
 
@@ -391,6 +399,31 @@ function get_bad_words_via_pattern($input_words_w_freq, $languages)
     // placeholder for future patterns
 
     return $badWords;
+}
+
+// Return a list of "bad" words where characters within a word are not all
+// of the same Unicode script type. For instance, this detects words that
+// contain a mix of Latin and Cyrillic characters.
+// Arguments:
+//   input_words_w_freq - an array whose keys are the distinct words of the input text
+//
+// Returns:
+//       -- an array of bad words
+//
+function get_bad_words_with_multi_scripts($input_words_w_freq)
+{
+    $bad_words = [];
+
+    foreach($input_words_w_freq as $word => $freq)
+    {
+        $scripts = utf8_string_scripts($word);
+        if(count(array_diff($scripts, ["Common", "Inherited"])) > 1)
+        {
+            $bad_words[] = $word;
+        }
+    }
+
+    return $bad_words;
 }
 
 // -----------------------------------------------------------------------------

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -153,6 +153,9 @@ function get_bad_words_for_text($text, $languages, $word_lists=[])
             get_bad_words_via_external_checker($input_words_w_freq, $languages);
         $acc->messages += $messages;
         $acc->add_bad_words($external_bad_words, WC_WORLD);
+
+        $acc->add_bad_words(
+            get_bad_words_with_diacritical_markup($input_words_w_freq), WC_WORLD);
     }
 
     // The site
@@ -310,7 +313,24 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
     }
     unset($misspellings);
 
-    // Consider non-Latin-1 characters, which we represent with []-notations.
+    // Finally, only return words that were in our original set. This ensures
+    // that aspell hasn't parsed words differently than we did and we then
+    // return partial words that aren't actually in the list.
+    $finalMisspellings = array_intersect($finalMisspellings, array_keys($input_words_w_freq));
+
+    return array($finalMisspellings, $messages);
+}
+
+// Return all words containing diacritical markup
+// Arguments:
+//   input_words_w_freq - an array whose keys are the distinct words of the input text
+//
+// Returns:
+//       -- an array of bad words
+//
+function get_bad_words_with_diacritical_markup($input_words_w_freq)
+{
+    // Consider words that contain diacritical markup via []-notation.
     // For example, consider the oe ligature, which we represent as "[oe]",
     // and the words "b[oe]uf" (which we want the word-checker to not flag),
     // and "b[oe]ut", a scanno for the former (which we do want flagged).
@@ -321,10 +341,6 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
     // don't see 'oe' and 'uf' (or 'ut') as words, and won't ever ask if 'oe' or
     // 'uf' (or 'ut') are misspelled.
     //
-    // Note that aspell appears to have no way to represent non-Latin-1
-    // characters, so there's no way to transform "b[oe]uf" into something
-    // (distinct from just "boeuf") that it understands.
-    //
     // So we give up on aspell being any help with such words, and instead put
     // the burden on site-level and project-level word lists.
     //
@@ -334,20 +350,16 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
     // and put those in a bad word list. Instead, we simply mark *all* words
     // containing non-Latin-1 characters as bad at the world-level.
     //
+    $bad_words = [];
     foreach($input_words_w_freq as $word => $freq)
     {
         if(str_contains($word, '['))
         {
-            $finalMisspellings[] = $word;
+            $bad_words[] = $word;
         }
     }
 
-    // Finally, only return words that were in our original set. This ensures
-    // that aspell hasn't parsed words differently than we did and we then
-    // return partial words that aren't actually in the list.
-    $finalMisspellings = array_intersect($finalMisspellings, array_keys($input_words_w_freq));
-
-    return array($finalMisspellings, $messages);
+    return($bad_words);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
This implements two updates to WordCheck:
* Correctly parse words that contain combining characters. (oops)
* Detect if words contain a mix of Unicode script characters and if so, flag them as bad words.

I _really_ expected aspell to detect that second one, but no, it ignores them as "invalid words". Thanks aspell.

While I was here I broke out the diacritical markup flagging into its own function.

This is available in the [wc-multi-script](https://www.pgdp.org/~cpeel/c.branch/wc-multi-script) sandbox.