### PR TITLE
Log SQL errors to disk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_script:
     - npm install
 script:
     - cd SETUP
+    # do minimal security checks
+    - make security_checks
     # linting is SUCH a low bar, but it is a bar!
     - make lint
     - npm run lint

--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -1,8 +1,13 @@
-.PHONY: all less lint tests
+.PHONY: all less security_checks lint tests
 
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-all: less lint
+all: less security_checks lint
+
+#----------------------------------------------------------------------------
+# Security checks
+security_checks:
+	$(SELF_DIR)check_security.sh $(SELF_DIR)..
 
 #----------------------------------------------------------------------------
 # PHP file linting

--- a/SETUP/MediaWiki_extensions/hospitalExtensions.php
+++ b/SETUP/MediaWiki_extensions/hospitalExtensions.php
@@ -54,7 +54,7 @@ function listHospitalProjects( $input, $argv )
         ORDER BY nameofwork ASC
     ");
     if (!$result) {
-        die ('Invalid: '. mysqli_error(DPDatabase::get_connection()));
+        die(DPDatabase::log_error());
     }
 
     $output = "";

--- a/SETUP/check_security.sh
+++ b/SETUP/check_security.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [ "_$1" != "_" ]; then
+    BASE_DIR=$1
+elif [ -d SETUP ]; then
+    BASE_DIR=.
+elif [ -d ../SETUP ]; then
+    BASE_DIR=../
+else
+    echo "Unable to determine base code directory"
+    exit 1
+fi
+
+echo "Checking PHP files for known security issues..."
+
+for file in $(find $BASE_DIR -name "*.php" -o -name "*.inc"); do
+    # skip files in SETUP
+    echo $file | grep -q SETUP
+    if [[ $? -eq 0 ]]; then
+        continue;
+    fi
+
+    echo $file
+
+    # die(mysqli_error(
+    egrep -q 'die\s*\(\s*mysqli_error\s*\(' $file
+    if [[ $? -eq 0 ]]; then
+        echo "ERROR: found die() with mysqli_error output"
+        exit 1
+    fi
+
+    # echo mysqli_error(
+    egrep -q 'echo\s*mysqli_error\s*\(' $file
+    if [[ $? -eq 0 ]]; then
+        echo "ERROR: found echo with mysqli_error output"
+        exit 1
+    fi
+
+    # mysqli_error(
+    egrep -q 'mysqli_error\s*\(' $file
+    if [[ $? -eq 0 ]]; then
+        echo "WARNING: mysqli_error found - confirm it does not leak data to user"
+    fi
+
+done

--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -115,7 +115,7 @@ $query = sprintf("
         mysqli_real_escape_string(DPDatabase::get_connection(), $user->u_intlang)
 );
 
-$result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+$result = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 $u_id = mysqli_insert_id(DPDatabase::get_connection()); // auto-incremented users.u_id
 
 // Delete record in non_activated_users.

--- a/accounts/login.php
+++ b/accounts/login.php
@@ -62,7 +62,7 @@ $q = sprintf("
     SELECT * FROM users WHERE username='%s'
     ", mysqli_real_escape_string(DPDatabase::get_connection(), $userNM)
 );
