### PR TITLE
Remove global variable $userP

### DIFF
--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -10,7 +10,8 @@ if ( isset($_GET['i_type']) )
 }
 else
 {
-    $i_type = $userP['i_type'];
+    $user = User::load_current();
+    $i_type = $user->profile->i_type;
 }
 
 // -----------------------------------------------------------------------------

--- a/locale/debug_ui_language.php
+++ b/locale/debug_ui_language.php
@@ -8,10 +8,12 @@ include_once($relPath."theme.inc");
 $title = "UI Language Debugger";
 output_header($title, NO_STATSBAR);
 
+$user = User::load_current();
+
 $detected_language = get_desired_language();
 $url_language = array_get($_GET, 'lang', "<i>not set</i>");
-$pref_language = array_get($userP, 'u_intlang', "<i>not set</i>");
-$user_logged_in = $pguser ? $pguser : "<i>not logged in</i>";
+$pref_language = $user ? $user->u_intlang : "<i>not set</i>";
+$user_logged_in = $user ? $user->username : "<i>not logged in</i>";
 if($pref_language == "") $pref_language = "<i>browser detect</i>";
 $cookie_language = array_get($_COOKIE, 'language', "<i>not set</i>");
 $http_accept_language = array_get($_SERVER, 'HTTP_ACCEPT_LANGUAGE', "<i>not set </i>");

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -51,7 +51,37 @@ class User
             );
         }
 
-        $this->table_row[$name] = $value;
+        switch($name)
+        {
+            case "profile":
+                // set the user's profile, but first make sure it's a valid
+                // profile and they own it
+                if((! $value instanceof UserProfile) || $value->u_ref != $this->u_id)
+                {
+                    throw new NonexistentUserProfileException(
+                        "Invalid profile"
+                    );
+                }
+                $this->current_profile = $value;
+
+                // persist the current profile ID to the database
+                $sql = sprintf("
+                    UPDATE users
+                    SET u_profile = %d
+                    WHERE u_id = %d
+                ", $this->current_profile->id, $this->u_id);
+                mysqli_query(DPDatabase::get_connection(), $sql)
+                    or DPDatabase::log_error();
+
+                // now set the profile cookie if this is for the current user
+                if($this->username == User::current_username())
+                {
+                    setcookie("profile", $this->current_profile->id);
+                }
+                break;
+            default:
+                $this->table_row[$name] = $value;
+        }
     }
 
     public function __get($name)
