### PR TITLE
Add project page access to APIs

### DIFF
--- a/api/ApiRouter.inc
+++ b/api/ApiRouter.inc
@@ -52,7 +52,7 @@ class ApiRouter
             {
                 list($param_name, $validator) = $this->get_validator($url_map);
                 $url_map = &$url_map[$param_name];
-                $data[$param_name] = $validator($part);
+                $data[$param_name] = $validator($part, $data);
             }
         }
         if(!isset($url_map["endpoint"]))

--- a/api/README.md
+++ b/api/README.md
@@ -91,7 +91,7 @@ into JSON error messages and HTTP error codes as appropriate. See
 
 The `dp-openapi.yaml` file should always contain the definitive OpenAPI on what
 is currently implemented. This file is best edited via
-[Swagger Editor](http://editor.swagger.io/). Indeed, that's a great place
+[Swagger Editor](https://editor.swagger.io/). Indeed, that's a great place
 to test out the APIs as well.
 
 ## References

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -166,6 +166,29 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/pagerounds:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid page rounds
+      responses:
+        200:
+          description: List of page rounds
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/states:
     get:
       tags:
@@ -289,6 +312,76 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/{projectid}/pages:
+    get:
+      tags:
+      - project
+      description: Gets a list of a project's page names
+      parameters:
+      - name: projectid
+        in: path
+        description: ID of project
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of a project's page names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/pagerounds/{pageroundid}:
+    get:
+      tags:
+      - project
+      description: Gets a list of a project's page names
+      parameters:
+      - name: projectid
+        in: path
+        description: ID of project
+        required: true
+        schema:
+          type: string
+      - name: pagename
+        in: path
+        description: Name of page
+        required: true
+        schema:
+          type: string
+      - name: pageroundid
+        in: path
+        description: Page round ID
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Project page information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/project_page'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /stats/site:
     get:
       tags:
@@ -403,6 +496,20 @@ components:
         includes a great deal of information, some fields of which are calculated
         and not directly modifyable. Not all fields are available to all users. Fields
         the user does not have access to will not be returned.
+
+    project_page:
+      required:
+      - pagename
+      type: object
+      properties:
+        pagename:
+          type: string
+        image_url:
+          type: string
+        text:
+          type: string
+        state:
+          type: string
 
     site_stats:
       type: object

--- a/api/index.php
+++ b/api/index.php
@@ -48,12 +48,21 @@ function api_authenticate()
     $api_key = @$_SERVER['HTTP_X_API_KEY'];
     if($api_key)
     {
-        try {
-            $user = User::load_from_api_key($api_key);
-        } catch (NonexistentUserException $exception) {
-            throw new UnauthorizedError();
+        // If the api_key is "SESSION" attempt to load the user session
+        if($api_key == "SESSION")
+        {
+            dpsession_resume();
         }
-        $pguser = $user->username;
+        // Otherwise use the API key in the HTTP header
+        else
+        {
+            try {
+                $user = User::load_from_api_key($api_key);
+            } catch (NonexistentUserException $exception) {
+                throw new UnauthorizedError();
+            }
+            $pguser = $user->username;
+        }
     }
 
     if(!isset($pguser))

--- a/api/index.php
+++ b/api/index.php
@@ -204,7 +204,7 @@ function handle_cors_headers()
 {
     // Enable CORS for some sites
     $allowed_origins = [
-        "http://editor.swagger.io",
+        "https://editor.swagger.io",
     ];
     $origin = @$_SERVER["HTTP_ORIGIN"];
     if(in_array($origin, $allowed_origins))

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -12,6 +12,8 @@ $router = ApiRouter::get_router();
 $router->add_validator(":wordlist_type", "validate_wordlist");
 $router->add_validator(":projectid", "validate_project");
 $router->add_validator(":roundid", "validate_round");
+$router->add_validator(":pagename", "validate_page_name");
+$router->add_validator(":pageroundid", "validate_page_round");
 
 // Add routes
 $router->add_route("GET", "v1/projects", "api_v1_projects");
@@ -22,6 +24,9 @@ $router->add_route("GET", "v1/projects/difficulties", "api_v1_projects_difficult
 $router->add_route("GET", "v1/projects/genres", "api_v1_projects_genres");
 $router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
 $router->add_route("GET", "v1/projects/states", "api_v1_projects_states");
+$router->add_route("GET", "v1/projects/pagerounds", "api_v1_projects_pagerounds");
+$router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
+$router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
 $router->add_route("GET", "v1/stats/site/rounds/:roundid", "api_v1_stats_site_round");

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -2,6 +2,7 @@
 include_once("ApiRouter.inc");
 
 // DP API v1
+include_once("v1_validators.inc");
 include_once("v1_projects.inc");
 include_once("v1_stats.inc");
 

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -7,31 +7,6 @@ include_once("exceptions.inc");
 // DP API v1 -- Projects
 
 //===========================================================================
-// Validators
-
-function validate_project($projectid)
-{
-    // validate and load the specified projectid
-    try
-    {
-        return new Project($projectid);
-    }
-    catch(NonexistentProjectException $exception)
-    {
-        throw new NotFoundError("No such project ID");
-    }
-}
-
-function validate_wordlist($wordlist)
-{
-    if(!in_array($wordlist, ["good", "bad"]))
-    {
-        throw new NotFoundError();
-    }
-    return $wordlist;
-}
-
-//===========================================================================
 // projects/
 
 function api_v1_projects($method, $data, $query_params)

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -184,6 +184,64 @@ function api_v1_project_wordlists($method, $data, $query_params)
 }
 
 //---------------------------------------------------------------------------
+// projects/:projectid/pages
+
+function api_v1_project_pages($method, $data, $query_params)
+{
+    return $data[":projectid"]->get_page_names_from_db();
+}
+
+//---------------------------------------------------------------------------
+// projects/:projectid/pages/:pagename/pagerounds/:pageroundid
+
+function api_v1_project_page_round($method, $data, $query_params)
+{
+    if($data[":pageroundid"] == "OCR")
+    {
+        $text_column = "master_text";
+        $user_column = "NULL";
+    }
+    else
+    {
+        $round = get_Round_for_round_id($data[":pageroundid"]);
+        $text_column = $round->text_column_name;
+        $user_column = $round->user_column_name;
+    }
+
+    $sql = sprintf("
+        SELECT
+            image,
+            %s AS text,
+            %s AS user,
+            state
+        FROM %s
+        WHERE image = '%s'
+    ", $text_column, $user_column, $data[":projectid"]->projectid,
+        DPDatabase::escape($data[":pagename"])
+    );
+    $result = DPDatabase::query($sql);
+    $row = mysqli_fetch_assoc($result);
+    $row["image_url"] = $data[":projectid"]->url . "/" . $row["image"];
+
+    # We can't show the username here unless the user has proofed the page
+    # in one round or they are an PF/SA. We need to abstract the conditional
+    # logic out of tools/project_manager/page_detail.inc
+    unset($row["user"]);
+
+    return render_project_page_json($row);
+}
+
+function render_project_page_json($row)
+{
+    return [
+        "pagename" => $row["image"],
+        "image_url" => $row["image_url"],
+        "text" => $row["text"],
+        "state" => $row["state"],
+    ];
+}
+
+//---------------------------------------------------------------------------
 // projects/difficulties
 
 function api_v1_projects_difficulties($method, $data, $query_params)
@@ -223,3 +281,12 @@ function api_v1_projects_states($method, $data, $query_params)
     return array_keys($states);
 }
 
+//---------------------------------------------------------------------------
+// projects/pagerounds
+
+function api_v1_projects_pagerounds($method, $data, $query_params)
+{
+    global $Round_for_round_id_;
+
+    return array_merge(["OCR"], array_keys($Round_for_round_id_));
+}

--- a/api/v1_stats.inc
+++ b/api/v1_stats.inc
@@ -3,20 +3,6 @@ include_once("exceptions.inc");
 
 // DP API v1 -- Stats
 
-//===========================================================================
-// Validators
-
-function validate_round($roundid)
-{
-    global $Round_for_round_id_;
-
-    if(!in_array($roundid, array_keys($Round_for_round_id_)))
-    {
-        throw new NotFoundError("Invalid round");
-    }
-    return $Round_for_round_id_[$roundid];
-}
-
 //---------------------------------------------------------------------------
 // stats/site
 

--- a/api/v1_validators.inc
+++ b/api/v1_validators.inc
@@ -1,0 +1,39 @@
+<?php
+include_once($relPath.'stages.inc');
+include_once($relPath.'Project.inc');
+
+//===========================================================================
+// Validators
+
+function validate_round($roundid)
+{
+    global $Round_for_round_id_;
+
+    if(!in_array($roundid, array_keys($Round_for_round_id_)))
+    {
+        throw new NotFoundError("Invalid round");
+    }
+    return $Round_for_round_id_[$roundid];
+}
+
+function validate_project($projectid)
+{
+    // validate and load the specified projectid
+    try
+    {
+        return new Project($projectid);
+    }
+    catch(NonexistentProjectException $exception)
+    {
+        throw new NotFoundError("No such project ID");
+    }
+}
+
+function validate_wordlist($wordlist)
+{
+    if(!in_array($wordlist, ["good", "bad"]))
+    {
+        throw new NotFoundError();
+    }
+    return $wordlist;
+}

--- a/api/v1_validators.inc
+++ b/api/v1_validators.inc
@@ -5,7 +5,7 @@ include_once($relPath.'Project.inc');
 //===========================================================================
 // Validators
 
-function validate_round($roundid)
+function validate_round($roundid, $data)
 {
     global $Round_for_round_id_;
 
@@ -16,7 +16,7 @@ function validate_round($roundid)
     return $Round_for_round_id_[$roundid];
 }
 
-function validate_project($projectid)
+function validate_project($projectid, $data)
 {
     // validate and load the specified projectid
     try
@@ -29,11 +29,34 @@ function validate_project($projectid)
     }
 }
 
-function validate_wordlist($wordlist)
+function validate_wordlist($wordlist, $data)
 {
     if(!in_array($wordlist, ["good", "bad"]))
     {
         throw new NotFoundError();
     }
     return $wordlist;
+}
+
+function validate_page_name($pagename, $data)
+{
+    $pages = $data[":projectid"]->get_page_names_from_db();
+    if(!in_array($pagename, $pages))
+    {
+        throw new NotFoundError("No such page in project");
+    }
+    return $pagename;
+}
+
+function validate_page_round($pageround, $data)
+{
+    global $Round_for_round_id_;
+
+    $pagerounds = array_merge(["OCR"], array_keys($Round_for_round_id_));
+
+    if(!in_array($pageround, $pagerounds))
+    {
+        throw new NotFoundError("Invalid page round");
+    }
+    return $pageround;
 }

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -22,8 +22,6 @@ if(!headers_sent())
     header("Content-Type: text/html; charset=$charset");
 }
 
-include_once($relPath.'dpsession.inc');
-
 // If we don't have a database connection, don't try to resume the session.
 if(DPDatabase::get_connection())
     $user_is_logged_in = dpsession_resume();

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -50,6 +50,10 @@ try {
         throw $e;
 }
 
+// Load the session libraries, but allow base.inc and api/index.php to do
+// the start/resume.
+include_once($relPath.'dpsession.inc');
+
 //----------------------------------------------------------------------------
 
 // Autoloading functions for DP classes in pinc/

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -78,6 +78,7 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     $js_files = array(
         "$code_url/pinc/3rdparty/jquery/jquery-3.4.1.min.js",
         "$code_url/pinc/3rdparty/xregexp/xregexp-all.js",
+        "$code_url/scripts/api.js",
     );
 
     // Per-page JS
@@ -91,12 +92,13 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     }
 
     // Per-page Javascript
