### PR TITLE
Move "Reject all suggestions" above round info

### DIFF
--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -202,9 +202,8 @@ echo "<br>";
 
         echo "<hr>";
         echo "<h3>$projectname</h3>";
-        echo "<p><b>" . pgettext("project state", "State") . ":</b> $projectstate</p>";
-
         echo "<input type='submit' name='" . REJECT_SUGGESTIONS . "_" . $projectid . "' value='$rejectAlllabel'>";
+        echo "<p><b>" . pgettext("project state", "State") . ":</b> $projectstate</p>";
 
         echo_checkbox_selects(count($suggestions_w_freq),$projectid);
 

--- a/tools/project_manager/show_good_word_suggestions.php
+++ b/tools/project_manager/show_good_word_suggestions.php
@@ -187,6 +187,8 @@ foreach($rounds as $round) {
         $roundsWithData++;
 }
 
+echo "<input type='submit' value='" . _("Reject all suggestions") . "' name='". REJECT_SUGGESTIONS . "'>";
+
 // print out the complete list first but only if
 // we have more than one round with data
 if($roundsWithData>1) {
@@ -226,8 +228,6 @@ foreach($rounds as $round) {
     $page_num_string=sprintf(_("Number of pages with suggestions: %d"), $round_page_count[$round]);
     echo "<h2>$round_string</h2>";
     echo "<p>$page_num_string</p>";
-
-    echo "<input type='submit' value='" . _("Reject all suggestions") . "' name='". REJECT_SUGGESTIONS . "'>";
 
     if(count($round_suggestions_w_freq[$round])==0)
     {


### PR DESCRIPTION
Move the "Reject all suggestions" button above the round data on both management pages to reinforce that the button applies to all rounds.

Done based on feedback from PMs.