### PR TITLE
Move round colors to theme

### DIFF
--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -20,10 +20,6 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $listing_bgcolors,
-            // These parameters have the same semantics as the
-            // corresponding parameters of the Stage constructor.
-            // See Stage.inc for documentation.
 
         $project_checkedout_state,
         $project_available_state,
@@ -49,7 +45,6 @@ class Pool extends Stage
             $access_change_callback,
             $description,
             $document,
-            $listing_bgcolors,
             "tools/pool.php?pool_id=$pool_id"
         );
 

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -29,10 +29,6 @@ class Round extends Stage
         $access_change_callback,
         $description,
         $document,
-        $listing_bgcolors,
-            // These parameters have the same semantics as the
-            // corresponding parameters of the Stage constructor.
-            // See Stage.inc for documentation.
 
         $pi_tools,
             // A list of which tools should be available in the proofreading
@@ -82,7 +78,6 @@ class Round extends Stage
             $access_change_callback,
             $description,
             $document,
-            $listing_bgcolors,
             "tools/proofers/round.php?round_id=$round_id"
         );
 

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -31,10 +31,6 @@ class Stage extends Activity
             // The path (relative to $code_url/faq/) of a document that tells you
             // everything you need to know about working in this stage.
             // Or NULL if there is no such document.
-        $listing_bgcolors,
-            // An array of (two) HTML colors that will be used as the bgcolor
-            // in alternating rows in the listing of projects in this round.
-
         $relative_url
             // The "home" location (relative to $code_url/) of the stage.
     )
@@ -51,7 +47,6 @@ class Stage extends Activity
         $this->description   = $description;
         $this->document      = $document;
         $this->relative_url  = $relative_url;
-        $this->listing_bgcolors = $listing_bgcolors;
 
         global $Stage_for_id_;
         $Stage_for_id_[$id] =& $this;

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -455,8 +455,8 @@ function show_project_listing(
     }
 
     // Start the table.
-    echo "\n<table id='$anchor' class='availprojectlisting'>";
-    echo "<tr class='center-align' style='background-color: {$stage->listing_bgcolors[1]};'>";
+    echo "\n<table id='$anchor' class='availprojectlisting stage_$stage->id'>";
+    echo "<tr class='center-align'>";
 
     // Print out the header row with links.
     foreach($columns as $col_id => $col_info)
