### PR TITLE
Mobile layout updates

### DIFF
--- a/default.php
+++ b/default.php
@@ -116,18 +116,17 @@ echo "\n"
     . "\n"
     . "\n";
 
-echo "<table><tr><td class='top-align'>";
-
 //Gold E-texts
-showstartexts($etext_limit,'gold'); echo "</td><td class='top-align'>";
+showstartexts($etext_limit,'gold');
 
 //Silver E-texts
-showstartexts($etext_limit,'silver'); echo "</td><td class='top-align'>";
+showstartexts($etext_limit,'silver');
 
 //Bronze E-texts
-showstartexts($etext_limit,'bronze'); echo "</td></tr></table>";
+showstartexts($etext_limit,'bronze');
 
-echo "<hr><p class='center-align'>\n";
+echo "<hr style='clear: both'>";
+echo "<p class='center-align'>\n";
 echo _("Our community of proofreaders, project managers, developers, etc. is composed entirely of volunteers.");
 echo "<br>\n";
 

--- a/pinc/showstartexts.inc
+++ b/pinc/showstartexts.inc
@@ -24,13 +24,16 @@ function showstartexts($etext_limit,$type) {
 
     $total = mysqli_num_rows(mysqli_query(DPDatabase::get_connection(), "SELECT projectid FROM projects WHERE $state"));
 
+    echo "<div class='star-text-summary'>";
+
+    echo "<div class='star-header'>";
     // Display star graphic
-    echo "<img src='$code_url/graphics/{$type}_star.jpg' height='38' width='40' alt='$type star'>\n";
+    echo "<img src='$code_url/graphics/{$type}_star.jpg' height='38' width='40' alt='$type star'><br>\n";
 
     // Display count and category as a link
     echo "<span class='large'>";
     echo "<a href='list_etexts.php?x=".substr($type,0,1)."&amp;sort=5'>";
-    echo sprintf($category, number_format($total)) . "</a>.</span><br>\n";
+    echo sprintf($category, number_format($total)) . "</a></span><br>\n";
 
     // Display feed buttons
     echo "
@@ -40,8 +43,14 @@ function showstartexts($etext_limit,$type) {
         <img src='$code_url/graphics/rss.gif' width='36' height='14' alt='[RSS]'></a>
 	\n";
 
+    echo "</div>";
+
     // Display description text
+    echo "<div class='star-description'>";
     echo "<p>$description</p>";
+    echo "</div>";
+
+    echo "</div>";
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -107,8 +107,11 @@ function output_footer($nameofpage, $show_statsbar = True) {
     echo "<small>\n";
 
     echo "&copy;$site_name";
+
+    echo "<span id='buildtime'>";
     echo " &middot; ";
     echo sprintf(_("Page built at %s in %0.3fs"), strftime("%Y-%m-%d %R %Z"), $totaltime);
+    echo "</span>";
 
     echo " &middot; ";
     echo "<a href='$code_url/credits.php'>";
@@ -148,11 +151,11 @@ function html_logobar() {
             WHERE $psd->state_selector
         ");
         $row = mysqli_fetch_assoc($result);
-        echo "<span class='sans-serif'><b>";
+        echo "<span id='x-preserved'>";
         echo sprintf(
             _('%s projects completed!'),
             number_format($row["numproj"]));
-        echo "</b></span>\n";
+        echo "</span>\n";
     }
 
     if (1) {
@@ -165,12 +168,14 @@ function html_logobar() {
             WHERE $psd->state_selector
         ");
         $row = mysqli_fetch_assoc($result);
-        echo "<span class='sans-serif'><b>";
+        echo "<span id='x-preserved'>";
         echo sprintf(
             _('%s titles preserved for the world!'),
             number_format($row["numproj"]));
-        echo "</b></span>\n";
+        echo "</span>\n";
+        echo "<span id='month-preserved-summary'>";
         show_completed_projects(TRUE);
+        echo "</span>";
     }
 
     echo "</p></div>\n";

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -50,14 +50,17 @@ header #titles-preserved,
 }
 header #logo,
 #header #logo {
-  left: 0;
-  padding: 0.375em;
+  padding: 0.5em 0.5em 0.1em;
 }
 header #titles-preserved,
 #header #titles-preserved {
-  right: 0;
   text-align: center;
   vertical-align: middle;
+  font-size: 0.9em;
+}
+header #titles-preserved #x-preserved,
+#header #titles-preserved #x-preserved {
+  font-weight: bold;
 }
 /* ------------------------------------------------------------------------ */
 /* Navbar */
