### PR TITLE
Better charsuite validation

### DIFF
--- a/SETUP/lint_charsuites.php
+++ b/SETUP/lint_charsuites.php
@@ -35,6 +35,9 @@ foreach(CharSuites::get_all() as $charsuite)
         exit(1);
     }
 
+    // Confirm that all hex codes are in lowercase
+    validate_hex_codes_lowercase($charsuite->codepoints, "uppercase hex values found in charsuite codepoints");
+
     // Validate pickersets only contain characters within the suite
     foreach($charsuite->pickerset->get_subsets() as $title => $picker_subset)
     {
@@ -51,6 +54,31 @@ foreach(CharSuites::get_all() as $charsuite)
                 }
                 exit(1);
             }
+
+            // Confirm hex codes are in lowercase
+            validate_hex_codes_lowercase($codepoints, "uppercase hex values found in picker set");
         }
+    }
+}
+
+function validate_hex_codes_lowercase($codepoints, $error_message)
+{
+    // Confirm that all hex codes are in lowercase
+    $uppercase_codepoints = [];
+    foreach($codepoints as $codepoint)
+    {
+        if(preg_match('/[ABCDEF]/', $codepoint))
+        {
+            $uppercase_codepoints[] = $codepoint;
+        }
+    }
+    if($uppercase_codepoints)
+    {
+        echo "ERROR: $error_message\n";
+        foreach($uppercase_codepoints as $codepoint)
+        {
+            echo sprintf("    %s\n", $codepoint);
+        }
+        exit(1);
     }
 }

--- a/SETUP/lint_charsuites.php
+++ b/SETUP/lint_charsuites.php
@@ -2,6 +2,7 @@
 <?php
 $relPath="../pinc/";
 include_once($relPath."CharSuites.inc");
+include_once($relPath."unicode.inc");
 
 foreach(CharSuites::get_all() as $charsuite)
 {
@@ -15,6 +16,21 @@ foreach(CharSuites::get_all() as $charsuite)
         foreach($nonnormalized_codepoints as $orig => $norm)
         {
             echo sprintf("    %s normalized is %s\n", $orig, $norm);
+        }
+        exit(1);
+    }
+
+    // Validate that the character suite does not contain codepoints we convert
+    // to ASCII
+    $disallowed_characters = convert_codepoint_ranges_to_characters(get_disallowed_codepoints());
+    $charsuite_characters = convert_codepoint_ranges_to_characters($charsuite->codepoints);
+    $characters = array_intersect($disallowed_characters, $charsuite_characters);
+    if($characters != [])
+    {
+        echo "ERROR: disallowed characters found in suite\n";
+        foreach($characters as $char)
+        {
+            echo sprintf("    %s: %s\n", $char, utf8_chr_to_hex($char));
         }
         exit(1);
     }

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -544,58 +544,6 @@ function _Page_UPDATE( $projectid, $image, $settings )
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function get_utf8_to_ascii_codepoints()
-// Return a list of UTF-8 codepoints we want to replace with some ASCII
-// equivalence.
-{
-    return [
-        '-' => [
-            'U+2011', # non-breaking hyphen
-            'U+2013', # en-dash
-        ],
-        '--' => [
-            'U+2014', # em-dash
-        ],
-        '"' => [
-            'U+201C', # open curly double quote
-            'U+201D', # closing curly double quote
-        ],
-        "'" => [
-            'U+2018', # open curly single quote
-            'U+2019', # closing curly single quote
-        ],
-        "..." => [
-            'U+2026', # ellipsis
-        ],
-        " " => [
-            'U+0009', # tab
-            'U+00A0', # no-break space
-            'U+1680', # ogham space mark
-            'U+2000', # en quad
-            'U+2001', # em quad
-            'U+2002', # en space
-            'U+2003', # em space
-            'U+2004', # three-per-em space
-            'U+2005', # four-per-em space
-            'U+2006', # six-per-em space
-            'U+2007', # figure space
-            'U+2008', # punctuation space
-            'U+2009', # thin space
-            'U+20A0', # hair space
-            'U+202F', # narrow no-break space
-            'U+205F', # medium mathematical space
-            'U+3000', # ideographic space
-        ],
-        "\n" => [
-            'U+000B', # vertical tab
-            'U+000C', # form feed
-            'U+0085', # next line
-            'U+2028', # line separator
-            'U+2029', # paragraph separator
-        ],
-    ];
-}
-
 function _normalize_page_text( $page_text, $projectid )
 // Normalize a page-text before we store it in the db. This does several
 // transformations to ensure we have a UTF-8 string with codepoints

