### PR TITLE
Don't translate email footer

### DIFF
--- a/pinc/maybe_mail.inc
+++ b/pinc/maybe_mail.inc
@@ -32,8 +32,6 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
     $additional_headers = implode($additional_headers, "\r\n") . "\r\n";
 
     // Append a standard footer to all emails sent out by the system.
-    // This replaces the $site_signoff in prior versions that was not
-    // translatable.
     if(!endswith($message, "\n"))
     {
         $message .= "\n";
@@ -45,7 +43,9 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
         $site_name,
         $site_url,
         "",
-        _("This is an automated message."),
+        // We intentionally don't translate this message because we don't know
+        // what the recipient's language is at this point.
+        "This is an automated message.",
     ]);
 
     if ( $testing )


### PR DESCRIPTION
When maybe_mail() is called we are not guaranteed to be using the
recipient's language in order to correctly translate the footer.
Rather than sending out an email with a footer in an unexpected
language, always send it out in English -- so at least we're
consistently wrong when we're wrong.

Task 1898