### PR TITLE
Fix quiz character suites

### DIFF
--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -203,7 +203,7 @@ class QuizCharSuites
     public function get_charsuites()
     {
         $charsuites[] = CharSuites::get('basic-latin');
-        $charsuites[] = CharSuites::get('extended-european-latin');
+        $charsuites[] = CharSuites::get('extended-european-latin-b');
         return $charsuites;
     }
 }


### PR DESCRIPTION
Now that the comprehensive Extended European Latin character suite is
no longer available, update `Quiz.inc` to point to Extended European
Latin B.

Issue discovered when trying to test an unrelated update. Can be tested at [fix-quiz-charsuites](https://www.pgdp.org/~srjfoo/c.branch/fix-quiz-charsuites/quiz/start.php)