### PR TITLE
Implement API project search and project metadata endpoints

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -19,6 +19,153 @@ servers:
   description: Development
 
 paths:
+  /projects:
+    get:
+      tags:
+      - project
+      description: Search for projects. If different parameters are included
+        they are ANDed together. To send multiple values of the same parameter
+        to OR together, append the name with [] (e.g. projectid[]).
+      parameters:
+      - name: projectid
+        in: query
+        schema:
+          type: string
+      - name: title
+        in: query
+        schema:
+          type: string
+        description: Title is treated as a subsearch
+      - name: author
+        in: query
+        schema:
+          type: string
+        description: Author is treated as a subsearch
+      - name: languages
+        in: query
+        schema:
+          type: string
+        description: Languages is treated as a subsearch
+      - name: genre
+        in: query
+        schema:
+          type: string
+      - name: difficulty
+        in: query
+        schema:
+          type: string
+      - name: special_day
+        in: query
+        schema:
+          type: string
+      - name: project_manager
+        in: query
+        schema:
+          type: string
+      - name: pg_ebook_number
+        in: query
+        schema:
+          type: integer
+      - name: state
+        in: query
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of projects found in search
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/project'
+          headers:
+            Links:
+              schema:
+                type: string
+              description: Links for accessing paginated response
+            X-Results-Total:
+              schema:
+                type: integer
+              description: Total number of projects matching query
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/difficulties:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid project difficulties
+      responses:
+        200:
+          description: List of difficulties
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/genres:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid project genres
+      responses:
+        200:
+          description: List of genres
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/languages:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid project languages
+      responses:
+        200:
+          description: List of languages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/{projectid}:
     get:
       tags:
@@ -46,7 +193,6 @@ paths:
           $ref: '#/components/responses/RateLimitExceeded'
         default:
           $ref: '#/components/responses/UnexpectedError'
-
 
   /projects/{projectid}/wordlists/{type}:
     get:

--- a/api/index.php
+++ b/api/index.php
@@ -17,7 +17,7 @@ if($maintenance)
     throw new ApiException("Site is in maintenance mode");
 }
 
-if(!$api_enabled)
+if(!@$api_enabled)
 {
     throw new ApiException("API is not enabled");
 }

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -15,4 +15,8 @@ $router->add_route("GET", "v1/projects", "api_v1_projects");
 $router->add_route("GET", "v1/projects/:projectid", "api_v1_project");
 $router->add_route("GET", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
 $router->add_route("PUT", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
+$router->add_route("GET", "v1/projects/difficulties", "api_v1_projects_difficulties");
+$router->add_route("GET", "v1/projects/genres", "api_v1_projects_genres");
+$router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
+$router->add_route("GET", "v1/projects/states", "api_v1_projects_states");
 

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
+include_once($relPath.'ProjectSearchForm.inc');
 include_once("exceptions.inc");
 
 // DP API v1 -- Projects
@@ -35,8 +36,105 @@ function validate_wordlist($wordlist)
 
 function api_v1_projects($method, $data, $query_params)
 {
-    // searching is not yet implemented
-    throw new NotImplementedError();
+    // set which fields are queryable and their column names
+    $valid_fields = [
+        "projectid" => "projectid",
+        "state" => "state",
+        "title" => "nameofwork",
+        "author" => "authorname",
+        "languages" => "language",
+        "genre" => "genre",
+        "difficulty" => "difficulty",
+        "special_day" => "special_day",
+        "project_manager" => "username",
+        "pg_ebook_number" => "postednum",
+        "pages_available" => "n_pages_available",
+        "pages_total" => "n_pages",
+    ];
+
+    // pull out the query parameters
+    $query = [];
+    foreach(array_intersect(array_keys($valid_fields), array_keys($query_params)) as $field)
+    {
+        $param = $query_params[$field];
+        $query[$field] = is_array($param) ? $param : [ $param ];;
+    }
+
+    // now build project query
+    $where = "1";
+    foreach($query as $field => $values)
+    {
+        $values = array_map("DPDatabase::escape", $values);
+        $column_name = $valid_fields[$field];
+
+        if(in_array($field, [ "author", "title", "languages" ]))
+        {
+            $likes_str = surround_and_join( $values, "$column_name LIKE '%", "%'", ' OR ' );
+            $where .= " AND ($likes_str)";
+        }
+        else
+        {
+            $values_list = surround_and_join( $values, "'", "'", "," );
+            $where .= " AND $column_name IN ($values_list)";
+        }
+    }
+
+    // build the order_by
+    $order_by = "projectid";
+    if(isset($query_params["sort"]))
+    {
+        $order_by = [];
+        $sort_fields = explode(",", $query_params["sort"]);
+        foreach($sort_fields as $field)
+        {
+            $order = "ASC";
+            if(startswith($field, "-"))
+            {
+                $order = "DESC";
+                $field = substr($field, 1);
+            }
+
+            if(!isset($valid_fields[$field]))
+            {
+                continue;
+            }
+            $order_by[] = $valid_fields[$field] . " $order";
+        }
+        $order_by[] = "projectid";
+        $order_by = implode(", ", $order_by);
+    }
+
+    $per_page = get_integer_param($query_params, "per_page", 20, 1, 100);
+    $page = get_integer_param($query_params, "page", 1, 1, NULL);
+    $offset = $per_page * ($page - 1);
+
+    $sql = "
+        SELECT SQL_CALC_FOUND_ROWS *
+        FROM projects
+        WHERE $where
+        ORDER BY $order_by
+        LIMIT $per_page OFFSET $offset
+    ";
+    $result = DPDatabase::query($sql, FALSE);
+    if(!$result)
+    {
+        throw new ServerError(DPDatabase::log_error());
+    }
+
+    $res_found = DPDatabase::query("SELECT FOUND_ROWS()");
+    list($total_rows) = mysqli_fetch_row($res_found);
+    $total_pages = round($total_rows / $per_page);
+
+    api_send_pagination_header($query_params, $total_rows, $per_page, $page);
+
+    $output = [];
+    while($row = mysqli_fetch_assoc($result))
+    {
+        $project = new Project($row);
+        $output[] = render_project_json($project);
+    }
+
+    return $output;
 }
 
 //---------------------------------------------------------------------------
@@ -109,3 +207,44 @@ function api_v1_project_wordlists($method, $data, $query_params)
         return [];
     }
 }
