### PR TITLE
Simplify splitter invocation.

### DIFF
--- a/SETUP/tests/jsTests/splitControlTests.js
+++ b/SETUP/tests/jsTests/splitControlTests.js
@@ -17,15 +17,8 @@ QUnit.module("splitControl tests", {
     },
 });
 
-QUnit.test("exposes split directions", function(assert) {
-    let splitter = splitControl();
-    assert.strictEqual(splitter.DIRECTION.HORIZONTAL, 0, 'Exposed horizontal');
-    assert.strictEqual(splitter.DIRECTION.VERTICAL, 1, 'Exposed vertical');
-});
-
 QUnit.test("splitter defaults config values", function(assert) {
-    let splitter = splitControl();
-    let mainSplit = splitter.setup("#container");
+    let mainSplit = splitControl("#container");
     mainSplit.reLayout();
 
     const dragBar = $($('#container div').get(1));
@@ -34,8 +27,7 @@ QUnit.test("splitter defaults config values", function(assert) {
 });
 
 QUnit.test("vertical split test draws east west drag bar", function(assert) {
-    let splitter = splitControl();
-    let mainSplit = splitter.setup("#container", {splitDirection: splitter.DIRECTION.VERTICAL});
+    let mainSplit = splitControl("#container", {splitVertical: true});
     mainSplit.reLayout();
 
     assert.strictEqual($($('#container div').get(1))
@@ -43,8 +35,7 @@ QUnit.test("vertical split test draws east west drag bar", function(assert) {
 });
 
 QUnit.test("horizontal split test draws north south drag bar", function(assert) {
-    let splitter = splitControl();
-    let mainSplit = splitter.setup("#container", {splitDirection: splitter.DIRECTION.HORIZONTAL});
+    let mainSplit = splitControl("#container", {splitVertical: false});
     mainSplit.reLayout();
 
     assert.strictEqual($($('#container div').get(1))
@@ -52,8 +43,7 @@ QUnit.test("horizontal split test draws north south drag bar", function(assert) 
 });
 
 QUnit.test("drag bar color is customizable", function(assert) {
-    let splitter = splitControl();
-    let mainSplit = splitter.setup("#container", {dragBarColor: 'rebeccapurple'});
+    let mainSplit = splitControl("#container", {dragBarColor: 'rebeccapurple'});
     mainSplit.reLayout();
 
     assert.strictEqual($($('#container div').get(1))

--- a/SETUP/tests/manual_web/split_test/switchable_split.js
+++ b/SETUP/tests/manual_web/split_test/switchable_split.js
@@ -1,13 +1,12 @@
 /* global $ splitControl */
 $(function () {
-    let splitter = splitControl();
 
-    function appendControlButton(controlDiv, theSplit, initialDirection) {
+    function appendControlButton(controlDiv, theSplit, splitVert) {
         let vSwitchButton = $("<input>", {type: 'button', value: 'Switch to Vertical Split'});
         let hSwitchButton = $("<input>", {type: 'button', value: 'Switch to Horizontal Split'});
 
-        function setSplitControls(splitDirection) {
-            if (splitDirection === splitter.DIRECTION.VERTICAL) {
+        function setSplitControls(splitVertical) {
+            if (splitVertical) {
                 hSwitchButton.show();
                 vSwitchButton.hide();
             } else {
@@ -16,21 +15,21 @@ $(function () {
             }
         }
 
-        function changeSplit(splitDirection) {
-            theSplit.setSplit(splitDirection);
-            setSplitControls(splitDirection);
+        function changeSplit(splitVertical) {
+            theSplit.setSplit(splitVertical);
+            setSplitControls(splitVertical);
         }
 
         vSwitchButton.click(function () {
-            changeSplit(splitter.DIRECTION.VERTICAL);
+            changeSplit(true);
         });
 
         hSwitchButton.click(function () {
-            changeSplit(splitter.DIRECTION.HORIZONTAL);
+            changeSplit(false);
         });
 
         $(controlDiv).append(vSwitchButton, hSwitchButton);
-        setSplitControls(initialDirection);
+        setSplitControls(splitVert);
     }
 
     function appendIndicator(controlDiv, theSplit) {
@@ -41,9 +40,9 @@ $(function () {
         });
     }
 
-    let initialSplitDirection = splitter.DIRECTION.HORIZONTAL;
-    let mainSplit = splitter.setup("#container", {splitDirection: initialSplitDirection});
-    appendControlButton("#control-div", mainSplit, initialSplitDirection);
+    let initialSplitVertical = false;
+    let mainSplit = splitControl("#container", {splitVertical: initialSplitVertical});
+    appendControlButton("#control-div", mainSplit, initialSplitVertical);
     appendIndicator("#control-div", mainSplit);
     mainSplit.reLayout();
 });

--- a/SETUP/tests/manual_web/split_test/vertical_horizontal_split.js
+++ b/SETUP/tests/manual_web/split_test/vertical_horizontal_split.js
@@ -1,7 +1,6 @@
 /* global $ splitControl */
 $(function () {
-    let splitter = splitControl();
-    let mainSplit = splitter.setup("#top-container", {dragBarColor: "green"});
-    splitter.setup("#sub-container", {splitDirection: splitter.DIRECTION.HORIZONTAL, reDraw: mainSplit.reSize, dragBarSize: 10, dragBarColor: "blue"});
+    let mainSplit = splitControl("#top-container", {dragBarColor: "green"});
+    splitControl("#sub-container", {splitVertical: false, reDraw: mainSplit.reSize, dragBarSize: 10, dragBarColor: "blue"});
     mainSplit.reLayout();
 });

--- a/SETUP/tests/manual_web/split_test/vertical_split.js
+++ b/SETUP/tests/manual_web/split_test/vertical_split.js
@@ -1,6 +1,5 @@
 /* global $ splitControl */
 $(function () {
-    let splitter = splitControl();
-    let mainSplit = splitter.setup("#container");
+    let mainSplit = splitControl("#container");
     mainSplit.reLayout();
 });

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -95,22 +95,21 @@ var pageChanger = function (theForm) {
 var viewSplitter = function(container) {
     const textImageSplitID = "text_image_split";
     const splitPercentID = "split_percent";
-    let splitter = splitControl();
 
     // stored value is "horizontal" or "vertical"
     let splitDirString = localStorage.getItem(textImageSplitID);
     if(!splitDirString) {
         splitDirString = "horizontal";
     }
-    // splitDirection is a value defined in splitter
-    let splitDirection = (splitDirString === "horizontal") ? splitter.DIRECTION.HORIZONTAL : splitter.DIRECTION.VERTICAL;
+    // splitVertical is true or false
+    let splitVertical = (splitDirString === "vertical");
 
     let splitPercent = localStorage.getItem(splitPercentID);
     if(!splitPercent) {
         splitPercent = 50;
     }
 
-    let mainSplit = splitter.setup(container, {splitDirection: splitDirection, splitPercent: splitPercent});
+    let mainSplit = splitControl(container, {splitVertical: splitVertical, splitPercent: splitPercent});
 
     let vSplitImage = $("<img>", {src: proofIntData.buttonImages.imgVSplit});
     let vSwitchButton = $("<button>", {type: 'button', class: 'img-button', title: proofIntData.strings.switchVert}).append(vSplitImage);
@@ -121,8 +120,8 @@ var viewSplitter = function(container) {
     vSplitImage.on("load", mainSplit.reLayout);
     hSplitImage.on("load", mainSplit.reLayout);
 
-    function setSplitControls(splitDirection) {
-        if (splitDirection === splitter.DIRECTION.VERTICAL) {
+    function setSplitControls(splitVertical) {
+        if (splitVertical) {
             hSwitchButton.show();
             vSwitchButton.hide();
         } else {
@@ -131,22 +130,22 @@ var viewSplitter = function(container) {
         }
     }
 
-    function changeSplit(splitDirection) {
-        mainSplit.setSplit(splitDirection);
-        setSplitControls(splitDirection);
-        splitDirString = (splitDirection === splitter.DIRECTION.HORIZONTAL) ? "horizontal" : "vertical";
+    function changeSplit(splitVertical) {
+        mainSplit.setSplit(splitVertical);
+        setSplitControls(splitVertical);
+        splitDirString = splitVertical ? "vertical" : "horizontal";
         localStorage.setItem(textImageSplitID, splitDirString);
     }
 
     vSwitchButton.click(function () {
-        changeSplit(splitter.DIRECTION.VERTICAL);
+        changeSplit(true);
     });
 
     hSwitchButton.click(function () {
-        changeSplit(splitter.DIRECTION.HORIZONTAL);
+        changeSplit(false);
     });
 
-    setSplitControls(splitDirection);
+    setSplitControls(splitVertical);
 
     mainSplit.dragEnd.add(function (percent) {
         localStorage.setItem(splitPercentID, percent);

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -4,14 +4,12 @@
 /*
  * Create a splitter between two <div>s within a container.
  * splitControl returns:
- * DIRECTION: an object containing VERTICAL and HORIZONTAL constants
- * setup: a function to setup the splitter
- * Arguments for setup:
+ * Arguments for splitControl:
  * container - ID of a <div> which contains two <div>s (herein referred
  *     to as pane1 and pane2). The splitter will be created between these.
  * config - optional dictionary that controls the div: (defaults in brackets)
  * {
- *   splitDirection: (DIRECTION.VERTICAL) DIRECTION.VERTICAL or DIRECTION.HORIZONTAL,
+ *   splitVertical: (true) true or false,
  *   splitPercent: (50), percentage of contaner occupied by pane1,
  *   reDraw - jQuery callback which should be fired when the container size changes.
  *       by default this is fired by $(window).resize()
@@ -21,7 +19,7 @@
  * }
  *
  * Returns:
- * setSplit(splitDirection): a function to change the splitDirection
+ * setSplit(splitVertical): a function to change the splitDirection
  * reLayout(): a function to re-draw the panes, this should be called after
  *     drawing any divs surrounding the container.
  * reSize: this jquery callback is fired after relayout has been called
@@ -31,165 +29,159 @@
  *     a percentage parameter. It enables the split percentage to be stored so
  *     that when splitControl is used again the split ratio can be persisted.
  */
-var splitControl = function() {
-    const DIRECTION = {VERTICAL: 1, HORIZONTAL: 0};
+var splitControl = function(container, config) {
 
     let windowResize = $.Callbacks();
     $(window).resize(function () {
         windowResize.fire();
     });
 
+    let theConfig = {reDraw: windowResize, splitVertical: true, splitPercent: 50, dragBarSize: 6, dragBarColor: "darkgray"};
+    for(let key in config) {
+        theConfig[key] = config[key];
+    }
+    let splitRatio = theConfig.splitPercent / 100;
+    // base, splitPos, range, minPos, maxPos units in principal direction
+    let base;
+    let splitPos;
+    let range;
+    let minPos;
+    let maxPos;
+    container = $(container);
+
+    let children = container.children();
+    let pane1 = $(children[0]).css({"position": "absolute"});
+    let pane2 = $(children[1]).css({"position": "absolute"});
+
+    let dragBar = $("<div>").css({"background-color": theConfig.dragBarColor, "position": "absolute"});
+    pane1.after(dragBar);
+
+    // coordinates of the container
+    let divTop;
+    let divLeft;
+    let height;
+    let width;
+
+    let reSize = $.Callbacks();
+    let dragEnd = $.Callbacks();
+
+    function moveSplit() {
+        if (splitPos < minPos) {
+            splitPos = minPos;
+        }
+        if (splitPos > maxPos) {
+            splitPos = maxPos;
+        }
+        let splitPlusDrag = splitPos + theConfig.dragBarSize;
+        if (theConfig.splitVertical) {
+            pane1.width(splitPos - base);
+            dragBar.offset({top: divTop, left: splitPos});
+            pane2.offset({top: divTop, left: splitPlusDrag});
+            pane2.width(width + divLeft - splitPlusDrag);
+        } else {
+            pane1.height(splitPos - base);
+            dragBar.offset({top: splitPos, left: divLeft});
+            pane2.height(height + divTop - splitPlusDrag);
+            pane2.offset({top: splitPlusDrag, left: divLeft});
+        }
+        reSize.fire();
+    }
+
+    function reLayout() {
+        height = container.height();
+        width = container.width();
+        let containerOffset = container.offset();
+        divTop = containerOffset.top;
+        divLeft = containerOffset.left;
+        pane1.offset(containerOffset);
+        if (theConfig.splitVertical) {
+            range = width;
+            base = divLeft;
+            pane1.height(height);
+            pane2.height(height);
+            dragBar.height(height);
+            dragBar.width(theConfig.dragBarSize);
+            dragBar.css("cursor", "ew-resize");
+        } else {
+            range = height;
+            base = divTop;
+            pane1.width(width);
+            pane2.width(width);
+            dragBar.width(width);
+            dragBar.css("cursor", "ns-resize");
+            dragBar.height(theConfig.dragBarSize);
+        }
+        range -= theConfig.dragBarSize;
+        minPos = base;
+        if(range < 0) {
+            range = 0;
+        }
+        splitPos = base + (range * splitRatio);
+        // mouse sets top/left of dragbar
+        maxPos = base + range;
+        moveSplit();
+    }
+
+    function dragStart(event) {
+        event.preventDefault();
+        // need this only if there is an iframe in a pane.
+        pane2.css("pointerEvents", "none");
+        pane1.css("pointerEvents", "none");
+    }
+
+    function dragMove(event) {
+        splitPos = (theConfig.splitVertical) ? event.pageX : event.pageY;
+        moveSplit();
+    }
+
+    function dragMoveEnd() {
+        // restore normal operation
+        pane2.css("pointerEvents", "auto");
+        pane1.css("pointerEvents", "auto");
+        if(range > 0) {
+            splitRatio = (splitPos - base) / range;
+            dragEnd.fire((splitRatio * 100).toFixed(0));
+        }
+    }
+
+    function dragMouseUp() {
+        $(document).unbind("mousemove mouseup");
+        dragMoveEnd();
+    }
+
+    function dragMouseDown(event) {
+        dragStart(event);
+        $(document).on("mousemove", dragMove)
+            .on("mouseup", dragMouseUp);
+    }
+
+    function dragTouchMove(event) {
+        dragMove(event.touches[0]);
+    }
+
+    function dragTouchEnd() {
+        $(document).unbind("touchmove touchend");
+        dragMoveEnd();
+    }
+
+    function dragTouchStart(event) {
+        dragStart(event);
+        $(document).on("touchmove", dragTouchMove)
+            .on("touchend", dragTouchEnd);
+    }
+
+    dragBar.on("mousedown", dragMouseDown);
+    dragBar.on("touchstart", dragTouchStart);
+    theConfig.reDraw.add(reLayout);
+
     return {
-        setup: function(container, config) {
-            let theConfig = {reDraw: windowResize, splitDirection: DIRECTION.VERTICAL, splitPercent: 50, dragBarSize: 6, dragBarColor: "darkgray"};
-            for(let key in config) {
-                theConfig[key] = config[key];
-            }
-            let splitRatio = theConfig.splitPercent / 100;
-            // base, splitPos, range, minPos, maxPos units in principal direction
-            let base;
-            let splitPos;
-            let range;
-            let minPos;
-            let maxPos;
-            container = $(container);
-
-            let children = container.children();
-            let pane1 = $(children[0]).css({"position": "absolute"});
-            let pane2 = $(children[1]).css({"position": "absolute"});
-
-            let dragBar = $("<div>").css({"background-color": theConfig.dragBarColor, "position": "absolute"});
-            pane1.after(dragBar);
-
-            // coordinates of the container
-            let divTop;
-            let divLeft;
-            let height;
-            let width;
-
-            let reSize = $.Callbacks();
-            let dragEnd = $.Callbacks();
-
-            function moveSplit() {
-                if (splitPos < minPos) {
-                    splitPos = minPos;
-                }
-                if (splitPos > maxPos) {
-                    splitPos = maxPos;
-                }
-                let splitPlusDrag = splitPos + theConfig.dragBarSize;
-                if (theConfig.splitDirection === DIRECTION.VERTICAL) {
-                    pane1.width(splitPos - base);
-                    dragBar.offset({top: divTop, left: splitPos});
-                    pane2.offset({top: divTop, left: splitPlusDrag});
-                    pane2.width(width + divLeft - splitPlusDrag);
-                } else {
-                    pane1.height(splitPos - base);
-                    dragBar.offset({top: splitPos, left: divLeft});
-                    pane2.height(height + divTop - splitPlusDrag);
-                    pane2.offset({top: splitPlusDrag, left: divLeft});
-                }
-                reSize.fire();
-            }
-
-            function reLayout() {
-                height = container.height();
-                width = container.width();
-                let containerOffset = container.offset();
-                divTop = containerOffset.top;
-                divLeft = containerOffset.left;
-                pane1.offset(containerOffset);
-                if (theConfig.splitDirection === DIRECTION.VERTICAL) {
-                    range = width;
-                    base = divLeft;
-                    pane1.height(height);
-                    pane2.height(height);
-                    dragBar.height(height);
-                    dragBar.width(theConfig.dragBarSize);
-                    dragBar.css("cursor", "ew-resize");
-                } else {
-                    range = height;
-                    base = divTop;
-                    pane1.width(width);
-                    pane2.width(width);
-                    dragBar.width(width);
-                    dragBar.css("cursor", "ns-resize");
-                    dragBar.height(theConfig.dragBarSize);
-                }
-                range -= theConfig.dragBarSize;
-                minPos = base;
-                if(range < 0) {
-                    range = 0;
-                }
-                splitPos = base + (range * splitRatio);
-                // mouse sets top/left of dragbar
-                maxPos = base + range;
-                moveSplit();
-            }
-
-            function dragStart(event) {
-                event.preventDefault();
-                // need this only if there is an iframe in a pane.
-                pane2.css("pointerEvents", "none");
-                pane1.css("pointerEvents", "none");
-            }
-
-            function dragMove(event) {
-                splitPos = (theConfig.splitDirection === DIRECTION.VERTICAL) ? event.pageX : event.pageY;
-                moveSplit();
-            }
-
-            function dragMoveEnd() {
-                // restore normal operation
-                pane2.css("pointerEvents", "auto");
-                pane1.css("pointerEvents", "auto");
-                if(range > 0) {
-                    splitRatio = (splitPos - base) / range;
-                    dragEnd.fire((splitRatio * 100).toFixed(0));
-                }
-            }
-
-            function dragMouseUp() {
-                $(document).unbind("mousemove mouseup");
-                dragMoveEnd();
-            }
-
-            function dragMouseDown(event) {
-                dragStart(event);
-                $(document).on("mousemove", dragMove)
-                    .on("mouseup", dragMouseUp);
-            }
-
-            function dragTouchMove(event) {
-                dragMove(event.touches[0]);
-            }
-
-            function dragTouchEnd() {
-                $(document).unbind("touchmove touchend");
-                dragMoveEnd();
-            }
-
-            function dragTouchStart(event) {
-                dragStart(event);
-                $(document).on("touchmove", dragTouchMove)
-                    .on("touchend", dragTouchEnd);
-            }
-
-            dragBar.on("mousedown", dragMouseDown);
-            dragBar.on("touchstart", dragTouchStart);
-            theConfig.reDraw.add(reLayout);
-
-            return {
-                setSplit: function (splitDirection) {
-                    theConfig.splitDirection = splitDirection;
-                    reLayout();
-                },
-
-                reLayout: reLayout,
-                reSize: reSize,
-                dragEnd: dragEnd,
-            };
+        setSplit: function (splitVertical) {
+            theConfig.splitVertical = splitVertical;
+            reLayout();
         },
-        DIRECTION: DIRECTION,
+
+        reLayout: reLayout,
+        reSize: reSize,
+        dragEnd: dragEnd,
     };
 };

--- a/tools/mentors/page_text_image.js
+++ b/tools/mentors/page_text_image.js
@@ -42,15 +42,14 @@ $(function () {
             pageControlForm.append(projectReset(), pageChanger(pageControlForm), roundSelect(true));
             fixHead.append(theImageControl.controls, theSplitter.buttons, theTextControl.controls);
 
-            let subSplitter = splitControl();
             const subSplitID = "sub_split_percent";
             let subSplitPercent = localStorage.getItem(subSplitID);
             if(!subSplitPercent) {
                 subSplitPercent = 100;
             }
 
-            let subSplitRef = subSplitter.setup(textDiv, {splitDirection: subSplitter.DIRECTION.HORIZONTAL, splitPercent: subSplitPercent, reDraw: theSplitter.mainSplit.reSize});
-            subSplitRef.dragEnd.add(function (percent) {
+            let subSplitter = splitControl(textDiv, {splitVertical: false, splitPercent: subSplitPercent, reDraw: theSplitter.mainSplit.reSize});
+            subSplitter.dragEnd.add(function (percent) {
                 localStorage.setItem(subSplitID, percent);
             });
 

--- a/tools/mentors/page_text_image.js
+++ b/tools/mentors/page_text_image.js
@@ -45,6 +45,7 @@ $(function () {
             const subSplitID = "sub_split_percent";
             let subSplitPercent = localStorage.getItem(subSplitID);
             if(!subSplitPercent) {
+                // in local storage 0 is stored as "0" and evaluates to true
                 subSplitPercent = 100;
             }
 


### PR DESCRIPTION
Remove the direction constants,
replace by vertical true or false.
This makes it possible to invoke the splitter with just one function call.
This will probably conflict with other active merge requests. I can redo it or the others as appropriate.