### PR TITLE
Variety pack of minor Unicode-related fixes

### DIFF
--- a/SETUP/README.md
+++ b/SETUP/README.md
@@ -4,6 +4,9 @@ This directory provides various documentation, installation & upgrading
 instructions, and other tools.
 
 * [CHANGELOG.md](CHANGELOG.md) notes major changes in each version.
+* [UNICODE.md](UNICODE.md) covers how the site supports Unicode.
+
+Installation and upgrading:
 * [INSTALL.md](INSTALL.md) includes installation instructions.
 * [ARCHIVING.md](ARCHIVING.md) describes how to set up the optional project
   archiving.

--- a/SETUP/apache2.conf.example
+++ b/SETUP/apache2.conf.example
@@ -9,8 +9,14 @@ DirectoryIndex index.php default.php index.html default.html
 
 # To ensure that word lists and other project artifacts are downloaded
 # with the correct character set, tell Apache to use UTF-8 for those
-# files in the /projects directory.
+# files in the _PROJECTS_DIR directory.
 <DirectoryMatch "/projects">
+    AddCharset utf-8 .txt
+</DirectoryMatch>
+
+# We need to do the same for the _DYN_DIR as things like site word lists
+# are served up from it.
+<DirectoryMatch "/d">
     AddCharset utf-8 .txt
 </DirectoryMatch>
 

--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -544,7 +544,7 @@ fi
 # Automatically determine an installed program (with parameters) to dump
 # the contents of a URL. The program is then used in SETUP/dp.cron.
 _URL_DUMP_PROGRAM=
-if [ "$_URL_DUMP_PROGRAM" == "" ]; then
+if [ ! -x "$_URL_DUMP_PROGRAM" ]; then
     # No program explicitly specified, attempt to find: wget, curl, lynx
     program_test=`which wget`
     if [ $? -eq 0 ]; then

--- a/SETUP/tests/pinc_WordCheckEngineTest.php
+++ b/SETUP/tests/pinc_WordCheckEngineTest.php
@@ -201,4 +201,24 @@ EOTEXT;
         $this->assertEquals($bad_words["a1l"], WC_SITE);
         $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
+
+    public function testWordListNormalization()
+    {
+        $words = [
+            " one",
+            "two ",
+            "three  3",
+            "Ṅice",  # U+004e>U+0307 but normalizes to U+1e44
+        ];
+        $norm_words = normalize_word_list($words);
+
+        $expected_words = [
+            "one",
+            "two",
+            "three",
+            "Ṅice",  # U+1e44
+        ];
+
+        $this->assertEquals($norm_words, $expected_words);
+    }
 }

--- a/SETUP/upgrade/14/20191211_convert_project_text_files.php
+++ b/SETUP/upgrade/14/20191211_convert_project_text_files.php
@@ -9,6 +9,14 @@ header('Content-type: text/plain');
 
 echo "Convert all text files in project directory to UTF-8\n";
 
+echo "\n";
+echo "If you get permission errors, you may need to execute this script as\n";
+echo "the user the web server is running under, eg:\n";
+echo "  sudo su -s /bin/bash \ \n";
+echo "      -c '/usr/bin/php 20191211_convert_project_text_files.php' \ \n";
+echo "      www-data\n";
+echo "\n";
+
 $dirs = get_project_dirs();
 $total = count($dirs);
 $index = 1;

--- a/SETUP/upgrade/14/20191211_convert_word_lists.php
+++ b/SETUP/upgrade/14/20191211_convert_word_lists.php
@@ -10,6 +10,14 @@ header('Content-type: text/plain');
 
 echo "Convert site word lists to UTF-8\n";
 
+echo "\n";
+echo "If you get permission errors, you may need to execute this script as\n";
+echo "the user the web server is running under, eg:\n";
+echo "  sudo su -s /bin/bash \ \n";
+echo "      -c '/usr/bin/php 20191211_convert_word_lists.php' \ \n";
+echo "      www-data\n";
+echo "\n";
+
 $files = get_site_word_files("/txt/", FALSE);
 
 foreach($files as $file)

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -258,8 +258,18 @@ function convert_text_file_to_utf8($filename)
         return [ TRUE, "$filename already in UTF-8." ];
     }
 
+    if(!is_writeable($filename))
+    {
+        return [ FALSE, "Unable to write to $filename." ];
+    }
+
     $text = mb_convert_encoding($text, "UTF-8", $encoding);