+    echo "<script>\n";
+    echo "const codeUrl = '$code_url';\n";
     if (isset($extra_args['js_data']))
     {
-        echo "<script>\n" .
-            $extra_args['js_data'] .
-            "</script>\n";
+        echo $extra_args['js_data'];
     }
+    echo "</script>\n";
 
     // Any additional head tags
     if(isset($extra_args['head_data']))

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,0 +1,17 @@
+/*global $ codeUrl */
+/* exported makeApiAjaxSettings */
+
+function makeApiAjaxSettings(apiUrl, queryParams) {
+    let queryParamString = "";
+    if(queryParams) {
+        queryParamString = "&" + $.param(queryParams);
+    }
+    let settings = {
+        "url": codeUrl + "/api/index.php?url=" + apiUrl + queryParamString,
+        "dataType": "json",
+        "headers": {
+            "X-API-KEY": "SESSION"
+        }
+    };
+    return settings;
+}


### PR DESCRIPTION
This adds (very) basic project page access to the APIs and allows the APIs to be accessed via session making them useful to JS UIs. Specifically it exposes the APIs needed to allow @70ray's new view images code to populate the data via AJAX instead of page loads.

I've also included a new global JS function to assist with creating the `$.ajax()` calls.

API examples:

## All the available page rounds (including OCR)
```
curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-project-pages/api/index.php?url=v1/projects/pagerounds"
```
Results:
```json
[
    "OCR",
    "P1",
    "P2",
    "P3",
    "F1",
    "F2"
]
```

