### PR TITLE
Unicode strict identity escaping

### DIFF
--- a/SETUP/tests/jsTests/srchrepTests.js
+++ b/SETUP/tests/jsTests/srchrepTests.js
@@ -5,7 +5,7 @@ QUnit.module("srchrep tests", {
     beforeEach: function() {
         // eslint-disable-next-line camelcase
         window.opener = { parent: { docRef: { editform: { text_data: {
-            value: 'Example search and replace search text <i>value</i>.',
+            value: 'Example search -- and replace search text <i>value</i>.',
         } } } } };
         $(document.body).append(`
         <form id='srchrep-form'>
@@ -27,7 +27,18 @@ QUnit.test("replaces all instances", function(assert) {
     srchrep.doReplace();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example search and replace search text value.',
+        'Example search -- and replace search text value.',
+        'Search replace replaces all instances.');
+    assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
+});
+
+QUnit.test("replaces -- instances", function(assert) {
+    $('#search').val('--');
+    $('#replace').val('-');
+    srchrep.doReplace();
+    assert.strictEqual(
+        window.opener.parent.docRef.editform.text_data.value,
+        'Example search - and replace search text <i>value</i>.',
         'Search replace replaces all instances.');
     assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
 });
@@ -50,13 +61,13 @@ QUnit.test("restore saved text undoes replace", function(assert) {
     srchrep.doReplace();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example sch and replace sch text <i>value</i>.',
+        'Example sch -- and replace sch text <i>value</i>.',
         'Search replace replaces all instances.');
     assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
     srchrep.restoreSavedText();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example search and replace search text <i>value</i>.',
+        'Example search -- and replace search text <i>value</i>.',
         'undo restores original text.');
     assert.ok($('#undo').prop('disabled'), 'Undo should be enabled.');
 });
@@ -67,7 +78,7 @@ QUnit.test("supports \\n for newlines as replace value", function(assert) {
     srchrep.doReplace();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example s\r\n and replace s\r\n text <i>value</i>.',
+        'Example s\r\n -- and replace s\r\n text <i>value</i>.',
         'Search replace replaces all instances with regular expressions.');
     assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
 });

--- a/SETUP/tests/jsTests/srchrepTests.js
+++ b/SETUP/tests/jsTests/srchrepTests.js
@@ -4,9 +4,6 @@ let originalOpener = opener;
 QUnit.module("srchrep tests", {
     beforeEach: function() {
         // eslint-disable-next-line camelcase
-        window.opener = { parent: { docRef: { editform: { text_data: {
-            value: 'Example search -- and replace search text <i>value</i>.',
-        } } } } };
         $(document.body).append(`
         <form id='srchrep-form'>
           <input type="text" id='search'>
@@ -22,57 +19,86 @@ QUnit.module("srchrep tests", {
 });
 
 QUnit.test("replaces all instances", function(assert) {
+    window.opener = { parent: { docRef: { editform: { text_data: {
+        value: '<i>value</i>.',
+    } } } } };
     $('#search').val('<i>value</i>.');
     $('#replace').val('value.');
     srchrep.doReplace();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example search -- and replace search text value.',
+        'value.',
         'Search replace replaces all instances.');
     assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
 });
 
 QUnit.test("replaces -- instances", function(assert) {
+    window.opener = { parent: { docRef: { editform: { text_data: {
+        value: 'brave -- new.',
+    } } } } };
     $('#search').val('--');
     $('#replace').val('-');
     srchrep.doReplace();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example search - and replace search text <i>value</i>.',
+        'brave - new.',
+        'Search replace replaces all instances.');
+    assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
+});
+
+QUnit.test("replaces with $ correctly", function(assert) {
+    window.opener = { parent: { docRef: { editform: { text_data: {
+        value: 'brave -- new.',
+    } } } } };
+    $('#search').val('--');
+    $('#replace').val('$');
+    srchrep.doReplace();
+    assert.strictEqual(
+        window.opener.parent.docRef.editform.text_data.value,
+        'brave $ new.',
         'Search replace replaces all instances.');
     assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
 });
 
 QUnit.test("supports regular expressions", function(assert) {
+    window.opener = { parent: { docRef: { editform: { text_data: {
+        value: 'Example search text.',
+    } } } } };
     $('#search').val('s.*ch');
     $('#replace').val('');
     $('#is_regex').prop('checked', true);
     srchrep.doReplace();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example  text <i>value</i>.',
+        'Example  text.',
         'Search replace replaces all instances with regular expressions.');
     assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
 });
 
 QUnit.test("restore saved text undoes replace", function(assert) {
+    window.opener = { parent: { docRef: { editform: { text_data: {
+        value: 'Example search text.',
+    } } } } };
     $('#search').val('search');
     $('#replace').val('sch');
     srchrep.doReplace();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example sch -- and replace sch text <i>value</i>.',
+        'Example sch text.',
         'Search replace replaces all instances.');
     assert.notOk($('#undo').prop('disabled'), 'Undo should be enabled.');
     srchrep.restoreSavedText();
     assert.strictEqual(
         window.opener.parent.docRef.editform.text_data.value,
-        'Example search -- and replace search text <i>value</i>.',
+        'Example search text.',
         'undo restores original text.');
     assert.ok($('#undo').prop('disabled'), 'Undo should be enabled.');
 });
 
 QUnit.test("supports \\n for newlines as replace value", function(assert) {
+    window.opener = { parent: { docRef: { editform: { text_data: {
+        value: 'Example search -- and replace search text <i>value</i>.',
+    } } } } };
     $('#search').val('search');
     $('#replace').val('s\\n');
     srchrep.doReplace();

--- a/tools/proofers/srchrep.js
+++ b/tools/proofers/srchrep.js
@@ -24,7 +24,9 @@ var srchrep = (function() {
         }
         opener.parent.docRef.editform.text_data.value = opener.parent.docRef.editform.text_data.value.replace(
             new RegExp(search,'gu'),
-            replacetext);
+            function () {
+                return replacetext;
+            });
         setUndoButtonDisabled(false);
     }
 

--- a/tools/proofers/srchrep.js
+++ b/tools/proofers/srchrep.js
@@ -8,7 +8,7 @@ var srchrep = (function() {
     }
 
     function escapeRegExp(string) {
-        return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
     }
 
     function setUndoButtonDisabled(state) {


### PR DESCRIPTION
It is due to unicode changes. As part of unicode changes, we updated search replace to support unicode characters. We accomplish this search by using regular expressions (even for non regular expression searches). To prevent searches in non regular expression searches from accidentally stumbling into a valid or invalid regular expression, we used an encoding algorithm defined here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping. You can see (not obviously) that it encodes '-' to '\\-'. This encoding is not necessary since we will never be in a character class restriction. Thus, it is called an identity escape. Here is where it gets fun. For unicode regular expressions, the javascript specification makes this escape an error (more strict). I can't find much documentation on this besides the spec itself: https://github.com/v8/v8/blob/master/src/regexp/regexp-parser.cc#L1673 and from the reg exp engine source code for chrome and firefox:
https://github.com/v8/v8/blob/master/src/regexp/regexp-parser.cc#L1673
https://github.com/mozilla/gecko-dev/blob/baf1cd492406a9ac31d9ccb7a51c924c7fbb151f/js/src/irregexp/imported/regexp-parser.cc#L390
