### PR TITLE
Updates for addproofer.php and privacy.php

### DIFF
--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -114,7 +114,7 @@ echo sprintf(_("Thank you for your interest in %s. To create an account, please 
 
 echo "<h2>" . _("Registration Hints") . "</h2>";
 echo "<ul>";
-echo "<li>" . _("Please choose your User Name carefully. It will be visible to other users and cannot be changed. We suggest that you don't use your e-mail address as a User Name since e-mail addresses can change, and you may not want to make that address viewable.") . "</li>";
+echo "<li>" . _("Your User Name will be visible to other volunteers and cannot be changed. Please choose it carefully. We suggest that you <strong>do not use your e-mail address as a User Name</strong> since e-mail addresses can change, and you may not want to make that address viewable.") . "</li>";
 echo "<li>" . sprintf(_("Please ensure that the e-mail address you provide is correct. %s will e-mail a confirmation link for you to follow in order to activate your account."), $site_name) . "</li>";
 echo "<li>" . sprintf(_("<strong>Before</strong> you submit this form, please add <i>%s</i> to your e-mail contacts list to avoid the activation e-mail being treated as spam."), $general_help_email_addr) . "</li>";
 echo "</ul>";

--- a/faq/privacy.php
+++ b/faq/privacy.php
@@ -41,7 +41,8 @@ output_section(
     array(
         _('When you register, %s will send a confirmation/introduction message to your e-mail address.'),
         _('You may also receive optional e-mail alerts from our discussion forums and occasional notifications and feedback related to your proofreading activities.'),
-        _('%1$s may also invite you by e-mail to vote in periodic Board Trustee elections and could contact you for site-related purposes authorized by %1$s management.'),
+        _('%1$s may also invite you by e-mail to vote in periodic Board of Trustees elections.'), 
+        _('You may also be contacted for site-related purposes by %1$s administrators.'),
     )
 );
 
@@ -51,26 +52,27 @@ output_section(
         _('Real Name: Each book that %1s produces includes a credits line to identify the people holding certain roles (Content Provider, Image Preparer, Text Preparer, Post Processor, and Project Manager) who have worked on the book.'),
         _('If you take on any of these roles, you can choose (in your Preferences) how or whether you prefer to be credited.'),
         _('Apart from this possibility, the information you enter as your Real Name in your Preferences will be accessible only to our site administrators.'),
+        $test_system_access_string,
     ),
     array(
-        _('E-mail Address: Your e-mail address will be accessible only to our site administrators unless you make it available to other volunteers yourself, either by telling them or sending email to them from your email client.'),
-        $test_system_access_string,
+        _('E-mail Address: Your e-mail address will be accessible only to %s administrators unless you make it available to other volunteers yourself, either by telling them or sending email to them from your email client.'),
     ),
     array(
         _('How did you hear about us: Your answer to the "How did you hear about us?" question on the registration form is for general statistical purposes and any tie to your profile will be visible only to our site administrators.'),
     ),
     array(
         _('During the various production phases, your User Name and your %s work may be viewable by other volunteers.'),
-        _('In addition, volunteers delegated to an evaluation or mentoring role will be able to review the work performed under your User Name.'),
+        _('In addition, administrators and volunteers delegated to an evaluation or mentoring role will be able to review the work performed under your User Name.'),
     ),
     array(
-        _('You have the option to make your %s statistics (Information normally viewable on the Statistics General page such as the number of pages you have proofread, when you were last on the site, etc.) private so that only registered users can see them, public so that anyone including non-registered visitors can see them, or anonymous so that only you and site administrators can see them.'),
+        _('You have the option to make your %1$s statistics private so that logged-in users can see them, or anonymous so that only you and %1$s administrators can see them.'),
+        _('This includes information such as the number of pages you have proofread, when you were last on the site, etc., that is viewable from your member details (personal stats) page, the sidebar on the round pages, and the Statistics Central page.'),
     ),
     array(
-        _('Your User Name and any public information you provide in your forum profile will be accessible to other %s volunteers and to unregistered guests.'),
+        _('Your User Name and any public information you provide in your forum profile will be accessible to other %s volunteers and to unregistered guests using the forums.'),
         _('Your posts on our discussion forums will be viewable by other volunteers.'),
         _('Certain clearly-designated forums are also viewable by unregistered guests to the forums.'),
-        _('Your User Name and any information you post on the wiki are visible to both volunteers and unregistered guests.'),
+        _('Your User Name and any information you post on the wiki are visible to both volunteers and unregistered guests using the wiki.'),
     )
 );
 
@@ -78,7 +80,8 @@ output_section(
     _('Tracking information'),
     array(
         _('%s tracks your User Name, the date your account was created and your last login date.'),
-        _('This tracking information will be available to other volunteers.'),
+        _('If you set your statistics to "anonymous," the date your account was created and your last login date will be visible only to administrators.'),
+        _('Otherwise, they will be visible to other logged-in users.'),
      ),
     array(
         _('%s automatically receives and records information from your computer and browser, including your IP address.'),
@@ -86,7 +89,7 @@ output_section(
     ),
     array(
         _("The system also tracks the number of pages you have completed, your best day ever, team memberships, proofreading roles, and the highest rank you've achieved."),
-        _('In your %s site profile, you can control whether this information is viewable by everyone, registered users only, or yourself and site administrators only.'),
+        _('In your %1$s site profile, as mentioned above, you can control whether this information is viewable by logged-in users or only by yourself and %1$s administrators.'),
     )
 );
 
@@ -94,8 +97,12 @@ output_section(
     _('Sharing Information'),
     array(
         _('For the purposes of this policy, the term "%s site administrators" includes the General Manager (GM) and the members of the GM\'s staff with the rank of "squirrel."'),
-        _('It does not include members of the Distributed Proofreaders Foundation Board.'),
-        sprintf(_('However, should you make a formal complaint to the Distributed Proofreaders Foundation Board pursuant to the DP <a href="%s">Code of Conduct</a>, it may be necessary for Board members as part of their investigation to review details concerning your work at DP and your DP communications.'), 'https://www.pgdp.net/wiki/DP_Official_Documentation:General/Code_of_Conduct'),
+        _('"%s administrators" includes site administrators and "project facilitators."'),
+        _('The terms "site administrator" and "administrator" refer to roles associated with the %1$s website.'),
+    ),
+    array(
+        _('The Distributed Proofreaders Foundation is a separate organization whose Trustees may happen to also be administrators of the %s website, but often are not.'),
+        sprintf(_('Should you make a formal complaint to the Distributed Proofreaders Foundation Board of Trustees pursuant to the DP <a href="%s">Code of Conduct</a>, it may be necessary for Board members as part of their investigation to review details concerning your work at DP and your DP communications.'), 'https://www.pgdp.net/wiki/DP_Official_Documentation:General/Code_of_Conduct'),
      ),
     array(
         _('%s will disclose user data in response to valid, compulsory legal processes from government agencies with appropriate jurisdiction and authority.'),

--- a/faq/privacy.php
+++ b/faq/privacy.php
@@ -80,7 +80,7 @@ output_section(
     _('Tracking information'),
     array(
         _('%s tracks your User Name, the date your account was created and your last login date.'),
-        _('If you set your statistics to "anonymous," the date your account was created and your last login date will be visible only to administrators.'),
+        _('If you set your statistics to "anonymous", the date your account was created and your last login date will be visible only to administrators.'),
         _('Otherwise, they will be visible to other logged-in users.'),
      ),
     array(
@@ -96,8 +96,8 @@ output_section(
 output_section(
     _('Sharing Information'),
     array(
-        _('For the purposes of this policy, the term "%s site administrators" includes the General Manager (GM) and the members of the GM\'s staff with the rank of "squirrel."'),
-        _('"%s administrators" includes site administrators and "project facilitators."'),
+        _('For the purposes of this policy, the term "%s site administrators" includes the General Manager (GM) and the members of the GM\'s staff with the rank of "squirrel".'),
+        _('"%s administrators" includes site administrators and "project facilitators".'),
         _('The terms "site administrator" and "administrator" refer to roles associated with the %1$s website.'),
     ),
     array(


### PR DESCRIPTION
Per GM, clarification updates for registration hints paragraph in
accounts/addproofer.php, and updates to faq/privacy.php.

Available for review at [https://www.pgdp.org/~srjfoo/c.branch/addproofer-privacy/accounts/addproofer.php](https://www.pgdp.org/~srjfoo/c.branch/addproofer-privacy/accounts/addproofer.php)