### PR TITLE
Allow PFs to see Anonymous user stats

### DIFF
--- a/pinc/privacy.inc
+++ b/pinc/privacy.inc
@@ -14,7 +14,8 @@ function can_reveal_details_about( $username, $user_privacy_setting )
 
         case PRIVACY_ANONYMOUS:
             // Details are visible to the user him/herself and to Site Admins.
-            return !is_null($pguser) && ( $pguser == $username || user_is_a_sitemanager() );
+            // and Project Facilitators
+            return !is_null($pguser) && ( $pguser == $username || user_is_proj_facilitator() );
 
         default:
             // Shouldn't happen.

--- a/stats/members/mdetail.php
+++ b/stats/members/mdetail.php
@@ -39,7 +39,7 @@ if ( $can_reveal )
 {
     if ( $user->u_privacy == PRIVACY_ANONYMOUS )
     {
-        $visibility_note = _("These stats are visible to Site Admins and the user only.");
+        $visibility_note = _("These stats are visible to Site Admins, Project Facilitators and the user only.");
         echo "<i>($visibility_note)</i><br>\n";
     }
     showMbrInformation( $user, $tally_name );


### PR DESCRIPTION
Allow Project Facilitators to see Anonymous user stats. Updated the message that is displayed to reflect the change.