### PR TITLE
Require login for various pages

### DIFF
--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -8,6 +8,7 @@ all: less security_checks lint
 # Security checks
 security_checks:
 	$(SELF_DIR)check_security.sh $(SELF_DIR)..
+	$(SELF_DIR)check_require_login.php
 
 #----------------------------------------------------------------------------
 # PHP file linting

--- a/SETUP/check_require_login.php
+++ b/SETUP/check_require_login.php
@@ -1,0 +1,189 @@
+#!/usr/bin/env php
+<?php
+$relPath="../pinc/";
+include_once($relPath."misc.inc");
+
+# List of accepted unauthenticated files
+$ok_files = [
+    # Base website
+    "default.php",
+    "credits.php",
+    "sitemap.php",
+    "project.php",
+    "list_etexts.php",
+    "locale/debug_ui_language.php",
+    # RSS and XML feeds
+    "feeds/backend.php",
+    # Account login / registration pages
+    "accounts/addproofer.php",
+    "accounts/login_failure.php",
+    "accounts/activate.php",
+    "accounts/logout.php",
+    "accounts/require_login.php",
+    "accounts/login.php",
+    # FAQs
+    "faq/cp.php",
+    "faq/default.php",
+    "faq/dev_process.php",
+    "faq/doc-copy.php",
+    "faq/dochist.php",
+    "faq/dpf.php",
+    "faq/DPflow.php",
+    "faq/faq_central.php",
+    "faq/feeds_sdk/index.php",
+    "faq/font_sample.php",
+    "faq/formatting_guidelines.php",
+    "faq/longabsent.php",
+    "faq/pm-faq.php",
+    "faq/post_proof.php",
+    "faq/ppv.php",
+    "faq/privacy.php",
+    "faq/ProoferFAQ.php",
+    "faq/prooffacehelp.php",
+    "faq/proofreading_guidelines.php",
+    "faq/scanning.php",
+    "faq/simple_proof_rules.php",
+    "faq/site_progress_snapshot_legend.php",
+    "faq/templates_guide.php",
+    "faq/translate.php",
+    "faq/wordcheck-faq.php",
+    "faq/de/formatting_guidelines.php",
+    "faq/de/proofreading_guidelines.php",
+    "faq/es/proofreading_guidelines.php",
+    "faq/fr/formatting_guidelines.php",
+    "faq/fr/proofreading_guidelines.php",
+    "faq/it/formatting_guidelines.php",
+    "faq/it/proofreading_guidelines.php",
+    "faq/nl/formatting_guidelines.php",
+    "faq/nl/proofreading_guidelines.php",
+    "faq/pt/formatting_guidelines.php",
+    "faq/pt/proofreading_guidelines.php",
+    # .inc pages hiding as .php pages
+    "pinc/site_vars.php",
+    "pinc/udb_user.php",
+    # 3rd party libraries
+    "pinc/functions_insert_post.php",
+    "pinc/3rdparty/mediawiki/DiffEngine.php",
+    "pinc/3rdparty/mediawiki/TableDiffFormatter.php",
+    "pinc/3rdparty/mediawiki/DairikiDiff.php",
+    "pinc/3rdparty/mediawiki/ComplexityException.php",
+    "pinc/3rdparty/mediawiki/WordAccumulator.php",
+    "pinc/3rdparty/mediawiki/WordLevelDiff.php",
+    "pinc/3rdparty/mediawiki/DiffFormatter.php",
+    "pinc/3rdparty/portable-utf8/portable-utf8.php",
+    # Quizzes we want externally available
+    "quiz/index.php",
+    "quiz/start.php",
+    "quiz/generic/proof.php",
+    "quiz/generic/orig.php",
+    "quiz/generic/hints.php",
+    "quiz/generic/returnfeed.php",
+    "quiz/generic/main.php",
+    "quiz/generic/right.php",
+    "quiz/tuts/tut_p_mod2_3.php",
+    "quiz/tuts/tut_p_mod2_1.php",
+    "quiz/tuts/tut_p_mod1_4.php",
+    "quiz/tuts/tut_p_greek_2.php",
+    "quiz/tuts/tut_p_mod1_5.php",
+    "quiz/tuts/tut_p_mod1_3.php",
+    "quiz/tuts/tut_p_basic_1.php",
+    "quiz/tuts/tut_p_basic_3.php",
+    "quiz/tuts/tut_p_basic_5.php",
+    "quiz/tuts/tut_p_old_3.php",
+    "quiz/tuts/tut_p_basic_4.php",
+    "quiz/tuts/tut_p_old_2.php",
+    "quiz/tuts/tut_p_aeoe_2.php",
+    "quiz/tuts/tut_p_mod2_2.php",
+    "quiz/tuts/tut_p_mod1_2.php",
+    "quiz/tuts/tut_p_thorn.php",
+    "quiz/tuts/tut_p_aeoe_1.php",
+    "quiz/tuts/tut_p_greek_5.php",
+    "quiz/tuts/tut_p_greek_1.php",
+    "quiz/tuts/tut_p_mod2_4.php",
+    "quiz/tuts/tut_p_mod1_1.php",
+    "quiz/tuts/tut_p_basic_2.php",
+    "quiz/tuts/tut_p_old_1.php",
+    "quiz/tuts/tut_p_greek_4.php",
+    "quiz/tuts/tut_p_mod2_5.php",
+    "quiz/tuts/tut_p_fraktur.php",
+    "quiz/tuts/tut_p_greek_3.php",
+    # Stats graphs that we make globally available
+    "stats/default.php",
+    "stats/jpgraph_files/percent_users_who_proof.php",
+    "stats/jpgraph_files/pages_daily.php",
+    "stats/jpgraph_files/cumulative_total_proj_summary_graph.php",
+    "stats/jpgraph_files/users_by_pages_proofed_graph.php",
+    "stats/jpgraph_files/users_by_country.php",
+    "stats/jpgraph_files/round_backlog_trend.php",
+    "stats/jpgraph_files/round_backlog_days.php",
+    "stats/jpgraph_files/round_backlog.php",
+    "stats/jpgraph_files/cumulative_total_proj_graph.php",
+    "stats/jpgraph_files/users_logging_on.php",
+    "stats/jpgraph_files/users_by_language.php",
+    "stats/jpgraph_files/total_proj_graph.php",
+    "stats/jpgraph_files/average_hour_users_logging_on.php",
+    "stats/jpgraph_files/total_pages_by_month_graph.php",
+    "stats/jpgraph_files/new_users.php",
+    "stats/jpgraph_files/cumulative_month_proj.php",
+    "stats/jpgraph_files/tallyboard_deltas.php",
+    "stats/jpgraph_files/curr_month_proj.php",
+    "stats/jpgraph_files/equilibria.php",
+    # Design documentation
+    "styles/style_demo.php",
+    "styles/design_philosophy.php",
+    # Tools
+    "tools/setlangcookie.php",  # allows unauth users to set their language
+    "tools/post_proofers/smooth_reading.php",
+    "tools/project_manager/automodify.php",  # requires localhost or login
+    "tools/proofers/ctrl_frame.php",  # required for unauth quiz access
+];
+
+$files = get_all_php_files("../");
+foreach($files as $file)
+{
+    echo "$file\n";
+
+    # If it requires authentication, skip it
+    if(file_requires_auth("../$file"))
+        continue;
+
+    # If it's in the SETUP directory, skip it
+    if(startswith($file, "SETUP/"))
+        continue;
+
+    # If it's on the OK list, skip it
+    if(in_array($file, $ok_files))
+        continue;
+
+    echo "ERROR: file does not require authentication and is not on the known-good list\n";
+    exit(1);
+}
+
+function get_all_php_files($basedir)
+{
+    $php_files = [];
+
+    $dir_iter = new RecursiveDirectoryIterator($basedir);
+    $files = new RecursiveIteratorIterator($dir_iter);
+    foreach($files as $file_info)
+    {
+        $file = $file_info->getPathname();
+        if(!endswith($file, ".php"))
+            continue;
+        $php_files[] = str_replace($basedir, "", $file);
+    }
+    return $php_files;
+}
+
+function file_requires_auth($filename)
+{
+    $contents = file_get_contents($filename);
+
+    # "regular" pages use require_login();
+    $login = preg_match("/^require_login\(\);$/m", $contents);
+
+    # crontab pages use require_localhost_request();
+    $localhost = preg_match("/^require_localhost_request\(/m", $contents);
+
+    return $login || $localhost;
+}

