### PR TITLE
Fix UTF-8 table detection for MySQL 8.0

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -125,7 +125,7 @@ final class DPDatabase
         $table_encoding = $row['TABLE_COLLATION'];
         mysqli_free_result($result);
 
-        return $table_encoding == 'utf8mb4_general_ci';
+        return stripos($table_encoding, 'utf8mb4') === 0;
     }
 
     // Prevent this class from being instantiated


### PR DESCRIPTION
MySQL 8.0 [changed the UTF8 table collation names](https://mysqlserverteam.com/new-collations-in-mysql-8-0-0/) which requires us being a little more flexible on how we determine if a table is UTF8. Now we just check if the collation starts with the string that mentions the encoding.