--- a/pinc/charsuite-basic-greek.inc
+++ b/pinc/charsuite-basic-greek.inc
@@ -4,18 +4,18 @@ include_once($relPath."CharSuites.inc");
 $charsuite = new CharSuite("basic-greek", _("Basic Greek"));
 $charsuite->codepoints = [
     # https://en.wikipedia.org/wiki/Greek_and_Coptic
-    'U+0391-U+03A1',
-    'U+03A3-U+03A9',
-    'U+03B1-U+03C9',
+    'U+0391-U+03a1',
+    'U+03a3-U+03a9',
+    'U+03b1-U+03c9',
 ];
 $charsuite->reference_urls = [
     "https://en.wikipedia.org/wiki/Greek_and_Coptic",
 ];
 
 $pickerset = new PickerSet();
-$pickerset->add_subset(utf8_chr('U+0391') . '-' . utf8_chr('U+03A9'), [
-    [ 'U+0391-U+03A1', NULL, 'U+03A3-U+03A9' ], # capital alpha through omega
-    [ 'U+03B1-U+03C9' ], # lowercase alpha through omega
+$pickerset->add_subset(utf8_chr('U+0391') . '-' . utf8_chr('U+03a9'), [
+    [ 'U+0391-U+03a1', NULL, 'U+03a3-U+03a9' ], # capital alpha through omega
+    [ 'U+03b1-U+03c9' ], # lowercase alpha through omega
 ]);
 $charsuite->pickerset = $pickerset;
 

--- a/pinc/charsuite-basic-latin.inc
+++ b/pinc/charsuite-basic-latin.inc
@@ -4,21 +4,21 @@ include_once($relPath."CharSuites.inc");
 $charsuite = new CharSuite("basic-latin", _("Basic Latin"));
 $charsuite->codepoints = [
     # https://en.wikipedia.org/wiki/Basic_Latin_(Unicode_block)
-    'U+0020-U+007E',
+    'U+0020-U+007e',
     # https://en.wikipedia.org/wiki/Latin-1_Supplement_(Unicode_block)
     # without the soft hyphen
-    'U+00A1-U+00AC',
-    'U+00AE-U+00FF',
+    'U+00a1-U+00ac',
+    'U+00ae-U+00ff',
     # codepoints that map to Windows-1252
     'U+0152', # OE ligature
     'U+0153', # oe ligature
     'U+0160', # [vS]
     'U+0161', # [vs]
-    'U+017D', # [vZ]
-    'U+017E', # [vz]
+    'U+017d', # [vZ]
+    'U+017e', # [vz]
     'U+0178', # [:Y]
     'U+2039', # open single guillemet
-    'U+203A', # close single guillemet
+    'U+203a', # close single guillemet
 ];
 $charsuite->reference_urls = [
     "https://en.wikipedia.org/wiki/Basic_Latin_(Unicode_block)",
@@ -35,12 +35,12 @@ $pickerset->add_subset(utf8_chr("U+00c0"), [
     [ 'U+00e0-U+00e7', 'U+00f0', 'U+00e8-U+00ef', 'U+00f1' ],
 ]);
 $pickerset->add_subset(utf8_chr("U+00d2"), [
-    [ 'U+00d2-U+00d6', 'U+00d8', 'U+0152', 'U+0160', NULL, 'U+00d9-U+00dd', 'U+00de-U+00de', 'U+0178', 'U+017D' ],
-    [ 'U+00f2-U+00f6', 'U+00f8', 'U+0153', 'U+0161', 'U+00df', 'U+00f9-U+00fd', 'U+00fe-U+00ff', 'U+017E' ],
+    [ 'U+00d2-U+00d6', 'U+00d8', 'U+0152', 'U+0160', NULL, 'U+00d9-U+00dd', 'U+00de-U+00de', 'U+0178', 'U+017d' ],
+    [ 'U+00f2-U+00f6', 'U+00f8', 'U+0153', 'U+0161', 'U+00df', 'U+00f9-U+00fd', 'U+00fe-U+00ff', 'U+017e' ],
 ]);
 $pickerset->add_subset("!", [
     [ 'U+0021', 'U+003f', 'U+002e', 'U+002c', 'U+0026', 'U+0022', 'U+0028-U+0029', 'U+005b', 'U+005d', 'U+003c', 'U+003e', 'U+005c', 'U+002a-U+002b', 'U+003d' ],
-    [ 'U+00a1', 'U+00bf', 'U+003a', 'U+003b', 'U+0040', 'U+0027', 'U+00ab', 'U+00bb', 'U+2039', 'U+203A', 'U+007b', 'U+007d', 'U+002f', 'U+005e', 'U+002d' ],
+    [ 'U+00a1', 'U+00bf', 'U+003a', 'U+003b', 'U+0040', 'U+0027', 'U+00ab', 'U+00bb', 'U+2039', 'U+203a', 'U+007b', 'U+007d', 'U+002f', 'U+005e', 'U+002d' ],
 ], _("Punctuation"));
 $pickerset->add_subset(utf8_chr("U+00b6"), [
     [ 'U+00b6', 'U+00b7', 'U+00b0', 'U+007c', 'U+00a6', 'U+00b4', 'U+00a2-U+00a5' ],

--- a/pinc/charsuite-extended-european-latin.inc
+++ b/pinc/charsuite-extended-european-latin.inc
@@ -5,7 +5,7 @@ $charsuite = new CharSuite("extended-european-latin", _("Extended European Latin
 $charsuite->codepoints = [
     # https://en.wikipedia.org/wiki/Latin_Extended-A
     'U+0100-U+0148',
-    'U+014A-U+017F',
+    'U+014a-U+017f',
 ];
 $charsuite->reference_urls = [
     'https://en.wikipedia.org/wiki/Latin_Extended-A',
@@ -20,7 +20,7 @@ $pickerset->add_subset(utf8_chr("\u0100"), [
       'U+010f', 'U+0111', 'U+0113', 'U+0115', 'U+0117', 'U+0119', 'U+011b' ],
 ]);
 # G-K with diacriticals
-$pickerset->add_subset(utf8_chr("\u011C"), [
+$pickerset->add_subset(utf8_chr("\u011c"), [
     [ 'U+011c', 'U+011e', 'U+0120', 'U+0122', 'U+0124', 'U+0126', 'U+0128',
       'U+012a', 'U+012c', 'U+012e', 'U+0130', 'U+0132', 'U+0134', 'U+0136' ],
     [ 'U+011d', 'U+011f', 'U+0121', 'U+0123', 'U+0125', 'U+0127', 'U+0129',

--- a/pinc/charsuite-polytonic-greek.inc
+++ b/pinc/charsuite-polytonic-greek.inc
@@ -4,87 +4,87 @@ include_once($relPath."CharSuites.inc");
 $charsuite = new CharSuite("polytonic-greek", _("Polytonic Greek"));
 $charsuite->codepoints = [
     # https://en.wikipedia.org/wiki/Greek_and_Coptic
-    'U+02B9',
+    'U+02b9',
     'U+0375',
-    'U+003B',
-    'U+00B7',
-    'U+0391-U+03A1',
-    'U+03A3-U+03A9',
-    'U+03AA-U+03AB',
-    'U+03B1-U+03C9',
-    'U+03CA',
-    'U+03CB',
-    'U+03DB',
-    'U+03DC',
-    'U+03DD',
-    'U+03F2',
-    'U+03F9',
+    'U+003b',
+    'U+00b7',
+    'U+0391-U+03a1',
+    'U+03a3-U+03a9',
+    'U+03aa-U+03ab',
+    'U+03b1-U+03c9',
+    'U+03ca',
+    'U+03cb',
+    'U+03db',
+    'U+03dc',
+    'U+03dd',
+    'U+03f2',
+    'U+03f9',
     # tonos accented characters
     'U+0386',
     'U+0388',
     'U+0389',
-    'U+038A',
-    'U+038C',
-    'U+038E',
-    'U+038F',
+    'U+038a',
+    'U+038c',
+    'U+038e',
+    'U+038f',
     'U+0390',
-    'U+03AC',
-    'U+03AD',
-    'U+03AE',
-    'U+03AF',
-    'U+03B0',
-    'U+03CC',
-    'U+03CD',
-    'U+03CE',
+    'U+03ac',
+    'U+03ad',
+    'U+03ae',
+    'U+03af',
+    'U+03b0',
+    'U+03cc',
+    'U+03cd',
+    'U+03ce',
     # polytonic characters
-    'U+1F00-U+1F15',
-    'U+1F18-U+1F1D',
-    'U+1F20-U+1F45',
-    'U+1F48-U+1F4D',
-    'U+1F50-U+1F57',
-    'U+1F59',
-    'U+1F5B',
-    'U+1F5D',
-    'U+1F5F',
-    'U+1F60-U+1F70',
-    # skip oxia U+1F71
-    'U+1F72',
-    # skip oxia U+1F73
-    'U+1F74',
-    # skip oxia U+1F75
-    'U+1F76',
-    # skip oxia U+1F77
-    'U+1F78',
-    # skip oxia U+1F79
-    'U+1F7A',
-    # skip oxia U+1F7B
-    'U+1F7C',
-    # skip oxia U+1F7D
-    'U+1F80-U+1FB4',
-    'U+1FB6-U+1FBA',
-    # skip oxia U+1FBB
-    'U+1FBC',
-    'U+1FC2-U+1FC4',
-    'U+1FC6-U+1FC8',
-    # skip oxia U+1FC9
-    'U+1FCA',
-    # skip oxia U+1FCB
-    'U+1FCC',
-    'U+1FD0-U+1FD2',
-    # skip oxia U+1FD3
-    'U+1FD6-U+1FDA',
-    # skip oxia U+1FDB
-    'U+1FE0-U+1FE2',
-    # skip oxia U+1FE3
-    'U+1FE4-U+1FEA',
-    # skip oxia U+1FEB
-    'U+1FEC',
-    'U+1FF2-U+1FF4',
-    'U+1FF6-U+1FF8',
-    # skip oxia U+1FF9
-    'U+1FFA',
-    # skip oxia U+1FFB
-    'U+1FFC',
+    'U+1f00-U+1f15',
+    'U+1f18-U+1f1d',
+    'U+1f20-U+1f45',
+    'U+1f48-U+1f4d',
+    'U+1f50-U+1f57',
+    'U+1f59',
+    'U+1f5b',
+    'U+1f5d',
+    'U+1f5f',
+    'U+1f60-U+1f70',
+    # skip oxia U+1f71
+    'U+1f72',
+    # skip oxia U+1f73
+    'U+1f74',
+    # skip oxia U+1f75
+    'U+1f76',
+    # skip oxia U+1f77
+    'U+1f78',
+    # skip oxia U+1f79
+    'U+1f7a',
+    # skip oxia U+1f7b
+    'U+1f7c',
+    # skip oxia U+1f7d
+    'U+1f80-U+1fb4',
+    'U+1fb6-U+1fba',
+    # skip oxia U+1fbb
+    'U+1fbc',
+    'U+1fc2-U+1fc4',
+    'U+1fc6-U+1fc8',
+    # skip oxia U+1fc9
+    'U+1fca',
+    # skip oxia U+1fcb
+    'U+1fcc',
+    'U+1fd0-U+1fd2',
+    # skip oxia U+1fd3
+    'U+1fd6-U+1fda',
+    # skip oxia U+1fdb
+    'U+1fe0-U+1fe2',
+    # skip oxia U+1fe3
+    'U+1fe4-U+1fea',
+    # skip oxia U+1feb
+    'U+1fec',
+    'U+1ff2-U+1ff4',
+    'U+1ff6-U+1ff8',
+    # skip oxia U+1ff9
+    'U+1ffa',
+    # skip oxia U+1ffb
+    'U+1ffc',
 ];
 $charsuite->reference_urls = [
     "https://www.pgdp.net/wiki/DP_Code_-_Unicode/Greek",
@@ -93,55 +93,55 @@ $charsuite->reference_urls = [
 ];
 
 $pickerset = new PickerSet();
-$pickerset->add_subset(utf8_chr('U+0391') . '-' . utf8_chr('U+03A9'), [
-    [ 'U+0391-U+03A1', NULL, 'U+03A3-U+03A9' ], # capital alpha through omega
-    [ 'U+03B1-U+03C9' ], # lowercase alpha through omega
+$pickerset->add_subset(utf8_chr('U+0391') . '-' . utf8_chr('U+03a9'), [
+    [ 'U+0391-U+03a1', NULL, 'U+03a3-U+03a9' ], # capital alpha through omega
+    [ 'U+03b1-U+03c9' ], # lowercase alpha through omega
 ]);
 $pickerset->add_subset(utf8_chr('U+0386'), [
     [ 'U+0386', 'U+1fba', NULL, 'U+1f08', 'U+1f09', 'U+1f0c', 'U+1f0d', 'U+1f0a', 
       'U+1f0b', 'U+1f0e', 'U+1f0f', 'U+1fbc', NULL, NULL, NULL, 'U+1f88', 'U+1f89',
       'U+1f8c', 'U+1f8d', 'U+1f8a', 'U+1f8b', 'U+1f8e', 'U+1f8f'  ],
-    [ 'U+03AC', 'U+1f70', 'U+1fb6', 'U+1f00', 'U+1f01', 'U+1f04', 'U+1f05', 'U+1f02', 
+    [ 'U+03ac', 'U+1f70', 'U+1fb6', 'U+1f00', 'U+1f01', 'U+1f04', 'U+1f05', 'U+1f02', 
       'U+1f03', 'U+1f06', 'U+1f07', 'U+1fb3', 'U+1fb4', 'U+1fb2', 'U+1fb7', 'U+1f80', 
       'U+1f81', 'U+1f84', 'U+1f85', 'U+1f82', 'U+1f83', 'U+1f86', 'U+1f87' ],
 ]);
 $pickerset->add_subset(utf8_chr('U+0388'), [
     [ 'U+0388', 'U+1fc8', 'U+1f18', 'U+1f19', 'U+1f1c', 'U+1f1d', 'U+1f1a', 'U+1f1b' ],
-    [ 'U+03AD', 'U+1f72', 'U+1f10', 'U+1f11', 'U+1f14', 'U+1f15', 'U+1f12', 'U+1f13' ],
+    [ 'U+03ad', 'U+1f72', 'U+1f10', 'U+1f11', 'U+1f14', 'U+1f15', 'U+1f12', 'U+1f13' ],
 ]);
 $pickerset->add_subset(utf8_chr('U+0389'), [
     [ 'U+0389', 'U+1fca', NULL, 'U+1f28', 'U+1f29', 'U+1f2c', 'U+1f2d', 'U+1f2a', 
       'U+1f2b', 'U+1f2e', 'U+1f2f', 'U+1fcc', NULL, NULL, NULL, 'U+1f98', 'U+1f99',
       'U+1f9c', 'U+1f9d', 'U+1f9a', 'U+1f9b', 'U+1f9e', 'U+1f9f', ],
-    [ 'U+03AE', 'U+1f74', 'U+1fc6', 'U+1f20', 'U+1f21', 'U+1f24', 'U+1f25', 'U+1f22',
+    [ 'U+03ae', 'U+1f74', 'U+1fc6', 'U+1f20', 'U+1f21', 'U+1f24', 'U+1f25', 'U+1f22',
       'U+1f23', 'U+1f26', 'U+1f27', 'U+1fc3', 'U+1fc4', 'U+1fc2', 'U+1fc7', 'U+1f90',
       'U+1f91', 'U+1f94', 'U+1f95', 'U+1f92', 'U+1f93', 'U+1f96', 'U+1f97' ],
 ]);
-$pickerset->add_subset(utf8_chr('U+038A'), [
-    [ 'U+038A', 'U+1fda', NULL, 'U+1f38', 'U+1f39', 'U+1f3c', 'U+1f3d', 'U+1f3a', 
+$pickerset->add_subset(utf8_chr('U+038a'), [
+    [ 'U+038a', 'U+1fda', NULL, 'U+1f38', 'U+1f39', 'U+1f3c', 'U+1f3d', 'U+1f3a', 
       'U+1f3b', 'U+1f3e', 'U+1f3f', 'U+03aa' ],
-    [ 'U+03AF', 'U+1f76', 'U+1fd6', 'U+1f30', 'U+1f31', 'U+1f34', 'U+1f35', 'U+1f32',
+    [ 'U+03af', 'U+1f76', 'U+1fd6', 'U+1f30', 'U+1f31', 'U+1f34', 'U+1f35', 'U+1f32',
       'U+1f33', 'U+1f36', 'U+1f37', 'U+03ca', 'U+0390', 'U+1fd2', 'U+1fd7' ],
 ]);
-$pickerset->add_subset(utf8_chr('U+038C'), [
-    [ 'U+038C', 'U+1ff8', 'U+1f48', 'U+1f49', 'U+1f4c', 'U+1f4d', 'U+1f4a', 'U+1f4b' ],
-    [ 'U+03CC', 'U+1f78', 'U+1f40', 'U+1f41', 'U+1f44', 'U+1f45', 'U+1f42', 'U+1f43' ],
+$pickerset->add_subset(utf8_chr('U+038c'), [
+    [ 'U+038c', 'U+1ff8', 'U+1f48', 'U+1f49', 'U+1f4c', 'U+1f4d', 'U+1f4a', 'U+1f4b' ],
+    [ 'U+03cc', 'U+1f78', 'U+1f40', 'U+1f41', 'U+1f44', 'U+1f45', 'U+1f42', 'U+1f43' ],
 ]);
 $pickerset->add_subset(utf8_chr('U+1fec'), [
     [ NULL, 'U+1fec' ],
     [ 'U+1fe4', 'U+1fe5' ],
 ]);
-$pickerset->add_subset(utf8_chr('U+038E'), [
-    [ 'U+038E', 'U+1fea', NULL, NULL, 'U+1f59', NULL, 'U+1f5d', NULL,
+$pickerset->add_subset(utf8_chr('U+038e'), [
+    [ 'U+038e', 'U+1fea', NULL, NULL, 'U+1f59', NULL, 'U+1f5d', NULL,
       'U+1f5b',NULL, 'U+1f5f', 'U+03ab' ],
-    [ 'U+03CD', 'U+1f7a', 'U+1fe6', 'U+1f50', 'U+1f51', 'U+1f54', 'U+1f55', 'U+1f52',
+    [ 'U+03cd', 'U+1f7a', 'U+1fe6', 'U+1f50', 'U+1f51', 'U+1f54', 'U+1f55', 'U+1f52',
       'U+1f53', 'U+1f56', 'U+1f57', 'U+03cb', 'U+03b0', 'U+1fe2', 'U+1fe7'  ],
 ]);
-$pickerset->add_subset(utf8_chr('U+038F'), [
-    [ 'U+038F', 'U+1ffa', NULL, 'U+1f68', 'U+1f69', 'U+1f6c', 'U+1f6d', 'U+1f6a',
+$pickerset->add_subset(utf8_chr('U+038f'), [
+    [ 'U+038f', 'U+1ffa', NULL, 'U+1f68', 'U+1f69', 'U+1f6c', 'U+1f6d', 'U+1f6a',
      'U+1f6b', 'U+1f6e', 'U+1f6f', 'U+1ffc', NULL, NULL, NULL, 'U+1fa8', 'U+1fa9',
      'U+1fac', 'U+1fad', 'U+1faa', 'U+1fab', 'U+1fae', 'U+1faf' ],
-    [ 'U+03CE', 'U+1f7c', 'U+1ff6', 'U+1f60', 'U+1f61', 'U+1f64', 'U+1f65', 'U+1f62',
+    [ 'U+03ce', 'U+1f7c', 'U+1ff6', 'U+1f60', 'U+1f61', 'U+1f64', 'U+1f65', 'U+1f62',
       'U+1f63', 'U+1f66', 'U+1f67', 'U+1ff3', 'U+1ff4', 'U+1ff2', 'U+1ff7', 'U+1fa0',
       'U+1fa1', 'U+1fa4', 'U+1fa5', 'U+1fa2', 'U+1fa3', 'U+1fa6', 'U+1fa7' ],
 ]);

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -310,3 +310,68 @@ function guess_string_encoding($text)
     # Give up and return ISO-8859-1
     return 'ISO-8859-1';
 }
+
+# Return a list of Unicode codepoints we want to replace with some ASCII
+# equivalence. We convert these codepoints to ASCII up on page save in
+# DPage.inc.
+function get_utf8_to_ascii_codepoints()
+{
+    return [
+        '-' => [
+            'U+2011', # non-breaking hyphen
+            'U+2013', # en-dash
+        ],
+        '--' => [
+            'U+2014', # em-dash
+        ],
+        '"' => [
+            'U+201C', # open curly double quote
+            'U+201D', # closing curly double quote
+        ],
+        "'" => [
+            'U+2018', # open curly single quote
+            'U+2019', # closing curly single quote
+        ],
+        "..." => [
+            'U+2026', # ellipsis
+        ],
+        " " => [
+            'U+0009', # tab
+            'U+00A0', # no-break space
+            'U+1680', # ogham space mark
+            'U+2000', # en quad
+            'U+2001', # em quad
+            'U+2002', # en space
+            'U+2003', # em space
+            'U+2004', # three-per-em space
+            'U+2005', # four-per-em space
+            'U+2006', # six-per-em space
+            'U+2007', # figure space
+            'U+2008', # punctuation space
+            'U+2009', # thin space
+            'U+20A0', # hair space
+            'U+202F', # narrow no-break space
+            'U+205F', # medium mathematical space
+            'U+3000', # ideographic space
+        ],
+        "\n" => [
+            'U+000B', # vertical tab
+            'U+000C', # form feed
+            'U+0085', # next line
+            'U+2028', # line separator
+            'U+2029', # paragraph separator
+        ],
+    ];
+}
+
+# Return a list of disallowed codepoints. These codepoints are converted
+# to ASCII upon page save and are not valid in character suites.
+function get_disallowed_codepoints()
+{
+    $invalid_codepoints = [];
+    foreach(get_utf8_to_ascii_codepoints() as $ascii => $codepoints)
+    {
+        $invalid_codepoints = array_merge($invalid_codepoints, $codepoints);
+    }
+    return $invalid_codepoints;
+}

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -325,8 +325,8 @@ function get_utf8_to_ascii_codepoints()
             'U+2014', # em-dash
         ],
         '"' => [
-            'U+201C', # open curly double quote
-            'U+201D', # closing curly double quote
+            'U+201c', # open curly double quote
+            'U+201d', # closing curly double quote
         ],
         "'" => [
             'U+2018', # open curly single quote
@@ -337,7 +337,7 @@ function get_utf8_to_ascii_codepoints()
         ],
         " " => [
             'U+0009', # tab
-            'U+00A0', # no-break space
+            'U+00a0', # no-break space
             'U+1680', # ogham space mark
             'U+2000', # en quad
             'U+2001', # em quad
@@ -349,14 +349,14 @@ function get_utf8_to_ascii_codepoints()
             'U+2007', # figure space
             'U+2008', # punctuation space
             'U+2009', # thin space
-            'U+20A0', # hair space
-            'U+202F', # narrow no-break space
-            'U+205F', # medium mathematical space
+            'U+20a0', # hair space
+            'U+202f', # narrow no-break space
+            'U+205f', # medium mathematical space
             'U+3000', # ideographic space
         ],
         "\n" => [
-            'U+000B', # vertical tab
-            'U+000C', # form feed
+            'U+000b', # vertical tab
+            'U+000c', # form feed
             'U+0085', # next line
             'U+2028', # line separator
             'U+2029', # paragraph separator


### PR DESCRIPTION
Add two new validation checks for character suites in the code:
1. The suites do not contain characters that we convert on page save.
2. The suites use lowercase hex values to match what portable-utf8 provides with `utf8_chr_to_hex()`.

This MR is all non-functional changes outside of the linting. I have also confirmed via case-insensitive diff that the character suites before and after are identical outside of case.

These two functions in `unicode.inc` will be used in the per-project custom suites as well.