### PR TITLE
Change format preview to use flexbox

### DIFF
--- a/styles/preview.css
+++ b/styles/preview.css
@@ -1,18 +1,17 @@
+/* preview div */
+#prevdiv {
+    height: 100%;
+}
+
 /* preview wrapper */
 #id_tp_outer {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 40px;
-    right: 0;
     margin: 0;
     text-align: left;
     overflow: auto;
 }
 
-/* preview div */
+/* text area */
 #text_preview {
-    position: absolute;
     padding: 0.2em;
     white-space: pre;
 }
@@ -22,8 +21,6 @@
 
 /* control panel */
 #id_controls {
-    position: absolute;
-    bottom: 0;
     border-left: 1px solid black;
     border-right: 1px solid black;
     padding-left: 2px;

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -120,7 +120,12 @@ function output_preview_div()
 
     echo <<<END
 <div id='prevdiv' class='no_display'>
-  <div id="id_controls">
+ <div class='flex_container'>
+  <div id="id_tp_outer" class='stretchbox'>
+    <div id="text_preview">
+    </div>
+  </div>
+  <div id="id_controls" class="fixedbox">
     <input type='button' onclick="previewControl.hide()" value="$quit">
     <span class='ilb'><label>$color_markup<input type="checkbox" id="id_color_on" onchange="previewControl.enableColor(this.checked)" ></label></span>
     <span class='ilb'>$image
@@ -145,10 +150,7 @@ function output_preview_div()
     <img src='$code_url/graphics/exclamation.gif' id='id_some_supp' title='$some_suppressed'>
     <input type='button' onclick="previewControl.configure()" value="$configure">
   </div>
-  <div id="id_tp_outer">
-    <div id="text_preview">
-    </div>
-  </div>
+ </div>
 </div>
 
 <div id="id_config_panel" class='no_display'>

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -23,7 +23,6 @@ $( function() {
     var prevWin = document.getElementById("text_preview");
     var txtarea = document.getElementById("text_data");
     var prevDiv = document.getElementById("prevdiv");
-    var controlDiv = document.getElementById("id_controls");
     var tagon = document.getElementById("show_tags");
     var proofDiv = document.getElementById("proofdiv");
     var testDiv = document.getElementById("color_test");

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -247,13 +247,6 @@ $( function() {
         );
     }
 
-    // The control buttons etc. in "controlDiv" will "wrap" according to the
-    // window width so the div height will vary.
-    // this function adjusts the bottom of the preview text area to fit.
-    function adjHeight() {
-        outerPrev.style.bottom = window.getComputedStyle(controlDiv, null).height;
-    }
-
     function leavePreview() {
         prevDiv.style.display = "none";
         window.removeEventListener("keydown", keyQuit, false);
@@ -280,7 +273,6 @@ $( function() {
     function hideConfig() {
         enterPreview();
         configPan.style.display = "none";
-        adjHeight();
     }
 
     function saveStyle() {
@@ -325,7 +317,6 @@ $( function() {
             font_size = parseFloat(window.getComputedStyle(txtarea, null).fontSize);
             this.reSizeText(1.0);
             writePreviewText();
-            adjHeight();
         },
 
         hide: previewToProof,
@@ -417,10 +408,6 @@ $( function() {
             } else {
                 testDraw();
             }
-        },
-
-        adjustHeight: function () { // to fit control box
-            adjHeight();
         },
 
         selectFont: function (font) {

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -37,7 +37,7 @@ function echo_proof_frame_enh( $ppage )
         var revertConfirm = '$revert_confirm';
         ",
         "css_data" => ibe_get_styles(),
-        "body_attributes" => 'id="enhanced_interface" onload="ldAll()" onresize="previewControl.adjustHeight()"',
+        "body_attributes" => 'id="enhanced_interface" onload="ldAll()"',
     );
 
     slim_header(_("Proofreading Page"), $header_args);

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -33,7 +33,7 @@ function echo_text_frame_std( $ppage )
         var switchConfirm = '$switch_confirm';
         var revertConfirm = '$revert_confirm';
         ",
-        "body_attributes" => "onload='ldAll()'  onresize='previewControl.adjustHeight()' class='no-margin'",
+        "body_attributes" => "onload='ldAll()' class='no-margin'",
         );
     slim_header(_("Text Frame"), $header_args);
     ?>


### PR DESCRIPTION
This should not make any visible difference. Previously the same
effect was achieved using javascript.
This is a simplification.
One user reported that the preview controls were not visible in the new Edge browser which prompted me to look at this but the problem subsequently went away spontaneously.