@@ -527,7 +527,7 @@ function show_project_listing(
 
     while ($book=mysqli_fetch_assoc($result))
     {
-        $bgcolor = $stage->listing_bgcolors[$rownum % 2];
+        $style_attr = "";
 
         // Special colours for special books of various types
         if ($show_special_colors)
@@ -535,11 +535,11 @@ function show_project_listing(
             $special_color = get_special_color_for_project($book);
             if (!is_null($special_color))
             {
-                $bgcolor = $special_color;
+                $style_attr = "style='background-color: $special_color;'";
             }
         }
 
-        echo "<tr style='background-color: $bgcolor;'>";
+        echo "<tr $style_attr>";
 
         foreach($columns as $col_id => $col_info)
         {

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -27,10 +27,6 @@ new Stage(
     NULL, /* access_change_callback */
     _('A qualified person must confirm that the work is in the public domain.'),
     NULL,
-    array(
-        'a',
-        'b',
-    ),
     "tools/site_admin/proj_approvals.php"
 );
 
@@ -50,10 +46,6 @@ new Stage(
     NULL, /* access_change_callback */
     _('We collect various bits of metadata for each page in a project.'),
     NULL,
-    array(
-        'a',
-        'b',
-    ),
     "tools/proofers/md_available.php"
 );
 
@@ -87,10 +79,6 @@ new Round(
     NULL, /* access_change_callback */
     _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
     'proofreading_guidelines.php',
-    array(
-        0 => '#FFE4B5', // mocassin
-        1 => '#FFF8DC', // cornsilk
-    ),
     $pi_tools_for_P,
     NULL, /* daily_page_limit */
     array(),
@@ -132,10 +120,6 @@ new Round(
     NULL, /* access_change_callback */
     _("The page-texts have already been proofread, and now need to have the text spellchecked and carefully compared to the image."),
     'proofreading_guidelines.php',
-    array(
-        0 => '#FFE4B5', // mocassin
-        1 => '#FFF8DC', // cornsilk
-    ),
     $pi_tools_for_P,
     NULL, /* daily_page_limit */
     array( 'P1' ),
@@ -177,10 +161,6 @@ new Round(
     NULL, /* access_change_callback */
     _("The page-texts have already been proofread, but now need to be examined <b>closely</b> for small errors that may have been missed."),
     'proofreading_guidelines.php',
-    array(
-        0 => '#DDA0DD', // plum
-        1 => '#D8BFD8', // thistle
-    ),
     $pi_tools_for_P,
     NULL, /* daily_page_limit */
     array( 'P1', 'P2' ),
@@ -222,10 +202,6 @@ new Round(
     "f1_access_change_email", /* access_change_callback */
     _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),
     'formatting_guidelines.php',
-    array(
-        0 => '#FFE4B5', // mocassin
-        1 => '#FFF8DC', // cornsilk
-    ),
     $pi_tools_for_F,
     NULL, /* daily_page_limit */
     array(),
@@ -267,10 +243,6 @@ new Round(
     NULL, /* access_change_callback */
     _("The page-texts in this round need to be carefully checked to remove any remaining formatting errors."),
     'formatting_guidelines.php',
-    array(
-        0 => '#DDA0DD', // plum
-        1 => '#D8BFD8', // thistle
-    ),
     $pi_tools_for_F,
     NULL, /* daily_page_limit */
     array( 'F1' ),
@@ -575,10 +547,6 @@ new Pool(
     "pp_access_change_email", /* access_change_callback */
     _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
     'post_proof.php',
-    array(
-        '#cccccc',
-        '#ffffff'
-    ),
 
     PROJ_POST_FIRST_CHECKED_OUT,
     PROJ_POST_FIRST_AVAILABLE,
@@ -647,10 +615,6 @@ new Stage(
     NULL, /* access_change_callback */
     _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
     NULL,
-    array(
-        '#CCFFCC',
-        '#CCFF99',
-    ),
     "tools/post_proofers/smooth_reading.php"
 );
 
@@ -665,10 +629,6 @@ new Pool(
     NULL, /* access_change_callback */
     _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
     'ppv.php',
-    array(
-        '#99FFFF', // "harshflourolightblue"
-        '#EAF7F7', // "paledarkskyblue"
-    ),
 
     PROJ_POST_SECOND_CHECKED_OUT,
     PROJ_POST_SECOND_AVAILABLE,
@@ -706,10 +666,6 @@ new Pool(
     NULL, /* access_change_callback */
     _('Readers can submit corrections. We need to review them and possibly revise the text.'), 
     NULL,
-    array(
-        '#e0e8dd',
-        '#ffffff',
-    ),
 
     PROJ_CORRECT_CHECKED_OUT,
     PROJ_CORRECT_AVAILABLE,

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -238,6 +238,9 @@ table.striped tr:nth-child(even) td {
 }
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
+table.availprojectlisting tr:nth-child(even) {
+  background-color: #ddd;
+}
 /* Default stage colors, which can be overridden by the themes */
 table.stage_P1 tr:nth-child(even) {
   background-color: #ffe4b5;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1,7 +1,5 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Classic Grey */
-/* ------------------------------------------------------------------------ */
-/* Import directive */
 body {
   background-color: #ffffff;
   color: #000000;
@@ -237,6 +235,57 @@ table.theme_striped tr:nth-child(odd) {
 }
 table.striped tr:nth-child(even) td {
   background-color: #ddd;
+}
+/* ------------------------------------------------------------------------ */
+/* Available Project Listings */
+/* Default stage colors, which can be overridden by the themes */
+table.stage_P1 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_P1 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_P2 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_P2 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_P3 tr:nth-child(even) {
+  background-color: plum;
+}
+table.stage_P3 tr:nth-child(odd) {
+  background-color: thistle;
+}
+table.stage_F1 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_F1 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_F2 tr:nth-child(even) {
+  background-color: plum;
+}
+table.stage_F2 tr:nth-child(odd) {
+  background-color: thistle;
+}
+table.stage_PP tr:nth-child(even) {
+  background-color: #cccccc;
+}
+table.stage_PP tr:nth-child(odd) {
+  background-color: #ffffff;
+}
+table.stage_PPV tr:nth-child(even) {
+  background-color: #99ffff;
+}
+table.stage_PPV tr:nth-child(odd) {
+  background-color: #eaf7f7;
+}
+table.stage_SR tr:nth-child(even) {
+  background-color: #ccffcc;
+}
+table.stage_SR tr:nth-child(odd) {
+  background-color: #ccff99;
 }
 /* ------------------------------------------------------------------------ */
 /* Sans-serif styling */

--- a/styles/themes/classic_grey.less
+++ b/styles/themes/classic_grey.less
@@ -1,5 +1,10 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Classic Grey */
+
+@import "theme.less";
+
+@theme-name: "classic_grey";
+
 @page-background: #ffffff;
 @page-text: #000000;
 @header-background: #dddddd;
@@ -15,12 +20,6 @@
 @visited-color: #0000ff;
 @active-color: #0000ff;
 @sans-serif-font: Verdana, Helvetica, sans-serif;
-
-@theme-name: "classic_grey";
-
-/* ------------------------------------------------------------------------ */
-/* Import directive */
-@import "theme.less";
 
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -238,6 +238,9 @@ table.striped tr:nth-child(even) td {
 }
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
+table.availprojectlisting tr:nth-child(even) {
+  background-color: #ddd;
+}
 /* Default stage colors, which can be overridden by the themes */
 table.stage_P1 tr:nth-child(even) {
   background-color: #ffe4b5;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1,7 +1,5 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Project Gutenberg */
-/* ------------------------------------------------------------------------ */
-/* Import directive */
 body {
   background-color: #ffffff;
   color: #000000;
@@ -237,6 +235,57 @@ table.theme_striped tr:nth-child(odd) {
 }
 table.striped tr:nth-child(even) td {
   background-color: #ddd;
+}
+/* ------------------------------------------------------------------------ */
+/* Available Project Listings */
+/* Default stage colors, which can be overridden by the themes */
+table.stage_P1 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_P1 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_P2 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_P2 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_P3 tr:nth-child(even) {
+  background-color: plum;
+}
+table.stage_P3 tr:nth-child(odd) {
+  background-color: thistle;
+}
+table.stage_F1 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_F1 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_F2 tr:nth-child(even) {
+  background-color: plum;
+}
+table.stage_F2 tr:nth-child(odd) {
+  background-color: thistle;
+}
+table.stage_PP tr:nth-child(even) {
+  background-color: #cccccc;
+}
+table.stage_PP tr:nth-child(odd) {
+  background-color: #ffffff;
+}
+table.stage_PPV tr:nth-child(even) {
+  background-color: #99ffff;
+}
+table.stage_PPV tr:nth-child(odd) {
+  background-color: #eaf7f7;
+}
+table.stage_SR tr:nth-child(even) {
+  background-color: #ccffcc;
+}
+table.stage_SR tr:nth-child(odd) {
+  background-color: #ccff99;
 }
 /* ------------------------------------------------------------------------ */
 /* Sans-serif styling */

--- a/styles/themes/project_gutenberg.less
+++ b/styles/themes/project_gutenberg.less
@@ -1,5 +1,10 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Project Gutenberg */
+
+@import "theme.less";
+
+@theme-name: "project_gutenberg";
+
 @page-background: #ffffff;
 @page-text: #000000;
 @header-background: #e0e8dd;
@@ -15,12 +20,6 @@
 @visited-color: #990099;
 @active-color: #ff0000;
 @sans-serif-font: Verdana, Helvetica, sans-serif;
-
-@theme-name: "project_gutenberg";
-
-/* ------------------------------------------------------------------------ */
-/* Import directive */
-@import "theme.less";
 
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -238,6 +238,9 @@ table.striped tr:nth-child(even) td {
 }
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
+table.availprojectlisting tr:nth-child(even) {
+  background-color: #ddd;
+}
 /* Default stage colors, which can be overridden by the themes */
 table.stage_P1 tr:nth-child(even) {
   background-color: #ffe4b5;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1,7 +1,5 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Royal Blues */
-/* ------------------------------------------------------------------------ */
-/* Import directive */
 body {
   background-color: #ffffff;
   color: #000000;
@@ -237,6 +235,57 @@ table.theme_striped tr:nth-child(odd) {
 }
 table.striped tr:nth-child(even) td {
   background-color: #ddd;
+}
+/* ------------------------------------------------------------------------ */
+/* Available Project Listings */
+/* Default stage colors, which can be overridden by the themes */
+table.stage_P1 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_P1 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_P2 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_P2 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_P3 tr:nth-child(even) {
+  background-color: plum;
+}
+table.stage_P3 tr:nth-child(odd) {
+  background-color: thistle;
+}
+table.stage_F1 tr:nth-child(even) {
+  background-color: #ffe4b5;
+}
+table.stage_F1 tr:nth-child(odd) {
+  background-color: cornsilk;
+}
+table.stage_F2 tr:nth-child(even) {
+  background-color: plum;
+}
+table.stage_F2 tr:nth-child(odd) {
+  background-color: thistle;
+}
+table.stage_PP tr:nth-child(even) {
+  background-color: #cccccc;
+}
+table.stage_PP tr:nth-child(odd) {
+  background-color: #ffffff;
+}
+table.stage_PPV tr:nth-child(even) {
+  background-color: #99ffff;
+}
+table.stage_PPV tr:nth-child(odd) {
+  background-color: #eaf7f7;
+}
+table.stage_SR tr:nth-child(even) {
+  background-color: #ccffcc;
+}
+table.stage_SR tr:nth-child(odd) {
+  background-color: #ccff99;
 }
 /* ------------------------------------------------------------------------ */
 /* Sans-serif styling */

--- a/styles/themes/royal_blues.less
+++ b/styles/themes/royal_blues.less
@@ -1,5 +1,10 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Royal Blues */
+
+@import "theme.less";
+
+@theme-name: "royal_blues";
+
 @page-background: #ffffff;
 @page-text: #000000;
 @header-background: #99ccff;
@@ -15,12 +20,6 @@
 @visited-color: #330099;
 @active-color: #330099;
 @sans-serif-font: Verdana, Arial, sans-serif;
-
-@theme-name: "royal_blues";
-
-/* ------------------------------------------------------------------------ */
-/* Import directive */
-@import "theme.less";
 
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -192,6 +192,42 @@ table.striped {
 }
 
 /* ------------------------------------------------------------------------ */
+/* Available Project Listings */
+
+/* Default stage colors, which can be overridden by the themes */
+@P1-even: #ffe4b5;
+@P1-odd: cornsilk;
+@P2-even: #ffe4b5;
+@P2-odd: cornsilk;
+@P3-even: plum;
+@P3-odd: thistle;
+@F1-even: #ffe4b5;
+@F1-odd: cornsilk;
+@F2-even: plum;
+@F2-odd: thistle;
+@PP-even: #cccccc;
+@PP-odd: #ffffff;
+@PPV-even: #99ffff;
+@PPV-odd: #eaf7f7;
+@SR-even: #ccffcc;
+@SR-odd: #ccff99;
+
+@stages: P1 P2 P3 F1 F2 PP PPV SR;
+
+each(@stages, {
+    @even-color: "@{value}-even";
+    @odd-color: "@{value}-odd";
+    table.stage_@{value} {
+        tr:nth-child(even) {
+            background-color: @@even-color;
+        }
+        tr:nth-child(odd) {
+            background-color: @@odd-color;
+        }
+    }
+})
+
+/* ------------------------------------------------------------------------ */
 /* Sans-serif styling */
 
 .sans-serif {

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -194,6 +194,12 @@ table.striped {
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
 
+table.availprojectlisting {
+    tr:nth-child(even) {
+        background-color: #ddd;
+    }
+}
+
 /* Default stage colors, which can be overridden by the themes */
 @P1-even: #ffe4b5;
 @P1-odd: cornsilk;


### PR DESCRIPTION
This moves the per-stage table colors from the code into `theme.less` which allows them to be (optionally) overridden by the theme. There are zero visual changes to the user in this MR, but this enables some work @srjfoo is doing.

[mini-rant]Why are these different? Why are P1, P2, and F1 the same but different than P3 and F2? Why are PP, PPV, and SR all different from everything else?[/mini-rant]

This is viewable in the [move-round-colors-to-styles](https://www.pgdp.org/~cpeel/c.branch/move-round-colors-to-styles) sandbox.