### PR TITLE
Updates to allow bypassing character suites

### DIFF
--- a/SETUP/UNICODE.md
+++ b/SETUP/UNICODE.md
@@ -39,6 +39,8 @@ character suites.
 
 Character suites also define Picker Sets. These are collections of characters
 that are shown to the users in the proofreading interface character picker.
+Picker sets are optional and, if they are used, need not cover the entire set
+of codepoints in the character suite.
 
 The code currently ships with 4 character suites:
 
@@ -47,8 +49,12 @@ The code currently ships with 4 character suites:
 * Basic Greek
 * Polytonic Greek
 
-All character suites can be viewed using the [All Character Suites](tools/charsuites.php)
+All character suites can be viewed using the [All Character Suites](../tools/charsuites.php)
 page.
+
+Character suites are defined by code in `../pinc/`, one file per suite -- for
+example: [charsuite-basic-latin.inc](../pinc/charsuite-basic-latin.inc). All
+files in `../pinc/` matching `charsuite-*.inc` are loaded automatically.
 
 Character suites are enabled or disabled by site administrators using the
 [Manage Site Character Suites](../tools/site_admin/manage_site_charsuites.php)
@@ -58,6 +64,32 @@ using them, but cannot be added to new projects.
 
 If you want all new projects to use one or more character suites by default,
 set `_DEFAULT_CHAR_SUITES` in your `configuration.sh` file.
+
+## Bypassing Character Suites
+
+While there is no way to bypass a character suite, it is possible to create one
+which includes a large swath of the Unicode range. This would effectively bypass
+validation as all characters in the range would be valid. This is not recommended
+as-is because it includes undefined codepoints, but may be desired for some sites.
+
+For example, to allow all characters in the Basic Multilingual Plane, the following
+file could be created in `../pinc/charsuite-bmp.inc` and then enabled.
+
+```php
+<?php
+include_once($relPath."CharSuites.inc");
+
+$charsuite = new CharSuite("bmp", _("Basic Multilingual Plane"));
+$charsuite->codepoints = [
+    # skip the C0 control block
+    'U+0020-U+FFFF',
+];
+$charsuite->reference_urls = [
+    "https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane",
+];
+
+CharSuites::add($charsuite);
+```
 
 ## Upgrading from Latin-1 projects
 
@@ -88,6 +120,9 @@ Upgrade scripts related to the Unicode conversion:
 * `20190819_convert_project_tables_to_utf8mb4.php`
 * `20191211_convert_project_text_files.php`
 * `20191211_convert_word_lists.php`
+* `20200127_add_charsuite_tables.php`
+* `20200404_normalize_project_details.php`
+* `20200511_convert_archive_db_to_utf8mb4.php`
 
 If, after the upgrade, you need to convert individual project tables to UTF-8,
 use the "Convert Project Table to UTF-8" site administrator tool under

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -177,13 +177,6 @@ class CharSuites
 
 #----------------------------------------------------------------------------
 
-// load all available charsuites
-$charsuite_files = glob($relPath."charsuite-*.inc");
-foreach($charsuite_files as $charsuite_file)
-{
-    include_once($charsuite_file);
-}
-
 trait CharSuiteSet
 {
     public function get_pickersets()
@@ -223,4 +216,13 @@ function get_project_or_quiz($identifier)
     {
         return new Project($identifier);
     }
+}
+
+#----------------------------------------------------------------------------
+
+// load all available charsuites
+$charsuite_files = glob($relPath."charsuite-*.inc");
+foreach($charsuite_files as $charsuite_file)
+{
+    include_once($charsuite_file);
 }

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -21,6 +21,11 @@ class CharacterSelector
 
         foreach ($this->picker_sets as $picker_set)
         {
+            if(!$picker_set)
+            {
+                continue;
+            }
+
             if(count($this->picker_sets) == 1)
             {
                 $prefix = "";

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -223,6 +223,7 @@ function output_codepoints_slice($slice)
         {
             $title = utf8_character_name($char);
             $codepoint = string_to_codepoints_string($char, "<br>");
+            $char = html_safe($char);
             echo "<td class='center-align' title='$title'>";
             echo "<span class='gs-char'>$char</span><br>";
             echo "<span class='gs-codepoint'>$codepoint</span>";

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -143,6 +143,11 @@ function output_charsuite($charsuite, $title=NULL, $test_font=NULL)
 function output_pickerset($pickerset, $all_codepoints)
 {
     echo "<h2>" . _("Character Picker Sets") . "</h2>";
+    if(!$pickerset)
+    {
+        echo "<p>" . _("No picker set is defined for this character suite.") . "</p>";
+        return;
+    }
     echo "<p>" . _("The following groupings represent sets of characters available in the character picker within the proofreading interface for projects using this character suite. Each grouping is labeled by a one- to four-character string that is used for the grouping's menu within the character picker.") . "</p>";
     $set = $pickerset->get_subsets();
     $picker_characters = [];

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -185,12 +185,16 @@ function output_pickerset($pickerset, $all_codepoints)
 
 function output_codepoints_table($charsuite, $table_width=16)
 {
+    # maximum number of codepoints to output
+    $MAX_CODEPOINTS = 2048;
+
     $characters = convert_codepoint_ranges_to_characters($charsuite);
 
     echo "<table class='basic'>";
 
     $offset = 0;
-    while($slice = array_slice($characters, $offset, $table_width))
+    while(($slice = array_slice($characters, $offset, $table_width)) &&
+        $offset < $MAX_CODEPOINTS)
     {
         echo "<tr>";
         output_codepoints_slice($slice);
@@ -198,6 +202,17 @@ function output_codepoints_table($charsuite, $table_width=16)
         $offset += $table_width;
     }
     echo "</table>";
+
+    if($offset >= $MAX_CODEPOINTS)
+    {
+        echo "<p class='warning'>";
+        echo sprintf(
+            _("Only %1\$s of %2\$s codepoints printed."),
+            $offset,
+            count($characters)
+        );
+        echo "</p>";
+    }
 }
 
 function output_codepoints_slice($slice)


### PR DESCRIPTION
It occurred to me that some sites may not want to restrict characters to character suites. This provides documentation and some very small code changes to allow defining **very** broad suites to the same effect.