-$u_res = mysqli_query(DPDatabase::get_connection(), $q) or die(mysqli_error(DPDatabase::get_connection()));
+$u_res = mysqli_query(DPDatabase::get_connection(), $q) or die(DPDatabase::log_error());
 $u_row = mysqli_fetch_assoc($u_res);
 if (!$u_row)
 {

--- a/activity_hub.php
+++ b/activity_hub.php
@@ -78,7 +78,7 @@ $res = mysqli_query(DPDatabase::get_connection(), "
     FROM project_events
     WHERE event_type = 'transition' AND timestamp >= $t_start_of_today
     GROUP BY details2
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 $n_projects_transitioned_to_state_ = array();
 while ( list($project_state,$count) = mysqli_fetch_row($res) )
@@ -91,7 +91,7 @@ $res = mysqli_query(DPDatabase::get_connection(), "
     SELECT state, COUNT(*)
     FROM projects
     GROUP BY state
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 $n_projects_in_state_ = array();
 while ( list($project_state,$count) = mysqli_fetch_row($res) )
@@ -358,7 +358,7 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects=FALSE,
             FROM projects
             WHERE state IN ($states_list) $project_filter
             GROUP BY state
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
         $total_projects = 0;
         while ( list($project_state,$count) = mysqli_fetch_row($res) )

--- a/crontab/archive_projects.php
+++ b/crontab/archive_projects.php
@@ -28,7 +28,7 @@ $result = mysqli_query(DPDatabase::get_connection(), "
         AND archived = '0'
         AND state = '".PROJ_SUBMIT_PG_POSTED."'
     ORDER BY modifieddate
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 echo "Archiving page-tables for ", mysqli_num_rows($result), " projects...\n";
 

--- a/crontab/extend_site_tally_goals.php
+++ b/crontab/extend_site_tally_goals.php
@@ -40,7 +40,7 @@ for ( $i = 1; ; $i++ )
     $date = strftime( '%Y-%m-%d', strtotime( "$current_max_date + $i day" ) );
     if ( $date > $desired_max_date ) break;
 
-    mysqli_data_seek( $res2, 0 ) or die(mysqli_error(DPDatabase::get_connection()));
+    mysqli_data_seek( $res2, 0 ) or die(DPDatabase::log_error());
     while ( list($tally_name,$goal) = mysqli_fetch_row($res2) )
     {
         if (!empty($values_list)) $values_list .= ',';

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -31,7 +31,7 @@ $result = mysqli_query(DPDatabase::get_connection(), "
         smoothread_deadline >= (UNIX_TIMESTAMP() + $from) 
         AND smoothread_deadline <= (UNIX_TIMESTAMP() + $to) 
         AND state = '".PROJ_POST_FIRST_CHECKED_OUT."'
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 $output = "Checking " . mysqli_num_rows($result) . " projects...\n";
 $any_work_done = false;

--- a/crontab/import_pg_catalog.php
+++ b/crontab/import_pg_catalog.php
@@ -276,7 +276,7 @@ foreach ($etexts as $etext_number => $formats )
     // echo $etext_number, ": ", $formats_string, "\n";
     $formats_string = mysqli_real_escape_string(DPDatabase::get_connection(), $formats_string);
     mysqli_query(DPDatabase::get_connection(),  "REPLACE INTO pg_books SET etext_number='$etext_number', formats='$formats_string'" )
-        or die( mysqli_error(DPDatabase::get_connection()) );
+        or die(DPDatabase::log_error());
 }
 
 trace("Done");

--- a/crontab/log_project_states.php
+++ b/crontab/log_project_states.php
@@ -21,7 +21,7 @@ $sql = "
     WHERE date = '$date_string'
 ";
 $res = mysqli_query(DPDatabase::get_connection(), $sql)
-    or die(mysqli_error(DPDatabase::get_connection()));
+    or die(DPDatabase::log_error());
 $row = mysqli_fetch_assoc($res);
 if($row["count"])
 {
@@ -86,7 +86,7 @@ foreach ( array_keys($num_projects_in_state_) as $state )
     else
     {
         mysqli_query(DPDatabase::get_connection(), $insert_query)
-            or die(mysqli_error(DPDatabase::get_connection()));
+            or die(DPDatabase::log_error());
     }
 }
 

--- a/crontab/onoff_special_event_queues.php
+++ b/crontab/onoff_special_event_queues.php
@@ -88,7 +88,7 @@ foreach ( array('open', 'close') as $which )
     ";
     echo $specials_query, "\n";
 
-    $res = mysqli_query(DPDatabase::get_connection(), $specials_query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $specials_query) or die(DPDatabase::log_error());
     $n = mysqli_num_rows($res);
     echo "
         Found $n special events which '$which' now.
@@ -111,7 +111,7 @@ foreach ( array('open', 'close') as $which )
 
         if (!$testing_this_script)
         {    
-            mysqli_query(DPDatabase::get_connection(), $update_query) or die(mysqli_error(DPDatabase::get_connection()));
+            mysqli_query(DPDatabase::get_connection(), $update_query) or die(DPDatabase::log_error());
 
             $n = mysqli_affected_rows(DPDatabase::get_connection());
             echo "

--- a/crontab/update_user_counts.php
+++ b/crontab/update_user_counts.php
@@ -37,6 +37,6 @@ mysqli_query(DPDatabase::get_connection(), "
 
     FROM users
     WHERE    t_last_activity > UNIX_TIMESTAMP() - 60 * 60 * 24 * 7 * 4
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 # vim: sw=4 ts=4 expandtab

--- a/default.php
+++ b/default.php
@@ -137,7 +137,7 @@ foreach ( array(1,7,30) as $days_back )
         SELECT COUNT(*)
         FROM users
         WHERE t_last_activity > UNIX_TIMESTAMP() - $days_back * 24*60*60
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $row = mysqli_fetch_row($res);
     $num_users = $row[0];
     

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -59,6 +59,17 @@ final class DPDatabase
         return self::$_connection;
     }
 
+    static public function log_error()
+    {
+        // Log the SQL error to the PHP error log and return a generic error
+        // for display to the user
+        $backtrace = debug_backtrace();
+        $caller = $backtrace[0]['file'] . ":" . $backtrace[0]['line'];
+        $error = str_replace("\n", "\\n", mysqli_error(DPDatabase::get_connection()));
+        error_log("DPDatabase.inc - log_error from $caller: $error");
+        return _("An error occurred during a database query and has been logged.");
+    }
+
     static public function get_default_db_charset()
     {
         $sql = sprintf("

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -80,7 +80,7 @@ final class DPDatabase
 
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
-            throw new DBQueryError(mysqli_error(DPDatabase::get_connection()));
+            throw new DBQueryError(DPDatabase::log_error());
 
         $row = mysqli_fetch_assoc($result);
         $default_charset = $row['DEFAULT_CHARACTER_SET_NAME'];
@@ -99,7 +99,7 @@ final class DPDatabase
 
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
-            throw new DBQueryError(mysqli_error(DPDatabase::get_connection()));
+            throw new DBQueryError(DPDatabase::log_error());
 
         $row = mysqli_fetch_assoc($result);
         $table_encoding = $row['table_collation'];

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -56,7 +56,7 @@ function project_allow_pages( $projectid )
                 ) NOT NULL default ''
         ) $engine
     ");
-    return ( $res ? '' : mysqli_error(DPDatabase::get_connection()) );
+    return ( $res ? '' : DPDatabase::log_error() );
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -138,7 +138,7 @@ function project_add_page(
     $res = mysqli_query(DPDatabase::get_connection(), $sql);
     if (!$res)
     {
-        $errs .= mysqli_error(DPDatabase::get_connection());
+        $errs .= DPDatabase::log_error();
     }
 
     // If the INSERT raised an error, don't do the other stuff.
@@ -480,11 +480,7 @@ function _Page_require(
     $res = mysqli_query(DPDatabase::get_connection(), $sql);
     if ( !$res )
     {
-        echo "The following mysql query:<br>\n";
-        echo $sql, "<br>\n";
-        echo "raised the following error:<br>\n";
-        echo mysqli_error(DPDatabase::get_connection()), "<br>\n";
-        exit;
+        die(DPDatabase::log_error());
     }
 
     list( $curr_page_state, $curr_page_owner ) = mysqli_fetch_row($res);
@@ -534,11 +530,7 @@ function _Page_UPDATE( $projectid, $image, $settings )
     $res = mysqli_query(DPDatabase::get_connection(), $sql);
     if ( !$res )
     {
-        echo "The following mysql query:<br>\n";
-        echo $sql, "<br>\n";
-        echo "raised the following error:<br>\n";
-        echo mysqli_error(DPDatabase::get_connection()), "<br>\n";
-        exit;
+        die(DPDatabase::log_error());
     }
 }
 
@@ -740,7 +732,7 @@ function _log_page_event( $projectid, $image, $event_type, $username, $round )
             event_type   = '$event_type',
             username     = '$username',
             round_id     = $round_id_setting
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -751,7 +743,7 @@ function _project_set_t_last_page_done( $projectid, $timestamp )
         UPDATE projects
         SET t_last_page_done = $timestamp
         WHERE projectid = '$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 function _project_adjust_n_pages( $projectid, $adjustment )
@@ -769,7 +761,7 @@ function _project_adjust_n_pages( $projectid, $adjustment )
         UPDATE projects
         SET n_pages = $expr
         WHERE projectid='$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 function _project_adjust_n_available_pages( $projectid, $adjustment )
@@ -804,7 +796,7 @@ function _project_adjust_n_available_pages( $projectid, $adjustment )
         UPDATE projects
         SET n_available_pages = $expr
         WHERE projectid='$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 function project_recalculate_page_counts( $projectid )
@@ -839,7 +831,7 @@ function project_recalculate_page_counts( $projectid )
         UPDATE projects
         SET $settings
         WHERE projectid='$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -137,7 +137,7 @@ function get_available_page( $projectid, $proj_state, $pguser, &$err )
         LIMIT 1
     ";
     $result = mysqli_query(DPDatabase::get_connection(), $dbQuery);
-    if ($result === FALSE) die(mysqli_error(DPDatabase::get_connection()));
+    if ($result === FALSE) die(DPDatabase::log_error());
     $npage = mysqli_fetch_assoc($result);
     if(!$npage)
     {
@@ -174,7 +174,7 @@ function get_indicated_LPage(
         SELECT state
         FROM $projectid
         WHERE image='$imagefile'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_row($res);
     if (!$row)

--- a/pinc/NonactivatedUser.inc
+++ b/pinc/NonactivatedUser.inc
@@ -84,7 +84,7 @@ class NonactivatedUser
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
         elseif(mysqli_num_rows($result) == 0)
         {
@@ -187,7 +187,7 @@ class NonactivatedUser
 
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
     }
 

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -28,7 +28,7 @@ class Project
                 FROM projects
                 WHERE projectid = '%s'
             ", mysqli_real_escape_string(DPDatabase::get_connection(), $arg));
-            $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+            $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
             $row = mysqli_fetch_assoc($res);
             if (!$row)
             {
@@ -483,7 +483,7 @@ class Project
             SELECT image
             FROM $projectid
             ORDER BY image
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
         while (list($page_image) = mysqli_fetch_row($res))
         {
             $page_image_names[] = $page_image;
@@ -662,7 +662,7 @@ EOS;
             SELECT state
             FROM project_holds
             WHERE projectid='{$this->projectid}'
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
         while( list($state) = mysqli_fetch_row($res) )
         {
             $hold_states[] = $state;
@@ -684,7 +684,7 @@ EOS;
         mysqli_query(DPDatabase::get_connection(), "
             INSERT INTO project_holds
             VALUES $values
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
         log_project_event($this->projectid, $pguser, 'add_holds', join($states, ' '));
     }
 
@@ -697,7 +697,7 @@ EOS;
             DELETE FROM project_holds
             WHERE projectid='$this->projectid'
                 AND state in ($states_str)
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
         log_project_event($this->projectid, $pguser, 'remove_holds', join($states, ' '));
     }
 
@@ -898,7 +898,7 @@ function project_has_a_hold_in_state($projectid, $state)
         SELECT *
         FROM project_holds
         WHERE projectid='$projectid' and state='$state'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     return (mysqli_num_rows($res) > 0);
 }
 

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -590,7 +590,7 @@ class ProjectSearchResults
         ";
         if ($testing)
             echo_html_comment($sql);
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
         return $result;
     }
 

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -307,7 +307,7 @@ class ProjectTransition
         ");
         if (!$res)
         {
-            return "mysql error: " . mysqli_error(DPDatabase::get_connection());
+            return "mysql error: " . DPDatabase::log_error();
         }
 
         // ---------------------------------------------------------------------

--- a/pinc/RandomRule.inc
+++ b/pinc/RandomRule.inc
@@ -44,7 +44,7 @@ class RandomRule
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
         $this->table_row = mysqli_fetch_assoc($result);
     }
@@ -66,7 +66,7 @@ class RandomRule
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
         $row = mysqli_fetch_assoc($result);
         mysqli_free_result($result);
@@ -92,7 +92,7 @@ class RandomRule
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
         $row = mysqli_fetch_assoc($result);
         mysqli_free_result($result);
@@ -117,7 +117,7 @@ class RandomRule
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
 
         $rules = [];

--- a/pinc/SettingsClass.inc
+++ b/pinc/SettingsClass.inc
@@ -240,7 +240,7 @@ class Settings
     private function ExecSQL($sql)
     {
         if (!mysqli_query(DPDatabase::get_connection(), $sql))
-            throw new RuntimeException(mysqli_error(DPDatabase::get_connection()));
+            throw new RuntimeException(DPDatabase::log_error());
     }
 
     // -------------------------------------------------------------------------

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -37,7 +37,7 @@ function get_all_current_tallyboards()
         SELECT DISTINCT tally_name, holder_type
         FROM current_tallies
         ORDER BY holder_type, tally_name
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     while ( list($tally_name, $holder_type) = mysqli_fetch_row($res) )
     {
         $tallyboards[] = new TallyBoard( $tally_name, $holder_type );
@@ -73,7 +73,7 @@ class TallyBoard
             intval($holder_id),
             intval($amount),
             intval($amount));
-        mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
     }
 
     // -------------------------------------------------------------------------
@@ -132,7 +132,7 @@ class TallyBoard
                 AND tally_value > 0
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type));
-        $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
         $row = mysqli_fetch_row($res);
         return $row[0];
     }
@@ -154,7 +154,7 @@ class TallyBoard
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type),
             intval($holder_id));
-        $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
         $row = mysqli_fetch_assoc($res);
         if ( !$row )
@@ -245,7 +245,7 @@ class TallyBoard
             ORDER BY tally_value DESC, holder_id ASC
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type));
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
         // Note that for the purposes of this function,
         // we pretend that holders with tally_value <= 0 don't exist,
         // with the possible exception of the target holder.
