### PR TITLE
Introduce UserProfile class

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -122,13 +122,13 @@ $u_id = mysqli_insert_id(DPDatabase::get_connection()); // auto-incremented user
 $user->delete();
 
 // create profile
-$profileString="INSERT INTO user_profiles SET u_ref=$u_id";
-$makeProfile = mysqli_query(DPDatabase::get_connection(), $profileString);
-$profile_id = mysqli_insert_id(DPDatabase::get_connection()); // auto-incremented user_profiles.id
+$profile = new UserProfile();
+$profile->u_ref = $u_id;
+$profile->save();
 
 // add ref to profile
 $refString=sprintf("
-    UPDATE users SET u_profile=$profile_id WHERE id='%s' AND username='%s'
+    UPDATE users SET u_profile=$profile->id WHERE id='%s' AND username='%s'
     ",  mysqli_real_escape_string(DPDatabase::get_connection(), $ID),
         mysqli_real_escape_string(DPDatabase::get_connection(), $user->username)
 );

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -10,6 +10,7 @@ class NonuniqueUserException extends Exception { }
 class User
 {
     private $table_row;
+    private $current_profile;
 
     // List of fields that when set for a user should never change
     private $immutable_fields = array(
@@ -55,7 +56,15 @@ class User
 
     public function __get($name)
     {
-        return $this->table_row[$name];
+        switch($name)
+        {
+            case "profile":
+                if(!$this->current_profile)
+                    $this->current_profile = new UserProfile($this->u_profile);
+                return $this->current_profile;
+            default:
+                return $this->table_row[$name];
+        }
     }
 
     public function __isset($name)

--- a/pinc/UserProfile.inc
+++ b/pinc/UserProfile.inc
@@ -1,0 +1,156 @@
+<?php
+include_once($relPath."misc.inc"); // create_mysql_update_string()
+
+class NonexistentUserProfileException extends Exception { }
+
+class UserProfile
+{
+    private $table_row;
+
+    // List of fields that when set for a profile should never change
+    private $immutable_fields = [
+        "id",
+        "u_ref",
+    ];
+
+    // Fields are assumed to be integers unless included here
+    private $string_fields = [
+        "profilename",
+        "v_fntf_other",
+        "h_fntf_other",
+    ];
+
+    public function __construct($id=NULL)
+    {
+        if($id !== NULL)
+        {
+            $this->load($id);
+        }
+    }
+
+    // The __set() and __get() methods allow access to user fields without
+    // creating accessors for them all individually.
+    // See the PHP docs for "magic methods".
+    public function __set($name, $value)
+    {
+        if(isset($this->$name) && in_array($name, $this->immutable_fields))
+        {
+            throw new DomainException(sprintf(
+                _("%s is an immutable field"), $name)
+            );
+        }
+
+        $this->table_row[$name] = $value;
+    }
+
+    public function __get($name)
+    {
+        return $this->table_row[$name];
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->table_row[$name]);
+    }
+
+    private function load($id)
+    {
+        $sql = sprintf("
+            SELECT *
+            FROM user_profiles
+            WHERE id = %d
+        ", $id);
+
+        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        if(!$result)
+        {
+            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+        }
+        elseif(mysqli_num_rows($result) == 0)
+        {
+            throw new NonexistentUserProfileException(sprintf(
+                _('No user profile found with id = %s'),
+                    $id)
+            );
+        }
+        $this->table_row = mysqli_fetch_assoc($result);
+
+        mysqli_free_result($result);
+    }
+
+    public function save()
+    {
+        if(!isset($this->id))
+        {
+            // validate that we have a u_ref
+            if(!isset($this->u_ref))
+            {
+                throw new UnexpectedValueException(
+                    _('Unable to save new profile without a user reference (u_ref)')
+                );
+            }
+
+            $set_string = create_mysql_update_string($this->table_row, $this->string_fields);
+            $sql = "
+                INSERT INTO user_profiles
+                SET $set_string
+            ";
+        }
+        else
+        {
+            // remove immutable rows
+            $update_data = $this->table_row;
+            foreach($this->immutable_fields as $field)
+                unset($update_data[$field]);
+
+            $set_string = create_mysql_update_string($update_data, $this->string_fields);
+            $sql = sprintf("
+                UPDATE user_profiles
+                SET $set_string
+                WHERE id = %d
+            ", $this->id);
+        }
+        mysqli_query(DPDatabase::get_connection(), $sql);
+
+        if(!isset($this->id))
+        {
+            $this->id = mysqli_insert_id(DPDatabase::get_connection());
+        }
+    }
+
+    public function delete()
+    {
+        if(!isset($this->id))
+        {
+            throw NonexistentUserProfileException(
+                _("Cannot delete nonexistent profile")
+            );
+        }
+
+        $sql = sprintf("
+            DELETE FROM user_profiles
+            WHERE id = %d
+        ", $this->id);
+        mysqli_query(DPDatabase::get_connection(), $sql);
+    }
+
+    // static functions
+    static public function load_user_profiles($u_ref)
+    {
+        $sql = sprintf("
+            SELECT id
+            FROM user_profiles
+            WHERE u_ref = %d
+            ORDER BY id
+        ", $u_ref);
+
+        $profiles = [];
+        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        while($row = mysqli_fetch_assoc($result))
+        {
+            $profiles[] = new UserProfile($row["id"]);
+        }
+        mysqli_free_result($result);
+        return $profiles;
+    }
+}

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -562,6 +562,39 @@ function surround_and_join( $strings, $L, $R, $joiner )
     return implode($joiner,$parts);
 }
 
+// Given an associative array, return a MySQL string that can be use in an
+// INSERT or UPDATE string.
+// $source_array is an associative array where the keys are MySQL column
+//    names and the values are the desired values to set in the database
+// $string_fields
+//    is a list of keys such that $source_array[$key] should be a string,
+//    otherwise the value is assumed to be an integer
+// This function checks that those expectations are satisfied, and constructs a
+// string of column=value 'assignments' that can be used in an SQL UPDATE
+// command (where each $key is assumed to be a column name). (String values
+// will be properly escaped in this string.)
+//
+// Currently this function will set default values ("" for strings, 0 for
+// numeric values) for all fields that are not within $source_array.
+function create_mysql_update_string($source_array, $string_fields = [])
+{
+    $update_fields = array();
+    foreach($source_array as $field => $value)
+    {
+        if(in_array($field, $string_fields))
+        {
+            $value = sprintf("'%s'", mysqli_real_escape_string(DPDatabase::get_connection(), trim($value)));
+        }
+        else
+        {
+            $value = $value ? intval($value) : 0;
+        }
+        array_push($update_fields, "$field = $value");
+    }
+
+    return implode(", ", $update_fields);
+}
+
 // Return a list of only the files directly inside in the specified directory.
 // On error, returns False.
 //

--- a/userprefs.php
+++ b/userprefs.php
@@ -105,40 +105,33 @@ if (array_get($_POST, "insertdb", "") != "") {
     }
     else if (isset($_POST["deletenc"]))
     {
-    // Delete the profile which was displayed on the previous screen.
-    // This is slightly cumbersome because the user has to switch to a profile
-    // profile in order to be able to delete it, meaning the code has to handle
-    // the aftereffects by setting a new current profile once that has been done.
-    // Deletion is prevented when the user has only one profile by disabling
-    // the button in the options at the bottom of the proofreading tab.
+        // Delete the profile which was displayed on the previous screen.
+        // This is slightly cumbersome because the user has to switch to a profile
+        // profile in order to be able to delete it, meaning the code has to handle
+        // the aftereffects by setting a new current profile once that has been done.
+        // Deletion is prevented when the user has only one profile by disabling
+        // the button in the options at the bottom of the proofreading tab.
 
-    // Get and delete currently selected profile.
-    // Since profilename is not unique, identify by u_profile.
-    $del_target_profile_id =$userP['u_profile'];
-    $del_target_profile_name = $userP['profilename'];
-    echo sprintf(_("Deleting usersettings profile: %1\$s (id=%2\$d)..."),$del_target_profile_name,$del_target_profile_id) . "\n<br>\n";
-    $profile = new UserProfile($del_target_profile_id);
-    $profile->delete();
+        // Get and delete currently selected profile.
+        $profile = new UserProfile($userP['u_profile']);
+        $profile->delete();
 
-    // Set the first remaining available profile to be active.
-    $profiles = UserProfile::load_user_profiles($uid);
-    $new_profile_name = $profiles[0]->profilename;
-    $new_profile_id = $profiles[0]->id;
-    echo sprintf(_("Active usersettings profile is now: %s"),$new_profile_name) . "\n<br>\n";
+        // Set the first remaining available profile to be active.
+        $profiles = UserProfile::load_user_profiles($uid);
+        $new_profile_id = $profiles[0]->id;
     
-    mysqli_query(DPDatabase::get_connection(), sprintf("
-        UPDATE users
-        SET u_profile='$new_profile_id'
-        WHERE u_id='$uid' AND username='%s'",
-        mysqli_real_escape_string(DPDatabase::get_connection(), $pguser))
-    );
-    // Reload preferences to reflect changed active profile.
-    dpsession_set_preferences_from_db();
+        mysqli_query(DPDatabase::get_connection(), sprintf("
+            UPDATE users
+            SET u_profile = %d
+            WHERE u_id = %d
+        ", $new_profile_id, $uid));
+        // Reload preferences to reflect changed active profile.
+        dpsession_set_preferences_from_db();
 
-    // Bounce user back to the proofreading preferences tab.
-    $selected_tab=1;
-    $url = "$code_url/userprefs.php?tab=$selected_tab&amp;origin=" . urlencode($origin);
-    metarefresh(3, $url, _('Delete profile'), _('Reloading current tab....'));
+        // Bounce user back to the proofreading preferences tab.
+        $selected_tab=1;
+        $url = "$code_url/userprefs.php?tab=$selected_tab&amp;origin=" . urlencode($origin);
+        metarefresh(0, $url, _('Delete profile'), _('Reloading current tab....'));
     }
     else
     {


### PR DESCRIPTION
Abstract interaction with the `user_profiles` table into a separate class. This is building up to the removal of the `$userP` global (which I have completed in a branch off of this code).

Note: This is _not_ meant for merging until after the Unicode deployment happens and we decide to open up `master` for merging again. But I wanted to get some eyes on it while we wait for that. 