### PR TITLE
Separate projectid/page param validation

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -1,0 +1,96 @@
+<?php
+
+class ProjectTest extends PHPUnit\Framework\TestCase
+{
+    private $valid_projectID = "projectID45c225f598e32";
+    private $valid_page_image = "001.png";
+
+    #------------------------------------------------------------------------
+    # projectID validation
+
+    public function test_validate_projectID_positive_path()
+    {
+        validate_projectID($this->valid_projectID);
+
+        // PHPUnit labels tests without at least one assert as risky
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @expectedException InvalidProjectIDException
+     */
+    public function test_validate_projectID_negative_path()
+    {
+        validate_projectID("1234");
+    }
+
+    public function test_get_projectID_param_positive_path()
+    {
+        $params = [
+            "projectid" => $this->valid_projectID,
+        ];
+        $projectid = get_projectID_param($params, "projectid");
+        $this->assertEquals($this->valid_projectID, $projectid);
+    }
+
+    public function test_get_projectID_param_null_positive_path()
+    {
+        $params = [];
+        $projectid = get_projectID_param($params, "projectid", TRUE);
+        $this->assertEquals(NULL, $projectid);
+    }
+
+    /**
+     * @expectedException InvalidProjectIDException
+     */
+    public function test_get_projectID_param_null_negative_path()
+    {
+        $params = [];
+        $projectid = get_projectID_param($params, "projectid");
+    }
+
+    #------------------------------------------------------------------------
+    # page image validation
+
+    public function test_validate_page_image_positive_path()
+    {
+        validate_page_image($this->valid_page_image);
+
+        // PHPUnit labels tests without at least one assert as risky
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @expectedException InvalidPageException
+     */
+    public function test_validate_page_image_negative_path()
+    {
+        validate_page_image("1234");
+    }
+
+    public function test_get_page_image_param_positive_path()
+    {
+        $params = [
+            "image" => $this->valid_page_image,
+        ];
+        $image = get_page_image_param($params, "image");
+        $this->assertEquals($this->valid_page_image, $image);
+    }
+
+    public function test_get_page_image_param_null_positive_path()
+    {
+        $params = [];
+        $image = get_page_image_param($params, "image", TRUE);
+        $this->assertEquals(NULL, $image);
+    }
+
+    /**
+     * @expectedException InvalidPageException
+     */
+    public function test_get_page_image_param_null_negative_path()
+    {
+        $params = [];
+        $image = get_page_image_param($params, "image");
+    }
+}
+

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -15,6 +15,7 @@ class UTF8ConversionException extends Exception { }
 class ProjectException extends Exception { }
 class NonexistentProjectException extends ProjectException { }
 class InvalidProjectIDException extends ProjectException { }
+class InvalidPageException extends ProjectException { }
 class NoProjectPageTable extends ProjectException { }
 class NoProjectDirectory extends ProjectException { }
 
@@ -1068,37 +1069,80 @@ function does_project_page_table_exist($projectid)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// Checks if $value has the form of a valid project ID, either in its
-// long form (projectID####) or just the project number (####).
-// If it does, it returns it, otherwise throws an exception.
-function validate_projectID($param_name, $value, $allownull = false)
+// Confirm that $projectid is a well-formed project ID or raise an exception.
+function validate_projectID($projectid)
 {
-    if (!isset($value) && $allownull)
-        return null;
-    if (1 == preg_match('/^projectID[0-9a-f]{13}$/', $value))
-        return $value;
-    if (1 == preg_match('/^[0-9a-f]{13}$/', $value))
-        return "projectID$value";
-    throw new InvalidProjectIDException(sprintf(
-        _("The value of parameter '%1\$s' ('%2\$s') is not a valid projectID."),
-        $param_name,
-        $value
-    ));
+    if (1 != preg_match('/^projectID[0-9a-f]{13}$/', $projectid))
+    {
+        throw new InvalidProjectIDException(sprintf(
+            _("%s is not a valid project ID."),
+            $projectid
+        ));
+    }
 }
 
-// Checks if $value contains only legitimate characters for
-// the filename of a page image file in a project.
-// If it does, it returns it, otherwise dies with a warning.
-function validate_page_image_filename($param_name, $value, $allownull = false)
+// Get a projectid from an array (usually $_GET or $_POST) and validate that
+// it is well-formed. This function mirrors the other get_*() functions in
+// misc.inc.
+function get_projectID_param( $arr, $key, $allownull = false )
 {
-    if (!isset($value) && $allownull) return null;
-    if (1 == preg_match('/^[a-zA-Z0-9_.-]{5,16}$/', $value)) return $value;
-    die(sprintf(
-        _("The value of parameter '%1\$s' ('%2\$s') is not a valid page image filename."),
-        html_safe($param_name),
-        html_safe($value)
-    ));
+    $projectid = @$arr[$key];
+    if($projectid == NULL && $allownull)
+    {
+        return NULL;
+    }
+
+    try
+    {
+        validate_projectID($projectid);
+    }
+    catch(InvalidProjectIDException $exception)
+    {
+        throw new InvalidProjectIDException(sprintf(
+            _("The value of parameter '%1\$s' ('%2\$s') is not a valid projectID."),
+            $key,
+            $projectid
+        ));
+    }
+    return $projectid;
+}
+
+// Confirm that $page_name is a well-formed page filename or raise an exception.
+function validate_page_image($page_name)
+{
+    if (1 != preg_match('/^[a-zA-Z0-9_.-]{5,16}$/', $page_name))
+    {
+        throw new InvalidPageException(sprintf(
+            _("%s is not a valid page image filename."),
+            $page_name
+        ));
+    }
+}
+
+// Get a page name from an array (usually $_GET or $_POST) and validate that
+// it is well-formed. This function mirrors the other get_*() functions in
+// misc.inc.
+function get_page_image_param($arr, $key, $allownull = false)
+{
+    $page_name = @$arr[$key];
+    if($page_name == NULL && $allownull)
+    {
+        return NULL;
+    }
+
+    try
+    {
+        validate_page_image($page_name);
+    }
+    catch(InvalidPageException $exception)
+    {
+        throw new InvalidPageException(sprintf(
+            _("The value of parameter '%1\$s' ('%2\$s') is not a valid page name."),
+            $key,
+            $page_name
+        ));
+    }
+    return $page_name;
 }
 
 // vim: sw=4 ts=4 expandtab
-?>

--- a/project.php
+++ b/project.php
@@ -45,7 +45,7 @@ $MAX_DETAIL_LEVEL = 4;
 $DEFAULT_DETAIL_LEVEL = 3;
 
 // Validate all the input
-$projectid = validate_projectID('id', @$_GET['id']);
+$projectid = get_projectID_param($_GET, 'id');
 $expected_state = get_enumerated_param($_GET, 'expected_state', null, $PROJECT_STATES_IN_ORDER, true);
 $detail_level   = get_integer_param($_GET, 'detail_level', $DEFAULT_DETAIL_LEVEL, $MIN_DETAIL_LEVEL, $MAX_DETAIL_LEVEL);
 

--- a/tools/change_sr_commitment.php
+++ b/tools/change_sr_commitment.php
@@ -23,7 +23,7 @@ require_login();
 *
 ****************************************************************************************/
 
-$projectid   = validate_projectID('projectid', @$_POST['projectid']);
+$projectid   = get_projectID_param($_POST, 'projectid');
 $action      = get_enumerated_param($_POST, 'action', null, array('commit', 'withdraw'));
 $refresh_url = @$_POST['next_url'];
 

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -15,7 +15,7 @@ require_login();
 header("Content-Type: text/html; charset=$charset");
 
 // Get Passed parameters to code
-$projectid  = validate_projectID('projectid', @$_POST['projectid']);
+$projectid  = get_projectID_param($_POST, 'projectid');
 $curr_state = get_enumerated_param($_POST, 'curr_state', null, $PROJECT_STATES_IN_ORDER);
 $next_state = get_enumerated_param($_POST, 'next_state', null, array_merge($PROJECT_STATES_IN_ORDER, array('automodify')));
 $confirmed  = get_enumerated_param($_POST, 'confirmed', null, array('yes'), true);

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -10,7 +10,7 @@ require_login();
 
 $charsuite_name = array_get($_GET, "charsuite", NULL);
 $font = array_get($_REQUEST, "font", NULL);
-$projectid = validate_projectID($_REQUEST, @$_REQUEST["projectid"], TRUE);
+$projectid = get_projectID_param($_REQUEST, "projectid", TRUE);
 
 $charsuite = NULL;
 

--- a/tools/download_images.php
+++ b/tools/download_images.php
@@ -10,7 +10,7 @@ include_once($relPath.'Project.inc');
 
 require_login();
 
-$projectid = validate_projectID('projectid', @$_GET['projectid']);
+$projectid = get_projectID_param($_GET, 'projectid');
 
 $zipfile_path = "$dyn_dir/download_tmp/{$projectid}_images.zip";
 $zipfile_url  = "$dyn_url/download_tmp/{$projectid}_images.zip";

--- a/tools/extend_sr.php
+++ b/tools/extend_sr.php
@@ -11,7 +11,7 @@ class ActionException extends Exception {}
 
 require_login();
 
-$projectid = validate_projectID('project', @$_REQUEST['project']);
+$projectid = get_projectID_param($_REQUEST, 'project');
 $project = new Project($projectid);
 $days = get_integer_param($_REQUEST, 'days', 0, 0, 56);
 

--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -39,7 +39,7 @@ else
 {
     try
     {
-        $projectid = validate_projectID('projectid', $projectid);
+        validate_projectID($projectid);
         $project = new Project($projectid);
     }
     catch(Exception $exception)

--- a/tools/post_proofers/postcomments.php
+++ b/tools/post_proofers/postcomments.php
@@ -7,7 +7,7 @@ include_once($relPath.'project_trans.inc');
 
 require_login();
 
-$projectid    = validate_projectID('projectid', @$_POST['projectid']);
+$projectid    = get_projectID_param($_POST, 'projectid');
 $postcomments = @$_POST['postcomments'];
 
 // Verify that it's the pp-er trying to perform this action.

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -3,7 +3,7 @@ $relPath="../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'maybe_mail.inc');
-include_once($relPath.'Project.inc'); // validate_projectID()
+include_once($relPath.'Project.inc'); // get_projectID_param()
 include_once($relPath.'Stage.inc'); //user_can_work_in_stage()
 include_once($relPath.'User.inc');
 include_once($relPath.'project_states.inc'); // get_project_status_descriptor()
@@ -72,7 +72,7 @@ else if (isset($_GET['send']))
 else
     $action = SHOW_BLANK_ENTRY_FORM;
 
-$projectid = validate_projectID('project', @$_REQUEST['project']);
+$projectid = get_projectID_param($_REQUEST, 'project');
 
 $project = new Project($projectid);
 

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -24,7 +24,7 @@ $extra_args = [
 $title = _("Add files");
 output_header($title, NO_STATSBAR, $extra_args);
 
-$projectid    = validate_projectID('project', @$_GET['project']);
+$projectid    = get_projectID_param($_GET, 'project');
 $loading_tpnv = (@$_GET['tpnv'] == '1');
 
 abort_if_cant_edit_project( $projectid );

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -15,7 +15,7 @@ include_once($relPath.'Project.inc'); // project_get_auto_PPer
 include_once($relPath.'misc.inc'); // requester_is_localhost(), html_safe()
 include_once('autorelease.inc');
 
-$one_project = validate_projectID('project', @$_GET['project'], true);
+$one_project = get_projectID_param($_GET, 'project', TRUE);
 $refresh_url = @$_GET['return_uri'];
 
 // The following users are authorized to run this script:

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -11,8 +11,8 @@ include_once($relPath."PageUnformatter.inc"); // PageUnformatter()
 
 require_login();
 
-$projectid   = validate_projectID('project', @$_GET['project']);
-$image       = validate_page_image_filename('image', @$_GET['image'], true);
+$projectid   = get_projectID_param($_GET, 'project');
+$image       = get_page_image_param($_GET, 'image', true);
 $L_round_num = get_integer_param($_GET, 'L_round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
 $R_round_num = get_integer_param($_GET, 'R_round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
 $format = get_enumerated_param($_GET, "format", null, array("keep", "remove"), true);

--- a/tools/project_manager/displayimage.php
+++ b/tools/project_manager/displayimage.php
@@ -10,8 +10,8 @@ require_login();
 $default_percent = array_get( @$_SESSION["displayimage"], 'percent', 100 );
 
 // get variables passed into page
-$projectid      = validate_projectID('project', @$_GET['project']);
-$imagefile      = validate_page_image_filename('imagefile', @$_GET['imagefile'], true);
+$projectid      = get_projectID_param($_GET, 'project');
+$imagefile      = get_page_image_param($_GET, 'imagefile', true);
 $percent        = get_integer_param($_GET, 'percent', $default_percent, 1, 999);
 $showreturnlink = get_integer_param($_GET, 'showreturnlink', 1, 0, 1);
 $preload        = get_enumerated_param($_GET, 'preload', '', array('', 'prev', 'next'));

--- a/tools/project_manager/downloadproofed.php
+++ b/tools/project_manager/downloadproofed.php
@@ -7,8 +7,8 @@ include_once($relPath.'misc.inc'); // get_integer_param()
 
 require_login();
 
-$project   = validate_projectID('project', @$_GET['project']);
-$image     = validate_page_image_filename('image', @$_GET['image']);
+$project   = get_projectID_param($_GET, 'project');
+$image     = get_page_image_param($_GET, 'image');
 $round_num = get_integer_param($_GET, 'round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
 
 if ($round_num == 0) {

--- a/tools/project_manager/edit_pages.php
+++ b/tools/project_manager/edit_pages.php
@@ -10,7 +10,7 @@ include_once('page_operations.inc');
 
 require_login();
 
-$projectid      = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid      = get_projectID_param($_REQUEST, 'projectid');
 $operation      = get_enumerated_param($_REQUEST, 'operation', null, array('clear', 'delete'));
 $selected_pages = @$_REQUEST['selected_pages'];
 if (!is_array($selected_pages))
@@ -18,7 +18,7 @@ if (!is_array($selected_pages))
     die(_('selected_pages is not a list of pages.'));
 }    
 foreach($selected_pages as $image => $setting)
-    validate_page_image_filename('selected_pages', $image);
+    validate_page_image($image);
 
 output_header( _("Edit Pages Confirmation"), NO_STATSBAR);
 echo "<br>\n";

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -104,7 +104,7 @@ class ProjectWordListHolder
     // load data from database
     function set_from_db()
     {
-        $projectid = validate_projectID('projectid', @$_REQUEST['projectid']);
+        $projectid = get_projectID_param($_REQUEST, 'projectid');
 
         $ucep_result = user_can_edit_project($projectid);
         // we only let people clone projects that they can edit, so this
@@ -181,7 +181,7 @@ class ProjectWordListHolder
     {
         if ( isset($_POST['projectid']) )
         {
-            $this->projectid = validate_projectID('projectid', @$_POST['projectid']);
+            $this->projectid = get_projectID_param($_POST, 'projectid');
 
             $ucep_result = user_can_edit_project($this->projectid);
             if ( $ucep_result == PROJECT_DOES_NOT_EXIST )
@@ -202,7 +202,7 @@ class ProjectWordListHolder
             }
         }
 
-        $this->projectid        = validate_projectID('projectid', @$_POST['projectid']);
+        $this->projectid        = get_projectID_param($_POST, 'projectid');
         $this->good_words       = @$_POST['good_words'];
         $this->bad_words        = @$_POST['bad_words'];
         $this->gwl_timestamp    = get_integer_param($_POST, 'gwl_timestamp', null, null, null);

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -301,7 +301,7 @@ class ProjectInfoHolder
         {
             return sprintf(_("parameter '%s' is empty"), 'project');
         }
-        $projectid = validate_projectID('project', $projectid);
+        validate_projectID($projectid);
 
         $ucep_result = user_can_edit_project($projectid);
         // we only let people clone projects that they can edit, so this
@@ -381,7 +381,7 @@ class ProjectInfoHolder
 
         if ( isset($_POST['projectid']) )
         {
-            $projectid = validate_projectID('projectid', @$_POST['projectid']);
+            $projectid = get_projectID_param($_POST, 'projectid');
             $this->projectid = $projectid;
 
             $ucep_result = user_can_edit_project($this->projectid);
@@ -405,7 +405,7 @@ class ProjectInfoHolder
         else if ( isset($_POST['clone_projectid']) )
         {
             // we're creating a clone
-            $clone_projectid = validate_projectID('clone_projectid', @$_POST['clone_projectid']);
+            $clone_projectid = get_projectID_param($_POST, 'clone_projectid');
             $this->clone_projectid = $clone_projectid;
         }
 

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -12,7 +12,7 @@ require_login();
 $valid_round_ids = array_keys($Round_for_round_id_);
 array_unshift($valid_round_ids, '[OCR]');
 
-$projectid            = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid            = get_projectID_param($_REQUEST, 'projectid');
 $round_id             = get_enumerated_param($_REQUEST, 'round_id', null, $valid_round_ids);
 $which_text           = get_enumerated_param($_REQUEST, 'which_text', null, array('EQ', 'LE'));
 $include_proofers     = get_integer_param($_REQUEST,'include_proofers',0,0,1);

--- a/tools/project_manager/graph_flags_per_page.php
+++ b/tools/project_manager/graph_flags_per_page.php
@@ -6,7 +6,7 @@ include_once('../../stats/jpgraph_files/common.inc');
 
 require_login();
 
-$projectid = validate_projectID("projectid", @$_GET["projectid"]);
+$projectid = get_projectID_param($_GET, "projectid");
 
 // data for this graph is generated in show_wordcheck_page_stats.php
 $data_filename = sys_get_temp_dir() . "/$projectid-graph_flags_per_page.dat";

--- a/tools/project_manager/graph_pages_per_number_of_flags.php
+++ b/tools/project_manager/graph_pages_per_number_of_flags.php
@@ -6,7 +6,7 @@ include_once('../../stats/jpgraph_files/common.inc');
 
 require_login();
 
-$projectid = validate_projectID("projectid", @$_GET["projectid"]);
+$projectid = get_projectID_param($_GET, "projectid");
 
 // data for this graph is generated in show_wordcheck_page_stats.php
 $data_filename = sys_get_temp_dir() . "/$projectid-graph_pages_per_number_of_flags.dat";

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -14,8 +14,8 @@ include_once('page_table.inc');  // page_state_is_a_bad_state()
 
 require_login();
 
-$projectid = validate_projectID('projectid', @$_REQUEST['projectid']);
-$image     = validate_page_image_filename('image', @$_REQUEST['image']);
+$projectid = get_projectID_param($_REQUEST, 'projectid');
+$image     = get_page_image_param($_REQUEST, 'image');
 $modify    = array_get($_REQUEST, 'modify', '');
 $cancel    = array_get($_POST, 'cancel', '');
 $prev_text = array_get($_POST, 'prev_text', NULL);

--- a/tools/project_manager/move_projects.php
+++ b/tools/project_manager/move_projects.php
@@ -15,7 +15,8 @@ $curr_state = get_enumerated_param($_GET, 'curr_state', null, $PROJECT_STATES_IN
 $new_state  = get_enumerated_param($_GET, 'new_state', null, $PROJECT_STATES_IN_ORDER);
 $projectids = array();
 foreach(explode( ',', @$_GET['projects'] ) as $projectid) {
-    $projectids[] = validate_projectID('projects', $projectid);
+    validate_projectID($projectid);
+    $projectids[] = $projectid;
 }
 
 echo "<pre>\n";

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -25,7 +25,7 @@ class Comparator
 
     function get_data()
     {
-        $this->projectid = validate_projectID('project', @$_GET['project']);
+        $this->projectid = get_projectID_param($_GET, 'project');
         $this->L_round_id = get_enumerated_param($_GET, "L_round_id", "P3", $this->L_round_options);
         $this->R_round_id = get_enumerated_param($_GET, "R_round_id", "F1", $this->R_round_options);
         $this->page_set = get_enumerated_param($_GET, "page_set", "all", array('left', 'right', 'all'));

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -8,7 +8,7 @@ include_once('page_table.inc');
 
 require_login();
 
-$projectid = validate_projectID('project', @$_GET['project']);
+$projectid = get_projectID_param($_GET, 'project');
 $show_image_size = get_integer_param($_GET,'show_image_size',0,0,1);
 
 $project = new Project( $projectid );

--- a/tools/project_manager/project_quick_check.php
+++ b/tools/project_manager/project_quick_check.php
@@ -13,7 +13,7 @@ require_login();
 set_time_limit(0); // no time limit
 
 // get data passed into the page
-$projectid = validate_projectID("projectid", @$_REQUEST['projectid'], true);
+$projectid = get_projectID_param($_REQUEST, "projectid", true);
 
 $title = _("Project Quick Check");
 $page_text = _("This page tests the project in an attempt to uncover some common errors.");

--- a/tools/project_manager/show_adhoc_word_details.php
+++ b/tools/project_manager/show_adhoc_word_details.php
@@ -13,7 +13,7 @@ require_login();
 
 set_time_limit(0); // no time limit
 
-$projectid  = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid  = get_projectID_param($_REQUEST, 'projectid');
 $freqCutoff = get_integer_param($_REQUEST, 'freqCutoff', 5, 0, null);
 
 $queryWordText = array_get($_POST, "queryWordText", "");

--- a/tools/project_manager/show_current_flagged_words.php
+++ b/tools/project_manager/show_current_flagged_words.php
@@ -12,7 +12,7 @@ require_login();
 
 set_time_limit(0); // no time limit
 
-$projectid  = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid  = get_projectID_param($_REQUEST, 'projectid');
 $freqCutoff = get_integer_param($_REQUEST, 'freqCutoff', 5, 0, null);
 
 enforce_edit_authorization($projectid);

--- a/tools/project_manager/show_good_word_suggestions.php
+++ b/tools/project_manager/show_good_word_suggestions.php
@@ -14,7 +14,7 @@ $datetime_format = "%A, %B %e, %Y %X";
 
 set_time_limit(0); // no time limit
 
-$projectid  = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid  = get_projectID_param($_REQUEST, 'projectid');
 $fileObject = get_project_word_file($projectid,"good");
 $timeCutoff = get_integer_param($_REQUEST, 'timeCutoff', $fileObject->mod_time, 0, null);
 $freqCutoff = get_integer_param($_REQUEST, 'freqCutoff', 5, 0, null);

--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -26,7 +26,7 @@ $watch->start();
 
 set_time_limit(0); // no time limit
 
-$projectid  = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid  = get_projectID_param($_REQUEST, 'projectid');
 $encWord    = array_get($_GET, "word", '');
 $word       = decode_word($encWord);
 $timeCutoff = get_integer_param($_REQUEST, 'timeCutoff', 0, 0, null);

--- a/tools/project_manager/show_project_possible_bad_words.php
+++ b/tools/project_manager/show_project_possible_bad_words.php
@@ -12,7 +12,7 @@ require_login();
 
 set_time_limit(0); // no time limit
 
-$projectid  = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid  = get_projectID_param($_REQUEST, 'projectid');
 $freqCutoff = get_integer_param($_REQUEST, 'freqCutoff', 5, 0, null);
 
 enforce_edit_authorization($projectid);

--- a/tools/project_manager/show_project_stealth_scannos.php
+++ b/tools/project_manager/show_project_stealth_scannos.php
@@ -14,7 +14,7 @@ require_login();
 
 set_time_limit(0); // no time limit
 
-$projectid = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid = get_projectID_param($_REQUEST, 'projectid');
 
 enforce_edit_authorization($projectid);
 

--- a/tools/project_manager/show_project_wordcheck_stats.php
+++ b/tools/project_manager/show_project_wordcheck_stats.php
@@ -12,7 +12,7 @@ require_login();
 
 set_time_limit(0); // no time limit
 
-$projectid = validate_projectID('projectid', @$_GET['projectid']);
+$projectid = get_projectID_param($_GET, 'projectid');
 $project = new Project($projectid);
 
 enforce_edit_authorization($projectid);

--- a/tools/project_manager/show_project_wordcheck_usage.php
+++ b/tools/project_manager/show_project_wordcheck_usage.php
@@ -11,7 +11,7 @@ require_login();
 
 set_time_limit(0); // no time limit
 
-$projectid = validate_projectID('projectid', @$_GET['projectid']);
+$projectid = get_projectID_param($_GET, 'projectid');
 
 enforce_edit_authorization($projectid);
 

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -20,7 +20,7 @@ define("MAX_WORD_INSTANCES", 100);
 
 set_time_limit(0); // no time limit
 
-$projectid = validate_projectID('projectid', @$_GET['projectid']);
+$projectid = get_projectID_param($_GET, 'projectid');
 $encWord   = @$_GET["word"];
 $word      = rtrim(decode_word($encWord));
 

--- a/tools/project_manager/update_illos.php
+++ b/tools/project_manager/update_illos.php
@@ -14,13 +14,13 @@ require_login();
 // (This script's functionality overlaps that of handle_bad_page.php.
 // They should perhaps be refactored.)
 
-$projectid = validate_projectID('projectid', @$_REQUEST['projectid']);
+$projectid = get_projectID_param($_REQUEST, 'projectid');
 $operation = get_enumerated_param($_REQUEST, 'operation', 'replace', array('replace', 'delete', 'delete_all'));
 
 if ($operation !== 'delete_all')
 {
     $image     = @$_REQUEST['image'];
-    // Note that using validate_page_image_filename() here would be inappropriate,
+    // Note that using validate_page_image() here would be inappropriate,
     // because it's specific to *page* images (which this isn't),
     // and so enforces a maximum filename length.
     if (!preg_match('/^\w[\w.-]*\.(png|jpg)$/', $image)) // see _check_file() in add_files.php

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -50,9 +50,9 @@ function url_for_pi_do_particular_page( $projectid, $proj_state, $imagefile, $pa
 function get_requested_PPage( $request_params )
 {
     global $PROJECT_STATES_IN_ORDER, $PAGE_STATES_IN_ORDER;
-    $projectid  = validate_projectID('projectid', @$request_params['projectid']);
+    $projectid  = get_projectID_param($request_params, 'projectid');
     $proj_state = get_enumerated_param($request_params, 'proj_state', null, $PROJECT_STATES_IN_ORDER);
-    $imagefile  = validate_page_image_filename('imagefile', @$request_params['imagefile']);
+    $imagefile  = get_page_image_param($request_params, 'imagefile');
     $page_state = get_enumerated_param($request_params, 'page_state', null, $PAGE_STATES_IN_ORDER);
     $reverting  = get_integer_param($request_params, 'reverting', 0, 0, 1);
 

--- a/tools/proofers/ctrl_frame.php
+++ b/tools/proofers/ctrl_frame.php
@@ -6,7 +6,6 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'misc.inc'); // get_enumerated_param()
 include_once($relPath.'Project.inc'); // validate_projectID()
 include_once($relPath.'ProofreadingToolbox.inc');
-include_once($relPath.'Project.inc'); // validate_projectID()
 
 $round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_));
 $round = get_Round_for_round_id($round_id);
@@ -16,7 +15,7 @@ $round = get_Round_for_round_id($round_id);
 $projectid = array_get($_GET, 'projectid', 'quiz');
 if($projectid != "quiz")
 {
-    $projectid = validate_projectID('projectid', $projectid);
+    validate_projectID($projectid);
 }
 
 $mru_title = javascript_safe(_("Most recently used"));

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -8,7 +8,7 @@ include_once($relPath.'project_states.inc'); // PROJ_NEW, PROJ_P1_UNAVAILABLE
 
 require_login();
 
-$projectid = validate_projectID('project', @$_GET['project']);
+$projectid = get_projectID_param($_GET, 'project');
 
 $zip_type = get_enumerated_param( $_GET, 'zip_type', NULL, array('pages', 'illos'), TRUE );
 

--- a/tools/proofers/md_phase1.php
+++ b/tools/proofers/md_phase1.php
@@ -12,7 +12,7 @@ require_login();
 
 $show_image_size = '';
 
-$projectid = validate_projectID('projectid', @$_GET['projectid']);
+$projectid = get_projectID_param($_GET, 'projectid');
 
 if (!$site_supports_metadata)
 {

--- a/tools/proofers/md_phase2.php
+++ b/tools/proofers/md_phase2.php
@@ -14,12 +14,8 @@ if (!$site_supports_metadata)
     exit();
 }
 
-$projectid = validate_projectID('projectid', @$_GET['projectid']);
-if (!isset($_GET['imagename'])) {
-    $imagename = null;
-} else {   
-    $imagename = validate_page_image_filename('imagename', @$_GET['imagename']);
-}
+$projectid = get_projectID_param($_GET, 'projectid');
+$imagename = get_page_image_param($_GET, 'imagename', true);
 
 // $ppage = get_requested_PPage();
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -18,9 +18,9 @@ $_POST:
     $button1_x, $button2_x, $button3_x, $button4_x, ...
 */
 
-$projectid  = validate_projectID('projectid', @$_POST['projectid']);
+$projectid  = get_projectID_param($_POST, 'projectid');
 $proj_state = $_POST['proj_state'];
-$imagefile  = validate_page_image_filename('imagefile', @$_POST['imagefile']);
+$imagefile  = get_page_image_param($_POST, 'imagefile');
 $text_data  = array_get($_POST, 'text_data', '');
 
 define('B_TEMPSAVE',                1);

--- a/tools/proofers/project_topic.php
+++ b/tools/proofers/project_topic.php
@@ -9,7 +9,7 @@ include_once($relPath.'slim_header.inc');
 require_login();
 
 // Which project?
-$project_id = validate_projectID('project', @$_GET['project']);
+$project_id = get_projectID_param($_GET, 'project');
 
 $project = new Project($project_id);
 

--- a/tools/proofers/proof.php
+++ b/tools/proofers/proof.php
@@ -9,7 +9,7 @@ require_login();
 // (User clicked on "Start Proofreading" link or
 // one of the links in "Done" or "In Progress" trays.)
 
-$projectid      = validate_projectID('projectid', @$_GET['projectid']);
+$projectid      = get_projectID_param($_GET, 'projectid');
 $expected_state = @$_GET['proj_state'];
 
 if (empty($expected_state)) die( "parameter 'proj_state' is empty" );

--- a/tools/proofers/proof_frame.php
+++ b/tools/proofers/proof_frame.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'LPage.inc');
 include_once($relPath.'abort.inc');
-include_once($relPath.'Project.inc'); // validate_projectID
+include_once($relPath.'Project.inc'); // get_projectID_param()
 include_once($relPath.'slim_header.inc');
 include_once('PPage.inc');
 include_once('proof_frame.inc');
@@ -35,7 +35,7 @@ else
 {
     // The user clicked "Start Proofreading" or "Save as 'Done' & Proofread Next Page".
 
-    $projectid  = validate_projectID('project', @$_REQUEST['projectid']);
+    $projectid  = get_projectID_param($_REQUEST, 'projectid');
     $proj_state = $_REQUEST['proj_state'];
 
     // Consider the page (if any) that this user most recently "opened" in

--- a/tools/remove_project_hold.php
+++ b/tools/remove_project_hold.php
@@ -4,12 +4,12 @@
 
 $relPath="./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'Project.inc'); // validate_projectID() Project() remove_holds()
+include_once($relPath.'Project.inc'); // get_projectID_param()
 include_once($relPath.'metarefresh.inc'); // metarefresh()
 
 require_login();
 
-$projectid = validate_projectID('projectid', @$_POST['projectid']);
+$projectid = get_projectID_param($_POST, 'projectid');
 
 $project = new Project($projectid);
 if (!$project->can_be_managed_by_current_user)

--- a/tools/set_project_event_subs.php
+++ b/tools/set_project_event_subs.php
@@ -2,11 +2,11 @@
 $relPath="./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'user_project_info.inc');
-include_once($relPath.'Project.inc');  // validate_projectID()
+include_once($relPath.'Project.inc');  // get_projectID_param()
 
 require_login();
 
-$projectid = validate_projectID('projectid', @$_POST['projectid']);
+$projectid = get_projectID_param($_POST, 'projectid');
 $return_uri = urldecode($_POST['return_uri']);
 
 $subs = array();

--- a/tools/set_project_holds.php
+++ b/tools/set_project_holds.php
@@ -4,11 +4,11 @@
 
 $relPath="./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'Project.inc'); // validate_projectID() get_hold_states() remove_holds() add_holds()
+include_once($relPath.'Project.inc'); // get_projectID_param()
 
 require_login();
 
-$projectid = validate_projectID('projectid', @$_POST['projectid']);
+$projectid = get_projectID_param($_POST, 'projectid');
 $return_uri = urldecode($_POST['return_uri']);
 
 $project = new Project($projectid);

--- a/tools/site_admin/convert_project_table_utf8.php
+++ b/tools/site_admin/convert_project_table_utf8.php
@@ -19,7 +19,7 @@ echo "<h1>$title</h1>";
 
 echo "<p>" . _("This tool will convert individual project tables to UTF-8 if they are not already. If the project table is already UTF-8 no changes will happen.") . "</p>";
 
-$projectid = validate_projectID('projectid', @$_REQUEST['projectid'], true);
+$projectid = get_projectID_param($_REQUEST, 'projectid', true);
 
 if ( !$projectid )
 {

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -30,12 +30,12 @@ echo "<p>" . _("This tool will allow you to copy pages from one project to anoth
 $projectid_  = array_get( $_POST, 'projectid_',  NULL );
 if (is_array($projectid_))
     foreach($projectid_ as $which => $projectid)
-        $projectid_[$which] = validate_projectID("projectid_[$which]", $projectid);
+        validate_projectID($projectid);
 $from_image_ = array_get( $_POST, 'from_image_', NULL );
 if (is_array($from_image_))
     foreach($from_image_ as $which => $filename)
         if($filename)
-            validate_page_image_filename("from_image_[$which]", $filename);
+            validate_page_image($filename);
 
 $action = get_enumerated_param($_POST, 'action', 'showform', array('showform', 'showagain', 'check', 'docopy'));
 $page_name_handling = get_enumerated_param($_POST, 'page_name_handling', null, array('PRESERVE_PAGE_NAMES', 'RENUMBER_PAGES'), true);

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -26,14 +26,12 @@ echo "<h1>$title</h1>";
 echo "<p>" . _("This tool will allow you to delete pages out of a project.") . "</p>";
 
 // validate inputs
-$projectid  = array_get( $_POST, 'projectid',  NULL );
-if($projectid)
-    $projectid = validate_projectID("projectid", $projectid);
+$projectid = get_projectID_param($_POST, 'projectid',  true);
 $from_image_ = array_get( $_POST, 'from_image_', NULL );
 if (is_array($from_image_))
     foreach($from_image_ as $which => $filename)
         if($filename)
-            validate_page_image_filename("from_image_[$which]", $filename);
+            validate_page_image($filename);
 
 $action = get_enumerated_param($_POST, 'action', 'showform', array('showform', 'check', 'dodelete'));
 

--- a/tools/site_admin/proj_approvals.php
+++ b/tools/site_admin/proj_approvals.php
@@ -23,7 +23,7 @@ if (!user_is_a_sitemanager())
 
 //----------------------------------------------------------------------------------
 
-$projectid = validate_projectID('projectid', @$_GET['projectid'], true);
+$projectid = get_projectID_param($_GET, 'projectid', true);
 if (isset($projectid))
 {
     //update project approval status

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -24,7 +24,7 @@ echo "<h1>$title</h1>";
 
 echo "<p>" . _("This tool will allow you to rename pages in a project.") . "</p>";
 
-$projectid = validate_projectID('projectid', @$_REQUEST['projectid'], true);
+$projectid = get_projectID_param($_REQUEST, 'projectid', true);
 
 if ( !$projectid )
 {

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -15,7 +15,7 @@ include_once($relPath.'upload_file.inc'); // show_upload_form(), detect_too_larg
 detect_too_large();
 require_login();
 
-$projectid = validate_projectID('project', @$_REQUEST['project']);
+$projectid = get_projectID_param($_REQUEST, 'project');
 $valid_stages = array('post_1', 'return_1', 'return_2', 'correct', 'smooth_avail', 'smooth_done');
 $stage = get_enumerated_param($_REQUEST, 'stage', NULL, $valid_stages, TRUE);
 // $stage==smooth_avail controls sr, 2 cases:


### PR DESCRIPTION
Create two new projectID and page name param fetching functions that
more closely mirror the syntax for the other param fetching functions
in misc.inc. This lets us make the validate_*() functions purely
for validation and more generally useful elsewhere.