### PR TITLE
Convert posted projects to UTF-8

### DIFF
--- a/SETUP/upgrade/14/20190818_convert_db_to_utf8mb4.php
+++ b/SETUP/upgrade/14/20190818_convert_db_to_utf8mb4.php
@@ -51,7 +51,7 @@ while($row = mysqli_fetch_assoc($result))
     $latin1_tables[] = $row['table_name'];
 }
 
-$stop_file = '/tmp/utf8_conversion';
+$stop_file = '/tmp/stop_utf8_conversion';
 
 echo <<<EOF
 This will now start converting all of the non-project latin1 tables in

--- a/SETUP/upgrade/14/20190819_convert_project_tables_to_utf8mb4.php
+++ b/SETUP/upgrade/14/20190819_convert_project_tables_to_utf8mb4.php
@@ -63,8 +63,6 @@ foreach($projects as $projectid)
             echo "project is already UTF-8";
         elseif($project->archived)
             echo "project was archived";
-        elseif($project->state == PROJ_SUBMIT_PG_POSTED)
-            echo "project has been posted to PG";
         elseif(!$project->check_pages_table_exists($message))
             echo "project page table does not exist";
         else

--- a/SETUP/upgrade/14/20190819_convert_project_tables_to_utf8mb4.php
+++ b/SETUP/upgrade/14/20190819_convert_project_tables_to_utf8mb4.php
@@ -24,7 +24,7 @@ while($row = mysqli_fetch_assoc($result))
     $projects[] = $row['projectid'];
 }
 
-$stop_file = '/tmp/utf8_conversion';
+$stop_file = '/tmp/stop_utf8_conversion';
 
 echo <<<EOF
 This will now start converting all of the project latin1 tables in

--- a/SETUP/upgrade/14/20200511_convert_archive_db_to_utf8mb4.php
+++ b/SETUP/upgrade/14/20200511_convert_archive_db_to_utf8mb4.php
@@ -70,7 +70,7 @@ while($row = mysqli_fetch_assoc($result))
     $latin1_tables[] = $row['table_name'];
 }
 
-$stop_file = '/tmp/utf8_conversion';
+$stop_file = '/tmp/stop_utf8_conversion';
 
 echo <<<EOF
 This will now start converting all of the non-project latin1 tables in

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -143,9 +143,10 @@ class Project
 
     // -------------------------------------------------------------------------
 
-    function convert_to_utf8($force=False)
+    function convert_to_utf8()
     {
         // nothing to do if the project table doesn't exist
+        // this covers archived projects which are moved into a different DB
         if(!$this->check_pages_table_exists($message))
         {
             return false;
@@ -153,13 +154,6 @@ class Project
 
         // and nothing to do if it is already UTF-8
         if($this->is_utf8)
-        {
-            return false;
-        }
-
-        // and don't convert tables that have been posted unless
-        // $force is True
-        if(!$force && ($this->state == PROJ_SUBMIT_PG_POSTED))
         {
             return false;
         }


### PR DESCRIPTION
Unarchived posted projects are used by evaluators, so they also need to be converted to UTF-8. This makes archived projects the only ones that are not converted.

This also adds @jmdyck's request for a more explicit stopfile name in all conversion files where one is used.