### PR TITLE
Add linting for combining and range codepoint specs

### DIFF
--- a/SETUP/lint_charsuites.php
+++ b/SETUP/lint_charsuites.php
@@ -8,6 +8,17 @@ foreach(CharSuites::get_all() as $charsuite)
 {
     echo "Validating charsuite $charsuite->name...\n";
 
+    // Validate that codepoint specifiers don't include both a range and a
+    // combining character.
+    foreach($charsuite->codepoints as $codepoint)
+    {
+        if(stripos($codepoint, "-") !== FALSE && stripos($codepoint, ">") !== FALSE)
+        {
+            echo sprintf("ERROR: %s codepoint has both a range and a combining character\n", $codepoint);
+            exit(1);
+        }
+    }
+
     // Validate that the character suite only contains normalized codepoints
     $nonnormalized_codepoints = $charsuite->get_nonnormalized_codepoints();
     if($nonnormalized_codepoints)


### PR DESCRIPTION
Character suite codepoints can either be specified in ranges or
individually. Individual specs can also have combining characters
but ranges cannot. Enforce this in the linter.