### PR TITLE
improve performance internet explorer

### DIFF
--- a/scripts/character_test.js
+++ b/scripts/character_test.js
@@ -13,7 +13,9 @@ var goodChar;
 $(function () {
     // need to define this after the page has loaded so validCharacterPattern
     // is available
-    goodChar = RegExp(validCharacterPattern, "u");
+    // need "u" flag if using astral plane but IE doesn't handle it
+    goodChar = RegExp(validCharacterPattern);
+    console.log(goodChar);
 });
 
 function testChar(character) {
@@ -22,7 +24,9 @@ function testChar(character) {
 
 // return false if text contains any bad characters
 function testText(text) {
-    text = text.normalize("NFC");
+    if("normalize" in String.prototype) {
+        text = text.normalize("NFC");
+    }
     let result;
     charMatch.lastIndex = 0;
     while(null != (result = charMatch.exec(text))) {

--- a/scripts/character_test.js
+++ b/scripts/character_test.js
@@ -13,18 +13,21 @@ var goodChar;
 $(function () {
     // need to define this after the page has loaded so validCharacterPattern
     // is available
-    // need "u" flag if using astral plane but IE doesn't handle it
-    goodChar = RegExp(validCharacterPattern);
-    console.log(goodChar);
+    goodChar = XRegExp(validCharacterPattern, "A");
 });
 
 function testChar(character) {
+    if(!goodChar) {
+        // IE HACK - IE sometimes says goodChar is undefined
+        goodChar = XRegExp(validCharacterPattern, "A");
+    }
     return goodChar.test(character);
 }
 
 // return false if text contains any bad characters
 function testText(text) {
-    if("normalize" in String.prototype) {
+    // IE HACK - IE11 does not support string normalization
+    if(String.prototype.normalize) {
         text = text.normalize("NFC");
     }
     let result;

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -47,7 +47,9 @@ $(function () {
 
     function _validateText() {
         var text = textArea.value;
-        text = text.normalize("NFC");
+        if("normalize" in String.prototype) {
+            text = text.normalize("NFC");
+        }
         // replace the text with normalised version
         textArea.value = text;
         // convert any markup so does not get interpreted in the checker div

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -47,7 +47,8 @@ $(function () {
 
     function _validateText() {
         var text = textArea.value;
-        if("normalize" in String.prototype) {
+        // IE HACK - IE11 does not support string normalization
+        if(String.prototype.normalize) {
             text = text.normalize("NFC");
         }
         // replace the text with normalised version

--- a/tools/proofers/process_diacritcal_markup.js
+++ b/tools/proofers/process_diacritcal_markup.js
@@ -77,6 +77,9 @@ $(function () {
                 maybeSubstitute();
                 return;
             }
+            if(!("normalize" in String.prototype)) {
+                return;
+            }
             let char1 = text[char1Index];
             let char2 = text[endIndex - 2];
             var code = above[char1];

--- a/tools/proofers/process_diacritcal_markup.js
+++ b/tools/proofers/process_diacritcal_markup.js
@@ -77,7 +77,8 @@ $(function () {
                 maybeSubstitute();
                 return;
             }
-            if(!("normalize" in String.prototype)) {
+            // IE HACK - IE11 does not support string normalization
+            if(!(String.prototype.normalize)) {
                 return;
             }
             let char1 = text[char1Index];


### PR DESCRIPTION
IE doesn't implement "u" flag in regular expressions. We don't need it for the validCharacterPattern if we're not using astral plane characters.
IE also doesn't do normalise. This means in IE the square bracket diacritical conversion won't work (but ligature conversion will). Also the character validation will not normalise, so if for example you put in an Angstrom symbol it would normally get normalized to A with ring above which could be a valid character but this will not happen.
This fix just avoids javascript errors.