@@ -207,8 +210,11 @@ footer small,
  window gets too narrow
 */
 @media only screen and (max-width: 768px) {
-  #header #titles-preserved {
+  #header #month-preserved-summary {
     display: none;
+  }
+  #header p {
+    margin: 0.25em 0.5em;
   }
   #page-body-container {
     display: flex;
@@ -219,6 +225,20 @@ footer small,
   #page-container,
   #content-container {
     display: block;
+  }
+}
+/* For even smaller screens, change the header and footer */
+@media only screen and (max-width: 481px) {
+  #header #titles-preserved {
+    display: table-row;
+    text-align: right;
+    font-size: 0.8em;
+  }
+  #header #logo img {
+    max-width: 100%;
+  }
+  #buildtime {
+    display: none;
   }
 }
 /* ------------------------------------------------------------------------ */

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -250,6 +250,32 @@ hr.divider {
 /* ------------------------------------------------------------------------ */
 /* Existing styling */
 /* ------------------------------------------------------------------------ */
+/* Star texts */
+.star-text-summary {
+  width: 33%;
+  float: left;
+}
+.star-text-summary p {
+  padding-right: 0.5em;
+}
+.star-text-summary .star-header {
+  text-align: center;
+}
+@media only screen and (max-width: 481px) {
+  .star-text-summary {
+    width: 100%;
+    padding-bottom: 1em;
+  }
+  .star-header,
+  .star-description {
+    display: table-cell;
+  }
+  .star-header {
+    width: 10em;
+    padding-right: 1em;
+  }
+}
+/* ------------------------------------------------------------------------ */
 /* News items */
 div.news {
   margin: 1em 0;

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -214,6 +214,34 @@ hr.divider {
 /* Existing styling */
 
 /* ------------------------------------------------------------------------ */
+/* Star texts */
+
+.star-text-summary {
+    width: 33%;
+    float: left;
+    p {
+        padding-right: 0.5em;
+    }
+    .star-header {
+        .center-align;
+    }
+}
+
+@media only screen and (max-width: 481px) {
+    .star-text-summary {
+        width: 100%;
+        padding-bottom: 1em;
+    }
+    .star-header, .star-description {
+        display: table-cell;
+    }
+    .star-header {
+        width: 10em;
+        padding-right: 1em;
+    }
+}
+
+/* ------------------------------------------------------------------------ */
 /* News items */
 div.news {
     margin: 1em 0;

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -45,13 +45,15 @@ header, #header {
         display: table-cell;
     }
     #logo {
-        left: 0;
-        padding: 3/8em;
+        padding: 0.5em 0.5em 0.1em;
     }
     #titles-preserved {
-        right: 0;
         .center-align;
         .middle-align;
+        font-size: 0.9em;
+        #x-preserved {
+            .bold;
+        }
     }
 }
 
@@ -163,11 +165,13 @@ footer, #footer {
 */
 @media only screen and (max-width: 768px) {
     #header {
-        #titles-preserved {
+        #month-preserved-summary {
             display: none;
         }
+        p {
+            margin: 0.25em 0.5em;
+        }
     }
-
     #page-body-container {
         display: flex;
         display: -ms-flexbox; /* for IE 11 */
@@ -176,6 +180,26 @@ footer, #footer {
 
     #page-container, #content-container {
         display: block;
+    }
+}
+
+/* For even smaller screens, change the header and footer */
+@media only screen and (max-width: 481px) {
+    #header {
+        #titles-preserved {
+            display: table-row;
+            .right-align;
+            font-size: 0.8em;
+        }
+        #logo {
+            img {
+                max-width: 100%;
+            }
+        }
+    }
+
+    #buildtime {
+        display: none;
     }
 }
 

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -20,6 +20,15 @@ header,
   background-color: #dddddd;
   color: #000000;
 }
+header #titles-preserved,
+#header #titles-preserved {
+  font-size: 0.9em;
+}
+header #titles-preserved #x-preserved,
+#header #titles-preserved #x-preserved {
+  font-weight: bold;
+  font-family: Verdana, Helvetica, sans-serif;
+}
 /* Navbar */
 nav,
 #navbar-outer,
@@ -125,6 +134,16 @@ nav input,
   background-color: #dddddd;
   color: #000000;
 }
+#sidebar p,
+#statsbar p,
+#sidebar li,
+#statsbar li,
+#sidebar td,
+#statsbar td,
+#sidebar th,
+#statsbar th {
+  font-family: Verdana, Helvetica, sans-serif;
+}
 footer,
 #footer {
   background-color: #cccccc;
