### PR TITLE
Use unique URLs for "proofread next page"

### DIFF
--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -1,9 +1,12 @@
 <?php
 include_once($relPath.'site_vars.php');
+include_once($relPath.'slim_header.inc'); // html_safe()
 include_once($relPath.'misc.inc'); // html_safe()
 
 function abort( $error_message )
 {
+    slim_header(_("Error"));
+
     echo "<p>";
     echo _("We are unable to complete your request.");
     echo "</p>\n";
@@ -17,9 +20,8 @@ function abort( $error_message )
 
     echo "<hr>\n";
 
+    echo "<p class='error'>$error_message</p>\n";
     echo "<pre>\n";
-    echo _("error message"), ": $error_message\n";
-    echo "\n";
     dump_request_info();
 
     if (0)

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -16,6 +16,10 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     global $code_url, $site_abbreviation;
     global $charset;
 
+    static $was_output = false;
+    if($was_output)
+        return;
+
     $intlang = get_desired_language();
 
     // HTML 5 dictates that ISO-8859-1 documents should declare their charset

--- a/tools/proofers/proof_frame.php
+++ b/tools/proofers/proof_frame.php
@@ -4,6 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'LPage.inc');
 include_once($relPath.'abort.inc');
+include_once($relPath.'metarefresh.inc');
 include_once($relPath.'Project.inc'); // get_projectID_param()
 include_once($relPath.'slim_header.inc');
 include_once('PPage.inc');
@@ -113,7 +114,8 @@ else
 
     setDebounceInfo( $lpage->projectid );
 
-    $ppage = new PPage( $lpage, $proj_state );
+    $url = "$code_url/tools/proofers/proof_frame.php?projectid=$lpage->projectid&imagefile=$lpage->imagefile&proj_state=$proj_state&page_state=$lpage->page_state";
+    metarefresh(0, $url);
 }
 
 echo_proof_frame($ppage);

--- a/tools/proofers/proof_frame.php
+++ b/tools/proofers/proof_frame.php
@@ -74,17 +74,13 @@ else
         $npage=getDebounceInfo();
         if(!($npage['pageTime'] <= (time()-3)) && $npage['project']==$projectid)
         {
-                // It probably doesn't matter what we say here.
-                // 1) Indications are that users will never see this.
-                // 2) The important thing is that we neither assign the user a
-                //    new page, nor send a proofing interface.
-                header('HTTP/1.1 409 Conflict');
-                echo "<p>";
-                echo sprintf(_("We received two near-simultaneous requests from you for the same resource, so we are ignoring the second one (other than to send this error message). If you are unsure of why this happened, please inform a <a href='%s'>Site Admin</a> that you received this message."),
-                             "mailto:".$GLOBALS['site_manager_email_addr']);
-                echo "</p>";
-                provide_escape_links();
-                exit();
+            // It probably doesn't matter what we say here.
+            // 1) Indications are that users will never see this.
+            // 2) The important thing is that we neither assign the user a
+            //    new page, nor send a proofing interface.
+            header('HTTP/1.1 409 Conflict');
+            $message = _("We received two near-simultaneous requests from you for the same resource, so we are ignoring the second one (other than to send this error message).");
+            abort($message);
         }
     }
 


### PR DESCRIPTION
In the Enhanced proofreading interface, when proofreaders use the "Start Proofreading" link, then the "Save and Proofread Next" button, and then use the browser's back button they can be presented with an image that does not match the text. If they then save the page the incorrect project page will be updated.

To fix this, we use a redirect from within the proofreading frame to ensure that "Start Proofreading" or "Save & Proofread Next" lead to a URL that is unique to that page. If the user tries to navigate back using the browser, they will be presented with an error because the page state does not match the expected state.

[Task 1911](https://www.pgdp.net/c/tasks.php?action=show&task_id=1911)

This is available in the [next-page-url](https://www.pgdp.org/~cpeel/c.branch/next-page-url) sandbox.