-    file_put_contents($filename, $text);
+    $success = file_put_contents($filename, $text);
+
+    if($success === FALSE)
+    {
+        return [ FALSE, "Failure trying to write to $filename." ];
+    }
 
     return [ TRUE, "$filename was converted from $encoding to UTF-8." ];
 }

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -10,7 +10,7 @@ include_once($relPath.'unicode.inc');
 // See faq/proofreading_guidelines.php#d_chars
 // and tools/proofers/process_diacritcal_markup.js
 // $base and $mark are only used to define $bracketed_character_pattern
-$base = "\w+";    // pattern for: markable base character
+$base = "\w{1,2}";    // pattern for: markable base character
 $mark = '[=:.`\\\\\'/v)(~,^\\\\\*]'; // pattern for: diacritical mark
 $bracketed_character_pattern = "\\[(?:oe|OE|$mark$base|$base$mark)\\]";
 

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -485,12 +485,7 @@ function save_project_good_words($projectid, $words)
 {
     $fileObject = get_project_word_file($projectid, "good");
 
-    // trim out leading spaces
-    $words = preg_replace('/^\s+/u', '', $words);
-    // trim out any word frequencies if they exist
-    $words = preg_replace('/\s.*$/u', '', $words);
-
-    return save_word_list($fileObject->abs_path, $words);
+    return save_word_list($fileObject->abs_path, normalize_word_list($words));
 }
 
 // -----------------------------------------------------------------------------
@@ -506,12 +501,23 @@ function save_project_bad_words($projectid, $words)
 {
     $fileObject = get_project_word_file($projectid, "bad");
 
+    return save_word_list($fileObject->abs_path, normalize_word_list($words));
+}
+
+// -----------------------------------------------------------------------------
+
+function normalize_word_list($words)
+{
+    // normalize the strings
+    $words = array_map('utf8_normalize', $words);
+
     // trim out leading spaces
     $words = preg_replace('/^\s+/u', '', $words);
+
     // trim out any word frequencies if they exist
     $words = preg_replace('/\s.*$/u', '', $words);
 
-    return save_word_list($fileObject->abs_path, $words);
+    return $words;
 }
 
 // -----------------------------------------------------------------------------

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -58,7 +58,7 @@ else
     $title = _("All Character Suites");
     output_header($title, NO_STATSBAR, $extra_args);
     echo "<h1>$title</h1>";
-    echo "<p>" . _("Below are all enabled charsuites in the system.") . "</p>";
+    echo "<p>" . _("Below are all enabled character suites in the system.") . "</p>";
     if($font !== NULL)
     {
         output_font_test_form($font);
@@ -73,7 +73,7 @@ else
     if(count($all_charsuites) > count($enabled_charsuites))
     {
         echo "<h1>" . _("Disabled Character Suites") . "</h1>";
-        echo "<p>" . _("The following charsuites are installed but not enabled and cannot be used for new projects. They may not be finalized.") . "</p>";
+        echo "<p>" . _("The following character suites are installed but not enabled and cannot be used for new projects. They may not be finalized.") . "</p>";
 
         foreach($all_charsuites as $charsuite)
         {

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -38,7 +38,7 @@ $sections = array(
         "manage_special_days.php" => _("Manage Special Days"),
         "shared_postednums.php" => _("Detect duplicate postednum"),
         "manage_site_charsuites.php" => _("Manage Site Character Suites"),
-        "manage_site_word_lists.php" => _("Manage site word lists"),
+        "manage_site_word_lists.php" => _("Manage Site Word Lists"),
         "show_common_words_from_project_word_lists.php" => _("Show common words from project word lists"),
         "../../locale/translators/index.php" => _("Translation Center"),
     ),

--- a/tools/site_admin/manage_site_word_lists.php
+++ b/tools/site_admin/manage_site_word_lists.php
@@ -73,7 +73,7 @@ if($display_list)
     echo "<input type='hidden' name='action' value='list'>";
     echo "<input type='submit' value='" . _("Refresh List") . "'>";
     echo "</form>";
-    echo "<table>";
+    echo "<table class='basic striped'>";
     echo "<tr>";
     echo "<th>" . _("Action") . "</th>";
     echo "<th>" . _("List Type") . "</th>";
@@ -102,7 +102,7 @@ if($display_list)
         echo "<td>$list_type</td>";
         echo "<td>$language</td>";
         echo "<td>" . new_window_link($url, $filename) . "</td>";
-        echo "<td>$word_count</td>";
+        echo "<td class='right-align'>$word_count</td>";
         echo "</tr>";
     }
     echo "</table>";


### PR DESCRIPTION
These are a few things that we discovered in yesterday's Unicode deployment or shortly thereafter. The two most notable code changes:
* Detect if writing out a converted text file fails and correctly report that back. Also provide some guidance to the user on permission during the upgrade scripts.
* UTF-8 normalize word lists upon save -- includes unit tests.