### PR TITLE
Allow a user to join more than 3 teams

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -794,14 +794,29 @@ CREATE TABLE `user_teams` (
   `owner` int(10) unsigned NOT NULL default '0',
   `created` int(20) NOT NULL default '0',
   `member_count` int(20) NOT NULL default '0',
-  `active_members` int(11) NOT NULL default '0',
-  `daily_average` int(11) NOT NULL default '0',
   `avatar` varchar(25) NOT NULL default 'avatar_default.png',
   `icon` varchar(25) NOT NULL default 'icon_default.png',
   `topic_id` int(10) default NULL,
   `latestUser` mediumint(9) NOT NULL default '0',
   PRIMARY KEY  (`id`),
   UNIQUE KEY `teamname` (`teamname`)
+);
+# --------------------------------------------------------
+
+#
+# Table structure for table `user_teams_membership`
+#
+# Creation:
+# Last update:
+#
+
+CREATE TABLE `user_teams_membership` (
+  `u_id` int(11) unsigned NOT NULL,
+  `t_id` int(11) unsigned NOT NULL,
+  PRIMARY KEY (`u_id`,`t_id`),
+  KEY (`t_id`),
+  FOREIGN KEY (`u_id`) REFERENCES `users` (`u_id`),
+  FOREIGN KEY (`t_id`) REFERENCES `user_teams` (`id`)
 );
 # --------------------------------------------------------
 