+
+//---------------------------------------------------------------------------
+// projects/difficulties
+
+function api_v1_projects_difficulties($method, $data, $query_params)
+{
+    $difficulties = ProjectSearchForm::difficulty_options();
+    unset($difficulties['']);
+    return array_keys($difficulties);
+}
+
+//---------------------------------------------------------------------------
+// projects/genres
+
+function api_v1_projects_genres($method, $data, $query_params)
+{
+    $genres = ProjectSearchForm::genre_options();
+    unset($genres['']);
+    return array_keys($genres);
+}
+
+//---------------------------------------------------------------------------
+// projects/languages
+
+function api_v1_projects_languages($method, $data, $query_params)
+{
+    $languages = ProjectSearchForm::language_options();
+    unset($languages['']);
+    return array_keys($languages);
+}
+
+//---------------------------------------------------------------------------
+// projects/states
+
+function api_v1_projects_states($method, $data, $query_params)
+{
+    $states = ProjectSearchForm::state_options();
+    unset($states['']);
+    return array_keys($states);
+}
+

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -174,7 +174,7 @@ class ProjectSearchForm
         $this->define_form_widgets();
     }
 
-    private function _get_options_special_day()
+    static public function special_day_options()
     {
         $special_day_options = array();
         $special_day_options[''] = _('Any day');
@@ -194,7 +194,7 @@ class ProjectSearchForm
         return $special_day_options;
     }
 
-    private function _get_options_lang()
+    static public function language_options()
     {
         global $lang_list;
 
@@ -206,12 +206,12 @@ class ProjectSearchForm
         return $lang_options;
     }
 
-    private function _get_options_genre()
+    static public function genre_options()
     {
         return array_merge( array( '' => _('Any') ), load_genre_translation_array());
     }
 
-    private function _get_options_difficulty()
+    static public function difficulty_options()
     {
         return array(
             ''         => _('Any'),
@@ -222,7 +222,7 @@ class ProjectSearchForm
         );
     }
 
-    private function _get_options_state()
+    static public function state_options()
     {
         global $PROJECT_STATES_IN_ORDER;
 
@@ -293,7 +293,7 @@ class ProjectSearchForm
                 'id'         => 'language',
                 'label'      => _('Language'),
                 'type'       => 'select',
-                'options'    => $this->_get_options_lang(),
+                'options'    => $this->language_options(),
                 'can_be_multiple' => TRUE,
                 'initial_value'   => '',
                 'q_contrib'  => array('language', 'LIKE'),
@@ -304,7 +304,7 @@ class ProjectSearchForm
                 'id'         => 'genre',
                 'label'      => _('Genre'),
                 'type'       => 'select',
-                'options'    => $this->_get_options_genre(),
+                'options'    => $this->genre_options(),
                 'can_be_multiple' => TRUE,
                 'q_contrib'  => array('genre', '='),
             )),
@@ -312,7 +312,7 @@ class ProjectSearchForm
                 'id'         => 'difficulty',
                 'label'      => _('Difficulty'),
                 'type'       => 'select',
-                'options'    => $this->_get_options_difficulty(),
+                'options'    => $this->difficulty_options(),
                 'can_be_multiple' => TRUE,
                 'q_contrib'  => array('difficulty', '='),
             )),
@@ -320,7 +320,7 @@ class ProjectSearchForm
                 'id'         => 'special_day',
                 'label'      => _('Special day'),
                 'type'       => 'select',
-                'options'    => $this->_get_options_special_day(),
+                'options'    => $this->special_day_options(),
                 'can_be_multiple' => TRUE,
                 'initial_value'   => '',
                 'q_contrib'  => array('special_code', '='),
@@ -329,7 +329,7 @@ class ProjectSearchForm
                 'id'           => 'state',
                 'label'        => pgettext('project state', 'State'),
                 'type'         => 'select',
-                'options'      => $this->_get_options_state(),
+                'options'      => $this->state_options(),
                 'can_be_multiple' => TRUE,
                 'q_contrib'    => array('state', '='),
             )),


### PR DESCRIPTION
Building on top of the first part, this MR implements the project search endpoint as well as metadata endpoints to see valid values for the languages, genre, state, and difficulty fields.

Sample search query for two languages:
```
curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects&languages[]=Afar&languages[]=Scots"
```

Query sorting descending by `pages_total`:
```
curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
     "https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects&sort=-pages_total"
```

Search results return an `X-Results-Total` header with the total number of search results and pagination links just like [GitHub does](https://developer.github.com/v3/#pagination).
```
X-Results-Total: 391
Link: <https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects&sort=-pages_total&per_page=20&page=1>; rel="first",
 <https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects&sort=-pages_total&per_page=20&page=2>; rel="next",
 <https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects&sort=-pages_total&per_page=20&page=20>; rel="last"
```

Metadata endpoints:
```
curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects/difficulties"

curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects/genres"

curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects/languages"

curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-part-1/api/index.php?url=v1/projects/states"
```

Like the first MR, this one is going into the `api` branch, not `master`, until we have a base set of functionality ready.