### PR TITLE
Fix CSRF in login, registration, and userprefs

### DIFF
--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -6,6 +6,7 @@ include_once($relPath.'User.inc');
 include_once($relPath.'email_address.inc');
 include_once($relPath.'new_user_mails.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath.'User.inc');
 include_once($relPath.'misc.inc'); // attr_safe()
 
 $real_name = array_get($_POST, 'real_name', '');
@@ -108,6 +109,14 @@ $header = _("Create An Account");
 output_header($header, SHOW_STATSBAR, array("js_files" => array("$code_url/accounts/addproofer.js")));
 
 echo "<h1>" . _("Account Registration") . "</h1>";
+
+// See if the user is already logged in
+if(User::load_current())
+{
+    echo "<p class='error'>" . _("You already have an account and cannot create another one while logged in.") . "</p>";
+    exit;
+}
+
 echo sprintf(_("Thank you for your interest in %s. To create an account, please complete the form below."), $site_name);
 
 echo "<h2>" . _("Registration Hints") . "</h2>";

--- a/accounts/login.php
+++ b/accounts/login.php
@@ -39,6 +39,16 @@ if ($userPW == '')
     login_failure('no_password', $destination);
 }
 
+// Validate CSRF
+try
+{
+    validate_csrf_token();
+}
+catch(InvalidCSRFTokenException $e)
+{
+    login_failure('form_timeout', $destination);
+}
+
 // Attempt to log into forum
 list($success, $reason) = login_forum_user($userNM, $userPW);
 if(!$success)

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -29,6 +29,7 @@ $login_failures = array(
     'unknown_failure'  => sprintf(_("An unexpected failure occurred, please contact a <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr"),
     'too_many_attempts'=> sprintf(_("You exceeded the maxiumum number of failed logins. Go <a href='%s'>log into the forums</a> and answer the CAPTCHA. Once you have successfully logged in there, return here and try again."), "$forums_url/ucp.php?mode=login"),
     'reg_mismatch'     => sprintf(_("You are registered with the forum software, but not with %s."), $site_abbreviation),
+    'form_timeout'     => _("Form submission timeout, go back and try again."),
 );
 
 $error = @$login_failures[@$_GET['error_code']];

--- a/accounts/logout.php
+++ b/accounts/logout.php
@@ -2,6 +2,7 @@
 //clear cookie if one is already set
 $relPath='./../pinc/';
 include_once($relPath.'base.inc');
+include_once($relPath.'misc.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'forum_interface.inc');
 
@@ -10,6 +11,8 @@ if($user_is_logged_in)
     logout_forum_user();
 
     dpsession_end();
+
+    destroy_csrf_token();
 }
 
 metarefresh(0, "../default.php", _("Logout Complete"),

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -50,6 +50,9 @@ if(!headers_sent())
     // to ensure others behind the proxy don't inadvertantly get a language
     // they aren't expecting.
     header("Vary: Accept-Language");
+
+    // Disallow other sites from embedding pages in frames/iframes
+    header("Content-Security-Policy: frame-ancestors 'self'", false);
 }
 
 include_once($relPath.'gettext_setup.inc');

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -20,6 +20,17 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     if($was_output)
         return;
 
+    $user = User::load_current();
+
+    // If the user isn't logged in, output a CSRF token for the login and
+    // registration form. We need to do this here before we output any other
+    // HTML and the login form can appear on multiple pages since it's in
+    // the navbar.
+    if(!$user)
+    {
+        set_csrf_token(FALSE);
+    }
+
     $intlang = get_desired_language();
 
     // HTML 5 dictates that ISO-8859-1 documents should declare their charset
@@ -49,7 +60,6 @@ function output_html_header($nameofpage, $extra_args = array(), $show_statsbar =
     echo "</title>\n";
 
     // Global CSS
-    $user = User::load_current();
     $theme_name = $user ? $user->i_theme : "project_gutenberg";
     $css_files = array(
         "$code_url/styles/themes/$theme_name.css",

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1162,6 +1162,50 @@ function return_bytes($size_str)
     }
 }
 
+// -----------------------------------------------------------------------------
+
+class InvalidCSRFTokenException extends UnexpectedValueException {}
+
+function set_csrf_token($force_set = TRUE)
+{
+    global $use_secure_cookies;
+
+    if(!$force_set && @$_COOKIE["CSRFtoken"])
+        return;
+
+    $token = bin2hex(openssl_random_pseudo_bytes(16));
+    setcookie("CSRFtoken", $token, time() + 60 * 60 * 24, '/', '', $use_secure_cookies);
+    $_COOKIE["CSRFtoken"] = $token;
+}
+
+function destroy_csrf_token()
+{
+    global $use_secure_cookies;
+
+    setcookie("CSRFtoken", "", time() - 60, '/', '', $use_secure_cookies);
+}
+
+function get_csrf_token_form_input()
+{
+    return "<input type='hidden' name='CSRFtoken' value='" . attr_safe($_COOKIE["CSRFtoken"]) . "'>";
+}
+
+function echo_csrf_token_form_input()
+{
+    echo get_csrf_token_form_input();
+}
+
+function validate_csrf_token()
+{
+    if(@$_POST["CSRFtoken"] != @$_COOKIE["CSRFtoken"])
+    {
+        throw new InvalidCSRFTokenException(
+            _("Form submission timeout, go back and try again.")
+        );
+    }
+}
+
+
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 // Useful exceptions

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -218,6 +218,8 @@ function html_navbar()
 
         $login_form = "<form action='$code_url/accounts/login.php' method='post'><div>\n";
 
+        $login_form .= get_csrf_token_form_input();
+
         // We pass a hidden 'destination' parameter to login.php to indicate
         // where the user should be sent (preferably, where they want to go)
         // after a successful login.

--- a/userprefs.php
+++ b/userprefs.php
@@ -76,6 +76,8 @@ if (array_get($_POST, "insertdb", "") != "") {
     // one of the tabs was displayed and now it has been posted
     // determine which and let that tab save 'itself'.
 
+    validate_csrf_token();
+
     if ($selected_tab == 0)
         save_general_tab($user);
     else if ($selected_tab == 1)
@@ -195,7 +197,8 @@ $theme_extra_args["js_data"] =
     var font_size_mapping = " . json_encode(get_available_proofreading_font_sizes()) . ";
     var font_face_fallback = \"" . get_proofreading_font_family_fallback() . "\";
 ";
-    
+
+set_csrf_token();
 output_header($header, NO_STATSBAR, $theme_extra_args);
 echo "<h1>$header</h1>";
 
@@ -204,6 +207,9 @@ echo_tabs($tabs, $selected_tab);
 echo "<p>" . _("Click the ? for help on that specific preference.") . "</p>";
 
 echo "<form action='userprefs.php' method='post'>";
+
+// Output CSRF token
+echo_csrf_token_form_input();
 
 echo "<input type='hidden' name='tab' value='$selected_tab'>";
 // Keep remembering the URL from which the preferences where entered.


### PR DESCRIPTION
Address CSRF vulnerability in user login, account registration, and user preferences as these are the most critical forms that deal with user data. I do not intend on retrofitting CSRF on all the forms at this time.

This also adds headers to prevent site pages from being loaded inside frames/iframes on another site.

This is available in the [fix-csrf](https://www.pgdp.org/~cpeel/c.branch/fix-csrf/) sandbox.

Things to test:
* login
* account creation
* user profile editing