### PR TITLE
Refinements to the CSRF token

### DIFF
--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -53,6 +53,7 @@ if(!headers_sent())
 
     // Disallow other sites from embedding pages in frames/iframes
     header("Content-Security-Policy: frame-ancestors 'self'", false);
+    header("X-Frame-Options: SAMEORIGIN");
 }
 
 include_once($relPath.'gettext_setup.inc');

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1173,8 +1173,8 @@ function set_csrf_token($force_set = TRUE)
     if(!$force_set && @$_COOKIE["CSRFtoken"])
         return;
 
-    $token = bin2hex(openssl_random_pseudo_bytes(16));
-    setcookie("CSRFtoken", $token, time() + 60 * 60 * 24, '/', '', $use_secure_cookies);
+    $token = bin2hex(random_bytes(32));
+    setcookie("CSRFtoken", $token, time() + 60 * 60 * 24, '/', '', $use_secure_cookies, TRUE);
     $_COOKIE["CSRFtoken"] = $token;
 }
 


### PR DESCRIPTION
Small set of refinements for the CSRF token from @chrismiceli. Note that we can't set the samesite attribute on the cookie because that was only added to `setcookie()` in PHP 7.3.0.

Available in the [improve-csrf](https://www.pgdp.org/~cpeel/c.branch/improve-csrf) sandbox.