@@ -340,7 +340,7 @@ class TallyBoard
                     AND holder_type = '%s'
             ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
                 mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type));
-            $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+            $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
             while ( list($holder_id, $prev_tally_value) = mysqli_fetch_row($result) )
             {
                 $prev_tally_for_[$holder_id] = $prev_tally_value;
@@ -355,7 +355,7 @@ class TallyBoard
                     AND holder_type = '%s'
             ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
                 mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type));
-            $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+            $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
             while ( list($holder_id, $best_rank ) = mysqli_fetch_row($result) )
             {
                 $best_rank_for_[$holder_id] = $best_rank;
@@ -372,7 +372,7 @@ class TallyBoard
             ORDER BY tally_value DESC
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type));
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
         $ranker = new Ranker(TRUE);
         while ( list($holder_id, $current_tally) = mysqli_fetch_row($result) )
@@ -400,7 +400,7 @@ class TallyBoard
             }
             else
             {
-                mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+                mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
             }
 
             if ( $rank > 0 && ( !isset($best_rank_for_[$holder_id]) || $rank < $best_rank_for_[$holder_id] ) )
@@ -424,7 +424,7 @@ class TallyBoard
                 }
                 else
                 {
-                    mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+                    mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
                 }
             }
         }
@@ -444,7 +444,7 @@ class TallyBoard
                 AND holder_type = '%s'
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type));
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
         $row = mysqli_fetch_assoc($result);
         if ( !$row )
@@ -481,7 +481,7 @@ class TallyBoard
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type),
             intval($holder_id));
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
         $info = mysqli_fetch_assoc($result);
         if (!$info)
@@ -522,7 +522,7 @@ class TallyBoard
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type),
             intval($holder_id));
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
         $info = mysqli_fetch_row($result);
         if(!$info)
@@ -552,7 +552,7 @@ class TallyBoard
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type),
             intval($holder_id));
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
         $info = mysqli_fetch_row($result);
         if(!$info)
@@ -587,7 +587,7 @@ class TallyBoard
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type),
             intval($holder_id));
-        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
         $delta_at_ = array();
         while( list($timestamp, $tally_delta) = mysqli_fetch_row($result) )
@@ -622,7 +622,7 @@ class TallyBoard
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $this->tally_name),
             mysqli_real_escape_string(DPDatabase::get_connection(), $this->holder_type),
             intval($holder_id));
