### PR TITLE
Document project archiving

### DIFF
--- a/SETUP/ARCHIVING.md
+++ b/SETUP/ARCHIVING.md
@@ -1,0 +1,58 @@
+# Project Archiving
+
+After projects are completed, they can be archived. This includes moving the
+project files into a separate archive directory, moving the project tables into
+a separate archive database, and moving a project's page_events and
+wordcheck_events into the archive database.
+
+The database instructions in this file resemble those for the main database. See
+[INSTALL.md](INSTALL.md) for more information on how to run database commands.
+
+To enable archiving you must set up the archive database and the archive
+project directory.
+
+1. Set the two archive settings in `configuration.sh`:
+
+   * `_ARCHIVE_DB_NAME` sets the name of the archive database. In the rest of
+     this document we use the name `dp_archive` for this value.
+
+   * `_ARCHIVE_PROJECTS_DIR` sets the directory where project filesystem
+     artifacts are moved.
+
+2. Run the `configure` script to update the site configuration with the new
+   archive settings. See [INSTALL.md](INSTALL.md) for more information on how
+   to do this.
+
+3. Create the database and grant access to it using the **same credentials used
+   for the primary database**. For example, from within a `mysql` client
+   session:
+   ```sql
+   CREATE DATABASE dp_archive CHARACTER SET utf8mb4;
+   GRANT ALL  ON dp_archive.* TO dp_user@localhost IDENTIFIED BY 'dp_password';
+   ```
+
+4. Create the `page_events` and `wordcheck_events` table in the archive
+   database. Find the 'CREATE TABLE' commands for those 2 tables in
+   `db_schema.sql`. These commands create those tables in the main database;
+   the corresponding tables in the archive database have exactly the same
+   structure. So to create them, make the archive db the current database
+   (e.g. `use dp_archive`), and then run those 2 'CREATE TABLE' commands.
+
+5. Create the archive directory referenced in `_ARCHIVE_PROJECTS_DIR`. A common
+   location for this is in the document root at the same level as the `projects`
+   directory. (It doesn't have to be in the document root; the DP code doesn't
+   assume that it's web-accessible. But you might choose to make it so [for
+   some reason].) Ensure that this directory is owned and writable by the web
+   server. For example:
+   ```bash
+   mkdir /var/www/htdocs/project.archives
+   chown -R www-data:www:data /var/www/htdocs/project.archives
+   ```
+
+Now that the archive database and filesystem directory are set up, you can
+enable periodic archiving by calling `crontab/archive_projects.php` via cron.
+The `dp.cron` crontab file includes a commented-out example.
+
+[`crontab/archive_projects.php`](../crontab/archive_projects.php) controls
+which projects are archived (and when), and the logic to do the archiving is in
+[`pinc/archiving.inc`](../pinc/archiving.inc).

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -209,7 +209,6 @@ installed.
 ### Configure MySQL
 Choose names for various MySQL items:
 * the DP database
-* the DP archive database (to house DP data of finished projects)
 * the DP user (to handle all DP and phpBB queries)
 * the DP user's password
 
@@ -218,7 +217,6 @@ as it confuses the code.
 
 In the examples in this document, we will use the following:
 * `dp_db`
-* `dp_archive`
 * `dp_user`
 * `dp_password`
 
@@ -243,12 +241,6 @@ CREATE DATABASE dp_db CHARACTER SET utf8mb4;
 Create the user. (See MySQL Manual 5.5.4 Adding New Users to MySQL.)
 ```
 GRANT ALL  ON dp_db.* TO dp_user@localhost IDENTIFIED BY 'dp_password';
-```
-
-Similarly for the archive database (if you want one):
-```
-CREATE DATABASE dp_archive CHARACTER SET utf8mb4;
-GRANT ALL  ON dp_archive.* TO dp_user@localhost IDENTIFIED BY 'dp_password';
 ```
 
 Exit from the MySQL client.
@@ -439,6 +431,9 @@ configuring rounds, defining queues, etc.
 ### Manage Character Suites
 You may want to enable additional character suites. See [UNICODE.md](UNICODE.md)
 for more information.
+
+### Set up project archiving (optional)
+If you want to enable project archiving, see [ARCHIVING.md](ARCHIVING.md).
 
 ### Install the modified `dp.cron`
 `dp.cron` contains entries for various processes necessary for site

--- a/SETUP/README.md
+++ b/SETUP/README.md
@@ -5,6 +5,8 @@ instructions, and other tools.
 
 * [CHANGELOG.md](CHANGELOG.md) notes major changes in each version.
 * [INSTALL.md](INSTALL.md) includes installation instructions.
+* [ARCHIVING.md](ARCHIVING.md) describes how to set up the optional project
+  archiving.
 * [site_admin_notes.txt](site_admin_notes.txt) discusses some post-installation
   activities for administrators.
 * [UPGRADE.md](UPGRADE.md) covers upgrading existing DP installs.

--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -39,7 +39,6 @@ _DB_SERVER=localhost
 _DB_USER=PICK_A_USER_NAME
 _DB_PASSWORD=PICK_A_HARD_PASSWORD
 _DB_NAME=PICK_A_DB_NAME
-_ARCHIVE_DB_NAME=PICK_ANOTHER_DB_NAME
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -263,12 +262,6 @@ _PROJECTS_URL=$base_url/projects
 #
 # The project directory also holds other files relating to the project.
 
