### PR TITLE
Remove charset conversion in MediaWiki extensions

### DIFF
--- a/SETUP/MediaWiki_extensions/dpExtensions.php
+++ b/SETUP/MediaWiki_extensions/dpExtensions.php
@@ -138,11 +138,6 @@ function showProjectInfo($input, $argv, $parser)
     if (empty($project['checkedoutby']))
         $project['checkedoutby'] = '(none)';
 
-    foreach ($project as $a => $b)
-    {
-        $project[$a] = iconv('ISO-8859-1','UTF-8',$b);
-    }
-
     if (isset ($argv['summary']) || empty($input))
     {
         $output = "<table class='projectinfo plainlinks'>".

--- a/SETUP/MediaWiki_extensions/hospitalExtensions.php
+++ b/SETUP/MediaWiki_extensions/hospitalExtensions.php
@@ -63,17 +63,17 @@ function listHospitalProjects( $input, $argv )
         // Get the preformatted remarks from PCs
         $matches = array();
         $problems = preg_match('/<pre>.*?<\/pre>/s', $project->comments,$matches);
-        $pstate   = iconv('ISO-8859-1','UTF-8',project_states_text($project->state));
+        $pstate   = project_states_text($project->state);
         $puri     = "$code_url/project.php?id=$project->projectid";
-        $plink    = iconv('ISO-8859-1','UTF-8',"<a href='$puri'>$project->nameofwork</a>");
+        $plink    = "<a href='$puri'>$project->nameofwork</a>";
 
         $output .= "<table style='border: 1px solid red; padding: 2px; width: 90%; margin: .75em;'>\n";
         $output .= "<tr><th width='12%' style='vertical-align: top;'>Title:</th><td>$plink</td></tr>\n";
-        $output .= "<tr><th>Author:</th><td>".iconv('ISO-8859-1','UTF-8',$project->authorsname)."</td></tr>\n";
-        $output .= "<tr><th>PM/State:</th><td>".iconv('ISO-8859-1','UTF-8',$project->username).": <u>$pstate</u></td></tr>\n";
+        $output .= "<tr><th>Author:</th><td>$project->authorsname</td></tr>\n";
+        $output .= "<tr><th>PM/State:</th><td>$project->username: <u>$pstate</u></td></tr>\n";
         $output .= "<tr><th style='vertical-align: top;'>Issues:</th><td style='font-size:90%;'>";
         if ($problems)
-            $output .= iconv('ISO-8859-1','UTF-8',($matches) ? wordwrap($matches[0],80) : '&nbsp;');
+            $output .= $matches ? wordwrap($matches[0],80) : '&nbsp;';
         $output .= "</td></tr>\n";
         $output .= "</table>\n";
         }


### PR DESCRIPTION
We no longer need to convert from ISO-8859-1 to UTF-8 in the DP MediaWiki extensions as the data is already UTF-8 now.

Thanks to @srjfoo for finding these!

See the extension demos at https://www.pgdp.org/wiki/User:Cpeel/MediaWiki_Extensions