@@ -221,12 +240,6 @@ table.striped tr:nth-child(even) td {
 }
 /* ------------------------------------------------------------------------ */
 /* Sans-serif styling */
-#statsbar p,
-#statsbar li,
-#statsbar td,
-#statsbar th {
-  font-family: Verdana, Helvetica, sans-serif;
-}
 .sans-serif {
   font-family: Verdana, Helvetica, sans-serif;
 }

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -20,6 +20,15 @@ header,
   background-color: #e0e8dd;
   color: #000000;
 }
+header #titles-preserved,
+#header #titles-preserved {
+  font-size: 0.9em;
+}
+header #titles-preserved #x-preserved,
+#header #titles-preserved #x-preserved {
+  font-weight: bold;
+  font-family: Verdana, Helvetica, sans-serif;
+}
 /* Navbar */
 nav,
 #navbar-outer,
@@ -125,6 +134,16 @@ nav input,
   background-color: #e0e8dd;
   color: #000000;
 }
+#sidebar p,
+#statsbar p,
+#sidebar li,
+#statsbar li,
+#sidebar td,
+#statsbar td,
+#sidebar th,
+#statsbar th {
+  font-family: Verdana, Helvetica, sans-serif;
+}
 footer,
 #footer {
   background-color: #336633;
@@ -221,12 +240,6 @@ table.striped tr:nth-child(even) td {
 }
 /* ------------------------------------------------------------------------ */
 /* Sans-serif styling */
-#statsbar p,
-#statsbar li,
-#statsbar td,
-#statsbar th {
-  font-family: Verdana, Helvetica, sans-serif;
-}
 .sans-serif {
   font-family: Verdana, Helvetica, sans-serif;
 }

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -20,6 +20,15 @@ header,
   background-color: #99ccff;
   color: #000000;
 }
+header #titles-preserved,
+#header #titles-preserved {
+  font-size: 0.9em;
+}
+header #titles-preserved #x-preserved,
+#header #titles-preserved #x-preserved {
+  font-weight: bold;
+  font-family: Verdana, Arial, sans-serif;
+}
 /* Navbar */
 nav,
 #navbar-outer,
@@ -125,6 +134,16 @@ nav input,
   background-color: #99ccff;
   color: #000000;
 }
+#sidebar p,
+#statsbar p,
+#sidebar li,
+#statsbar li,
+#sidebar td,
+#statsbar td,
+#sidebar th,
+#statsbar th {
+  font-family: Verdana, Arial, sans-serif;
+}
 footer,
 #footer {
   background-color: #000099;
@@ -221,12 +240,6 @@ table.striped tr:nth-child(even) td {
 }
 /* ------------------------------------------------------------------------ */
 /* Sans-serif styling */
-#statsbar p,
-#statsbar li,
-#statsbar td,
-#statsbar th {
-  font-family: Verdana, Arial, sans-serif;
-}
 .sans-serif {
   font-family: Verdana, Arial, sans-serif;
 }

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -17,6 +17,13 @@ body {
 header, #header {
     background-color: @header-background;
     color: @header-text;
+    #titles-preserved {
+        font-size: 0.9em;
+        #x-preserved {
+            .bold;
+            .sans-serif;
+        }
+    }
 }
 
 /* Navbar */
@@ -72,6 +79,9 @@ nav, #navbar-outer, #navbar, #navbar-left, #navbar-right, #navbar-login {
 #sidebar, #statsbar {
     background-color: @sidebar-background;
     color: @sidebar-text;
+    p, li, td, th {
+        .sans-serif;
+    }
 }
 
 footer, #footer {
@@ -183,12 +193,6 @@ table.striped {
 
 /* ------------------------------------------------------------------------ */
 /* Sans-serif styling */
-
-#statsbar {
-    p, li, td, th {
-        .sans-serif;
-    }
-}
 
 .sans-serif {
     font-family: @sans-serif-font;


### PR DESCRIPTION
This addresses two mobile-layout related bugs:
* [Task 1884](https://www.pgdp.net/c/tasks.php?action=show&task_id=1884) - footer wraps and non-ideal Current Progress layout on the main page on very narrow screens.
* [Task 1872](https://www.pgdp.net/c/tasks.php?action=show&task_id=1872) - Retaining the "# preserved for the world!" text in the header as much as possible on mobile layout.

These can be seen in the [mobile-layout-updates](https://www.pgdp.org/~cpeel/c.branch/mobile-layout-updates) sandbox.