## All the pages for a project
```
curl -i -g -H "Accept: application/json" -H "X-API-KEY: reviw" \
    "https://www.pgdp.org/~cpeel/c.branch/api-project-pages/api/index.php?url=v1/projects/projectID45c225f598e32/pages"
```
Results:
```json
[
    "001.png",
    "002.png",
    "003.png",
    "004.png",
...
    "417.png",
    "418.png"
]
```


## Page details
```
curl -i -g -H "Accept: application/json" -H "X-API-KEY: review" \
    "https://www.pgdp.org/~cpeel/c.branch/api-project-pages/api/index.php?url=v1/projects/projectID45c225f598e32/pages/006.png/pagerounds/OCR"
```
Results:
```json
{
    "pagename": "006.png",
    "image_url": "https://www.pgdp.org/projects/projectID45c225f598e32/006.png",
    "text": "\"The social revolution which is impending in Europe is\r\nchiefly concerned with the future of the workers and the\r\nwomen. It is for this that I hope and wait, and for this I\r\nwill work with all my powers.\"--IBSEN.",
    "state": "P1.page_saved"
}
```

### jQuery AJAX example:
```js
settings = makeApiAjaxSettings("v1/projects/projectID45c225f598e32/pages");
$(document).ready(function() {
    $.ajax(
        settings
    ).then(function(data) {
    	console.log(data)
    });
});
```