-_ARCHIVE_PROJECTS_DIR=$base_dir/archive
-
-# After projects are completed, they are eventually archived to a separate
-# database and project directory. This specifies where the project files
-# are archived to. See also: _ARCHIVE_DB_NAME
-
 # ----------------------------------------------------------------------
 
 _EXTERNAL_CATALOG_LOCATOR='lx2.loc.gov:210/LCDB'
@@ -350,6 +343,23 @@ _WIKIHIERO_URL=
 # these variables to the location you installed it, and a link will
 # appear in the proofreading interface. See INSTALL.md for more info.
 # If you haven't installed wikihiero, leave them empty.
+
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Archiving Projects
+# ------------------
+
+# After projects are completed, they are eventually archived to a separate
+# database and project directory. See SETUP/ARCHIVING.md for how to set up
+# project archiving.
+
+_ARCHIVE_DB_NAME=
+
+# Archive database name.
+
+_ARCHIVE_PROJECTS_DIR=$base_dir/archive
+
+# Where the project files are archived to.
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -9,7 +9,8 @@
 # daily:
 01  0 * * * URL=<<CODE_URL>>/crontab/take_tally_snapshots.php; <<URL_DUMP_PROGRAM>> $URL
 01  0 * * * URL=<<CODE_URL>>/crontab/log_project_states.php; <<URL_DUMP_PROGRAM>> $URL
-10  0 * * * URL=<<CODE_URL>>/crontab/archive_projects.php; <<URL_DUMP_PROGRAM>> $URL
+# See SETUP/ARCHIVING.md to set up archiving before enabling the line below
+#10  0 * * * URL=<<CODE_URL>>/crontab/archive_projects.php; <<URL_DUMP_PROGRAM>> $URL
 50  0 * * * URL=<<CODE_URL>>/crontab/clean_tmp.php; <<URL_DUMP_PROGRAM>> $URL
 50  0 * * * URL=<<CODE_URL>>/crontab/clean_uploads_trash.php; <<URL_DUMP_PROGRAM>> $URL
 55  0 * * * URL=<<CODE_URL>>/crontab/extend_site_tally_goals.php; <<URL_DUMP_PROGRAM>> $URL

--- a/SETUP/upgrade/14/20200511_convert_archive_db_to_utf8mb4.php
+++ b/SETUP/upgrade/14/20200511_convert_archive_db_to_utf8mb4.php
@@ -1,0 +1,109 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+include_once($relPath.'misc.inc');
+// We need to include udb_user to get the archive name ($archive_db_name)
+// We require() it instead of include_once() since it may also be
+// loaded elsewhere and we can't continue without it.
+require($relPath.'udb_user.php');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "This script will migrate all non-project tables in $archive_db_name from latin1 to utf8mb4.\n";
+
+// First confirm the user has changed the default database character set
+// Lift this code from pinc/DPDatabase.inc since it's for the archive DB
+$sql = sprintf("
+    SELECT *
+    FROM information_schema.schemata
+    WHERE schema_name='%s';
+", $archive_db_name);
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql);
+if(!$result)
+{
+    echo "Unable to determine archive database character set.\n";
+    exit(1);
+}
+
+$row = mysqli_fetch_assoc($result);
+if(!$row)
+{
+    echo "No archive database found. Nothing to do.\n";
+    echo "If you think this is incorrect, ensure user $db_user has access to $archive_db_name.\n";
+    exit(0);
+}
+
+$default_charset = $row['DEFAULT_CHARACTER_SET_NAME'];
+if($default_charset != 'utf8mb4')
+{
+    echo <<<EOF
+The default character set for $archive_db_name is $default_charset, not utf8mb4.
+Before proceeding, run the following command as mysql root user (or other
+sufficiently privileged user) to update the default character set.
+
+    ALTER DATABASE $archive_db_name DEFAULT CHARACTER SET utf8mb4;
+
+EOF;
+    exit(1);
+}
+
+// Now get all of the tables to iterate over that are still latin1
+
+$sql = "
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE
+        table_schema='$archive_db_name' AND
+        table_collation LIKE 'latin1_%' AND
+        table_name NOT LIKE 'projectID%'
+    ORDER BY table_name;
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+$latin1_tables = array();
+while($row = mysqli_fetch_assoc($result))
+{
+    $latin1_tables[] = $row['table_name'];
+}
+
+$stop_file = '/tmp/utf8_conversion';
+
+echo <<<EOF
+This will now start converting all of the non-project latin1 tables in
+$archive_db_name to utf8mb4. This will likely take a while.
+
+To stop the process gracefully create $stop_file
+(eg: touch $stop_file) and it will stop after it
+finishes the table it is working on.
+
+EOF;
+
+echo count($latin1_tables) . " tables to convert.\n";
+
+foreach($latin1_tables as $table)
+{
+    if(file_exists($stop_file))
+    {
+        echo "\n\n";
+        echo "Detected stop file ($stop_file), so stopping before starting $table.\n";
+        echo "Delete this file and restart to continue.\n";
+        exit();
+    }
+
+    $sql = "
+        ALTER TABLE $archive_db_name.$table CONVERT TO CHARACTER SET utf8mb4;
+    ";
+
+    echo "Converting $table...\n";
+    mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+}
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
After reviewing remaining UTF-8 bits, I realized I had overlooked converting the `page_events` and `wordcheck_events` tables in the archive database. Which then lead me to realize that we don't talk about creating those tables anywhere.

This MR includes:
* A commit to convert the non-project tables in the archive database to UTF-8, since we will be inserting new values in that from UTF-8 tables in the main database.
* A new `ARCHIVING.md` file describing how to set up project archiving.