### PR TITLE
Updated quiz default_feedbacktext message

### DIFF
--- a/quiz/generic/quiz_defaults.inc
+++ b/quiz/generic/quiz_defaults.inc
@@ -4,7 +4,7 @@
 
 $default_hintlink         = _("Desperate? Can't find it?");
 $default_challenge        = _("Try to correct that or press 'restart'.");
-$default_feedbacktext     = _("The algorithm for finding errors in this quiz is a quite simple one. If you feel the message doesn't make any sense, please visit <a href='%s' target='_blank'>this forum topic</a> and click on the \"post reply\" button to post a feedback message.");
+$default_feedbacktext     = _("If you can't find the error(s) remaining on the page, please visit <a href='%s' target='_blank'>this forum topic</a>, click on the \"post reply\" button to post a feedback request, and provide the link to the quiz you're having trouble with, your version of the quiz text, and the exact error message.");
 
 
 // urls for links

--- a/quiz/generic/quiz_defaults.inc
+++ b/quiz/generic/quiz_defaults.inc
@@ -4,7 +4,7 @@
 
 $default_hintlink         = _("Desperate? Can't find it?");
 $default_challenge        = _("Try to correct that or press 'restart'.");
-$default_feedbacktext     = _("If you can't find the error(s) remaining on the page, please visit <a href='%s' target='_blank'>this forum topic</a>, click on the \"post reply\" button to post a feedback request, and provide the link to the quiz you're having trouble with, your version of the quiz text, and the exact error message.");
+$default_feedbacktext     = _("If you can't find the error(s) remaining on the page, please visit <a href='%s' target='_blank'>this forum topic</a>, click on the \"post reply\" button to post a feedback request. In your post, provide the link to the quiz you're having trouble with, your version of the quiz text, and the exact error message.");
 
 
 // urls for links


### PR DESCRIPTION
In other places in the quizzes, quiz-takers are advised to provide the url for the specific quiz they're taking, the text they think should pass the quiz, and the error message they're getting, but this default feedback message was missing that advice. Added more specific instructions and removed "The algorithm for finding errors in this quiz is a quite simple one." This is an admin/GM request.

Can be tested in [update-quiz-message](https://www.pgdp.org/~srjfoo/c.branch/update-quiz-message/quiz/start.php). To trigger the message, go to one of the quizzes, scroll down and click on the "Check" button below the text box. The message should appear at the bottom of the feedback section on the right-hand side of the page.