@@ -833,9 +848,6 @@ CREATE TABLE `users` (
   `u_profile` int(10) unsigned NOT NULL default '0',
   `u_intlang` varchar(25) default '',
   `u_privacy` tinyint(1) default '0',
-  `team_1` int(10) unsigned NOT NULL default '0',
-  `team_2` int(10) unsigned NOT NULL default '0',
-  `team_3` int(10) unsigned NOT NULL default '0',
   PRIMARY KEY  (`username`),
   UNIQUE KEY `username` (`username`),
   KEY `u_id` (`u_id`),

--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -146,8 +146,8 @@ class UserTest extends PHPUnit\Framework\TestCase
     public function testSetters()
     {
         $user = new User();
-        $user->team_1 = 1;
-        $this->assertEquals($user->team_1, 1);
+        $user->i_theme = 1;
+        $this->assertEquals($user->i_theme, 1);
     }
 
     public function testSetNewImmutable()

--- a/SETUP/upgrade/15/20200815_create_team_membership.php
+++ b/SETUP/upgrade/15/20200815_create_team_membership.php
@@ -1,0 +1,96 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Creating user_teams_membership table\n";
+
+$sql = "
+    CREATE TABLE user_teams_membership (
+        u_id int unsigned NOT NULL,
+        t_id int unsigned NOT NULL,
+        PRIMARY KEY (u_id, t_id),
+        KEY (t_id),
+        FOREIGN KEY (u_id) REFERENCES users(u_id),
+        FOREIGN KEY (t_id) REFERENCES user_teams(id)
+    )
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "Populating new table from users table\n";
+
+$sql = "
+    INSERT INTO user_teams_membership (u_id, t_id)
+        SELECT u_id, team_1
+        FROM users
+        WHERE team_1 <> 0
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+$sql = "
+    INSERT INTO user_teams_membership (u_id, t_id)
+        SELECT u_id, team_2
+        FROM users
+        WHERE team_2 <> 0
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+$sql = "
+    INSERT INTO user_teams_membership (u_id, t_id)
+        SELECT u_id, team_3
+        FROM users
+        WHERE team_3 <> 0
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "Dropping team_# columns from users table\n";
+
+$sql = "
+    ALTER TABLE users
+        DROP COLUMN team_1,
+        DROP COLUMN team_2,
+        DROP COLUMN team_3
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "Dropping active_members and daily_average column from user_teams table\n";
+
+$sql = "
+    ALTER TABLE user_teams
+        DROP COLUMN active_members,
+        DROP COLUMN daily_average
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/Team.inc
+++ b/pinc/Team.inc
@@ -1,0 +1,34 @@
+<?php
+include_once($relPath.'misc.inc');
+
+// This is an incomplete abstration around the Teams
+
+class Team
+{
+    // static functions
+
+    static public function log_recent_join($tid, $uid)
+    {
+        $sql = sprintf("
+            UPDATE user_teams
+            SET latestUser = %d, member_count = member_count+1
+            WHERE id = %d
+        ", $uid, $tid);
+
+        DPDatabase::query($sql);
+    }
+
+    static public function active_member_count($tid)
+    {
+        $sql = sprintf("
+            SELECT count(*)
+            FROM user_teams_membership
+            WHERE t_id = %d
+        ", $tid);
+
+        $result = DPDatabase::query($sql);
+        list($count) = mysqli_fetch_row($result);
+        mysqli_free_result($result);
+        return $count;
+    }
+}

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -186,6 +186,48 @@ class User
         throw new NotImplementedException();
     }
 
+    public function load_teams()
+    {
+        $sql = sprintf("
+            SELECT t_id
+            FROM user_teams_membership
+            WHERE u_id = %d
+        ", $this->u_id);
+        $result = DPDatabase::query($sql);
+        $teams = [];
+        while($row = mysqli_fetch_assoc($result))
+        {
+            $teams[] = $row["t_id"];
+        }
+        mysqli_free_result($result);
+        return $teams;
+    }
+
+    public function add_team($team_id)
+    {
+        if(in_array($team_id, $this->load_teams()))
+        {
+            return;
+        }
+
+        $sql = sprintf("
+            INSERT INTO user_teams_membership
+            SET u_id = %d, t_id = %d
+        ", $this->u_id, $team_id);
+        DPDatabase::query($sql);
+
+        Team::log_recent_join($team_id, $this->u_id);
+    }
+
+    public function remove_team($team_id)
+    {
+        $sql = sprintf("
+            DELETE FROM user_teams_membership
+            WHERE u_id = %d AND t_id = %d
+        ", $this->u_id, $team_id);
+        DPDatabase::query($sql);
+    }
+
     //
     // Activity access functions
     //

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -73,14 +73,9 @@ function page_tallies_add( $tally_name, $username, $amount )
 
     // update page tally for each team
     $team_tallyboard = new TallyBoard( $tally_name, 'T' );
-    // (The 'array_unique' shouldn't be necessary, but just in case.)
-    $teams = array_unique(array($user->team_1, $user->team_2, $user->team_3));
-    foreach ($teams as $team_id)
+    foreach ($user->load_teams() as $team_id)
     {
-        if ( $team_id != 0 )
-        {
-            $team_tallyboard->add_to_tally( $team_id, $amount );
-        }
+        $team_tallyboard->add_to_tally( $team_id, $amount );
     }
 }
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -740,17 +740,22 @@ function show_user_teams()
     echo "<div id='teams-nav'>\n";
     echo "<h2>" .  _("Your Teams") . "</h2>\n";
     echo "<ul>\n";
-    $teamRes=mysqli_query(DPDatabase::get_connection(), "
-        SELECT teamname, id
-        FROM user_teams
-        WHERE id IN ({$user->team_1}, {$user->team_2}, {$user->team_3})
-    ");
-    while($row = mysqli_fetch_assoc($teamRes))
+    $user_teams = $user->load_teams();
+    if($user_teams)
     {
-        echo "<li>";
-        echo "<a href='$code_url/stats/teams/tdetail.php?tid=".$row['id']."'>".html_safe($row['teamname'])."</a>";
-        echo "</li>";
-        echo "\n";
+        $sql = sprintf("
+            SELECT id, teamname
+            FROM user_teams
+            WHERE id IN (%s)
+            ORDER BY teamname
+        ", implode(",", $user_teams));
+        $result = DPDatabase::query($sql);
+        while(list($tid, $teamname) = mysqli_fetch_row($result))
+        {
+            echo "<li>";
+            echo "<a href='$code_url/stats/teams/tdetail.php?tid=$tid'>" . html_safe($teamname) . "</a>";
+            echo "</li>\n";
+        }
     }
     echo "</ul>\n";
     echo "<p class='more-link'>";

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -556,9 +556,13 @@ function showMbrNeighbors($user, $tally_name) {
     $t->end();
 }
 
-function showMbrTeams($user) {
+function showMbrTeams($user)
+{
+    global $code_url;
 
-    if (empty($user->team_1) && empty($user->team_2) && empty($user->team_3)) { return; }
+    $user_teams = $user->load_teams();
+    if(!$user_teams)
+        return;
 
     $t = new ThemedTable(
         2,
@@ -571,17 +575,19 @@ function showMbrTeams($user) {
         _("Active Members")
     );
 
-    $result = mysqli_query(DPDatabase::get_connection(), "
-        SELECT *
+    $sql = sprintf("
+        SELECT id, teamname
         FROM user_teams
-        WHERE id IN ({$user->team_1}, {$user->team_2}, {$user->team_3})
-    ") or die(DPDatabase::log_error());
+        WHERE id IN (%s)
+        ORDER BY teamname
+    ", implode(",", $user_teams));
+    $result = DPDatabase::query($sql);
 
-    while ($row = mysqli_fetch_assoc($result)) {
-        $url = $GLOBALS['code_url']."/stats/teams/tdetail.php?tid=".$row['id'];
+    while (list($tid, $teamname) = mysqli_fetch_row($result)) {
+        $url = "$code_url/stats/teams/tdetail.php?tid=$tid";
         $t->row(
-            "<a href='$url'>".$row['teamname']."</a>",
-            sprintf(_("%s members"), number_format($row['active_members']))
+            "<a href='$url'>" . html_safe($teamname) . "</a>",
+            sprintf(_("%s members"), number_format(Team::active_member_count($tid)))
         );
     }
 

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -15,6 +15,9 @@ $team_avatars_url = "$dyn_url/teams/avatar";
 $team_icons_dir   = "$dyn_dir/teams/icon";
 $team_icons_url   = "$dyn_url/teams/icon";
 
+// Define the maximum number of teams the user can be a member of.
+define("MAX_USER_TEAM_MEMBERSHIP", 3);
+
 function select_from_teams( $where_body, $other_clauses='' )
 {
     list(, $teams_ELR_page_tallyboard) = get_ELR_tallyboards();
@@ -97,7 +100,7 @@ function showTeamProfile($curTeam, $preview=FALSE)
     }
     else
     {
-        if ($user->team_1 != $team_id && $user->team_2 != $team_id && $user->team_3 != $team_id)
+        if(!in_array($team_id, $user->load_teams()))
         {
             $op = 'jointeam';
             $text = _('Join');
@@ -190,11 +193,11 @@ function showTeamProfile($curTeam, $preview=FALSE)
     );
     $t->row(
         _("Current Members"),
-        number_format($curTeam['active_members'])
+        number_format(Team::active_member_count($team_id))
     );
     $t->row(
         _("Retired Members"),
-        number_format($curTeam['member_count'] - $curTeam['active_members'])
+        number_format($curTeam['member_count'] - Team::active_member_count($team_id))
     );
 
     $t->end();
@@ -363,12 +366,17 @@ function showTeamMbrs($curTeam, $tally_name) {
     list( $joined_with_user_tallies, $user_tally_column ) =
         $users_tallyboard->get_sql_joinery_for_current_tallies( 'u_id' );
 
-    $mbrQuery = mysqli_query(DPDatabase::get_connection(), "
+    $sql = sprintf("
         SELECT *, $user_tally_column AS current_tally
         FROM users $joined_with_user_tallies
-        WHERE {$req_team_id} IN (team_1, team_2, team_3)
+        WHERE u_id IN (
+            SELECT u_id
+            FROM user_teams_membership
+            WHERE t_id = %d
+        )
         ORDER BY $orderby $direction
-    ");
+    ", $req_team_id);
+    $mbrQuery = DPDatabase::query($sql);
 
     $totalAnonUsers = 0;
     $totalPagesAnonUsers = 0;
@@ -482,12 +490,12 @@ function showEdit($tname,$ttext,$twebpage,$tedit,$tsid)
 
     echo "<tr>";
     echo "<td class='right-align'><b>"._("Team Name")."</b>:</td>";
-    echo "<td class='left-align'><input type='text' value='" . attr_safe($tname) . "' name='teamname' size='50' required>&nbsp;<b><a href=\"JavaScript:newHelpWin('teamname');\">?</a></b></td>";
+    echo "<td class='left-align'><input type='text' value='" . attr_safe($tname) . "' name='teamname' size='50' maxlength='50' required>&nbsp;<b><a href=\"JavaScript:newHelpWin('teamname');\">?</a></b></td>";
     echo "</tr>";
 
     echo "<tr>";
     echo "<td class='right-align'><b>"._("Team Webpage")."</b>:</td>";
-    echo "<td class='left-align'><input type='text' value='$twebpage' name='teamwebpage' size='50'>&nbsp;<b><a href=\"JavaScript:newHelpWin('teamwebpage');\">?</a></b></td>";
+    echo "<td class='left-align'><input type='text' value='$twebpage' name='teamwebpage' size='50' maxlength='255'>&nbsp;<b><a href=\"JavaScript:newHelpWin('teamwebpage');\">?</a></b></td>";
     echo "</tr>";
 
     echo "<tr>";
@@ -507,12 +515,19 @@ function showEdit($tname,$ttext,$twebpage,$tedit,$tsid)
 
     echo "<tr>";
     echo "<td class='center-align' colspan='2'>";
-    if ($tedit == 1 && $user->team_1 != 0 && $user->team_2 != 0 && $user->team_3 != 0) {
+    $user_teams = $user->load_teams();
+    if($tedit == 1 && count($user_teams) >= MAX_USER_TEAM_MEMBERSHIP) {
         echo "<tr><td style='text-align: center;' colspan='2'>"._("You must join the team to create it, which team space would you like to use?")."<br>";
-        echo "<select name='tteams' title='".attr_safe(_("Team List"))."'>";
-        $teamQuery = mysqli_query(DPDatabase::get_connection(), "SELECT teamname, id FROM user_teams WHERE id IN ({$user->team_1}, {$user->team_2}, {$user->team_3})");
-        while ($row = mysqli_fetch_assoc($teamQuery)) {
-            echo "<option value='".$row['id']."'>".html_safe($row['teamname'])."</option>";
+        echo "<select name='otid' title='".attr_safe(_("Team List"))."'>";
+        $sql = sprintf("
+            SELECT id, teamname
+            FROM user_teams
+            WHERE id IN (%s)
+            ORDER BY teamname
+        ", implode(",", $user_teams));
+        $result = DPDatabase::query($sql);
+        while (list($id, $teamname) = mysqli_fetch_row($result)) {
+            echo "<option value='$id'>" . html_safe($teamname) . "</option>";
         }
         echo "</select>";
     } else {
@@ -525,13 +540,13 @@ function showEdit($tname,$ttext,$twebpage,$tedit,$tsid)
         echo "\n<tr><th style='text-align: center;' colspan='2'>";
         echo "<input type='submit' name='mkPreview' value='".attr_safe(_("Preview Team Display"))."'>&nbsp;&nbsp;&nbsp;";
         echo "<input type='submit' name='mkMake' value='".attr_safe(_("Make Team"))."'>&nbsp;&nbsp;&nbsp;";
-        echo "<input type='submit' name='mkQuit' value='".attr_safe(_("Quit"))."'>";
+        echo "<input type='submit' name='mkQuit' value='".attr_safe(_("Quit"))."' formnovalidate>";
         echo "</th></tr>";
     } else {
         echo "\n<tr><th style='text-align: center;' colspan='2'>";
         echo "<input type='submit' name='edPreview' value='".attr_safe(_("Preview Changes"))."'>&nbsp;&nbsp;&nbsp;";
         echo "<input type='submit' name='edMake' value='".attr_safe(_("Save Changes"))."'>&nbsp;&nbsp;&nbsp;";
-        echo "<input type='submit' name='edQuit' value='".attr_safe(_("Quit"))."'>";
+        echo "<input type='submit' name='edQuit' value='".attr_safe(_("Quit"))."' formnovalidate>";
         echo "</th></tr>";
     }
     echo "</table>";

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -16,7 +16,7 @@ $team_icons_dir   = "$dyn_dir/teams/icon";
 $team_icons_url   = "$dyn_url/teams/icon";
 
 // Define the maximum number of teams the user can be a member of.
-define("MAX_USER_TEAM_MEMBERSHIP", 3);
+define("MAX_USER_TEAM_MEMBERSHIP", 6);
 
 function select_from_teams( $where_body, $other_clauses='' )
 {

--- a/stats/members/jointeam.php
+++ b/stats/members/jointeam.php
@@ -3,67 +3,60 @@ $relPath="./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'metarefresh.inc');
+include_once($relPath.'theme.inc');
 include_once('../includes/team.inc');
 
 require_login();
 
-$otid = get_integer_param( $_GET, 'otid', 0, 0, 3 );
+$otid = get_integer_param( $_GET, 'otid', 0, 0, null );
 $tid  = get_integer_param( $_GET, 'tid', null, 0, null );
 
 $user = User::load_current();
+$user_teams = $user->load_teams();
 
-if ($user->team_1 != $tid && $user->team_2 != $tid && $user->team_3 != $tid) {
-    if ($user->team_1 == 0 || $otid == 1) {
-        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_1 = $tid WHERE u_id = $user->u_id");
-        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = $user->u_id, member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
-        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = $user->team_1"); }
-        $redirect_team = 1;
-    } elseif ($user->team_2 == 0 || $otid == 2) {
-        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_2 = $tid WHERE u_id = $user->u_id");
-        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = $user->u_id, member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
-        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = $user->team_2"); }
-        $redirect_team = 1;
-    } elseif ($user->team_3 == 0 || $otid == 3) {
-        $teamResult = mysqli_query(DPDatabase::get_connection(), "UPDATE users SET team_3 = $tid WHERE u_id = $user->u_id");
-        mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET latestUser = $user->u_id, member_count = member_count+1, active_members = active_members+1 WHERE id = $tid");
-        if ($otid != 0) { mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id = $user->team_3"); }
-        $redirect_team = 1;
-    } else {
-        include_once($relPath.'theme.inc');
-        $title = _("Three Team Maximum");
-        output_header($title);
-        echo "<h1>$title</h1>\n";
-        echo "<p>" . _("You have already joined three teams.<br>Which team would you like to replace?") . "</p>";
-        echo "<ul>";
-        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id = $user->team_1");
-        $row = mysqli_fetch_assoc($teamR);
-        $teamname = $row["teamname"];
-        echo "<li><a href='jointeam.php?tid=$tid&otid=1'>$teamname</a></li>";
-        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id = $user->team_2");
-        $row = mysqli_fetch_assoc($teamR);
-        $teamname = $row["teamname"];
-        echo "<li><a href='jointeam.php?tid=$tid&otid=2'>$teamname</a></li>";
-        $teamR=mysqli_query(DPDatabase::get_connection(), "SELECT teamname FROM user_teams WHERE id = $user->team_3");
-        $row = mysqli_fetch_assoc($teamR);
-        $teamname = $row["teamname"];
-        echo "<li><a href='jointeam.php?tid=$tid&otid=3'>$teamname</a></li>";
-        echo "</ul>";
-
-        echo "<p><a href='../teams/tdetail.php?tid=$tid'>" . _("Do Not Join Team"). "</a></p>";
-        $redirect_team = 0;
-    }
-} else {
+if(in_array($tid, $user_teams))
+{
     $title = _("Unable to Join the Team");
     $desc = _("You are already a member of this team....");
 
     metarefresh(4,"../teams/tdetail.php?tid=$tid", $title, $desc);
-    $redirect_team = 0;
 }
 
-if ($redirect_team == 1) {
-    $title = _("Join the Team");
-    $desc = _("Joining the team....");
-    metarefresh(0,"../teams/tdetail.php?tid=$tid",$title, $desc);
+// If we have an $otid we need to remove them from the team
+if($otid)
+{
+    $user->remove_team($otid);
+    $user_teams = $user->load_teams();
 }
+
+if(count($user_teams) >= MAX_USER_TEAM_MEMBERSHIP)
+{
+    $title = _("Team Membership Limit Reached");
+    output_header($title);
+    echo "<h1>" . html_safe($title) . "</h1>\n";
+    echo "<p>" . sprintf(_("You have already joined the maximum of %d teams. Which team would you like to replace?"), MAX_USER_TEAM_MEMBERSHIP) . "</p>";
+    echo "<ul>";
+    $sql = sprintf("
+        SELECT id, teamname
+        FROM user_teams
+        WHERE id IN (%s)
+        ORDER BY teamname
+    ", implode(",", $user_teams));
+    $result = DPDatabase::query($sql);
+    while(list($old_team_id, $teamname) = mysqli_fetch_row($result))
+    {
+        echo "<li><a href='jointeam.php?tid=$tid&otid=$old_team_id'>" . html_safe($teamname) . "</a></li>";
+    }
+    echo "</ul>";
+
+    echo "<p><a href='../teams/tdetail.php?tid=$tid'>" . _("Do Not Join Team"). "</a></p>";
+    exit;
+}
+
+// They aren't a member of the team or at their max, so add them
+$user->add_team($tid);
+$title = _("Join the Team");
+$desc = _("Joining the team....");
+metarefresh(0,"../teams/tdetail.php?tid=$tid", $title, $desc);
 
 // vim: sw=4 ts=4 expandtab

--- a/stats/members/mbr_xml.php
+++ b/stats/members/mbr_xml.php
@@ -76,15 +76,19 @@ if ($user->u_privacy == PRIVACY_PRIVATE)
         </userinfo>";
 
 //Team info
-    $result = select_from_teams("id IN ({$user->team_1}, {$user->team_2}, {$user->team_3})");
     echo "
         <teaminfo>";
-    while ($row = mysqli_fetch_assoc($result)) {
-        echo "
-            <team>
-            <name>".xmlencode($row['teamname'])."</name>
-            <activemembers>".$row['active_members']."</activemembers>
-            </team>";
+    $user_teams = $user->load_teams();
+    if($user_teams) {
+        $teams_clause = implode(",", $user_teams);
+        $result = select_from_teams("id IN ($teams_clause)");
+        while ($row = mysqli_fetch_assoc($result)) {
+            echo "
+                <team>
+                <name>".xmlencode($row['teamname'])."</name>
+                <activemembers>".Team::active_member_count($row['id'])."</activemembers>
+                </team>";
+        }
     }
     echo "
         </teaminfo>";

--- a/stats/members/quitteam.php
+++ b/stats/members/quitteam.php
@@ -10,22 +10,7 @@ require_login();
 $tid = get_integer_param($_GET, 'tid', null, 0, null);
 
 $user = User::load_current();
-
-if ($user->team_1 == $tid || $user->team_2 == $tid || $user->team_3 == $tid) {
-    $quitQuery = "UPDATE users SET ";
-    if ($user->team_1 == $tid) { $quitQuery .= "team_1 = '0'"; }
-    if ($user->team_2 == $tid) { $quitQuery .= "team_2 = '0'"; }
-    if ($user->team_3 == $tid) { $quitQuery .= "team_3 = '0'"; }
-    $quitQuery.=" WHERE u_id = $user->u_id";
-    $teamResult=mysqli_query(DPDatabase::get_connection(), $quitQuery);
-    mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET active_members = active_members-1 WHERE id='".$tid."'");
-    $title = _("Quit the Team");
-    $desc = _("Quitting the team....");
-    metarefresh(0,"../teams/tdetail.php?tid=".$tid."",$title,$desc);
-}  else {
-    $title = _("Not a member");
-    $desc = _("Unable to quit team....");
-    metarefresh(3,"../teams/tdetail.php?tid=".$tid."",$title,$desc);
-}
+$user->remove_team($tid);
+metarefresh(0, "../teams/tdetail.php?tid=$tid");
 
 // vim: sw=4 ts=4 expandtab

--- a/stats/teams/new_team.php
+++ b/stats/teams/new_team.php
@@ -26,7 +26,6 @@ if (isset($_POST['mkPreview']))
     $curTeam['owner'] = $user->u_id;
     $curTeam['created'] = time();
     $curTeam['member_count'] = 0;
-    $curTeam['active_members'] = 0;
     $curTeam['avatar'] = $teamimages['avatar'];
     echo "<div class='center-align'><br>";
     showEdit($_POST['teamname'], $_POST['text_data'], $_POST['teamwebpage'], 1, 0);
@@ -60,7 +59,7 @@ else if (isset($_POST['mkMake']))
         mysqli_query(DPDatabase::get_connection(), sprintf("
             INSERT INTO user_teams
                 (teamname, team_info, webpage, createdby, owner, created)
-            VALUES('%s', '%s', '%s', '%s', %s, %s)
+            VALUES(LEFT('%s', 50), '%s', LEFT('%s', 255), '%s', %s, %s)
         ", mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString(trim($_POST['teamname']))),
             mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString($_POST['text_data'])),
             mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString($_POST['teamwebpage'])),
@@ -94,22 +93,7 @@ else if (isset($_POST['mkMake']))
         }
 
         //figure out which team to overwrite
-        $otid=0;
-        if (!isset($_POST['teamall']))
-        {
-            if ($user->team_1 == $_POST['tteams'])
-            {
-                $otid=1;
-            }
-            elseif ($user->team_2 == $_POST['tteams'])
-            {
-                $otid=2;
-            }
-            else if ($user->team_3 == $_POST['tteams'])
-            {
-                $otid=3;
-            }
-        }
+        $otid = get_integer_param($_POST, 'otid', 0, 0, null);
     
         $title = _("Join the Team");
         $desc = _("Creating the team....");
@@ -120,7 +104,7 @@ elseif (isset($_POST['mkQuit']))
 {
     $title = _("Quit Without Saving");
     $desc = _("Quitting without saving...");
-    metarefresh(4,"$code_url/activity_hub.php",$title,$desc);
+    metarefresh(0,"$code_url/activity_hub.php",$title,$desc);
     exit;
 }
 else

--- a/stats/teams/tedit.php
+++ b/stats/teams/tedit.php
@@ -44,7 +44,7 @@ elseif (isset($_POST['edQuit']))
 {
     $title = _("Quit Without Saving");
     $desc = _("Quitting without saving...");
-    metarefresh(4,"tdetail.php?tid=$tid",$title,$desc);
+    metarefresh(0,"tdetail.php?tid=$tid",$title,$desc);
     exit;
 }
 elseif (isset($_POST['edPreview']))
@@ -117,9 +117,9 @@ elseif (isset($_POST['edMake']))
         mysqli_query(DPDatabase::get_connection(), sprintf("
             UPDATE user_teams
             SET
-                teamname='%s',
-                team_info='%s',
-                webpage='%s'
+                teamname = LEFT('%s', 50),
+                team_info = '%s',
+                webpage = LEFT('%s', 255),
             WHERE id='%s'
         ", mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString(trim($_POST['teamname']))),
             mysqli_real_escape_string(DPDatabase::get_connection(), stripAllString($_POST['text_data'])),

--- a/stats/teams/tlist.php
+++ b/stats/teams/tlist.php
@@ -9,7 +9,7 @@ include_once('../includes/team.inc');
 require_login();
 
 $order = get_enumerated_param(
-        $_GET, 'order', 'id', array('id', 'teamname', 'member_count') );
+        $_GET, 'order', 'teamname', array('id', 'teamname', 'member_count') );
 $direction = get_enumerated_param(
         $_GET, 'direction', 'asc', array('asc', 'desc') );
 $tname = array_get($_REQUEST, 'tname', null);
@@ -44,44 +44,45 @@ if ($tname) {
 }
 
 $user = User::load_current();
+$user_teams = $user->load_teams();
 
 $name = _("Team List");
 
 output_header($name);
-echo "<h1>$name</h1>\n";
+echo "<h1>" . html_safe($name) . "</h1>\n";
+
+echo "<p><a href='new_team.php'>"._("Create a New Team")."</a></p>";
 
 //Display of user teams
 echo "<table class='themed theme_striped'>\n";
 echo "<tr>";
-    echo "<th>"._("Icon")."</th>";
-    if ($order == "id" && $direction == "asc") { $newdirection = "desc"; } else { $newdirection = "asc"; }
-        echo "<th><a href='tlist.php?".$tname."tstart=$tstart&amp;order=id&amp;direction=$newdirection'>"._("ID")."</a></th>";
+    echo "<th></th>";
     if ($order == "teamname" && $direction == "asc") { $newdirection = "desc"; } else { $newdirection = "asc"; }
         echo "<th><a href='tlist.php?".$tname."tstart=$tstart&amp;order=teamname&amp;direction=$newdirection'>"._("Team Name")."</a></th>";
     if ($order == "member_count" && $direction == "desc") { $newdirection = "asc"; } else { $newdirection = "desc"; }
-        echo "<th><a href='tlist.php?".$tname."tstart=$tstart&amp;order=member_count&amp;direction=$newdirection'>"._("Total Members")."</a></th>";
-    echo "<th>"._("Options")."</th>";
+        echo "<th class='center-align'><a href='tlist.php?".$tname."tstart=$tstart&amp;order=member_count&amp;direction=$newdirection'>"._("Total Members")."</a></th>";
+    echo "<th class='center-align'>"._("Options")."</th>";
 echo "</tr>\n";
 if (!empty($tRows)) {
     while ($row = mysqli_fetch_assoc($tResult)) {
+        $tid = $row["id"];
         echo "<tr>";
-        echo "<td class='center-align'><a href='tdetail.php?tid=".$row['id']."'><img src='$team_icons_url/".$row['icon']."' width='25' height='25' alt='".attr_safe($row['teamname'])."'></a></td>\n";
-        echo "<td class='center-align'><b>".$row['id']."</b></td>\n";
-        echo "<td>", html_safe($row['teamname']), "</td>\n";
+        echo "<td class='center-align'><a href='tdetail.php?tid=$tid'><img src='$team_icons_url/".$row['icon']."' width='25' height='25' alt='".attr_safe($row['teamname'])."'></a></td>\n";
+        echo "<td><a href='tdetail.php?tid=$tid'>" . html_safe($row['teamname']) . "</a></td>\n";
         echo "<td class='center-align'>".$row['member_count']."</td>\n";
-        echo "<td class='center-align'><b><a href='tdetail.php?tid=".$row['id']."'>"._("View")."</a>&nbsp;";
-        if ($user->team_1 != $row['id'] && $user->team_2 != $row['id'] && $user->team_3 != $row['id']) {
-            echo "<a href='../members/jointeam.php?tid=".$row['id']."'>"._("Join")."</a></b></td>";
+        echo "<td class='center-align'>";
+        if(!in_array($tid, $user_teams)) {
+            echo "<a href='../members/jointeam.php?tid=$tid'>"._("Join")."</a></td>";
         } else {
-            echo "<a href='../members/quitteam.php?tid=".$row['id']."'>"._("Quit")."</a></b></td>";
+            echo "<a href='../members/quitteam.php?tid=$tid'>"._("Quit")."</a></td>";
         }
         echo "</tr>\n";
     }
 } else {
-    echo "<tr><td colspan='5' class='center-align'><b>"._("No more teams available.")."</b></td></tr>\n";
+    echo "<tr><td colspan='4' class='center-align'><b>"._("No more teams available.")."</b></td></tr>\n";
 }
 
-echo "<tr><td colspan='3' class='left-align'>";
+echo "<tr><td colspan='2' class='left-align'>";
 if (!empty($tstart)) {
     echo "<b><a href='tlist.php?".$tname."order=$order&amp;direction=$direction&tstart=".($tstart-20)."'>"._("Previous")."</a></b>";
 }
@@ -90,7 +91,6 @@ if ($tRows == 20) {
     echo "<b><a href='tlist.php?".$tname."order=$order&amp;direction=$direction&amp;tstart=".($tstart+20)."'>"._("Next")."</a></b>";
 }
 echo "</td></tr>\n";
-echo "<tr><th colspan='5' class='center-align'><b><a href='new_team.php'>"._("Create a New Team")."</a></b></th></tr>\n";
 echo "</table>";
 
 // vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
Allow users to join more than 3 teams by providing a proper mapping table between user and team. The teams code is ... let's just call it "rough". I tried to focus my changes only on what is needed to enable joining more than 3 teams although I did futz with the team listing page.

The number of teams is entirely configurable right now and I set it somewhat arbitrarily to 6. I need to consult with the other admins to determine the desired number.

This is [Task 773](https://www.pgdp.net/c/tasks.php?action=show&task_id=773) with 18 votes.

You can play with this in the [dynamic-team-membership](https://www.pgdp.org/~cpeel/c.branch/dynamic-team-membership/) sandbox.