--- a/crontab/README.txt
+++ b/crontab/README.txt
@@ -11,8 +11,8 @@ them.
 ---------------------------------------
 Script development notes
 
-The function requester_is_localhost(), located in misc.inc, should be used at
-the top of each script to enforce that they are only run locally.
+The function require_localhost_request(), located in misc.inc, should be used
+at the top of each script to enforce that they are only run locally.
 
 Usually, the output of the scripts are collected by crontab and emailed to the
 user. With this in mind they should only output upon error unless you think the

--- a/crontab/archive_projects.php
+++ b/crontab/archive_projects.php
@@ -5,9 +5,7 @@ include_once($relPath.'misc.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'archiving.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 header('Content-type: text/plain');
 

--- a/crontab/clean_tmp.php
+++ b/crontab/clean_tmp.php
@@ -3,9 +3,7 @@ $relPath="./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 // remove temporary spellcheck files older than 1 day
 unset($output);

--- a/crontab/clean_uploads_trash.php
+++ b/crontab/clean_uploads_trash.php
@@ -3,9 +3,7 @@ $relPath="./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc'); // requester_is_localhost()
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 $trash_dir = realpath("$uploads_dir/$uploads_subdir_trash");
 if(!$trash_dir)

--- a/crontab/del_teams.php
+++ b/crontab/del_teams.php
@@ -3,9 +3,7 @@ $relPath="./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 $old_date = time() - 7776000;
     

--- a/crontab/extend_site_tally_goals.php
+++ b/crontab/extend_site_tally_goals.php
@@ -4,9 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'misc.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 $res = dpsql_query("
     SELECT MAX(date) FROM site_tally_goals

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -7,9 +7,7 @@ include_once($relPath.'project_events.inc');
 include_once($relPath.'user_project_info.inc');
 include_once($relPath.'Project.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 header('Content-type: text/plain');
 

--- a/crontab/genthumbs.php
+++ b/crontab/genthumbs.php
@@ -3,9 +3,7 @@ $relPath="./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 if (!$site_supports_metadata)
 {

--- a/crontab/import_pg_catalog.php
+++ b/crontab/import_pg_catalog.php
@@ -4,9 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'Stopwatch.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost() && php_sapi_name() != 'cli' )
-    die("You are not authorized to perform this request.");
+require_localhost_request(TRUE /* deny_cli */);
 
 // Download the XML version of the Project Gutenberg catalog,
 // extract desired data from it, and put that into a MySQL table.

--- a/crontab/log_project_states.php
+++ b/crontab/log_project_states.php
@@ -4,9 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'misc.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 header('Content-type: text/plain');
 

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -7,9 +7,7 @@ include_once($relPath.'misc.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'post_processing.inc'); // get_pp_projects_past_threshold
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 $projects_by_PPer = get_pp_projects_past_threshold();
 

--- a/crontab/onoff_special_event_queues.php
+++ b/crontab/onoff_special_event_queues.php
@@ -14,9 +14,7 @@ $relPath='../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 header('Content-type: text/plain');
 

--- a/crontab/take_tally_snapshots.php
+++ b/crontab/take_tally_snapshots.php
@@ -8,9 +8,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'TallyBoard.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 header('Content-type: text/plain');
 

--- a/crontab/update_user_counts.php
+++ b/crontab/update_user_counts.php
@@ -3,9 +3,7 @@ $relPath='./../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 
-// check that caller is localhost or bail
-if(!requester_is_localhost())
-    die("You are not authorized to perform this request.");
+require_localhost_request();
 
 // Each L_<interval> field gives the number of distinct users
 // who logged in sometime in the <interval> preceding the row's timestamp.

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1068,6 +1068,11 @@ function factor_strings( $strings )
 function requester_is_localhost()
 // function to determine if page requester is from localhost
 {
+    if(php_sapi_name() == "cli")
+    {
+        return TRUE;
+    }
+
     if($_SERVER['REMOTE_ADDR'] == '127.0.0.1' ||
         $_SERVER['REMOTE_ADDR'] == $_SERVER['SERVER_ADDR'])
     {
@@ -1076,6 +1081,16 @@ function requester_is_localhost()
     else
     {
         return FALSE;
+    }
+}
+
+function require_localhost_request($deny_cli=FALSE)
+// If the requester is not localhost, bail
+{
+    if(!requester_is_localhost() ||
+        ($deny_cli && php_sapi_name() == 'cli'))
+    {
+        die("You are not authorized to perform this request.\n");
     }
 }
 

--- a/pophelp.php
+++ b/pophelp.php
@@ -6,6 +6,8 @@ include_once($relPath.'slim_header.inc');
 include_once('faq/pophelp/prefs/prefs_pophelp.inc');
 include_once('faq/pophelp/teams/teams_pophelp.inc');
 
+require_login();
+
 $pophelp = array(
     'prefs' => $prefs_pophelp,
     'teams' => $teams_pophelp,

--- a/quiz/generic/wizard/checks.php
+++ b/quiz/generic/wizard/checks.php
@@ -4,6 +4,8 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once('../quiz_defaults.inc'); // $messages
 
+require_login();
+
 output_header(_('Quiz Wizard'));
 
 function evalchecks()

--- a/quiz/generic/wizard/default_messages.php
+++ b/quiz/generic/wizard/default_messages.php
@@ -7,6 +7,8 @@ include_once('../quiz_defaults.inc'); // $messages
 $theme_args["css_data"] = "h2 {font-size:110%; margin: 0;}
     p.message_id {margin: 0 0 .5em 1em; background-color: #dddddd;}";
 
+require_login();
+
 output_header(_('Quiz Messages'), SHOW_STATSBAR, $theme_args);
 
 echo "<h1>" . _("Default Quiz Messages") . "</h1>";

--- a/quiz/generic/wizard/general.php
+++ b/quiz/generic/wizard/general.php
@@ -3,6 +3,8 @@ $relPath='../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 
+require_login();
+
 output_header(_('Quiz Wizard'));
 
 

--- a/quiz/generic/wizard/messages.php
+++ b/quiz/generic/wizard/messages.php
@@ -5,6 +5,8 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // html_safe()
 include_once('../quiz_defaults.inc'); // $default_*
 
+require_login();
+
 output_header(_('Quiz Wizard'));
 
 function evalmessages()

--- a/quiz/generic/wizard/new_quiz.php
+++ b/quiz/generic/wizard/new_quiz.php
@@ -3,6 +3,8 @@ $relPath='../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 
+require_login();
+
 output_header(_('Quiz Wizard'));
 
 if ($_SESSION['quiz_data']['lastpage'] == 'start')

--- a/quiz/generic/wizard/output.php
+++ b/quiz/generic/wizard/output.php
@@ -5,6 +5,8 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // html_safe()
 include_once('../quiz_defaults.inc'); // ?
 
+require_login();
+
 output_header(_('Quiz Wizard'), NO_STATSBAR);
 
 function ssqs($x)

--- a/quiz/generic/wizard/output_quiz.php
+++ b/quiz/generic/wizard/output_quiz.php
@@ -4,6 +4,8 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // html_safe()
 
+require_login();
+
 output_header(_('Quiz Wizard'));
 
 function ssqs($x)

--- a/quiz/generic/wizard/quiz_pages.php
+++ b/quiz/generic/wizard/quiz_pages.php
@@ -4,6 +4,8 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // html_safe()
 
+require_login();
+
 output_header(_('Quiz Wizard'));
 
 function evalpages()

--- a/quiz/generic/wizard/start.php
+++ b/quiz/generic/wizard/start.php
@@ -3,6 +3,8 @@ $relPath='../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 
+require_login();
+
 output_header(_('Quiz Wizard'));
 
 $_SESSION['quiz_data']['lastpage'] = 'start';

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -9,6 +9,8 @@ include_once($relPath.'forum_interface.inc');
 include_once('../includes/team.inc');
 include_once('../includes/member.inc');
 
+require_login();
+
 $order = get_enumerated_param(
     $_GET, 'order', 'u_id', array('u_id', 'username', 'date_created') );
 $direction = get_enumerated_param(

--- a/stats/members/mbr_xml.php
+++ b/stats/members/mbr_xml.php
@@ -9,6 +9,8 @@ include_once($relPath.'User.inc');
 include_once('../includes/team.inc');
 include_once('../includes/member.inc');
 
+require_login();
+
 $username = @$_GET['username'];
 $user = new User($username);
 $forum_profile= get_forum_user_details($username);

--- a/stats/members/mdetail.php
+++ b/stats/members/mdetail.php
@@ -9,6 +9,8 @@ include_once($relPath.'User.inc');
 include_once('../includes/team.inc');
 include_once('../includes/member.inc');
 
+require_login();
+
 $id = get_integer_param($_GET, 'id', null, 0, null);
 $user = User::load_from_uid($id);
 

--- a/stats/misc_user_stats.php
+++ b/stats/misc_user_stats.php
@@ -3,6 +3,8 @@ $relPath='./../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 
+require_login();
+
 $title=_("Miscellaneous User Statistics");
 output_header($title);
 echo "<h1>$title</h1>";

--- a/stats/pages_proofed_graphs.php
+++ b/stats/pages_proofed_graphs.php
@@ -4,6 +4,8 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // get_enumerated_param()
 
+require_login();
+
 $valid_tally_names = array_keys(get_page_tally_names());
 $tally_name   = get_enumerated_param($_GET, 'tally_name', null, $valid_tally_names);
 

--- a/stats/projects_Xed_graphs.php
+++ b/stats/projects_Xed_graphs.php
@@ -5,6 +5,8 @@ include_once($relPath.'project_states.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // get_enumerated_param()
 
+require_login();
+
 $which = get_enumerated_param($_GET, 'which', null, $project_status_descriptors);
 
 $psd = get_project_status_descriptor($which);

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -7,6 +7,8 @@ include_once($relPath.'ThemedTable.inc');
 include_once($relPath.'site_news.inc');
 include_once($relPath.'misc.inc');
 
+require_login();
+
 $title = _("Statistics Central");
 output_header($title);
 

--- a/stats/teams/tdetail.php
+++ b/stats/teams/tdetail.php
@@ -6,6 +6,7 @@ include_once($relPath.'http_headers.inc');
 include_once($relPath.'theme.inc');
 include_once('../includes/team.inc'); // showTeamInformation()
 
+require_login();
 
 # tally_name may be empty/unspecified, or a round name.
 $valid_tally_names = array_keys(get_page_tally_names());

--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -9,6 +9,8 @@ include_once($relPath.'misc.inc'); // get_integer_param()
 include_once('../includes/team.inc');
 include_once('../includes/member.inc');
 
+require_login();
+
 if (empty($_GET["id"])) {
     include_once($relPath.'theme.inc');
     output_header(_("Error!"));

--- a/stats/teams/tlist.php
+++ b/stats/teams/tlist.php
@@ -6,6 +6,8 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'metarefresh.inc');
 include_once('../includes/team.inc');
 
+require_login();
+
 $order = get_enumerated_param(
         $_GET, 'order', 'id', array('id', 'teamname', 'member_count') );
 $direction = get_enumerated_param(

--- a/stats/user_logon_stats.php
+++ b/stats/user_logon_stats.php
@@ -3,6 +3,8 @@ $relPath='./../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 
+require_login();
+
 $title = _("User Logon Statistics");
 output_header($title);
 echo "<h1>$title</h1>";

--- a/tools/download_images.php
+++ b/tools/download_images.php
@@ -8,6 +8,8 @@ include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'Project.inc');
 
+require_login();
+
 $projectid = validate_projectID('projectid', @$_GET['projectid']);
 
 $zipfile_path = "$dyn_dir/download_tmp/{$projectid}_images.zip";

--- a/tools/post_proofers/download_scannos.php
+++ b/tools/post_proofers/download_scannos.php
@@ -9,6 +9,8 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
+require_login();
+
 
 $lang     = get_enumerated_param($_GET, 'language', null, array('eng', 'es', 'fr', 'ger'));
 $flavour  = get_enumerated_param($_GET, 'type', null, array('common', 'suspect', 'rare'));

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -6,6 +6,8 @@ include_once($relPath.'misc.inc'); // startswith str_contains
 include_once($relPath.'bad_bytes.inc'); // $_bad_byte_sequences
 include_once($relPath.'project_quick_check.inc'); // $css_for_bad_bytes_tables tds_for_bad_bytes
 
+require_login();
+
 output_header(_("Bad Bytes Explainer"), NO_STATSBAR);
 
 ?>

--- a/tools/proofers/mktable.php
+++ b/tools/proofers/mktable.php
@@ -3,6 +3,8 @@ $relPath="../../pinc/";
 include_once($relPath."base.inc");
 include_once($relPath."misc.inc");
 
+require_login();
+
 $charset="UTF-8";
 header("Content-Type: text/html; charset=$charset");
 


### PR DESCRIPTION
Reduce our public-facing surface area by requiring log-in on various pages. In particular this MR changes all statistics pages to require the user to be logged in to view. It leaves the jpgraph files as the browser is expecting those to be images, not an HTML redirect.

The list in `SETUP/check_require_login.php` is going to be the authoritative source of PHP files that can be publicly accessed as it will be added to our CI/CD as an additional validation check after https://github.com/DistributedProofreaders/dproofreaders/pull/332 merges.