-        $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+        $res = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
         $row = mysqli_fetch_row($res);
         return $row[0];
     }

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -92,7 +92,7 @@ class User
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
         elseif(mysqli_num_rows($result) == 0)
         {

--- a/pinc/UserProfile.inc
+++ b/pinc/UserProfile.inc
@@ -64,7 +64,7 @@ class UserProfile
         $result = mysqli_query(DPDatabase::get_connection(), $sql);
         if(!$result)
         {
-            throw new UnexpectedValueException(mysqli_error(DPDatabase::get_connection()));
+            throw new UnexpectedValueException(DPDatabase::log_error());
         }
         elseif(mysqli_num_rows($result) == 0)
         {

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -34,7 +34,7 @@ function archive_project( $project, $dry_run )
         mysqli_query(DPDatabase::get_connection(), "
             ALTER TABLE $projectid
             RENAME AS $archive_db_name.$projectid
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
     }
 
     global $projects_dir;
@@ -71,7 +71,7 @@ function archive_project( $project, $dry_run )
             UPDATE projects
             SET archived = '1'
             WHERE projectid='$projectid'
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
         log_project_event( $projectid, '[archiver]', 'archive' );
     }
@@ -93,7 +93,7 @@ function archive_ancillary_data_for_project_etc( $project, $indent, $dry_run )
         WHERE state = '".PROJ_DELETE."'
         AND deletion_reason = 'merged into $project->projectid'
         ORDER BY modifieddate
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     while ( $project2 = mysqli_fetch_object($res2) )
     {
         archive_ancillary_data_for_project( $project2, $indent, $dry_run );
@@ -157,7 +157,7 @@ function move_project_rows_to_archive_db( $projectid, $table_name, $indent, $dry
         SELECT *
         FROM $table_name
         WHERE projectid='$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $n_copied = mysqli_affected_rows(DPDatabase::get_connection());
     echo sprintf( "%4d rows copied", $n_copied );
 
@@ -171,7 +171,7 @@ function move_project_rows_to_archive_db( $projectid, $table_name, $indent, $dry
         DELETE 
         FROM $table_name
         WHERE projectid='$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $n_deleted = mysqli_affected_rows(DPDatabase::get_connection());
     if ( $n_deleted == $n_copied )
     {

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -112,7 +112,7 @@ function _update_user_activity_time( $update_login_time_too )
         UPDATE users
         SET $settings
         WHERE username='$pguser' $additional_where
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -222,7 +222,7 @@ function mysql_session_garbage_collect($lifetime)
 function do_session_query( $query )
 {
     // write_to_session_log( $query );
-    $result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $result = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
     return $result;
 }
 

--- a/pinc/dpsql.inc
+++ b/pinc/dpsql.inc
@@ -49,11 +49,7 @@ function dpsql_query( $query )
 	$result = mysqli_query(DPDatabase::get_connection(),  $query );
 	if (!$result)
 	{
-		print "The following mysql query:<br>\n";
-		print $query . "<br>\n";
-		print "raised the following error:<br>\n";
-		print mysqli_error(DPDatabase::get_connection()) . "<br>\n";
-		print "<br>\n";
+		print DPDatabase::log_error();
 	}
 	return $result;
 }

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -66,7 +66,7 @@ class ProjectFilterElement
     {
         $query = "SELECT distinct $this->id FROM projects WHERE ($this->state_sql) ORDER BY $this->id";
         $options = [];
-        $result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
         while ($cols = mysqli_fetch_row($result))
         {
             $options[$cols[0]] = $cols[0];
@@ -91,7 +91,7 @@ class GenreElement extends ProjectFilterElement
             FROM projects NATURAL JOIN genre_translations
             WHERE ($this->state_sql) ORDER BY trans_genre";
         $options = [];
-        $result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
         while ($cols = mysqli_fetch_row($result))
         {
             $options[$cols[0]] = $cols[1];
@@ -109,7 +109,7 @@ class SpecialDayElement extends ProjectFilterElement
             FROM projects, special_days
             WHERE projects.special_code = special_days.spec_code AND ($this->state_sql) ORDER BY display_name";
         $options = [];
-        $result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+        $result = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
         while ($cols = mysqli_fetch_row($result))
         {
             $options[$cols[0]] = $cols[1];
@@ -401,7 +401,7 @@ function save_raw_data($pguser, $data_name, $data)
 {
     $enc_data = mysqli_real_escape_string(DPDatabase::get_connection(), $data);
     $query = "REPLACE INTO user_filters (username, filtertype, value) VALUES ('$pguser', '$data_name', '$enc_data')";
-    mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 }
 
 function get_saved_data($pguser, $filter_type)
@@ -418,7 +418,7 @@ function get_raw_saved_data($pguser, $data_name)
 {
     $data_name = mysqli_real_escape_string(DPDatabase::get_connection(), $data_name);
     $query = "SELECT value FROM user_filters WHERE username = '$pguser' AND filtertype = '$data_name'";
-    $result = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $result = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
     $row = mysqli_fetch_assoc($result);
     if($row)
     {

--- a/pinc/forum_interface.inc
+++ b/pinc/forum_interface.inc
@@ -62,7 +62,7 @@ function phpbb_lang($locale=FALSE)
                 WHERE lang_iso='%s'
                 ", mysqli_real_escape_string(DPDatabase::get_connection(), $lang));
             $res = mysqli_query(DPDatabase::get_connection(), $query) or
-                die(mysqli_error(DPDatabase::get_connection()));
+                die(DPDatabase::log_error());
 
             if (mysqli_num_rows($res) == 1)
                 return $lang;
@@ -122,7 +122,7 @@ function create_forum_user($username, $password, $email, $password_is_digested=F
                 SET user_password='%s'
                 WHERE user_id=%d",
                 mysqli_real_escape_string(DPDatabase::get_connection(), $password), $user_id);
-            mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+            mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
         }
 
         return TRUE;
@@ -311,7 +311,7 @@ function get_forum_user_details($username)
         FROM {$phpbb_table_prefix}_users
         WHERE username='%s'
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $username));
-    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_assoc($res);
     if (!$row)
@@ -372,7 +372,7 @@ function get_forum_user_id($username)
         FROM {$phpbb_table_prefix}_users
         WHERE username = '%s' 
         ", mysqli_real_escape_string(DPDatabase::get_connection(), $username));
-    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_assoc($res);
     mysqli_free_result($res);
@@ -396,7 +396,7 @@ function get_forum_rank_title($rank)
         FROM {$phpbb_table_prefix}_ranks
         WHERE rank_id = %d
         ",$rank);
-    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_assoc($res);
     mysqli_free_result($res);
@@ -533,7 +533,7 @@ function get_number_of_unread_messages($username)
             ";
     }
 
-    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 
     list($num_messages) = mysqli_fetch_row($res);
     mysqli_free_result($res);
@@ -554,7 +554,7 @@ function does_topic_exist($topic_id)
         FROM {$phpbb_table_prefix}_topics
         WHERE topic_id = $topic_id;
         ";
-    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 
     $exists = (mysqli_num_rows($res) > 0);
 
@@ -579,7 +579,7 @@ function get_last_post_time_in_topic($topic_id)
         FROM {$phpbb_table_prefix}_posts
         WHERE topic_id = $topic_id
         ";
-    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_assoc($res);
     mysqli_free_result($res);
@@ -636,7 +636,7 @@ function get_topic_details($topic_id)
         INNER JOIN $phpbb_users ON $phpbb_topics.topic_poster = $phpbb_users.user_id
         WHERE $phpbb_topics.topic_id = $topic_id
         ";
-    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_assoc($res);
     mysqli_free_result($res);

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -62,7 +62,7 @@ function list_projects( $where_condition, $order_clause, $url_base, $per_page = 
         $order_clause
         LIMIT $per_page OFFSET $offset
     ";
-    $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()) . $sql);
+    $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 
     $numrows = mysqli_num_rows($result);
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -109,7 +109,7 @@ function user_get_ELR_page_tally( $username )
         SELECT $user_ELR_page_tally_column
         FROM users $joined_with_user_ELR_page_tallies
         WHERE username='$username'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_row($res);
 
@@ -304,7 +304,7 @@ function get_site_tally_goal_summed( $tally_name, $date_condition )
         SELECT SUM(goal)
         FROM site_tally_goals
         WHERE tally_name = '$tally_name' AND ($date_condition)
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_row($res);
     return $row[0];

--- a/pinc/project_events.inc
+++ b/pinc/project_events.inc
@@ -19,7 +19,7 @@ function log_project_event( $projectid, $who, $event_type, $details1='', $detail
     ");
     if ( !$res )
     {
-        return mysqli_error(DPDatabase::get_connection());
+        return DPDatabase::log_error();
     }
     else
     {

--- a/pinc/projectinfo.inc
+++ b/pinc/projectinfo.inc
@@ -9,7 +9,7 @@ function Project_getNumPagesInState( $projectid, $page_state , $counter = "*")
     $res = mysqli_query(DPDatabase::get_connection(), "SELECT COUNT($counter) FROM $projectid WHERE state='$page_state'");
     if (!$res)
     {
-        echo mysqli_error(DPDatabase::get_connection());
+        echo DPDatabase::log_error();
         return 0;
     }
 
@@ -23,7 +23,7 @@ function Project_getNumPages( $projectid )
     $res = mysqli_query(DPDatabase::get_connection(), "SELECT COUNT(*) FROM $projectid");
     if (!$res)
     {
-        echo mysqli_error(DPDatabase::get_connection());
+        echo DPDatabase::log_error();
         return 0;
     }
 

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -31,7 +31,7 @@ function get_news_page_last_modified_date( $news_page_id )
         SELECT t_last_change
         FROM news_pages 
         WHERE news_page_id = '$news_page_id'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_assoc($res);
     if (!$row)
@@ -72,7 +72,7 @@ function show_news_for_page( $news_page_id )
             AND (news_page_id = '$news_page_id' OR news_page_id = 'GLOBAL')
             AND (locale = '' OR locale = '$user_locale')
         ORDER BY ORDERING DESC
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     // Get a randomly selected news item from the set of 
     // 'recent' news items defined for the given page.
@@ -83,7 +83,7 @@ function show_news_for_page( $news_page_id )
             AND (news_page_id = '$news_page_id' OR news_page_id = 'GLOBAL')
             AND (locale = '' OR locale = '$user_locale')
         ORDER BY RAND() LIMIT 1
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     // -------------------------------------------
 

--- a/pinc/smoothread.inc
+++ b/pinc/smoothread.inc
@@ -41,7 +41,7 @@ function sr_user_is_committed($projectid, $username)
         FROM smoothread
         WHERE projectid = '$projectid' 
         AND user = '$username'
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_assoc($res);
     if(!$row)
@@ -77,7 +77,7 @@ function sr_commit($projectid, $username)
     mysqli_query(DPDatabase::get_connection(), "
         INSERT INTO smoothread
         SET projectid='$projectid',  user='$username', committed='1'
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
 }
 
@@ -101,7 +101,7 @@ function sr_withdraw_commitment($projectid, $username)
         DELETE FROM smoothread
         WHERE projectid = '$projectid' 
         AND user = '$username'
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
 }
 
@@ -127,7 +127,7 @@ function sr_get_committed_users($projectid)
         WHERE projectid = '$projectid' 
         AND committed <> '0'
         ORDER BY user
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
     if (mysqli_num_rows($res) == 0)
     {
@@ -165,7 +165,7 @@ function sr_number_users_committed($projectid)
         WHERE projectid = '$projectid' 
         AND committed <> '0'
         ORDER BY user
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
     $row = mysqli_fetch_row($res);
     if(!$row)

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -27,7 +27,7 @@ function upi_set_t_latest_home_visit( $username, $projectid, $timestamp )
             t_latest_home_visit = $timestamp
         ON DUPLICATE KEY UPDATE
             t_latest_home_visit = $timestamp
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 function upi_set_t_latest_page_event( $username, $projectid, $timestamp )
@@ -40,7 +40,7 @@ function upi_set_t_latest_page_event( $username, $projectid, $timestamp )
             t_latest_page_event = $timestamp
         ON DUPLICATE KEY UPDATE
             t_latest_page_event = $timestamp
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -96,7 +96,7 @@ function set_user_project_event_subscription( $username, $projectid, $event, $bi
             iste_$event = $bit
         ON DUPLICATE KEY UPDATE
             iste_$event = $bit
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 function user_is_subscribed_to_project_event( $username, $projectid, $event )
@@ -109,7 +109,7 @@ function user_is_subscribed_to_project_event( $username, $projectid, $event )
         FROM user_project_info
         WHERE username    = '$username'
             AND projectid = '$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $row = mysqli_fetch_row($res);
     if ( !$row )
     {
@@ -205,7 +205,7 @@ function notify_project_event_subscribers( $project, $event, $extras=array() )
         FROM user_project_info
         WHERE projectid = '$projectid'
             AND iste_$event = 1
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $n_subscribers = mysqli_num_rows($res1);
     while ( list($username) = mysqli_fetch_row($res1) )
     {
@@ -225,7 +225,7 @@ function notify_project_event_subscribers( $project, $event, $extras=array() )
             UPDATE projects
             SET int_level = '$n_subscribers'
             WHERE projectid = '$projectid'
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
     }
 }
 
@@ -247,7 +247,7 @@ function get_n_users_subscribed_to_events_for_project( $projectid )
         SELECT $selects
         FROM user_project_info
         WHERE projectid='$projectid'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $r = mysqli_fetch_assoc($res);
 
     // If there are no rows for this project, the SUMs will all return NULL;
@@ -274,7 +274,7 @@ function create_temporary_project_event_subscription_summary_table()
         FROM user_project_info
         WHERE iste_posted = 1
         GROUP BY projectid
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 // -----------------------------------------------------------------------------

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -599,7 +599,7 @@ function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions,
             corrections='$correction_list'";
 
     if(mysqli_query(DPDatabase::get_connection(), $sql) === FALSE) {
-        return sprintf(_("Error adding suggestions to wordcheck_events: %s"), mysqli_error(DPDatabase::get_connection()));
+        return DPDatabase::log_error();
     }
 }
 

--- a/project.php
+++ b/project.php
@@ -1083,7 +1083,7 @@ function do_waiting_queues()
         FROM queue_defns
         WHERE round_id='{$round->id}'
         ORDER BY ordering
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     if ( mysqli_num_rows($res) == 0 )
     {
         // No queues defined for this round.
@@ -1110,7 +1110,7 @@ function do_waiting_queues()
                 SELECT projectid
                 FROM projects
                 WHERE projectid='{$project->projectid}' AND ($cooked_project_selector)
-            ") or die(mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
             if ( mysqli_num_rows($res2) > 0 )
             {
                 $n_queues += 1;
@@ -1268,7 +1268,7 @@ function do_history()
         FROM project_events
         WHERE projectid = '{$project->projectid}'
         ORDER BY event_id
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     $events = array();
     while ( $event = mysqli_fetch_assoc($res) )
@@ -1701,7 +1701,7 @@ function do_post_downloads()
     $res = mysqli_query(DPDatabase::get_connection(), "
             SELECT $sums_str
             FROM $projectid
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
     $sums = mysqli_fetch_assoc($res);
 
     foreach ( $Round_for_round_id_ as $round )

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -575,7 +575,7 @@ function showMbrTeams($user) {
         SELECT *
         FROM user_teams
         WHERE id IN ({$user->team_1}, {$user->team_2}, {$user->team_3})
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     while ($row = mysqli_fetch_assoc($result)) {
         $url = $GLOBALS['code_url']."/stats/teams/tdetail.php?tid=".$row['id'];

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -33,7 +33,7 @@ function select_from_teams( $where_body, $other_clauses='' )
         $other_clauses
     ";
     $res = mysqli_query(DPDatabase::get_connection(), $q);
-    if (!$res) die(mysqli_error(DPDatabase::get_connection()));
+    if (!$res) die(DPDatabase::log_error());
     return $res;
 }
 
@@ -555,7 +555,7 @@ function uploadImages($preview,$tid,$type)
             $upload_avatar_dir = "$team_avatars_dir/$avatarID";
             move_uploaded_file($_FILES['teamavatar']['tmp_name'], $upload_avatar_dir);
             if ($preview != 1) {
-                mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET avatar='$avatarID' WHERE id = $tid") or die(mysqli_error(DPDatabase::get_connection()));
+                mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET avatar='$avatarID' WHERE id = $tid") or die(DPDatabase::log_error());
             }
             $teamimages['avatar'] = $avatarID;
         } else {

--- a/stats/jpgraph_files/new_users.php
+++ b/stats/jpgraph_files/new_users.php
@@ -35,7 +35,7 @@ $res = mysqli_query(DPDatabase::get_connection(), "
     FROM users
     GROUP BY 1
     ORDER BY date_created
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 list($datax, $datay) = dpsql_fetch_columns($res);
 

--- a/stats/jpgraph_files/pages_in_states.php
+++ b/stats/jpgraph_files/pages_in_states.php
@@ -15,7 +15,7 @@ $res = mysqli_query(DPDatabase::get_connection(), "
     FROM projects
     WHERE state != 'proj_submit_pgposted' AND state != 'project_delete'
     GROUP BY state
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 while (list($state,$sum_n_pages,$sum_n_available_pages) = mysqli_fetch_row($res) )
 {
     $n_pages_[$state] = $sum_n_pages;

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -70,7 +70,7 @@ if (!isset($name))
         FROM queue_defns
         WHERE round_id='$round_id'
         ORDER BY ordering
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     while ( $qd = mysqli_fetch_object($q_res) )
     {
         $cooked_project_selector = cook_project_selector($qd->project_selector);

--- a/tasks.php
+++ b/tasks.php
@@ -1608,7 +1608,7 @@ function RelatedTasks($tid)
     {
         $result = wrapped_mysql_query("
             SELECT task_status, task_summary FROM tasks WHERE task_id = $val
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
         $row = mysqli_fetch_assoc($result);
         if (!$row) {
             // The task must have been deleted from the table manually.
@@ -1643,7 +1643,7 @@ function load_related_tasks($task_id)
     ";
 
     $result = mysqli_query(DPDatabase::get_connection(), $sql)
-        or die( mysqli_error(DPDatabase::get_connection()) );
+        or die(DPDatabase::log_error());
 
     $related_tasks = [];
     while($row = mysqli_fetch_assoc($result))
@@ -1672,7 +1672,7 @@ function insert_related_task($task1, $task2)
     ";
 
     $result = mysqli_query(DPDatabase::get_connection(), $sql)
-        or die( mysqli_error(DPDatabase::get_connection()) );
+        or die(DPDatabase::log_error());
     $row = mysqli_fetch_assoc($result);
     if($row['count'] > 0)
         return;
@@ -1683,7 +1683,7 @@ function insert_related_task($task1, $task2)
         SET task_id_1 = $task_id_1, task_id_2 = $task_id_2
     ";
     $result = mysqli_query(DPDatabase::get_connection(), $sql)
-        or die( mysqli_error(DPDatabase::get_connection()) );
+        or die(DPDatabase::log_error());
 }
 
 function remove_related_task($task1, $task2)
@@ -1698,7 +1698,7 @@ function remove_related_task($task1, $task2)
             AND task_id_2 = $task_id_2
     ";
     $result = mysqli_query(DPDatabase::get_connection(), $sql)
-        or die( mysqli_error(DPDatabase::get_connection()) );
+        or die(DPDatabase::log_error());
 }
 
 function RelatedPostings($tid)
@@ -1955,7 +1955,7 @@ function wrapped_mysql_query($sql_query)
     global $testing;
     if ($testing) echo_html_comment($sql_query);
     $res = mysqli_query(DPDatabase::get_connection(), $sql_query);
-    if ($res === FALSE) die(mysqli_error(DPDatabase::get_connection()));
+    if ($res === FALSE) die(DPDatabase::log_error());
     return $res;
 }
 

--- a/tools/authors/addbio.php
+++ b/tools/authors/addbio.php
@@ -65,8 +65,9 @@ elseif (isset($_POST['author_id'])) {
         else {
             // failure!
             output_header(_('An error occurred'));
-            echo _('It was not possible to save the biography.') . _('The following error-message was received:') . ' ' .
-                         mysqli_error(DPDatabase::get_connection());
+            echo _('It was not possible to save the biography.');
+            echo "<br>";
+            echo DPDatabase::log_error();
         }
         exit;
     }

--- a/tools/authors/harvest.php
+++ b/tools/authors/harvest.php
@@ -207,7 +207,7 @@ else {
             else {
                 $store_result = mysqli_query(DPDatabase::get_connection(), $query);
                 if (!$store_result) {
-                    echo '    ' . _("An error occurred while saving the author:") . ' ' . mysqli_error(DPDatabase::get_connection()) . "\n";
+                    echo '    ' . _("An error occurred while saving the author:") . ' ' . DPDatabase::log_error() . "\n";
                     exit;
                 }
                 $author_id = mysqli_insert_id(DPDatabase::get_connection());
@@ -224,7 +224,7 @@ else {
             else {
                 $store_result = mysqli_query(DPDatabase::get_connection(), $query);
                 if (!$store_result) {
-                    echo '    ' . _("An error occurred while saving the biography:") . ' ' . mysqli_error(DPDatabase::get_connection()) . "\n";
+                    echo '    ' . _("An error occurred while saving the biography:") . ' ' . DPDatabase::log_error() . "\n";
                     exit;
                 }
                 echo '    ' . sprintf( _("The biography was inserted into the database with the id %d."), mysqli_insert_id(DPDatabase::get_connection())) . "\n\n";

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -51,7 +51,7 @@ else
 // See if the requested page (if any) exists in the project table
 if(!count($error_messages)) {
     if($page) {
-        $res2 = mysqli_query(DPDatabase::get_connection(), sprintf("SELECT 1 FROM $projectid WHERE image = '%s'", mysqli_real_escape_string(DPDatabase::get_connection(), $page))) or die(mysqli_error(DPDatabase::get_connection()));
+        $res2 = mysqli_query(DPDatabase::get_connection(), sprintf("SELECT 1 FROM $projectid WHERE image = '%s'", mysqli_real_escape_string(DPDatabase::get_connection(), $page))) or die(DPDatabase::log_error());
         if (mysqli_num_rows($res2) == 0) {
             $error_messages[] = sprintf(_("no page '%1\$s' in project with projectID '%2\$s'"),
                 html_safe($page),
@@ -127,7 +127,7 @@ elseif ($frame=="top") {
     {
         $prev_image = "";
         $next_image = "";
-        $res = mysqli_query(DPDatabase::get_connection(),  "SELECT image FROM $projectid ORDER BY image ASC") or die(mysqli_error(DPDatabase::get_connection()));
+        $res = mysqli_query(DPDatabase::get_connection(),  "SELECT image FROM $projectid ORDER BY image ASC") or die(DPDatabase::log_error());
         if($res) {
             // load all images into an array
             $images = array();

--- a/tools/pending_access_requests.php
+++ b/tools/pending_access_requests.php
@@ -28,7 +28,7 @@ $res = mysqli_query(DPDatabase::get_connection(), "
     SELECT DISTINCT REPLACE(setting,'.access', '')
     FROM usersettings
     WHERE setting LIKE '%.access' AND value='requested'
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 while ( list($activity_id) = mysqli_fetch_row($res) )
 {
     if ( !in_array( $activity_id, $activity_ids ) )
@@ -48,7 +48,7 @@ mysqli_query(DPDatabase::get_connection(), "
         MAX( timestamp * (action='deny_request_for') ) AS t_latest_deny
     FROM access_log
     GROUP BY activity, subject_username
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 foreach ( $activity_ids as $activity_id )
 {
@@ -74,7 +74,7 @@ foreach ( $activity_ids as $activity_id )
             )
         WHERE setting = '$access_name' AND value='requested'
         ORDER BY username
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     if ( mysqli_num_rows($res) == 0 )
     {

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -382,7 +382,7 @@ class Loader
             SELECT image
             FROM $this->projectid
             LIMIT 0
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
         $field_data = mysqli_fetch_field_direct($res, 0);
         $this->image_field_len = $field_data->length;
 

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -226,7 +226,7 @@ while ( $project = mysqli_fetch_assoc($allprojects) ) {
         ");
         if ( !$res )
         {
-            echo mysqli_error(DPDatabase::get_connection()), "\n";
+            echo DPDatabase::log_error(), "\n";
             echo "Skipping further processing of this project.\n";
             continue;
         }

--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -73,7 +73,7 @@ function autorelease_for_round( $round )
         FROM queue_defns
         WHERE round_id='{$round->id}'
         ORDER BY ordering
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     if ( mysqli_num_rows($q_res) == 0 )
     {
@@ -114,7 +114,7 @@ function autorelease_for_round( $round )
         FROM queue_defns
         WHERE enabled AND round_id='{$round->id}'
         ORDER BY ordering
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     while ( $qd = mysqli_fetch_object($q_res) )
     {
@@ -233,7 +233,7 @@ function maybe_release_projects(
         WHERE state = '{$round->project_waiting_state}' $and_extra_condition
             AND project_holds.state IS NULL
         ORDER BY modifieddate ASC, nameofwork ASC
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     $n_projects->waiting = mysqli_num_rows($waiting_res);
 
@@ -369,7 +369,7 @@ class ReleaseRestrictor
                 FROM projects
                 WHERE state = '{$round->project_available_state}'
                 ORDER BY authorsname
-            ") or die(mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
         while ( $author_row = mysqli_fetch_assoc($author_res) )
         {
             $author = $author_row['authorsname'];
@@ -391,7 +391,7 @@ class ReleaseRestrictor
                 FROM projects
                 WHERE state = '{$round->project_available_state}'
                 ORDER BY username
-            ") or die(mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
         while ( $pm_row = mysqli_fetch_assoc($pm_res) )
         {
             $pm = $pm_row['username'];
@@ -544,7 +544,7 @@ function AP_setup( $round )
             projectid  varchar(22),
             pages      INT(4)
         )
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     // Get a list of active projects.
     $projects_res =
@@ -552,7 +552,7 @@ function AP_setup( $round )
         SELECT projectid
         FROM projects
         WHERE state = '{$round->project_available_state}'
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     // Run through them and fill up the table.
     while( $project = mysqli_fetch_assoc($projects_res) )
@@ -565,7 +565,7 @@ function AP_teardown( $round )
 {
     mysqli_query(DPDatabase::get_connection(), "
         DROP TABLE active_page_counts
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 function AP_add_project( $round, $projectid )
@@ -576,7 +576,7 @@ function AP_add_project( $round, $projectid )
             '$projectid',
             SUM( state != '{$round->page_save_state}' ) as pages
         FROM $projectid
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 }
 
 function AP_evaluate_criteria( $round, $cooked_project_selector, $release_criterion )
@@ -589,7 +589,7 @@ function AP_evaluate_criteria( $round, $cooked_project_selector, $release_criter
             SUM(active_page_counts.pages) as pages
         FROM projects NATURAL JOIN active_page_counts
         WHERE $cooked_project_selector
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $env = mysqli_fetch_assoc($res);
     // print_r($env);
 

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -80,7 +80,7 @@ $query = "
     FROM $projectid
     WHERE image='$image'";
 
-$res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+$res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
 list($L_text, $R_text, $L_user, $R_user) = mysqli_fetch_row($res);
 $can_see_names_for_this_page = can_see_names_for_page($projectid, $image);
 if ( $can_see_names_for_this_page) {
@@ -177,7 +177,7 @@ function do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_c
     $navigation_text .= "\n" . _("Jump to") . ": <select name='jumpto' onChange='$jump_to_js'>\n";
 
     $query = "SELECT image, $L_user_column_name, ($L_text_column_name = $R_text_column_name) AS is_empty_diff FROM $projectid ORDER BY image ASC";
-    $res = mysqli_query(DPDatabase::get_connection(),  $query) or die(mysqli_error(DPDatabase::get_connection()));
+    $res = mysqli_query(DPDatabase::get_connection(),  $query) or die(DPDatabase::log_error());
     $prev_image = "";
     $next_image = "";
     $prev_from_proofer = "";
@@ -281,7 +281,7 @@ function can_see_names_for_page($projectid, $image)
             $fields .= $round->user_column_name;
         }
         $query = "SELECT $fields from $projectid WHERE image = '$image'";
-        $res = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+        $res = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
         $page_res = mysqli_fetch_array($res);
         foreach ($page_res as $page_user) {
             if ($page_user == $pguser) {

--- a/tools/project_manager/displayimage.php
+++ b/tools/project_manager/displayimage.php
@@ -24,7 +24,7 @@ $_SESSION["displayimage"]["percent"]=$percent;
 // next <link rel=... href=...> tags in <head> if needed.
 // NB The query results are used later to populate a popup menu too.
 $images = array();
-$res = mysqli_query(DPDatabase::get_connection(),  "SELECT image FROM $projectid ORDER BY image ASC") or die(mysqli_error(DPDatabase::get_connection()));
+$res = mysqli_query(DPDatabase::get_connection(),  "SELECT image FROM $projectid ORDER BY image ASC") or die(DPDatabase::log_error());
 while($row = mysqli_fetch_assoc($res))
 {
     $images[] = $row["image"];

--- a/tools/project_manager/downloadproofed.php
+++ b/tools/project_manager/downloadproofed.php
@@ -24,7 +24,7 @@ if ($result === FALSE)
     // Likely the project's page-table does not exist (in this database).
     // This could happen if a user saved a URL involving this script,
     // and the project's page-table later got archived.
-    die(mysqli_error(DPDatabase::get_connection()));
+    die(DPDatabase::log_error());
 }
 $row = mysqli_fetch_assoc($result);
 if (!$row)

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -267,7 +267,7 @@ function image_source_list($image_source)
         FROM image_sources
         WHERE is_active = 1
         ORDER BY display_name
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
 
     $imso_array = array(
         // TRANSLATORS: %s is the site abbreviation

--- a/tools/project_manager/edit_uberproject.php
+++ b/tools/project_manager/edit_uberproject.php
@@ -105,7 +105,7 @@ if ( isset($_REQUEST['action']) &&
         }
         else
         {
-            $result = mysqli_query(DPDatabase::get_connection(), "SELECT * FROM uber_projects WHERE up_projectid = '$up_projectid'") or die(mysqli_error(DPDatabase::get_connection()));
+            $result = mysqli_query(DPDatabase::get_connection(), "SELECT * FROM uber_projects WHERE up_projectid = '$up_projectid'") or die(DPDatabase::log_error());
             if (mysqli_num_rows($result))
             {
                 // check that user has permission to edit this UP

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -532,7 +532,7 @@ class ProjectInfoHolder
                 SELECT state, checkedoutby, username
                 FROM projects
                 WHERE projectid='{$this->projectid}'
-            ") or die(mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
             list($state, $PPer, $PM) = mysqli_fetch_row($res);
             $this->state = $state;
 
@@ -661,7 +661,7 @@ class ProjectInfoHolder
                 SELECT username
                 FROM projects
                 WHERE projectid='{$this->clone_projectid}'
-            ") or die(mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
             list($projectmanager) = mysqli_fetch_row($res);
 
             $pm_setter = sprintf("
@@ -721,7 +721,7 @@ class ProjectInfoHolder
                     $md_setter
                     $common_project_settings
                 WHERE projectid='{$this->projectid}'
-            ") or die(mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
 
             $details1 = implode(' ', $changed_fields);
 
@@ -778,7 +778,7 @@ class ProjectInfoHolder
                     t_last_change_comments = UNIX_TIMESTAMP(),
                     postcomments = '',
                     $common_project_settings
-            ") or die(mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
 
             $e = log_project_event( $this->projectid, $GLOBALS['pguser'], 'creation' );
             if ( !empty($e) ) die($e);

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -457,7 +457,7 @@ class ImageSource
                 $std_fields_sql
                 url = '$esc_url',
                 is_active = '$this->is_active'
-        ") or die("Couldn't add/edit source: ".mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
     }
 
     function enable()

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -114,7 +114,7 @@ class Comparator
             FROM $this->projectid
             WHERE $condition
             ORDER BY image ASC
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
         $num_rows = mysqli_num_rows($res);
         if($num_rows == 0)

--- a/tools/project_manager/page_table.inc
+++ b/tools/project_manager/page_table.inc
@@ -486,7 +486,7 @@ function get_rounds_with_data( $projectid )
     $res = mysqli_query(DPDatabase::get_connection(), "
         SELECT $body
         FROM $projectid
-    ") or die(mysqli_error(DPDatabase::get_connection()));
+    ") or die(DPDatabase::log_error());
     $num_filled_user_fields_for_round_ = mysqli_fetch_assoc($res);
 
     foreach ( $Round_for_round_id_ as $round_id => $round )

--- a/tools/project_manager/post_files.inc
+++ b/tools/project_manager/post_files.inc
@@ -516,9 +516,7 @@ function page_info_query( $projectid, $limit_round_id, $which_text )
     ");
     if ($res === FALSE)
     {
-        echo "page_info_query(): SQL error:\n";
-        echo mysqli_error(DPDatabase::get_connection());
-        echo "\n";
+        echo DPDatabase::log_error();
         return FALSE;
     }
 

--- a/tools/project_manager/show_project_wordcheck_usage.php
+++ b/tools/project_manager/show_project_wordcheck_usage.php
@@ -76,7 +76,7 @@ $sql = "
     FROM $projectid
     ORDER BY image ASC
 ";
-$res = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+$res = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
 while($result = mysqli_fetch_assoc($res)) {
     $page = $result["image"];
     echo "<tr>";

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -36,7 +36,7 @@ $res = mysqli_query(DPDatabase::get_connection(), "
     SELECT image
     FROM $projectid
     ORDER BY image
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 while ( list($image) = mysqli_fetch_row($res) )
 {
     $page_image_names[] = $image;

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -372,7 +372,7 @@ while ( list($projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_
     }
     else
     {
-        die( mysqli_error(DPDatabase::get_connection()) );
+        die(DPDatabase::log_error());
     }
 
     // don't include this project if none of the user's pages have been proofread in the

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -244,7 +244,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
         $res= mysqli_query(DPDatabase::get_connection(),
             sprintf("DESCRIBE %s",
             mysqli_real_escape_string(DPDatabase::get_connection(), $projectid_[$which]))
-        ) or die(mysqli_error(DPDatabase::get_connection()));
+        ) or die(DPDatabase::log_error());
 
         $column_names = array();
         while ( $row = mysqli_fetch_assoc($res) )
@@ -287,7 +287,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
             FROM %s
             ORDER BY image",
             mysqli_real_escape_string(DPDatabase::get_connection(), $projectid)
-        )) or die(mysqli_error(DPDatabase::get_connection()));
+        )) or die(DPDatabase::log_error());
 
         $n_pages = mysqli_num_rows($res);
 
@@ -614,7 +614,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
         echo html_safe($query) . "\n";
         if ($for_real)
         {
-            mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+            mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
             $n = mysqli_affected_rows(DPDatabase::get_connection());
             echo sprintf(_("%d rows inserted."), $n) . "\n";
             if ( $n != 1 )
@@ -656,7 +656,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
                             iste_$event = 1",
                     mysqli_real_escape_string(DPDatabase::get_connection(), $projectid_['from'])
             );
-            $res1 = mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+            $res1 = mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
             while ( list($username) = mysqli_fetch_row($res1) )
             {
                 set_user_project_event_subscription( $username, 
@@ -680,7 +680,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
         echo "<code>" . html_safe($query) . "</code>";
         if ($for_real)
         {
-            mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+            mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
             $n = mysqli_affected_rows(DPDatabase::get_connection());
             echo "<p>" . sprintf(_("%d rows updated."), $n) . "</p>\n";
         }

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -117,7 +117,7 @@ function do_stuff( $projectid, $from_image_, $just_checking )
             SELECT nameofwork
             FROM projects
             WHERE projectid='$projectid'
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
     $n_projects = mysqli_num_rows($res);
     if ( $n_projects == 0 )
@@ -139,7 +139,7 @@ function do_stuff( $projectid, $from_image_, $just_checking )
             SELECT image, fileid
             FROM $projectid
             ORDER BY image
-        ") or die(mysqli_error(DPDatabase::get_connection()));
+        ") or die(DPDatabase::log_error());
 
     $n_pages = mysqli_num_rows($res);
 

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -351,7 +351,7 @@ class SpecialDay
                 $std_fields_sql
                 info_url  = '$esc_info_url',
                 image_url = '$esc_image_url'
-            ") or die(_("Couldn't add/edit special day:") . " " . mysqli_error(DPDatabase::get_connection()));
+            ") or die(DPDatabase::log_error());
     }
 
     function _set_field($field,$value)

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -48,7 +48,7 @@ $res = mysqli_query(DPDatabase::get_connection(), "
     SELECT fileid, image
     FROM $projectid
     ORDER BY image
-") or die(mysqli_error(DPDatabase::get_connection()));
+") or die(DPDatabase::log_error());
 
 $current_image_for_fileid_ = array();
 while ( list($fileid,$image) = mysqli_fetch_row($res) )
@@ -387,7 +387,7 @@ switch ( $submit_button )
                 echo $query;
                 if ($for_real)
                 {
-                    mysqli_query(DPDatabase::get_connection(), $query) or die(mysqli_error(DPDatabase::get_connection()));
+                    mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
                     $n = mysqli_affected_rows(DPDatabase::get_connection());
                     echo "
                         $n rows affected.

--- a/userprefs.php
+++ b/userprefs.php
@@ -430,7 +430,8 @@ function save_general_tab() {
         SET $update_string
         WHERE u_id=$uid AND username='%s'",
         mysqli_real_escape_string(DPDatabase::get_connection(), $pguser));
-    mysqli_query(DPDatabase::get_connection(), $users_query);
+    mysqli_query(DPDatabase::get_connection(), $users_query) or
+        print(DPDatabase::log_error());
 
     // Opt-out of credits when Content-Providing (deprecated), Image Preparing, 
     // Text Preparing, Project-Managing and/or Post-Processing.
@@ -446,9 +447,7 @@ function save_general_tab() {
 
     $userSettings->set_boolean('hide_special_colors', $_POST["show_special_colors"]=='no');
 
-    echo mysqli_error(DPDatabase::get_connection());
     dpsession_set_preferences_from_db();
-
 }
 
 /*************** PROOFREADING TAB ***************/
@@ -759,8 +758,8 @@ function save_proofreading_tab() {
             SET u_profile = $profile->id
             WHERE u_id = $uid
         ";
-        mysqli_query(DPDatabase::get_connection(), $users_query);
-        echo mysqli_error(DPDatabase::get_connection());
+        mysqli_query(DPDatabase::get_connection(), $users_query) or
+            print(DPDatabase::log_error());
     }
 
     dpsession_set_preferences_from_db();
@@ -826,8 +825,8 @@ function save_pm_tab() {
         SET $update_string
         WHERE u_id=$uid AND username='%s'",
         mysqli_real_escape_string(DPDatabase::get_connection(), $pguser));
-    mysqli_query(DPDatabase::get_connection(), $users_query);
-    echo mysqli_error(DPDatabase::get_connection());
+    mysqli_query(DPDatabase::get_connection(), $users_query) or
+        print(DPDatabase::log_error());
 
     // remember if the PM wants to be automatically signed up for email notifications of
     // replies made to their project threads


### PR DESCRIPTION
Rather than printing SQL error messages to the user, which might reveal information we'd rather not show, log them to the `php_errors` file.