### PR TITLE
Revert param names back to their original values

### DIFF
--- a/tools/mentors/view_page_text_image.php
+++ b/tools/mentors/view_page_text_image.php
@@ -11,8 +11,8 @@ $projectid = "";
 $imagefile = "";
 try
 {
-    $projectid = get_projectID_param($_GET, 'project', true);
-    $imagefile = get_page_image_param($_GET, 'imagefile', true);
+    $projectid = get_projectID_param($_GET, 'projectid', true);
+    $imagefile = get_page_image_param($_GET, 'page', true);
 }
 catch(Exception $exception)
 {


### PR DESCRIPTION
Change the parameter names back to their original values to ensure that older links continue to work. This page isn't linked from anywhere in the code(!) so no other place to update.

See https://www.pgdp.net/phpBB3/viewtopic.php?p=1215773#p1215773