### PR TITLE
Define font sizes in javascript.

### DIFF
--- a/pinc/page_controls.inc
+++ b/pinc/page_controls.inc
@@ -84,8 +84,6 @@ function get_proofreading_interface_data_js()
     $font_data = [
         "faces" => get_font_styles(),
         "faceFamilies" => get_full_font_families(),
-        "sizes" => get_font_sizes(),
-        "sizeFamilies" => get_font_sizes_css(),
     ];
 
     $strings = [
@@ -109,6 +107,7 @@ function get_proofreading_interface_data_js()
         "reset" => _("Select a different project"),
         "projectid" => _("Project ID"),
         "selectAPage" => _("Please select a page"),
+        "browserDefault" => BROWSER_DEFAULT_STR,
     ];
 
     global $code_url;

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -148,25 +148,6 @@ function get_full_font_families($interface = NULL)
     return $full_font_family;
 }
 
-// return an array of strings which the user sees in the font size selector
-// The array is indexed like get_available_proofreading_font_sizes()
-// this is used in the format preview font selector.
-function get_font_sizes()
-{
-    $font_sizes = get_available_proofreading_font_sizes();
-    $font_sizes[0] = BROWSER_DEFAULT_STR;
-    return $font_sizes;
-}
-
-// return an array of strings to use to render text
-// The array is indexed like get_available_proofreading_font_sizes()
-function get_font_sizes_css()
-{
-    $font_sizes = get_available_proofreading_font_sizes();
-    $font_sizes[0] = 'unset';
-    return $font_sizes;
-}
-
 function get_user_proofreading_font_other($interface=NULL)
 {
     $user = User::load_current();

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -222,23 +222,29 @@ var textControl = function() {
         localStorage.setItem(fontFaceID, fontFaceIndex);
     });
 
-    function setFontSize(fontSizeIndex) {
-        textArea.css("font-size", proofIntData.font.sizeFamilies[fontSizeIndex]);
+    let fontSizes = ["unset", "11px", "12px", "13px", "14px", "15px", "16px", "17px", "18px", "19px", "20px", "21px", "22px", "24px", "26px"];
+
+    function setFontSize(fontSize) {
+        textArea.css("font-size", fontSize);
     }
 
-    let currentFontSizeIndex = localStorage.getItem(fontSizeID);
+    let currentFontSize = localStorage.getItem(fontSizeID);
+    // if key does not exist we get null
+    if(currentFontSize === null) {
+        currentFontSize = "unset";
+    }
 
-    let fontSizes = proofIntData.font.sizes;
-    Object.keys(fontSizes).forEach(function(fontSizeIndex) {
-        let selected = (currentFontSizeIndex === fontSizeIndex);
-        fontSizeSelector.add(new Option(fontSizes[fontSizeIndex], fontSizeIndex, selected, selected));
+    fontSizes.forEach(function(fontSize) {
+        let selected = (currentFontSize === fontSize);
+        let displayFontSize = (fontSize === "unset") ? proofIntData.strings.browserDefault : fontSize;
+        fontSizeSelector.add(new Option(displayFontSize, fontSize, selected, selected));
     });
-    setFontSize(currentFontSizeIndex);
+    setFontSize(currentFontSize);
 
     $(fontSizeSelector).change(function () {
-        let fontSizeIndex = fontSizeSelector.value;
-        setFontSize(fontSizeIndex);
-        localStorage.setItem(fontSizeID, fontSizeIndex);
+        let fontSize = fontSizeSelector.value;
+        setFontSize(fontSize);
+        localStorage.setItem(fontSizeID, fontSize);
     });
 
     function setWrap(textWrap) {


### PR DESCRIPTION
The order of the elements in the font sizes array defined in php
is lost when transferred to javascript so the sizes in the
selector appear in the order of the keys which is different to the font sizes. Rather than adding more
complexity to fix this define the sizes in a simple way in js.