### PR TITLE
Remove public stats and make private the default

### DIFF
--- a/SETUP/upgrade/14/20200724_update_users_privacy.php
+++ b/SETUP/upgrade/14/20200724_update_users_privacy.php
@@ -1,0 +1,25 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Removing public privacy option...\n";
+
+$sql = "
+    UPDATE users
+    SET u_privacy = 0
+    WHERE u_privacy = 2;
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/faq/pophelp/prefs/prefs_pophelp.inc
+++ b/faq/pophelp/prefs/prefs_pophelp.inc
@@ -116,7 +116,6 @@ so be sure that your current email address is on record.</p>")
     'content' =>
 _("<p>This setting controls who is able to see your statistics.</p>
 <ul>
-<li><b>Public:</b> Everyone.</li>
 <li><b>Private:</b> Only registered users.</li>
 <li><b>Anonymous:</b> Only you.</li>
 </ul>")

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -179,8 +179,7 @@ function get_rank_neighbor_options()
     return ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18', '20'];
 }
 
-define('PRIVACY_PUBLIC',    0);
+define('PRIVACY_PRIVATE',   0);
 define('PRIVACY_ANONYMOUS', 1);
-define('PRIVACY_PRIVATE',   2);
 // See ../faq/pophelp/prefs/set_privacy.html
 // for definitions of these privacy categories.

--- a/pinc/privacy.inc
+++ b/pinc/privacy.inc
@@ -8,10 +8,6 @@ function can_reveal_details_about( $username, $user_privacy_setting )
 
     switch ($user_privacy_setting)
     {
-        case PRIVACY_PUBLIC:
-            // Details are visible to all.
-            return TRUE;
-
         case PRIVACY_PRIVATE:
             // Details are visible to anyone logged in.
             return !is_null($pguser);

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -304,7 +304,7 @@ function showTeamMbrs($curTeam, $tally_name) {
     $latestMbr = mysqli_query(DPDatabase::get_connection(), "SELECT users.username AS Username, users.u_privacy AS Privacy FROM user_teams INNER JOIN users ON user_teams.latestUser = users.u_id WHERE user_teams.id = ".$curTeam['id']." AND user_teams.latestUser <> 0");
     $row = mysqli_fetch_assoc($latestMbr);
     if ($row) {
-        if ($row["Privacy"] == PRIVACY_PUBLIC || ($row["Privacy"] == PRIVACY_PRIVATE && isset($GLOBALS['pguser']))) {
+        if ($row["Privacy"] == PRIVACY_PRIVATE && isset($GLOBALS['pguser'])) {
             $subtitle = sprintf(_("Please welcome <b>%s</b> as the latest member to join this team!"), $row["Username"]);
         }
     }

--- a/stats/members/mbr_xml.php
+++ b/stats/members/mbr_xml.php
@@ -30,7 +30,7 @@ $daysInExistence = floor(($now - $user->date_created)/86400);
 
 
 //User info
-if ($user->u_privacy == PRIVACY_PUBLIC)
+if ($user->u_privacy == PRIVACY_PRIVATE)
 {
     echo "
         <userinfo id='$user->u_id'>

--- a/stats/proof_stats.php
+++ b/stats/proof_stats.php
@@ -19,41 +19,31 @@ output_header($title);
 
 echo "<h1>$title</h1>\n";
 
-$sql_anonymous = mysqli_real_escape_string(DPDatabase::get_connection(), _("Anonymous"));
-
-// if user logged on
-if($pguser)
-{
-    // hide names of users who don't want even logged on people to see their names
-    $proofreader_expr = "IF(u_privacy = ".PRIVACY_ANONYMOUS.",'$sql_anonymous', username)";
-} 
-else
-{
-    // hide names of users who don't want unlogged on people to see their names
-    $proofreader_expr = "IF(u_privacy != ".PRIVACY_PUBLIC.",'$sql_anonymous', username)";
-}
-
-$subtitle = sprintf( _('Users with the Highest Number of Pages Saved-as-Done in Round %s'), $tally_name );
-
-echo "<h2>$subtitle</h2>\n";
+echo "<p>" . sprintf( _('Users with the Highest Number of Pages Saved-as-Done in Round %s'), $tally_name ) . "</p>";
 
 $users_tallyboard = new TallyBoard( $tally_name, 'U' );
 
 list($joined_with_user_page_tallies,$user_page_tally_column) =
     $users_tallyboard->get_sql_joinery_for_current_tallies('users.u_id');
 
-$sql_upt_column_name = mysqli_real_escape_string(DPDatabase::get_connection(),
-    // TRANSLATORS: %s is a page tally name (i.e. 'P1' or 'F2' or 'R*')
-    sprintf(_("%s Pages Completed"), $tally_name));
-dpsql_dump_themed_query("
+// TRANSLATORS: %s is a page tally name (i.e. 'P1' or 'F2' or 'R*')
+$sql_upt_column_name = sprintf(_("%s Pages Completed"), $tally_name);
+
+$sql = sprintf("
     SELECT
-        $proofreader_expr AS '" . mysqli_real_escape_string(DPDatabase::get_connection(), _("Proofreader")) . "',
-        $user_page_tally_column AS '$sql_upt_column_name'
+        IF(u_privacy = %d, '%s', username) AS '%s',
+        $user_page_tally_column AS '%s'
     FROM users $joined_with_user_page_tallies
     WHERE $user_page_tally_column > 0
     ORDER BY 2 DESC, 1 ASC
     LIMIT 100
-", 1, DPSQL_SHOW_RANK);
+", PRIVACY_ANONYMOUS,
+    DPDatabase::escape(_("Anonymous")),
+    DPDatabase::escape(_("Proofreader")),
+    DPDatabase::escape($sql_upt_column_name)
+);
+
+dpsql_dump_themed_query($sql, 1, DPSQL_SHOW_RANK);
 
 echo "<br>\n";
 

--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -88,7 +88,7 @@ $mbrQuery = mysqli_query(DPDatabase::get_connection(), "
 ");
 while ($curMbr = mysqli_fetch_assoc($mbrQuery))
 {
-    if ($curMbr['u_privacy'] == PRIVACY_PUBLIC)
+    if ($curMbr['u_privacy'] == PRIVACY_PRIVATE)
     {
         $data .= "<member id=\"".$curMbr['u_id']."\">
             <username>".xmlencode($curMbr['username'])."</username>

--- a/userprefs.php
+++ b/userprefs.php
@@ -263,7 +263,6 @@ function echo_general_tab($user) {
     $u_intlang_options = array_merge($u_intlang_options, $options);
 
     $i_stats_privacy = array(
-        PRIVACY_PUBLIC    => _("Public"),
         PRIVACY_ANONYMOUS => _("Anonymous"),
         PRIVACY_PRIVATE   => _("Private"),
     );


### PR DESCRIPTION
Now that all statistics require a login to access, remove the public option and default everyone to private.

When new user records are created the `u_privacy` field defaults to `0`, which is why set `PRIVACY_PRIVATE` to have that value instead of leaving it at 2 and removing `PRIVACY_PUBLIC`.

Available in the [remove-public-stats](https://www.pgdp.org/~cpeel/c.branch/remove-public-stats) sandbox.