### PR TITLE
Improve quiz query escaping

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -59,12 +59,32 @@ final class DPDatabase
         return self::$_connection;
     }
 
-    static public function log_error()
+    static public function escape($value)
+    {
+        return mysqli_real_escape_string(self::$_connection, $value);
+    }
+
+    static public function query($sql, $throw_on_failure=TRUE)
+    {
+        $result = mysqli_query(self::$_connection, $sql);
+        if(!$result)
+        {
+            // include this function's caller in the backtrace
+            $error = self::log_error(1);
+            if($throw_on_failure)
+            {
+                throw new DBQueryError($error);
+            }
+        }
+        return $result;
+    }
+
+    static public function log_error($backtrace_level=0)
     {
         // Log the SQL error to the PHP error log and return a generic error
         // for display to the user
         $backtrace = debug_backtrace();
-        $caller = $backtrace[0]['file'] . ":" . $backtrace[0]['line'];
+        $caller = $backtrace[$backtrace_level]['file'] . ":" . $backtrace[$backtrace_level]['line'];
         $error = str_replace("\n", "\\n", mysqli_error(DPDatabase::get_connection()));
         error_log("DPDatabase.inc - log_error from $caller: $error");
         return _("An error occurred during a database query and has been logged.");

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -68,10 +68,12 @@ class Quiz
             $pages_required_results[$quiz_page_id] = "no";
         }
 
-        $result = mysqli_query(DPDatabase::get_connection(), "
-            SELECT * FROM quiz_passes
-            WHERE username='$username'
-        ");
+        $sql = sprintf("
+            SELECT *
+            FROM quiz_passes
+            WHERE username = '%s'
+        ", DPDatabase::escape($username));
+        $result = DPDatabase::query($sql);
         while ($attempt = mysqli_fetch_object($result))
         {
             if($attempt->result != "pass") continue;
@@ -240,25 +242,37 @@ function get_Quiz_containing_page($quiz_page_id)
 
 function record_quiz_attempt($username, $quiz_page_id, $result)
 {
-    $res = mysqli_query(DPDatabase::get_connection(), "
-        SELECT * FROM quiz_passes
-        WHERE username='$username' AND quiz_page='$quiz_page_id'
-    ");
-    $now = time();
+    $sql = sprintf("
+        SELECT *
+        FROM quiz_passes
+        WHERE username = '%s' AND quiz_page = '%s'
+    ", DPDatabase::escape($username), DPDatabase::escape($quiz_page_id));
+    $res = DPDatabase::query($sql);
+
     if (mysqli_num_rows($res) > 0)
     {
         // The user has already passed this page; update the timestamp
-        mysqli_query(DPDatabase::get_connection(), "
-            UPDATE quiz_passes SET date= '$now'
-            WHERE username='$username' AND quiz_page='$quiz_page_id'
-        ");
+        $sql = sprintf("
+            UPDATE quiz_passes
+            SET date = %d
+            WHERE username = '%s' AND quiz_page = '%s'
+        ", time(),
+            DPDatabase::escape($username),
+            DPDatabase::escape($quiz_page_id)
+        );
+        DPDatabase::query($sql);
     }
     else
     {
-        mysqli_query(DPDatabase::get_connection(), "
+        $sql = sprintf("
             INSERT INTO quiz_passes
-            VALUES('$username', '$now', '$quiz_page_id', '$result')
-        ");
+            VALUES ('%s', %d, '%s', '%s')
+        ", DPDatabase::escape($username),
+            time(),
+            DPDatabase::escape($quiz_page_id),
+            DPDatabase::escape($result)
+        );
+        DPDatabase::query($sql);
     }
 }
 
@@ -266,10 +280,12 @@ function user_has_passed_quiz_page($username, $quiz_page_id, $pass_requirements 
 {
     // This function could fairly easily lookup the quizzes to see what $pass_requirements should be,
     // but by calling it without that argument, it's possible to tell the user *why* they haven't passed.
-    $res = mysqli_query(DPDatabase::get_connection(), "
-        SELECT * FROM quiz_passes
-        WHERE username='$username' AND quiz_page='$quiz_page_id'
-    ");
+    $sql = sprintf("
+        SELECT *
+        FROM quiz_passes
+        WHERE username = '%s' AND quiz_page = '%s'
+    ", DPDatabase::escape($username), DPDatabase::escape($quiz_page_id));
+    $res = DPDatabase::query($sql);
     $row = mysqli_fetch_assoc($res);
     if(!$row)
         return false;
@@ -284,10 +300,12 @@ function user_has_passed_quiz_page($username, $quiz_page_id, $pass_requirements 
 
 function get_last_attempt_date_for_quiz_page($username, $quiz_page_id)
 {
-    $res = mysqli_query(DPDatabase::get_connection(), "
-        SELECT date FROM quiz_passes
-        WHERE username='$username' AND quiz_page='$quiz_page_id'
-    ");
+    $sql = sprintf("
+        SELECT *
+        FROM quiz_passes
+        WHERE username = '%s' AND quiz_page = '%s'
+    ", DPDatabase::escape($username), DPDatabase::escape($quiz_page_id));
+    $res = DPDatabase::query($sql);
     $row = mysqli_fetch_assoc($res);
     if(!$row)
         return false;


### PR DESCRIPTION
This improves escaping for the quiz queries. It does so by introducing two new static methods in `DPDatabase` that wrap some common functionality. I wanted to get a wider set of eyes on it to see if these look reasonable to build off of elsewhere in the code before pulling them in.

Notably we can now escape queries in SQL with:
```php
DPDatabase::escape($value)
```
instead of:
```php
mysqli_real_escape_string(DPDatabase::get_connection(), $value)
```

And the new `DPDatabase::query($sql)` method will automatically log query errors and optionally raise an exception if the query fails.

So we could use this:
```php
$result = DPDatabase::query($sql);
```
instead of:
```php
$result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
```
