### PR TITLE
Handle missing project tables better

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -10,9 +10,13 @@ include_once($relPath.'stages.inc'); // is_formatting_round()
 include_once($relPath.'project_events.inc'); // log_project_event
 include_once($relPath.'CharSuites.inc');
 
-class NonexistentProjectException extends Exception { }
-class InvalidProjectIDException extends Exception { }
 class UTF8ConversionException extends Exception { }
+
+class ProjectException extends Exception { }
+class NonexistentProjectException extends ProjectException { }
+class InvalidProjectIDException extends ProjectException { }
+class NoProjectPageTable extends ProjectException { }
+class NoProjectDirectory extends ProjectException { }
 
 class Project
 {
@@ -475,8 +479,11 @@ class Project
         return $this->can_be_managed_by_current_user || $this->PPer_is_current_user;
     }
 
-    function get_illustrations()
+    function get_page_names_from_db()
     {
+        if(!$this->pages_table_exists)
+            throw new NoProjectPageTable(_("Project page table does not exist."));
+
         $projectid = $this->projectid;
         $page_image_names = array();
         $res = mysqli_query(DPDatabase::get_connection(), "
@@ -489,8 +496,36 @@ class Project
             $page_image_names[] = $page_image;
         }
 
+        return $page_image_names;
+    }
+
+    function get_page_names_from_dir()
+    {
+        if(!$this->dir_exists)
+            throw new NoProjectDirectory(_("Project directory does not exist."));
+
+        // Because the project directory has both page images as well as
+        // illustrations, the page images are defined as the subset of files in
+        // the directory that also exist in the database.
+
+        $db_names = $this->get_page_names_from_db();
+
+        chdir($this->dir);
+        $disk_names  = glob("*.{png,jpg}", GLOB_BRACE);
+        sort($disk_names);
+        return array_intersect($db_names, $disk_names);
+    }
+
+    function get_illustrations()
+    {
+        // Illustrations are the set of files in the project directory that
+        // do not match existing image names in the database.
+
+        $page_image_names = $this->get_page_names_from_db();
+
         chdir($this->dir);
         $existing_image_names = glob("*.{png,jpg}", GLOB_BRACE);
+        sort($existing_image_names);
         return array_diff($existing_image_names, $page_image_names);
     }
 

--- a/project.php
+++ b/project.php
@@ -610,7 +610,7 @@ function do_project_info_table()
         echo_row_a( _("Word Lists"), $links );
     }
 
-    if(!$project->is_utf8)
+    if($project->pages_table_exists && !$project->is_utf8)
     {
         echo_row_a(_("Encoding"), "<span class='error'>" . _("Project table is not UTF-8.") . "</span>");
     }

--- a/tools/project_manager/displayimage.php
+++ b/tools/project_manager/displayimage.php
@@ -20,15 +20,13 @@ $width = 10 * $percent;
 
 $_SESSION["displayimage"]["percent"]=$percent;
 
+$project = new Project($projectid);
+
+
 // Get a list of images in the project so we can populate the prev and
 // next <link rel=... href=...> tags in <head> if needed.
 // NB The query results are used later to populate a popup menu too.
-$images = array();
-$res = mysqli_query(DPDatabase::get_connection(),  "SELECT image FROM $projectid ORDER BY image ASC") or die(DPDatabase::log_error());
-while($row = mysqli_fetch_assoc($res))
-{
-    $images[] = $row["image"];
-}
+$images = $project->get_page_names_from_db();
 $prev_image = "";
 $next_image = "";
 $num_rows = count($images);
@@ -42,9 +40,9 @@ for ($row=0; $row<$num_rows; $row++)
 }
 $link_tags = "";
 if ($prev_image != "" && $preload == "prev")
-    $link_tags .= "<link rel=\"prefetch prev\" href=\"$projects_url/$projectid/$prev_image\">\n";
+    $link_tags .= "<link rel=\"prefetch prev\" href=\"$project->url/$prev_image\">\n";
 if ($next_image != "" && $preload == "next")
-    $link_tags .= "<link rel=\"prefetch next\" href=\"$projects_url/$projectid/$next_image\">\n";
+    $link_tags .= "<link rel=\"prefetch next\" href=\"$project->url/$next_image\">\n";
 
 $title = sprintf(_("Display Image: %s"),$imagefile);
 slim_header($title, array("head_data" => $link_tags));
@@ -87,8 +85,6 @@ function prevnext_buttons()
 
 prevnext_buttons();
 if($showreturnlink) {
-    $project = new Project($projectid);
-
     $label = sprintf(_("Return to Project Page for %s"), html_safe($project->nameofwork));
 
     echo "<br>\n";


### PR DESCRIPTION
`displayimage.php` and `images_index.php` return a database error if the project table for the requested project doesn't exist. This MR abstracts out querying for project pages into the Project class and raises appropriate exceptions if the project table or directory doesn't exist.

This is available in the [no-project-table](https://www.pgdp.org/~cpeel/c.branch/no-project-table) sandbox.