@@ -59,8 +89,38 @@ class User
         switch($name)
         {
             case "profile":
+                if($this->current_profile)
+                    return $this->current_profile;
+
+                // If this is the current user and a profile cookie is set,
+                // use that profile ID if it exists and belongs to the user.
+                // This allows a user to use different profiles across
+                // different browsers/devices.
+                if($this->username == User::current_username() && @$_COOKIE["profile"])
+                {
+                    try
+                    {
+                        $profile = new UserProfile($_COOKIE["profile"]);
+                        if($profile->u_ref != $this->u_id)
+                        {
+                            throw new NonexistentUserProfileException(
+                                "Profile does not belong to user"
+                            );
+                        }
+                        $this->current_profile = $profile;
+                    }
+                    catch(NonexistentUserProfileException $exception)
+                    {
+                        // reset the cookie since the value was invalid
+                        setcookie("profile");
+
+                        // fall through to getting the profile from the user record
+                    }
+                }
+
                 if(!$this->current_profile)
                     $this->current_profile = new UserProfile($this->u_profile);
+
                 return $this->current_profile;
             default:
                 return $this->table_row[$name];

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -191,6 +191,37 @@ class User
 
     // static functions
 
+    // Return the username of the currently-logged-in user
+    public static function current_username()
+    {
+        global $pguser;
+        return $pguser;
+    }
+
+    // Load the current user object
+    public static function load_current()
+    {
+        static $current_user = NULL;
+
+        if(is_null(User::current_username()))
+        {
+            return NULL;
+        }
+
+        if(!$current_user)
+        {
+            try
+            {
+                $current_user = new User(User::current_username());
+            }
+            catch(NonexistentUserException $e)
+            {
+                return NULL;
+            }
+        }
+        return $current_user;
+    }
+
     // Load a User record by u_id
     // e.g. $user = User::load_from_uid($u_id);
     public static function load_from_uid($u_id)

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -24,7 +24,6 @@ define('PREVIEW',                     'S');
 
 function echo_button( $button_id, $which_interface )
 {
-    global $userP;
     global $charset;
     $CRLF = '\r\n';
     if ($which_interface == 's')
@@ -43,7 +42,8 @@ function echo_button( $button_id, $which_interface )
     switch ($button_id)
     {
         case CHANGE_LAYOUT:
-            if ( $userP['i_layout']==1)
+            $user = User::load_current();
+            if ( $user->profile->i_layout==1)
             {
                 $horvert = _("Horizontal");
                 $n = "5";

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -4,25 +4,15 @@
 //
 // dpsession_begin( $userID )
 //     Start a session. (The user has logged in.)
-//     Record the session variables 'pguser' (from $userID)
-//     and 'userP'(via a call to dpsession_set_preferences_from_db).
+//     Record the session variable 'pguser' (from $userID)
 //
 // dpsession_resume()
 //     If the request claimed to belong to a session,
 //     and that session is valid/current/non-expired,
 //     then refresh the session,
-//     reinstate the global variables ($pguser and $userP) of that session,
+//     reinstate the global variable ($pguser) of that session,
 //     and return TRUE.
 //     Otherwise, return FALSE.
-//
-// dpsession_set_preferences_from_db()
-//     Read the user's preferences from the database
-//     and install them for this session.
-//
-// dpsession_set_preferences_temp( $user_preferences )
-//     Install the given preferences for this session.
-//     (If the caller doesn't put them in the database too,
-//     they'll only last for this session.)
 //
 // dpsession_end()
 //     End a session. (The user has logged out.)
@@ -34,7 +24,6 @@
 // dpsession_page_get()
 
 $pguser = NULL;
-$userP  = NULL;
 
 include_once($relPath.'site_vars.php');
 

--- a/pinc/dpsession_via_cookies.inc
+++ b/pinc/dpsession_via_cookies.inc
@@ -6,7 +6,7 @@ define( 'COOKIE_DOMAIN', substr_count($server_name, ".") > 0 ?  $server_name : "
 
 // -----------------------------------------------------------------------------
 
-// 'user' cookie and 'prefs' cookie...
+// 'user' cookie
 
 function dpsession_begin_( $userID )
 {
@@ -15,13 +15,11 @@ function dpsession_begin_( $userID )
     $pguser = $userID;
 
     user_cookie_send();
-
-    dpsession_set_preferences_from_db();
 }
 
 function dpsession_resume_()
 {
-    global $pguser, $userP;
+    global $pguser;
 
     if ( !user_cookie_was_received_from_client() )
     {
@@ -37,103 +35,7 @@ function dpsession_resume_()
     // Refresh the user's cookies
     user_cookie_send();
 
-    $user_prefs_string = prefs_cookie_getvalue();
-    prefs_cookie_send( $user_prefs_string );
-
-    // ---------------
-
-    // (I don't understand why we use the error-suppressing '@' here.)
-
-    @$user_pref_values = explode("|", $user_prefs_string);
-
-    $userP = array();
-    $i = 0;
-    // from users
-    @$userP['u_id'         ] = $user_pref_values[$i++];
-    @$userP['u_profile'    ] = $user_pref_values[$i++];
-    @$userP['email_updates'] = $user_pref_values[$i++];
-    @$userP['u_neigh'      ] = $user_pref_values[$i++];
-    @$userP['u_align'      ] = $user_pref_values[$i++];
-    @$userP['i_prefs'      ] = $user_pref_values[$i++];
-    @$userP['i_theme'      ] = $user_pref_values[$i++];
-    @$userP['i_pmdefault'  ] = $user_pref_values[$i++];
-    @$userP['user_id'      ] = $user_pref_values[$i++];
-    @$userP['team_1'       ] = $user_pref_values[$i++];
-    @$userP['team_2'       ] = $user_pref_values[$i++];
-    @$userP['team_3'       ] = $user_pref_values[$i++];
-    @$userP['u_intlang'    ] = $user_pref_values[$i++];
-    @$userP['u_privacy'    ] = $user_pref_values[$i++];
-    @$userP['last_login'   ] = $user_pref_values[$i++];
-
-    // from user_profiles
-    @$userP['profilename'  ] = $user_pref_values[$i++];
-    @$userP['i_res'        ] = $user_pref_values[$i++];
-    @$userP['i_type'       ] = $user_pref_values[$i++];
-    @$userP['i_layout'     ] = $user_pref_values[$i++];
-    @$userP['i_toolbar'    ] = $user_pref_values[$i++];
-    @$userP['i_statusbar'  ] = $user_pref_values[$i++];
-    @$userP['i_newwin'     ] = $user_pref_values[$i++];
-    @$userP['v_fnts'       ] = $user_pref_values[$i++];
-    @$userP['v_fntf'       ] = $user_pref_values[$i++];
-    @$userP['v_fntf_other' ] = $user_pref_values[$i++];
-    @$userP['v_zoom'       ] = $user_pref_values[$i++];
-    @$userP['v_tframe'     ] = $user_pref_values[$i++];
-    @$userP['v_tlines'     ] = $user_pref_values[$i++];
-    @$userP['v_tchars'     ] = $user_pref_values[$i++];
-    @$userP['v_tscroll'    ] = $user_pref_values[$i++];
-    @$userP['v_twrap'      ] = $user_pref_values[$i++];
-    @$userP['h_fnts'       ] = $user_pref_values[$i++];
-    @$userP['h_fntf'       ] = $user_pref_values[$i++];
-    @$userP['h_fntf_other' ] = $user_pref_values[$i++];
-    @$userP['h_zoom'       ] = $user_pref_values[$i++];
-    @$userP['h_tframe'     ] = $user_pref_values[$i++];
-    @$userP['h_tlines'     ] = $user_pref_values[$i++];
-    @$userP['h_tchars'     ] = $user_pref_values[$i++];
-    @$userP['h_tscroll'    ] = $user_pref_values[$i++];
-    @$userP['h_twrap'      ] = $user_pref_values[$i++];
-
-    @$userP['prefschanged' ] = $user_pref_values[$i++];
-
     return TRUE;
-}
-
-function dpsession_set_preferences_from_db()
-{
-    global $pguser;
-
-    $users_q = "
-        SELECT
-            u_id, u_profile, email_updates,
-            u_neigh, u_align,
-            i_prefs, i_theme, i_pmdefault, id,
-            team_1, team_2, team_3,
-            u_intlang, u_privacy, last_login
-        FROM users
-        WHERE username='$pguser'
-        ";
-    $users_res = mysqli_query(DPDatabase::get_connection(), $users_q);
-    $users_data = mysqli_fetch_assoc($users_res);
-
-    $user_profiles_q = "
-        SELECT
-            profilename,
-            i_res, i_type, i_layout, i_toolbar, i_statusbar, i_newwin,
-            v_fnts, v_fntf, v_zoom, v_tframe, v_tlines, v_tchars, v_tscroll, v_twrap,
-            h_fnts, h_fntf, h_zoom, h_tframe, h_tlines, h_tchars, h_tscroll, h_twrap
-        FROM user_profiles
-        WHERE u_ref='{$users_data['u_id']}' AND id='{$users_data['u_profile']}'
-        ";
-    $user_profiles_res = mysqli_query(DPDatabase::get_connection(), $user_profiles_q);
-    $user_profiles_data = mysqli_fetch_assoc($user_profiles_res);
-
-    $user_prefs_string = implode("|",$users_data)."|".implode("|",$user_profiles_data)."|0";
-    prefs_cookie_send( $user_prefs_string );
-}
-
-function dpsession_set_preferences_temp( $user_prefs )
-{
-    $user_prefs_string = implode( "|", $user_prefs );
-    prefs_cookie_send( $user_prefs_string );
 }
 
 function dpsession_end()
@@ -196,24 +98,6 @@ function user_cookie_getvalue()
 function user_cookie_disable()
 {
     local_send_cookie('pguser', "");
-}
-
-// -------------
-
-function prefs_cookie_send( $cookie_value )
-{
-    global $pguser;
-
-    $cookieName = md5($pguser."_prefs");
-    local_send_cookie( $cookieName, $cookie_value );
-}
-
-function prefs_cookie_getvalue()
-{
-    global $pguser;
-
-    $cookieName = md5($pguser."_prefs");
-    return $_COOKIE[$cookieName];
 }
 
 // -------------

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -16,16 +16,15 @@ function dpsession_begin_( $userID )
 
     $pguser = $userID;
     $_SESSION['pguser'] = $pguser;
-    dpsession_set_preferences_from_db();
 }
 
 function dpsession_resume_()
 {
-    global $pguser, $userP, $use_secure_cookies;
+    global $pguser, $use_secure_cookies;
 
     session_set_handlers_and_start();
 
-    if ( isset($_SESSION['userP']) && !empty($_SESSION['userP']) )
+    if ( isset($_SESSION['pguser']) && !empty($_SESSION['pguser']) )
     {
         // Refresh the cookie
         // (session_start() used to do this for us,
@@ -39,10 +38,9 @@ function dpsession_resume_()
             $use_secure_cookies
         );
 
-        // set global variables $pguser and $userP.
+        // set global variable $pguser
         if (isset($_SESSION['pguser'])) 
             $pguser = $_SESSION['pguser'];
-        $userP = $_SESSION['userP'];
         return TRUE;
     }
     else
@@ -51,43 +49,6 @@ function dpsession_resume_()
         session_destroy();
         return FALSE;
     }
-}
-
-function dpsession_set_preferences_from_db()
-{
-    global $pguser;
-
-    $users_res = mysqli_query(DPDatabase::get_connection(), "
-        SELECT
-            u_id, u_profile, email_updates,
-            u_neigh, u_align,
-            i_prefs, i_theme, i_pmdefault, id,
-            team_1, team_2, team_3,
-            u_intlang, u_privacy, last_login
-        FROM users
-        WHERE username='$pguser'
-        ");
-    $users_data = mysqli_fetch_assoc($users_res);
-
-    $user_profiles_res = mysqli_query(DPDatabase::get_connection(), "
-        SELECT
-            profilename,
-            i_res, i_type, i_layout, i_toolbar, i_statusbar, i_newwin,
-            v_fnts, v_fntf, v_fntf_other, v_zoom, v_tframe, v_tlines, v_tchars, v_tscroll, v_twrap,
-            h_fnts, h_fntf, h_fntf_other, h_zoom, h_tframe, h_tlines, h_tchars, h_tscroll, h_twrap
-        FROM user_profiles
-        WHERE u_ref='{$users_data['u_id']}' AND id='{$users_data['u_profile']}'
-        ");
-    $user_profiles_data = mysqli_fetch_assoc($user_profiles_res);
-
-    $prefsChanged_data = array("prefschanged" => 0);
-
-    $_SESSION['userP'] = array_merge($users_data, $user_profiles_data, $prefsChanged_data);
-}
-
-function dpsession_set_preferences_temp( $user_prefs )
-{
-    $_SESSION['userP'] = $user_prefs;
 }
 
 function dpsession_end()

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -20,7 +20,7 @@ include_once($relPath.'languages.inc');
 // * If everything else fails, default to en_US.
 function get_desired_language()
 {
-    global $pguser, $userP, $use_secure_cookies;
+    global $use_secure_cookies;
 
     // This function maybe called multiple times within a page load.
     // Only do the calculations to determine the locale once.
@@ -28,16 +28,16 @@ function get_desired_language()
     if($locale)
         return $locale;
 
+    $user = User::load_current();
     // If the below logic changes, update locale/debug_ui_language.php too
     if (isset($_GET['lang']) && lang_code($_GET['lang'])) {
         // User requested a specific language for this page
         $locale = lang_code($_GET['lang']);
         setcookie("language", $locale, time()+31536000, "/", "", $use_secure_cookies);
-    } else if (isset($userP)  && $userP['u_intlang']){
+    } else if ($user && $user->u_intlang){
         // User is logged in and has set their language preference
-        $locale = $userP['u_intlang'];
-    } else if (!$pguser &&
-               isset($_COOKIE['language']) && $_COOKIE['language']) {
+        $locale = $user->u_intlang;
+    } else if (!$user && isset($_COOKIE['language']) && $_COOKIE['language']) {
         // User is not logged in but we have a language cookie
         $locale=$_COOKIE['language'];
     } else if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -13,7 +13,7 @@ define('SHOW_STATSBAR', True);
 // page title, etc. eg:
 function output_html_header($nameofpage, $extra_args = array(), $show_statsbar = True)
 {
-    global $code_url, $site_abbreviation, $userP;
+    global $code_url, $site_abbreviation;
     global $charset;
 
     $intlang = get_desired_language();
@@ -45,7 +45,8 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     echo "</title>\n";
 
     // Global CSS
-    $theme_name = array_get($userP, 'i_theme', "project_gutenberg");
+    $user = User::load_current();
+    $theme_name = $user ? $user->i_theme : "project_gutenberg";
     $css_files = array(
         "$code_url/styles/themes/$theme_name.css",
         "$code_url/styles/layout.css",

--- a/pinc/js_newpophelp.inc
+++ b/pinc/js_newpophelp.inc
@@ -2,9 +2,11 @@
 include_once($relPath.'resolution.inc');
 
 function get_newHelpWin_javascript($popHelpDir) {
-    global $userP, $i_resolutions;
+    global $i_resolutions;
 
-    $wSize=explode("x",$i_resolutions[$userP['i_res']]);
+    $user = User::load_current();
+
+    $wSize=explode("x",$i_resolutions[$user->profile->i_res]);
     $top=($wSize[1]-300)/2;
     $left=($wSize[0]-400)/2;
 
@@ -18,4 +20,3 @@ function get_newHelpWin_javascript($popHelpDir) {
 }
 
 // vim: sw=4 ts=4 expandtab
-?>

--- a/pinc/js_newwin.inc
+++ b/pinc/js_newwin.inc
@@ -1,23 +1,25 @@
 <?php
 
 // This file implements the "Launch in New Window" preference.
-// This should be the only code that uses $userP['i_newwin']
+// This should be the only code that uses $user->profile->i_newwin
 // (leaving aside code to save/restore/display/update it).
 
 include_once($relPath.'resolution.inc');
 
 function get_js_for_links_to_project_pages()
 {
-    global $userP, $i_resolutions;
+    global $i_resolutions;
 
-    $wSize = explode("x",$i_resolutions[$userP['i_res']*1]);
+    $user = User::load_current();
+
+    $wSize = explode("x",$i_resolutions[$user->profile->i_res*1]);
     $window_width  = $wSize[0] - 20;
     $window_height = $wSize[1] - 80;
 
     return "
         function newProofWin(winURL)
         {
-            newFeatures='toolbar={$userP['i_toolbar']},status={$userP['i_statusbar']},location=0,directories=0,menubar=0,scrollbars=1,resizable=1,width=$window_width,height=$window_height,top=0,left=5';
+            newFeatures='toolbar={$user->profile->i_toolbar},status={$user->profile->i_statusbar},location=0,directories=0,menubar=0,scrollbars=1,resizable=1,width=$window_width,height=$window_height,top=0,left=5';
             nwWin=window.open(winURL,'_blank',newFeatures);
         }
     ";
@@ -38,8 +40,8 @@ function get_onclick_attr_for_link_to_project_page($url)
 // Get the 'onclick' attribute (if any) for an <a> element
 // that links to a project page.
 {
-    global $userP;
-    if ( $userP['i_newwin'] == 1 )
+    $user = User::load_current();
+    if ( $user->profile->i_newwin == 1 )
     {
         $attr = "onclick=\"newProofWin('$url'); return false;\"";
     }

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -167,8 +167,10 @@ function get_proofreading_font_family_fallback()
     return "monospace";
 }
 
-// $u_n = show rank neighbors
-$u_n= array('0', '2', '4', '6', '8', '10', '12', '14', '16', '18', '20');
+function get_rank_neighbor_options()
+{
+    return ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18', '20'];
+}
 
 define('PRIVACY_PUBLIC',    0);
 define('PRIVACY_ANONYMOUS', 1);

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -60,28 +60,28 @@ function get_available_proofreading_font_sizes()
 // $full_font_family is the current selection from get_full_font_families() below.
 function get_user_proofreading_font($interface=NULL)
 {
-    global $userP;
     $proofreading_font_faces = get_available_proofreading_font_faces();
     $proofreading_font_sizes = get_available_proofreading_font_sizes();
 
+    $user = User::load_current();
     if($interface === NULL)
     {
-        $interface = @$userP['i_layout'];
+        $interface = $user ? $user->profile->i_layout : NULL;
     }
 
-    if( !$userP ) {
+    if( !$user ) {
         $font_size_i = 0;
         $font_style_i = 0;
     }
-    elseif ( $interface  == 1 )   // "vertical"
+    elseif ( $interface == 1 )   // "vertical"
     {
-        $font_size_i = $userP['v_fnts'];
-        $font_style_i = $userP['v_fntf'];
+        $font_size_i = $user->profile->v_fnts;
+        $font_style_i = $user->profile->v_fntf;
     }
     else   // "horizontal"
     {
-        $font_size_i = $userP['h_fnts'];
-        $font_style_i = $userP['h_fntf'];
+        $font_size_i = $user->profile->h_fnts;
+        $font_style_i = $user->profile->h_fntf;
     }
 
     if($font_style_i == 1) // other
@@ -145,19 +145,26 @@ function get_full_font_families($interface = NULL)
 
 function get_user_proofreading_font_other($interface=NULL)
 {
-    global $userP;
+    $user = User::load_current();
+
+    // If we don't have a current user, they can't have an other font
+    if(!$user)
+    {
+        return "";
+    }
+
     if($interface === NULL)
     {
-        $interface = @$userP['i_layout'];
+        $interface = $user->profile->i_layout;
     }
 
     if ( $interface == 1 )   // "vertical"
     {
-        return @$userP['v_fntf_other'];
+        return $user->profile->v_fntf_other;
     }
     else   // "horizontal"
     {
-        return @$userP['h_fntf_other'];
+        return $user->profile->h_fntf_other;
     }
 }
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -657,8 +657,7 @@ function show_tally_specific_stats( $tally_name )
             }
         }
 
-        // Get userid for personal stats link
-        $user = new User($pguser);
+        $user = User::load_current();
 
         // get yesterday's and today's page count
         $snapshot_info = $tallyboard->get_info_from_latest_snapshot($user->u_id);

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -19,10 +19,10 @@ include_once($relPath.'faq.inc');
 // to close the page after the caller finishes output.
 function output_header($nameofpage, $show_statsbar = True, $extra_args = array())
 {
-    global $pguser, $userP;
+    $user = User::load_current();
 
     // Display stats bar on left (1) or right (0)
-    $statsbar_align = isset($pguser) ? $userP['u_align'] : 0;
+    $statsbar_align = $user ? $user->u_align : 0;
 
     // The theme layout consists of:
     // * Two full width headers at the top,
@@ -65,10 +65,10 @@ function output_header($nameofpage, $show_statsbar = True, $extra_args = array()
 
 function output_footer($nameofpage, $show_statsbar = True) {
     global $code_url, $site_name, $PAGE_START_TIME;
-    global $pguser, $userP;
 
+    $user = User::load_current();
     // Display stats bar on left (1) or right (0)
-    $statsbar_align = isset($pguser) ? $userP['u_align'] : 0;
+    $statsbar_align = $user ? $user->u_align : 0;
 
     // The main page content has been emited so close the main page content column.
     echo "</div>\n";
@@ -197,13 +197,14 @@ function html_navbar()
 // Display the horizontal bar containing links to various important points
 // within the site (and the login form if the user is not logged in).
 {
-    global $code_url, $site_abbreviation, $pguser, $forums_url, $blog_url, $wiki_url;
+    global $code_url, $site_abbreviation, $forums_url, $blog_url, $wiki_url;
 
     echo "<div id='navbar-outer'>";
     echo "<div id='navbar'>";
 
     //Code to display login form if not logged in
-    if (!isset($pguser)) {
+    $user = User::load_current();
+    if (!$user) {
         $links = array();
         $links[] = array('text' => $site_abbreviation, 'url' => "default.php");
         if ( !empty($blog_url) )
@@ -254,7 +255,7 @@ function html_navbar()
         //Code to display if the user is logged in
 
         // Fetch some values from the database for use in links later
-        $numofPMs = get_number_of_unread_messages($pguser);
+        $numofPMs = get_number_of_unread_messages($user->username);
 
         // left side
         echo "<span id='navbar-left'>";
@@ -267,7 +268,7 @@ function html_navbar()
 
         // use white-space: nowrap; to keep the rounds within []s together
         $activities_string = "<span style='white-space: nowrap;'>[ ";
-        if(get_pages_proofed_maybe_simulated($pguser) < 100)
+        if(get_pages_proofed_maybe_simulated() < 100)
             $activities_string .= "<span class='text'>" . _("Activities") . ": </span>";
 
         $activities_string .= headerbar_text_array(get_activity_links());
@@ -311,7 +312,7 @@ function html_navbar()
         $links[] = array('text' => _("Stats"), 'url' => "stats/stats_central.php");
         $links[] = array('text' => _("Prefs"), 'url' => "userprefs.php");
         $links[] = array('text' => _('Help'), 'url' => get_faq_url("faq_central.php"));
-        $links[] = array('text' => sprintf(_("Log Out (%s)"),$pguser), 'url' => "accounts/logout.php");
+        $links[] = array('text' => sprintf(_("Log Out (%s)"), $user->username), 'url' => "accounts/logout.php");
 
         echo headerbar_text_array($links);
         echo "</span>";
@@ -396,12 +397,13 @@ function headerbar_text_array($entries)
 
 function html_statsbar($nameofpage) {
 
-    global $code_url, $PG_home_url, $pguser;
+    global $code_url, $PG_home_url;
     global $Round_for_round_id_;
     maybe_show_language_selector();
 
     // For logged-in users, show links to key help documents:
-    if (isset($pguser))
+    $user = User::load_current();
+    if ($user)
     {
         show_key_help_links();
         echo "<hr class='divider'>\n";
@@ -459,7 +461,7 @@ function html_statsbar($nameofpage) {
 
         // Only show completed projects list to signed in users, to
         // keep front page uncluttered for visitors.
-        if (isset($pguser)) {
+        if ($user) {
             echo "<div id='completed-projects'>\n";
             show_completed_projects();
             echo "</div>\n";
@@ -476,7 +478,7 @@ function html_statsbar($nameofpage) {
     echo "</a>";
     echo "</p>";
 
-    if (isset($pguser))
+    if ($user)
     {
         // requestor is a logged-in user.
         echo "<hr class='divider'>\n";
@@ -485,7 +487,7 @@ function html_statsbar($nameofpage) {
 
     // SITE-SPECIFIC
     //Display the "About DP" section if user is not logged in
-    if (!isset($pguser))
+    if (!$user)
     {
         echo "<hr><p id='about-dp'>";
         echo sprintf(_("Distributed Proofreaders was founded in 2000 by Charles Franks to support the digitization of Public Domain books. Originally conceived to assist <a href='%s'>Project Gutenberg</a> (PG), Distributed Proofreaders (DP) is now the main source of PG e-books. In 2002, Distributed Proofreaders became an official PG site. In May 2006, Distributed Proofreaders became a separate legal entity and continues to maintain a strong relationship with PG."), $PG_home_url);
@@ -497,7 +499,7 @@ function html_statsbar($nameofpage) {
 
 function maybe_show_language_selector()
 {
-    global $code_url, $userP, $user_is_logged_in;
+    global $code_url, $user_is_logged_in;
 
     // if user is logged in, return instead of showing the drop-down
     if($user_is_logged_in)
@@ -532,9 +534,11 @@ function get_activity_links()
 // return a list of round/stage links for the user
 // the returned links are in a format usable by headerbar_text_array
 {
-    global $Stage_for_id_, $pguser;
+    global $Stage_for_id_;
 
-    if (is_null($pguser)) return;
+    $user = User::load_current();
+
+    if (!$user) return;
     // Should show links to stages that are accessible to people
     // that aren't logged in? (i.e., SR)?
 
@@ -546,7 +550,7 @@ function get_activity_links()
     }
 
     // Get all stages the user has access to
-    $stages_can_access_and_access_prereqs = get_stages_user_can_work_in($pguser);
+    $stages_can_access_and_access_prereqs = get_stages_user_can_work_in($user->username);
 
     // we still need to loop through $Stage_for_id_ to output the stages
     // in order
@@ -559,7 +563,7 @@ function get_activity_links()
             // for PPers, get the number of their projects requiring attention
             if($stage->id == "PP")
             {
-                $total = count_pp_projects_past_threshold($pguser);
+                $total = count_pp_projects_past_threshold($user->username);
                 if($total)
                     $text .= " ($total)";
             }
@@ -584,7 +588,7 @@ function get_activity_links()
 
 function show_tally_specific_stats( $tally_name )
 {
-    global $code_url, $userP, $pguser;
+    global $code_url;
 
     // Put the whole thing in a div, just so we can put a box around it.
     echo "<div id='tally-stats'>\n";
@@ -624,7 +628,8 @@ function show_tally_specific_stats( $tally_name )
 
     // ---------------------------------------------------------------------
 
-    if (isset($pguser))
+    $user = User::load_current();
+    if ($user)
     {
         // The requestor is a logged-in user.
         // Show the user's personal statistics
@@ -632,7 +637,7 @@ function show_tally_specific_stats( $tally_name )
         //Get the personal statistics array
         $neighbors =
             user_get_page_tally_neighborhood(
-                $tally_name, $pguser, $userP['u_neigh']);
+                $tally_name, $user->username, $user->u_neigh);
         $usern = $neighbors[0];
 
         //get rank
@@ -688,11 +693,11 @@ function show_tally_specific_stats( $tally_name )
         echo "$rankname<br>\n";
         echo "</p>\n";
         echo "<p class='more-link'><a href='$code_url/stats/members/mdetail.php?id=".$user->u_id."&amp;tally_name=".$tally_name."'>" . $tally_name . " " .  _("Details...") . "</a></p>\n";
-        echo "<" . "!-- " . $userP['u_id'] . " -->";
 
         // -------------------------------------------------------------
         //Show the Neighbor table if the user has requested so
-        if ($userP['u_neigh']) {
+        $user = User::load_current();
+        if ($user->u_neigh) {
             echo "<h2>" . sprintf(_("Your %s Neighborhood"), $tally_name) . "</h2>\n";
             echo "<p>\n";
 
@@ -728,7 +733,9 @@ function show_tally_vs_goal($label, $goal, $actual)
 
 function show_user_teams()
 {
-    global $code_url, $userP;
+    global $code_url;
+
+    $user = User::load_current();
 
     echo "<div id='teams-nav'>\n";
     echo "<h2>" .  _("Your Teams") . "</h2>\n";
@@ -736,7 +743,7 @@ function show_user_teams()
     $teamRes=mysqli_query(DPDatabase::get_connection(), "
         SELECT teamname, id
         FROM user_teams
-        WHERE id IN ({$userP['team_1']}, {$userP['team_2']}, {$userP['team_3']})
+        WHERE id IN ({$user->team_1}, {$user->team_2}, {$user->team_3})
     ");
     while($row = mysqli_fetch_assoc($teamRes))
     {

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -63,10 +63,10 @@ function showTeamInformation($curTeam, $tally_name)
 
 function showTeamProfile($curTeam, $preview=FALSE)
 {
-    global $userP;
     global $team_avatars_url;
     global $code_url;
 
+    $user = User::load_current();
     $team_id = $curTeam['id'];
 
     if($team_id)
@@ -78,7 +78,7 @@ function showTeamProfile($curTeam, $preview=FALSE)
     $xml_button = "<a href='$xml_doc_url'>$xml_img_tag</a>";
 
     // Allow team owner and site administrators to edit the team
-    if (!$preview && (($userP['u_id'] == $curTeam['owner']) || user_is_a_sitemanager()))
+    if (!$preview && $user && (($user->u_id == $curTeam['owner']) || user_is_a_sitemanager()))
     {
         $op_url = "tedit.php?tid=$team_id";
         $text = _('Edit');
@@ -89,7 +89,7 @@ function showTeamProfile($curTeam, $preview=FALSE)
         $editlink = '';
     }
 
-    if ($preview || empty($userP))
+    if ($preview || !$user)
     {
         // The requestor is not logged in,
         // so they can't join or quit the team.
@@ -97,7 +97,7 @@ function showTeamProfile($curTeam, $preview=FALSE)
     }
     else
     {
-        if ($userP['team_1'] != $team_id && $userP['team_2'] != $team_id && $userP['team_3'] != $team_id)
+        if ($user->team_1 != $team_id && $user->team_2 != $team_id && $user->team_3 != $team_id)
         {
             $op = 'jointeam';
             $text = _('Join');
@@ -455,7 +455,9 @@ function unstripAllString($ttext) {
 
 function showEdit($tname,$ttext,$twebpage,$tedit,$tsid)
 {
-    global $teamimages, $userP;
+    global $teamimages;
+
+    $user = User::load_current();
 
     echo "<form enctype='multipart/form-data' id='mkTeam' name='mkTeam' action='";
     if ($tedit == 1) { echo "new_team.php"; } else { echo "tedit.php"; }
@@ -505,10 +507,10 @@ function showEdit($tname,$ttext,$twebpage,$tedit,$tsid)
 
     echo "<tr>";
     echo "<td class='center-align' colspan='2'>";
-    if ($tedit == 1 && $userP['team_1'] != 0 && $userP['team_2'] != 0 && $userP['team_3'] != 0) {
+    if ($tedit == 1 && $user->team_1 != 0 && $user->team_2 != 0 && $user->team_3 != 0) {
         echo "<tr><td style='text-align: center;' colspan='2'>"._("You must join the team to create it, which team space would you like to use?")."<br>";
         echo "<select name='tteams' title='".attr_safe(_("Team List"))."'>";
-        $teamQuery = mysqli_query(DPDatabase::get_connection(), "SELECT teamname, id FROM user_teams WHERE id IN ({$userP['team_1']}, {$userP['team_2']}, {$userP['team_3']})");
+        $teamQuery = mysqli_query(DPDatabase::get_connection(), "SELECT teamname, id FROM user_teams WHERE id IN ({$user->team_1}, {$user->team_2}, {$user->team_3})");
         while ($row = mysqli_fetch_assoc($teamQuery)) {
             echo "<option value='".$row['id']."'>".html_safe($row['teamname'])."</option>";
         }

--- a/stats/members/jointeam.php
+++ b/stats/members/jointeam.php
@@ -10,21 +10,23 @@ require_login();
 $otid = get_integer_param( $_GET, 'otid', 0, 0, 3 );
 $tid  = get_integer_param( $_GET, 'tid', null, 0, null );
 
-if ($userP['team_1'] != $tid && $userP['team_2'] != $tid && $userP['team_3'] != $tid) {
-    if ($userP['team_1'] == 0 || $otid == 1) {
-        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_1 = $tid WHERE username = '".$GLOBALS['pguser']."' AND u_id = ".$userP['u_id']."");
-        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = ".$userP['u_id'].", member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
-        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = ".$userP['team_1'].""); }
+$user = User::load_current();
+
+if ($user->team_1 != $tid && $user->team_2 != $tid && $user->team_3 != $tid) {
+    if ($user->team_1 == 0 || $otid == 1) {
+        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_1 = $tid WHERE u_id = $user->u_id");
+        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = $user->u_id, member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
+        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = $user->team_1"); }
         $redirect_team = 1;
-    } elseif ($userP['team_2'] == 0 || $otid == 2) {
-        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_2 = $tid WHERE username = '".$GLOBALS['pguser']."' AND u_id = ".$userP['u_id']."");
-        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = ".$userP['u_id'].", member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
-        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = ".$userP['team_2'].""); }
+    } elseif ($user->team_2 == 0 || $otid == 2) {
+        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_2 = $tid WHERE u_id = $user->u_id");
+        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = $user->u_id, member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
+        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = $user->team_2"); }
         $redirect_team = 1;
-    } elseif ($userP['team_3'] == 0 || $otid == 3) {
-        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_3 = $tid WHERE username = '".$GLOBALS['pguser']."' AND u_id = ".$userP['u_id']."");
-        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = ".$userP['u_id'].", member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
-        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = ".$userP['team_3'].""); }
+    } elseif ($user->team_3 == 0 || $otid == 3) {
+        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_3 = $tid WHERE u_id = $user->u_id");
+        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = $user->u_id, member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
+        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = $user->team_3"); }
         $redirect_team = 1;
     } else {
         include_once($relPath.'theme.inc');
@@ -33,15 +35,15 @@ if ($userP['team_1'] != $tid && $userP['team_2'] != $tid && $userP['team_3'] != 
         echo "<h1>$title</h1>\n";
         echo "<p>" . _("You have already joined three teams.<br>Which team would you like to replace?") . "</p>";
         echo "<ul>";
-        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id='".$userP['team_1']."'");
+        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id = $user->team_1");
         $row = mysqli_fetch_assoc($teamR);
         $teamname = $row["teamname"];
         echo "<li><a href='jointeam.php?tid=$tid&otid=1'>$teamname</a></li>";
-        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id='".$userP['team_2']."'");
+        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id = $user->team_2");
         $row = mysqli_fetch_assoc($teamR);
         $teamname = $row["teamname"];
         echo "<li><a href='jointeam.php?tid=$tid&otid=2'>$teamname</a></li>";
-        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id='".$userP['team_3']."'");
+        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id = $user->team_3");
         $row = mysqli_fetch_assoc($teamR);
         $teamname = $row["teamname"];
         echo "<li><a href='jointeam.php?tid=$tid&otid=3'>$teamname</a></li>";
@@ -59,7 +61,6 @@ if ($userP['team_1'] != $tid && $userP['team_2'] != $tid && $userP['team_3'] != 
 }
 
 if ($redirect_team == 1) {
-    dpsession_set_preferences_from_db();
     $title = _("Join the Team");
     $desc = _("Joining the team....");
     metarefresh(0,"../teams/tdetail.php?tid=$tid",$title, $desc);

--- a/stats/members/quitteam.php
+++ b/stats/members/quitteam.php
@@ -9,15 +9,16 @@ require_login();
 
 $tid = get_integer_param($_GET, 'tid', null, 0, null);
 
-if ($userP['team_1'] == $tid || $userP['team_2'] == $tid || $userP['team_3'] == $tid) {
+$user = User::load_current();
+
+if ($user->team_1 == $tid || $user->team_2 == $tid || $user->team_3 == $tid) {
     $quitQuery = "UPDATE users SET ";
-    if ($userP['team_1'] == $tid) { $quitQuery .= "team_1 = '0'"; }
-    if ($userP['team_2'] == $tid) { $quitQuery .= "team_2 = '0'"; }
-    if ($userP['team_3'] == $tid) { $quitQuery .= "team_3 = '0'"; }
-    $quitQuery.=" WHERE username='$pguser' AND u_id='".$userP['u_id']."'";
+    if ($user->team_1 == $tid) { $quitQuery .= "team_1 = '0'"; }
+    if ($user->team_2 == $tid) { $quitQuery .= "team_2 = '0'"; }
+    if ($user->team_3 == $tid) { $quitQuery .= "team_3 = '0'"; }
+    $quitQuery.=" WHERE u_id = $user->u_id";
     $teamResult=mysqli_query(DPDatabase::get_connection(), $quitQuery);
     mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id='".$tid."'");
-    dpsession_set_preferences_from_db();
     $title = _("Quit the Team");
     $desc = _("Quitting the team....");
     metarefresh(0,"../teams/tdetail.php?tid=".$tid."",$title,$desc);

--- a/stats/teams/new_team.php
+++ b/stats/teams/new_team.php
@@ -8,6 +8,8 @@ include_once('../includes/team.inc'); // showEdit()
 
 require_login();
 
+$user = User::load_current();
+
 $theme_extra_args = array("js_data" => get_newHelpWin_javascript("$code_url/pophelp.php?category=teams&name=edit_"));
 
 if (isset($_POST['mkPreview']))
@@ -20,8 +22,8 @@ if (isset($_POST['mkPreview']))
     $curTeam['teamname'] = stripAllString($_POST['teamname']);
     $curTeam['team_info'] = stripAllString($_POST['text_data']);
     $curTeam['webpage'] = stripAllString($_POST['teamwebpage']);
-    $curTeam['createdby'] = $pguser;
-    $curTeam['owner'] = $userP['u_id'];
+    $curTeam['createdby'] = $user->username;
+    $curTeam['owner'] = $user->u_id;
     $curTeam['created'] = time();
     $curTeam['member_count'] = 0;
     $curTeam['active_members'] = 0;
@@ -62,7 +64,7 @@ else if (isset($_POST['mkMake']))
         ", mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString(trim($_POST['teamname']))),
             mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString($_POST['text_data'])),
             mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString($_POST['teamwebpage'])),
-            $pguser, $userP['u_id'], time()));
+            $user->username, $user->u_id, time()));
         $tid = mysqli_insert_id(DPDatabase::get_connection());
         if (!empty($_POST['tavatar']))
         {
@@ -95,20 +97,19 @@ else if (isset($_POST['mkMake']))
         $otid=0;
         if (!isset($_POST['teamall']))
         {
-            if ($userP['team_1'] == $_POST['tteams'])
+            if ($user->team_1 == $_POST['tteams'])
             {
                 $otid=1;
             }
-            elseif ($userP['team_2'] == $_POST['tteams'])
+            elseif ($user->team_2 == $_POST['tteams'])
             {
                 $otid=2;
             }
-            else if ($userP['team_3'] == $_POST['tteams'])
+            else if ($user->team_3 == $_POST['tteams'])
             {
                 $otid=3;
             }
         }
-        dpsession_set_preferences_from_db();
     
         $title = _("Join the Team");
         $desc = _("Creating the team....");

--- a/stats/teams/tedit.php
+++ b/stats/teams/tedit.php
@@ -21,8 +21,10 @@ if (!isset($tid)) {
 $result = select_from_teams("id = $tid");
 $curTeam = mysqli_fetch_assoc($result);
 
+$user = User::load_current();
+
 // Allow team owner and site administrators to edit the team
-if (($userP['u_id'] != $curTeam['owner']) && (!user_is_a_sitemanager()))
+if (($user->u_id != $curTeam['owner']) && (!user_is_a_sitemanager()))
 {
     $title = _("Authorization Failed");
     $desc = _("You are not authorized to edit this team....");

--- a/stats/teams/tlist.php
+++ b/stats/teams/tlist.php
@@ -43,6 +43,8 @@ if ($tname) {
     $tname = "";
 }
 
+$user = User::load_current();
+
 $name = _("Team List");
 
 output_header($name);
@@ -68,7 +70,7 @@ if (!empty($tRows)) {
         echo "<td>", html_safe($row['teamname']), "</td>\n";
         echo "<td class='center-align'>".$row['member_count']."</td>\n";
         echo "<td class='center-align'><b><a href='tdetail.php?tid=".$row['id']."'>"._("View")."</a>&nbsp;";
-        if ($userP['team_1'] != $row['id'] && $userP['team_2'] != $row['id'] && $userP['team_3'] != $row['id']) {
+        if ($user->team_1 != $row['id'] && $user->team_2 != $row['id'] && $user->team_3 != $row['id']) {
             echo "<a href='../members/jointeam.php?tid=".$row['id']."'>"._("Join")."</a></b></td>";
         } else {
             echo "<a href='../members/quitteam.php?tid=".$row['id']."'>"._("Quit")."</a></b></td>";

--- a/tasks.php
+++ b/tasks.php
@@ -17,7 +17,8 @@ require_login();
 
 $tasks_url = $code_url . "/" . basename(__FILE__);
 
-$requester_u_id = $userP['u_id'];
+$user = User::load_current();
+$requester_u_id = $user->u_id;
 
 $now_sse = time();
 // The current time, expressed as Seconds Since the (Unix) Epoch.

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -234,19 +234,21 @@ elseif ($frame=="text") {
         $row = mysqli_fetch_assoc($result);
         $data = $row[$text_column_name];
 
+        $user = User::load_current();
+
         // Use the font and wrap prefs for the user's default interface layout, 
         // since they're more likely to have set those prefs
-        if ( $userP['i_layout']==1 ) {
-            $line_wrap   = $userP['v_twrap'];
+        if ($user->profile->i_layout == 1) {
+            $line_wrap = $user->profile->v_twrap;
         } else {
-            $line_wrap   = $userP['h_twrap'];
+            $line_wrap = $user->profile->h_twrap;
         }
         list($font_face, $font_size) = get_user_proofreading_font();
 
         // Since this page doesn't have a vertical layout version, 
         // we'll use their horizontal prefs for textarea size
-        $n_cols = $userP['h_tchars'];
-        $n_rows = $userP['h_tlines'];
+        $n_cols = $user->profile->h_tchars;
+        $n_rows = $user->profile->h_tlines;
 
         list( , $font_size, $font_family) = get_user_proofreading_font();
         $font_size_string = '';

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -830,7 +830,7 @@ else if ($action == HANDLE_ENTRY_FORM_SUBMISSION)
 else if ($action == SEND_OUT_REPORTCARD)
 {
     $pper = new User($project->postproofer);
-    $ppver = new User($pguser);
+    $ppver = User::load_current();
 
     $reportcard = $_POST["reportcard"];
 

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -15,7 +15,8 @@ include_once('projectmgr.inc'); // echo_manager_links();
 
 require_login();
 
-switch ($userP['i_pmdefault'])
+$user = User::load_current();
+switch ($user->i_pmdefault)
 {
     case 0:
         $default_view = "user_all";
@@ -87,16 +88,16 @@ if ($show_view == 'search_form')
 
 if($show_view == "user_all")
 {
-    $condition = "username = '$pguser'";
+    $condition = "username = '$user->username'";
     // adjust $_GET so will work corectly with refine search and sort and navigate
     // keep "user_all" or we won't know it is user all
-    $_GET = array_merge($_GET, array('project_manager' => $pguser));
+    $_GET = array_merge($_GET, array('project_manager' => $user->username));
 }
 elseif ($show_view == "user_active")
 {
-    $condition = "$PROJECT_IS_ACTIVE_sql AND username = '$pguser'";
+    $condition = "$PROJECT_IS_ACTIVE_sql AND username = '$user->username'";
     $_GET = array_merge($_GET, array(
-        'project_manager' => $pguser,
+        'project_manager' => $user->username,
         'state' => array_diff($PROJECT_STATES_IN_ORDER, array(PROJ_SUBMIT_PG_POSTED, PROJ_DELETE))
     ));
 }

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -207,25 +207,25 @@ class PPage
 
     function echo_proofing_textarea()
     {
-        global $userP;
+        $user = User::load_current();
 
         $page_text = $this->lpage->get_text();
 
         $lang = $this->lpage->get_language();
 
-        if ( $userP['i_layout']==1 )
+        if ($user->profile->i_layout == 1)
         {
             // "vertical"
-            $n_cols      = $userP['v_tchars'];
-            $n_rows      = $userP['v_tlines'];
-            $line_wrap   = $userP['v_twrap'];
+            $n_cols      = $user->profile->v_tchars;
+            $n_rows      = $user->profile->v_tlines;
+            $line_wrap   = $user->profile->v_twrap;
         }
         else
         {
             // "horizontal"
-            $n_cols      = $userP['h_tchars'];
-            $n_rows      = $userP['h_tlines'];
-            $line_wrap   = $userP['h_twrap'];
+            $n_cols      = $user->profile->h_tchars;
+            $n_rows      = $user->profile->h_tlines;
+            $line_wrap   = $user->profile->h_twrap;
         }
 
         echo "<textarea

--- a/tools/proofers/button_menu.inc
+++ b/tools/proofers/button_menu.inc
@@ -7,7 +7,7 @@ include_once('PPage.inc');
 
 function echo_button_menu( $ppage )
 {
-    global $userP;
+    $user = User::load_current();
     $proofreading_font_faces = get_available_proofreading_font_faces();
     $proofreading_font_sizes = get_available_proofreading_font_sizes();
     $font_family_fallback = get_proofreading_font_family_fallback();
@@ -75,9 +75,11 @@ name="fntSize" ID="fntSize"  class="dropsmall" title="<?php
 ?></select>
 <input
 type="text" value="<?php
-  if ($userP['i_layout']==1)
-    {echo $userP['v_zoom'];}
-  else{echo $userP['h_zoom'];}
+    if ($user->profile->i_layout == 1) {
+        echo $user->profile->v_zoom;
+    } else {
+        echo $user->profile->h_zoom;
+    }
 ?>" name="zmSize" ID="zmSize" class="boxnormal bottom-align" size="3" title="<?php 
     # xgettext:no-php-format
     echo attr_safe(_("Input Zoom %"));

--- a/tools/proofers/image_block_enh.inc
+++ b/tools/proofers/image_block_enh.inc
@@ -29,21 +29,21 @@ function ibe_get_styles()
 // as percentages of its container box
 // (which is typically the "proofframe" of the proofing interface).
 {
-    global $userP;
+    $user = User::load_current();
 
-    if ($userP['i_layout']=='1') {
-        $textWidth=$userP['v_tframe'];
-        $block_width_pc=(100-$userP['v_tframe'])-1;
+    if ($user->profile->i_layout == '1') {
+        $textWidth = $user->profile->v_tframe;
+        $block_width_pc = (100 - $user->profile->v_tframe) - 1;
         $textHeight=99;
         $block_height_pc=99;
         $textTop="0px";
-        $textLeft=(100-$userP['v_tframe'])."%";
+        $textLeft = (100 - $user->profile->v_tframe) . "%";
     } else {
         $textWidth=99;
         $block_width_pc=99;
-        $textHeight=$userP['h_tframe'];
-        $block_height_pc=(100-$userP['h_tframe'])-1;
-        $textTop=100-$userP['h_tframe']."%";
+        $textHeight = $user->profile->h_tframe;
+        $block_height_pc = (100 - $user->profile->h_tframe) - 1;
+        $textTop = (100 - $user->profile->h_tframe) . "%";
         $textLeft="1%";
     }
 

--- a/tools/proofers/image_frame_std.php
+++ b/tools/proofers/image_frame_std.php
@@ -11,10 +11,11 @@ $ppage = get_requested_PPage($_GET);
 
 slim_header("Image Frame", array('body_attributes' => 'id="standard_interface"'));
 
-if ($userP['i_layout']==1)
-    $iWidth=$userP['v_zoom'];
+$user = User::load_current();
+if ($user->profile->i_layout == 1)
+    $iWidth = $user->profile->v_zoom;
 else
-    $iWidth=$userP['h_zoom'];
+    $iWidth = $user->profile->h_zoom;
 $iWidth=round((1000*$iWidth)/100);
 ?>
 

--- a/tools/proofers/md_phase2.php
+++ b/tools/proofers/md_phase2.php
@@ -168,9 +168,12 @@ output_header(_("Image Frame"));
 echo "<table cols ='2' border = '1'>";
 
 //Display image
-if ($userP['i_layout']==1)
-    {$iWidth=$userP['v_zoom'];}
-else {$iWidth=$userP['h_zoom'];}
+$user = User::load_current();
+if ($user->profile->i_layout == 1) {
+    $iWidth = $user->profile->v_zoom;
+} else {
+    $iWidth = $user->profile->h_zoom;
+}
 $iWidth=round((1000*$iWidth)/100);
 
 // The outside table has a single row containing two cells.

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -54,7 +54,8 @@ if (isset($_POST['spsaveandnext']))    {$tbutton=103;} // Save and do another fr
 if (isset($_POST['rerunauxlanguage'])) {$tbutton=104;} // Spellcheck against another language
 
 // set prefs
-if ($userP['i_type']==1)
+$user = User::load_current();
+if ($user->profile->i_type == 1)
 {
     if(isset($_POST['fntFace']))
         $fntFace = $_POST['fntFace'];
@@ -63,21 +64,21 @@ if ($userP['i_type']==1)
     if(isset($_POST['zmSize']))
         $zmSize  = $_POST['zmSize'];
     
-    $isChg=0;
-    if ($userP['i_layout']==1)
+    if ($user->profile->i_layout == 1)
     {
-        if (isset($fntFace) && $userP['v_fntf']!=$fntFace) {$userP['v_fntf']=$fntFace;$isChg=1;}
-        if (isset($fntSize) && $userP['v_fnts']!=$fntSize) {$userP['v_fnts']=$fntSize;$isChg=1;}
-        if (isset($zmSize) && $userP['v_zoom']!=$zmSize) {$userP['v_zoom']=$zmSize;$isChg=1;}
+        if (isset($fntFace)) { $user->profile->v_fntf = $fntFace; }
+        if (isset($fntSize)) { $user->profile->v_fnts = $fntSize; }
+        if (isset($zmSize))  { $user->profile->v_zoom = $zmSize; }
     }
     else
     {
-        if (isset($fntFace) && $userP['h_fntf']!=$fntFace) {$userP['h_fntf']=$fntFace;$isChg=1;}
-        if (isset($fntSize) && $userP['h_fnts']!=$fntSize) {$userP['h_fnts']=$fntSize;$isChg=1;}
-        if (isset($zmSize) && $userP['h_zoom']!=$zmSize) {$userP['h_zoom']=$zmSize;$isChg=1;}
+        if (isset($fntFace)) { $user->profile->h_fntf = $fntFace; }
+        if (isset($fntSize)) { $user->profile->h_fnts = $fntSize; }
+        if (isset($zmSize))  { $user->profile->h_zoom = $zmSize; }
     }
-    $userP['prefschanged']=$isChg;
-    dpsession_set_preferences_temp( $userP );
+
+    if(isset($fntFace) || isset($fntSize) || isset($zmSize))
+        $user->profile->save();
 }
 
 // If the user simply wants to leave the proofing interface,
@@ -274,21 +275,21 @@ switch( $tbutton )
 
 function switch_layout()
 {
-    global $userP;
-    $userP['i_layout'] = $userP['i_layout']==1 ? 0 : 1;
-    $userP['prefschanged'] = 1;
-    dpsession_set_preferences_temp( $userP );
+    $user = User::load_current();
+    $user->profile->i_layout = $user->profile->i_layout == 1 ? 0 : 1;
+    $user->profile->save();
 }
 
 function leave_spellcheck_mode( $ppage )
 {
-    global $userP;
+
+    $user = User::load_current();
 
     // The user has requested a return from spellcheck mode.
     // The response that we send will replace the frame/document
     // containing the spellcheck form.
 
-    if ( $userP['i_type'] == 0 )
+    if ($user->profile->i_type == 0)
     {
         // standard interface:
         // The spellcheck document (containing text only) is in 'textframe'.

--- a/tools/proofers/proof_frame.inc
+++ b/tools/proofers/proof_frame.inc
@@ -8,9 +8,9 @@ include_once('proof_frame_enh.inc');
 
 function echo_proof_frame( $ppage )
 {
-    global $userP;
+    $user = User::load_current();
 
-    $interface_type = $userP['i_type'];
+    $interface_type = $user->profile->i_type;
     switch ($interface_type)
     {
         case 0:

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -10,7 +10,7 @@ include_once('preview.inc');
 
 function echo_proof_frame_enh( $ppage )
 {
-    global $code_url, $userP;
+    global $code_url;
 
     $project = new Project($ppage->projectid());
     $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints()));
@@ -42,10 +42,11 @@ function echo_proof_frame_enh( $ppage )
 
     slim_header(_("Proofreading Page"), $header_args);
 
-    if ($userP['i_layout']==1)
-        $iWidth=$userP['v_zoom'];
+    $user = User::load_current();
+    if ($user->profile->i_layout == 1)
+        $iWidth = $user->profile->v_zoom;
     else
-        $iWidth=$userP['h_zoom'];
+        $iWidth = $user->profile->h_zoom;
     $iWidth=round((1000*$iWidth)/100);
 
     ibe_echo_block( $ppage->url_for_image(TRUE), $iWidth );

--- a/tools/proofers/proof_frame_std.inc
+++ b/tools/proofers/proof_frame_std.inc
@@ -1,29 +1,25 @@
 <?php
-// The following variables must be defined by the file that includes this one:
-// $relPath
-// $userP
-
 include_once($relPath.'http_headers.inc');
 include_once($relPath.'slim_header.inc');
 
 function echo_proof_frame_std( $ppage )
 {
-    global $userP;
+    $user = User::load_current();
 
-    if ($userP['i_layout']=='1')
+    if ($user->profile->i_layout == '1')
     {
-        $rows_or_cols = "COLS='*,{$userP['v_tframe']}%'";
+        $rows_or_cols = "COLS='*,{$user->profile->v_tframe}%'";
     }
     else
     {
-        $rows_or_cols = "ROWS='*,{$userP['h_tframe']}%'";
+        $rows_or_cols = "ROWS='*,{$user->profile->h_tframe}%'";
     }
 
     $params = $ppage->urlencoded(TRUE);
 
-    if ( ($userP['i_layout']=='1' && $userP['v_tscroll']==0)
+    if ( ($user->profile->i_layout == '1' && $user->profile->v_tscroll == 0)
         ||
-         ($userP['i_layout']=='0' && $userP['h_tscroll']==0) )
+         ($user->profile->i_layout == '0' && $user->profile->h_tscroll == 0) )
     {
         $text_scrolling = "SCROLLING='no'";
     }

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -31,12 +31,14 @@ $word_check_messages = json_encode([
     "rerun" => $rerun,
 ]);
 
+$user = User::load_current();
+
 $header_args = array(
     "js_files" => array(
         "$code_url/tools/proofers/wordcheck.js",
         "$code_url/scripts/character_test.js",
     ),
-    "js_data" => get_page_js($userP['i_type']==1 ? 2 : 3) . "
+    "js_data" => get_page_js($user->profile->i_type == 1 ? 2 : 3) . "
         var validCharacterPattern = '$valid_character_pattern';
         var wordCheckMessages = $word_check_messages;
     ",
@@ -44,7 +46,7 @@ $header_args = array(
     "body_attributes" => 'id="wordcheck_interface" onload="ldAll()"',
 );
 
-if($userP['i_type']==1)
+if($user->profile->i_type == 1)
 {
     $header_args["js_data"] .= ibe_get_js();
     $header_args["css_data"] = ibe_get_styles();
@@ -53,10 +55,10 @@ if($userP['i_type']==1)
 slim_header(_("WordCheck"), $header_args);
 
 // print basic image html
-if ($userP['i_type']==1) {
-    if ($userP['i_layout']==1)
-       { $iWidth = $userP['v_zoom']; }
-    else { $iWidth = $userP['h_zoom']; }
+if ($user->profile->i_type != 1) {
+    if ($user->profile->i_layout == 1)
+       { $iWidth = $user->profile->v_zoom; }
+    else { $iWidth = $user->profile->h_zoom; }
     $iWidth = round((1000*$iWidth)/100);
 
     ibe_echo_block( $ppage->url_for_image(TRUE), $iWidth );
@@ -119,7 +121,7 @@ if ($userP['i_type']==1) {
 
     // for the vertical layout, stick in a line break
     // for the horizontal one, stick in a space
-    if ($userP['i_layout']==1) echo "<br>";
+    if ($user->profile->i_layout == 1) echo "<br>";
     else echo " ";
 
     // output the code allowing the user to select another language

--- a/tools/proofers/text_frame_std.php
+++ b/tools/proofers/text_frame_std.php
@@ -7,12 +7,6 @@ include_once('text_frame_std.inc');
 
 require_login();
 
-// This script is invoked only for the standard interface now.
-// cpeel - disabled assert 2016-04-04. foofAid is loading this
-// page even if the user's editing interface is set to enhanced
-// resulting in PHP errors.
-//assert($userP['i_type'] == 0);
-
 $ppage = get_requested_PPage($_GET);
 
 echo_text_frame_std($ppage);

--- a/tools/request_access.php
+++ b/tools/request_access.php
@@ -58,7 +58,7 @@ else
             break;
 
         case 'sat-available':
-            $user = new User($pguser);
+            $user = User::load_current();
             if ( $stage->after_satisfying_minima == 'REQ-AUTO' )
             {
                 $user->grant_access($stage_id, 'AUTO-GRANTED');

--- a/userprefs.php
+++ b/userprefs.php
@@ -286,7 +286,7 @@ function echo_general_tab() {
         PRIVACY_PRIVATE   => _("Private"),
     );
 
-    $user = new User($pguser);
+    $user = User::load_current();
 
     echo "<tr>\n";
     show_preference(

--- a/userprefs.php
+++ b/userprefs.php
@@ -281,7 +281,6 @@ function echo_tabs($tab_names, $selected_tab) {
 function echo_general_tab() {
     global $uid, $pguser, $userP;
     global $userSettings;
-    global $u_n;
 
     $options = get_locale_translation_selection_options();
 
@@ -379,7 +378,7 @@ function echo_general_tab() {
         _('Show Rank Neighbors'), 'u_neigh', 'neighbors',
         $userP['u_neigh'],
         'dropdown',
-        $u_n
+        get_rank_neighbor_options()
     );
     echo "</tr>\n";
 

--- a/userprefs.php
+++ b/userprefs.php
@@ -80,13 +80,6 @@ if (isset($_POST["quitnc"]))
     metarefresh(0, $origin, _("Quit"), "");
 }
 
-// restore session values from db
-if (isset($_POST["restorec"]))
-{
-    dpsession_set_preferences_from_db();
-    metarefresh(0, $origin, _("Restore"), "");
-}
-
 if (array_get($_POST, "insertdb", "") != "") {
     // one of the tabs was displayed and now it has been posted
     // determine which and let that tab save 'itself'.
@@ -690,12 +683,6 @@ function echo_proofreading_tab() {
 
     // buttons
     echo "<tr><td colspan='6' class='center-align'>";
-    if ($userP['prefschanged']==1)
-    {
-        echo "<input type='submit' value='" 
-            . attr_safe(_("Restore to Saved Preferences")) 
-            . "' name='restorec'> &nbsp;";
-    }
     echo "<input type='submit' value='" . attr_safe(_("Save Preferences"))
         . "' name='change'> &nbsp;";
     echo "<input type='submit' value='" 

--- a/userprefs.php
+++ b/userprefs.php
@@ -437,32 +437,39 @@ function echo_proofreading_tab($user) {
 
     // see if they already have 10 profiles, etc.
     $profiles = UserProfile::load_user_profiles($user->u_id);
-    $pf_num = count($profiles);
-
-    echo "<tr>\n";
-    th_label_long( 6, _('Profiles') );
-    echo "</tr>\n";
 
     echo "<tr>\n";
     show_preference(
-        _('Current Profile'), 'profilename', 'profilename',
+        _('Profile Name'), 'profilename', 'profilename',
         $user->profile->profilename,
         'textfield',
         array( '100%', 'required', '' )
     );
-    echo "<td colspan='2' class='center-align'>";
-    // show all profiles
-    echo "<select name='c_profile' ID='c_profile'>";
-    foreach($profiles as $profile)
+    // show profile switcher if there are more than one
+    if( count($profiles) > 1 )
     {
-        echo "<option value='$profile->id'";
-        if ($profile->id == $user->u_profile) { echo " SELECTED"; }
-        echo ">$profile->profilename</option>";
+        echo "<td colspan='2' class='center-align'>";
+        echo "<select name='c_profile' ID='c_profile'>";
+        foreach($profiles as $profile)
+        {
+            echo "<option value='$profile->id'";
+            if ($profile->id == $user->u_profile) { echo " SELECTED"; }
+            echo ">$profile->profilename</option>";
+        }
+        echo "</select>";
+        echo " <input type='submit' value='".attr_safe(_("Switch Profiles"))."' name='swProfile'>";
+
+        echo "</td>";
+        td_pophelp( 'switch' );
     }
-    echo "</select>";
-    echo " <input type=\"submit\" value=\"".attr_safe(_("Switch Profiles"))."\" name=\"swProfile\">&nbsp;";
-    echo "</td>";
-    td_pophelp( 'switch' );
+    else
+    {
+        echo "<td colspan='3'></td>";
+    }
+    echo "</tr>\n";
+
+    echo "<tr>\n";
+    th_label_long( 6, _('Profile details') );
     echo "</tr>\n";
 
     echo "<tr>\n";
@@ -675,7 +682,7 @@ function echo_proofreading_tab($user) {
     echo "<input type='submit' value='" 
         . attr_safe(_("Save Preferences and Quit"))
         . "' name='saveAndQuit'> &nbsp;";
-    if ($pf_num < 10)
+    if (count($profiles) < 10)
     {
         echo "<input type='submit' value='"
             . attr_safe(_("Save as New Profile")) 
@@ -686,10 +693,11 @@ function echo_proofreading_tab($user) {
     }
     echo "<input type='submit' value='" . attr_safe(_("Quit")) 
         . "' name='quitnc'> &nbsp;";
-    // Grey out the delete option if user has only one profile
-    $disabled = ($pf_num <= 1) ? "disabled" : "";
-    echo "<input type='submit' value='" . attr_safe(_("Delete this Profile"))
-        . "' name='deletenc' $disabled>";
+    if (count($profiles) > 1)
+    {
+        echo "<input type='submit' value='" . attr_safe(_("Delete this Profile"))
+            . "' name='deletenc'>";
+    }
     echo "</td></tr>\n";
 }
 


### PR DESCRIPTION
A user's current proofreading profile is saved in the user's session upon login. Sessions are then persisted across page accesses in the database and loaded into global variable `$userP` on every page load.

Persisting the proofreading sessions in the user's session is problematic when we want to add or remove settings from the profile. For instance, earlier this year we rolled out the profile updates that allow a user to specify a custom proofreading font. To roll this out we had to log out all users to ensure they logged back in and picked up the new profile options.

This also means that if a user is accessing DP with two different browsers and makes a changes to their proofreading profile, that change is not picked up by the second browser until they log out and back in.

This MR entirely removes the `$userP` global and instead accesses the user's profile whenever it is needed. This means we no longer need to store profile information in the user's session.

This change touches a lot of code because we used `$userP` in a number of different places for a variety of things. This code is live in the [remove-userP](https://www.pgdp.org/~cpeel/c.branch/remove-userP) sandbox.