### PR TITLE
Implement API for site statistics

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -166,6 +166,29 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/states:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid project states
+      responses:
+        200:
+          description: List of states
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/{projectid}:
     get:
       tags:

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -289,6 +289,39 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /stats/site:
+    get:
+      tags:
+      - stats
+      description: Get site statistics
+      responses:
+        200:
+          description: Site statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/site_stats'
+
+  /stats/site/rounds/{roundid}:
+    get:
+      tags:
+      - stats
+      description: Gets the site statistics for a round
+      parameters:
+      - name: roundid
+        in: path
+        description: Round ID
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Requested round statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/round_stats'
+
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -370,6 +403,41 @@ components:
         includes a great deal of information, some fields of which are calculated
         and not directly modifyable. Not all fields are available to all users. Fields
         the user does not have access to will not be returned.
+
+    site_stats:
+      type: object
+      properties:
+        server_time:
+          type: string
+          format: dateTime
+          readOnly: true
+        registered_users:
+          type: integer
+          readOnly: true
+      description: Statistics for the site
+
+    round_stats:
+      type: object
+      properties:
+        today_goal:
+          type: integer
+          readOnly: true
+        today_actual:
+          type: integer
+          readOnly: true
+        yesterday_goal:
+          type: integer
+          readOnly: true
+        yesterday_actual:
+          type: integer
+          readOnly: true
+        month_goal:
+          type: integer
+          readOnly: true
+        month_actual:
+          type: integer
+          readOnly: true
+      description: Statistics for a round
 
     wordlist:
       type: array

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -3,12 +3,14 @@ include_once("ApiRouter.inc");
 
 // DP API v1
 include_once("v1_projects.inc");
+include_once("v1_stats.inc");
 
 $router = ApiRouter::get_router();
 
 // Add validators
 $router->add_validator(":wordlist_type", "validate_wordlist");
 $router->add_validator(":projectid", "validate_project");
+$router->add_validator(":roundid", "validate_round");
 
 // Add routes
 $router->add_route("GET", "v1/projects", "api_v1_projects");
@@ -20,3 +22,5 @@ $router->add_route("GET", "v1/projects/genres", "api_v1_projects_genres");
 $router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
 $router->add_route("GET", "v1/projects/states", "api_v1_projects_states");
 
+$router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
+$router->add_route("GET", "v1/stats/site/rounds/:roundid", "api_v1_stats_site_round");

--- a/api/v1_stats.inc
+++ b/api/v1_stats.inc
@@ -1,0 +1,50 @@
+<?php
+include_once("exceptions.inc");
+
+// DP API v1 -- Stats
+
+//===========================================================================
+// Validators
+
+function validate_round($roundid)
+{
+    global $Round_for_round_id_;
+
+    if(!in_array($roundid, array_keys($Round_for_round_id_)))
+    {
+        throw new NotFoundError("Invalid round");
+    }
+    return $Round_for_round_id_[$roundid];
+}
+
+//---------------------------------------------------------------------------
+// stats/site
+
+function api_v1_stats_site($method, $data, $query_params)
+{
+    $res = DPDatabase::query("SELECT COUNT(*) FROM users");
+    list($registered_users) = mysqli_fetch_row($res);
+
+    return [
+        "server_time" => date(DATE_ATOM),
+        "registered_users" => $registered_users,
+    ];
+}
+
+//---------------------------------------------------------------------------
+// stats/site/:roundid
+
+function api_v1_stats_site_round($method, $data, $query_params)
+{
+    $round = $data[":roundid"];
+
+    $stats = get_site_page_tally_summary($round->id);
+    return [
+        "today_goal" => $stats->curr_day_goal,
+        "today_actual" => $stats->curr_day_actual,
+        "yesterday_goal" => $stats->prev_day_goal,
+        "yesterday_actual" => $stats->prev_day_actual,
+        "month_goal" => $stats->curr_month_goal,
+        "month_actual" => $stats->curr_month_actual,
+    ];
+}


### PR DESCRIPTION
This builds on top of the other two MRs (again, into the `api` branch, not `master`). This adds very basic site and round statistics.

To get some basic statistics about the site:
```bash
curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-part-2/api/index.php?url=v1/stats/site"
```

To get round statistics:
```bash
curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-part-2/api/index.php?url=v1/stats/site/P1"

```

My primary question is: should the round statistics URL be `v1/stats/site/P1` or `v1/stats/site/round/P1`? Now that I'm looking at it afresh the second one seems better (although I have implemented the first one).