### PR TITLE
Add PPV project transitions

### DIFF
--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1074,7 +1074,7 @@ new ProjectTransition(
     'holder',
     array(
         'project_restriction'   => null,
-        'action_name'           => _("Return to Post-Processing"),
+        'action_name'           => _("Return to Post-Processor for further work"),
         'confirmation_question' => _("Are you sure you want to take this book back for further work?"),
         'detour'                => null,
         'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=''",

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -4,7 +4,7 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'DPage.inc'); // project_drop_pages Pages_prepForRound
 include_once($relPath.'forum_interface.inc'); // topic_change_forum
-include_once($relPath.'maybe_mail.inc');
+include_once($relPath.'maybe_mail.inc'); // maybe_mail_project_manager
 include_once($relPath.'../tools/project_manager/post_files.inc');
 include_once($relPath.'project_events.inc');
 include_once($relPath.'site_vars.php'); // $auto_post_to_project_topic
@@ -1198,17 +1198,16 @@ function return_to_PP_collateral( $old_project, $project, $transition, $who )
     global $site_abbreviation;
 
     $PPer_username = $project->checkedoutby;
-
     $PPer = new User($PPer_username);
     $PPer_email_addr = $PPer->email;
-    $body_blurb =
-        $project->email_introduction() .
-        "\nThis project has been returned to you for further work.\n";
 
-    maybe_mail(
-        $PPer_email_addr,
-        "$site_abbreviation: Book returned to PPer",
-        $body_blurb);
+    configure_gettext_for_user($PPer_username);
+    $body_blurb = $project->email_introduction() . "\n" .
+        _("This project has been returned to you for further work.") . "\n";
+    $subject = "$site_abbreviation: " . _("Return to Post-Processor");
+    configure_gettext_for_user();
+
+    maybe_mail($PPer_email_addr, $subject, $body_blurb);
 }
 
 new ProjectTransition(
@@ -1243,17 +1242,16 @@ function return_from_PP_to_PPV_collateral( $old_project, $project, $transition, 
     global $site_abbreviation;
 
     $PPVer_username = $project->checkedoutby;
-
     $PPVer = new User($PPVer_username);
     $PPVer_email_addr = $PPVer->email;
-    $body_blurb =
-        $project->email_introduction() .
-        "\nThis project has been returned to you for verification after further work by the post-processor.\n";
 
-    maybe_mail(
-        $PPVer_email_addr,
-        "$site_abbreviation: Book returned to PPVer",
-        $body_blurb);
+    configure_gettext_for_user($PPVer_username);
+    $body_blurb = $project->email_introduction() . "\n" .
+        _("This project has been returned to you for verification after further work by the post-processor.") . "\n";
+    $subject = "$site_abbreviation: " . _("Return to Post Processing Verifier");
+    configure_gettext_for_user();
+
+    maybe_mail($PPVer_email_addr, $subject, $body_blurb);
 }
 
 // -----------------------------------------------------------------------------

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -367,6 +367,7 @@ class ProjectTransition
         if ( $this->collateral_actions )
         {
             // Because of the "UPDATE projects" command, $project is now out of date.
+            // *** but maybe not, see above "$project = new Project($projectid);"
             // So get an up-to-date version of the project info (in 
             // $new_project) and pass both versions to the collateral_actions
             // function
@@ -1169,9 +1170,27 @@ new ProjectTransition(
         'confirmation_question' => _("Are you sure you want to return this book to the post-processor for further work?"),
         'detour'                => null,
         'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=postproofer, postproofer=''",
-        'collateral_actions'    => null,
+        'collateral_actions'    => "return_to_PP_collateral",
     )
 );
+
+function return_to_PP_collateral( $old_project, $project, $transition, $who )
+{
+    global $site_abbreviation;
+
+    $PPer_username = $project->checkedoutby;
+
+    $PPer = new User($PPer_username);
+    $PPer_email_addr = $PPer->email;
+    $body_blurb =
+        $project->email_introduction() .
+        "\nThis project has been returned to you for further work.\n";
+
+    maybe_mail(
+        $PPer_email_addr,
+        "$site_abbreviation: Book returned to PPer",
+        $body_blurb);
+}
 
 // -----------------------------------------------------------------------------
 // Transitions to and from PROJ_POST_FIRST_UNAVAILABLE:

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1097,7 +1097,7 @@ new ProjectTransition(
         'action_name'           => _("Return to Available"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=return_1",
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', smoothread_deadline='0', postcomments=CONCAT(postcomments,'<G:postcomments>')",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier='', smoothread_deadline='0', postcomments=CONCAT(postcomments,'<G:postcomments>')",
         'collateral_actions'    => null,
         'disabled_during_SR'    => true,
     )
@@ -1145,11 +1145,11 @@ new ProjectTransition(
     PROJ_POST_SECOND_AVAILABLE,
     'holder',
     array(
-        'project_restriction'   => null,
+        'project_restriction'   => "project_was_not_returned_from_PPV",
         'action_name'           => _("Upload for Verification"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
-        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, postcomments=CONCAT(postcomments,'<G:postcomments>')",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier='', postcomments=CONCAT(postcomments,'<G:postcomments>')",
         'collateral_actions'    => 'PP_to_PPV_collateral',
         'disabled_during_SR'    => true,
     )
@@ -1169,7 +1169,11 @@ new ProjectTransition(
         'action_name'           => _("Return to Post-Processor"),
         'confirmation_question' => _("Are you sure you want to return this book to the post-processor for further work?"),
         'detour'                => null,
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=postproofer, postproofer=''",
+        // formerly ppverifier was only set when the project was uploaded to PG
+        // it is set here so the PPer can return it to the same PPVer
+        // any transition out of PROJ_POST_FIRST_CHECKED_OUT sets it to ''
+        // this will not affect how the PPVer is ultimately set.
+        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=postproofer, postproofer='', ppverifier=checkedoutby",
         'collateral_actions'    => "return_to_PP_collateral",
     )
 );
@@ -1189,6 +1193,51 @@ function return_to_PP_collateral( $old_project, $project, $transition, $who )
     maybe_mail(
         $PPer_email_addr,
         "$site_abbreviation: Book returned to PPer",
+        $body_blurb);
+}
+
+new ProjectTransition(
+    PROJ_POST_FIRST_CHECKED_OUT,
+    PROJ_POST_SECOND_CHECKED_OUT,
+    'holder',
+    array(
+        'project_restriction'   => "project_was_returned_from_PPV",
+        'action_name'           => _("Return to Post Processing Verifier"),
+        'confirmation_question' => null,
+        'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=re_post_1",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=ppverifier, postproofer=checkedoutby, ppverifier=''",
+        'collateral_actions'    => "return_from_PP_to_PPV_collateral",
+        'disabled_during_SR'    => true,
+    )
+);
+
+function project_was_not_returned_from_PPV($project, $transition )
+{
+    assert( $project->state == $transition->from_state );
+    return $project->ppverifier == "";
+}
+
+function project_was_returned_from_PPV($project, $transition )
+{
+    assert( $project->state == $transition->from_state );
+    return $project->ppverifier != "";
+}
+
+function return_from_PP_to_PPV_collateral( $old_project, $project, $transition, $who )
+{
+    global $site_abbreviation;
+
+    $PPVer_username = $project->checkedoutby;
+
+    $PPVer = new User($PPVer_username);
+    $PPVer_email_addr = $PPVer->email;
+    $body_blurb =
+        $project->email_introduction() .
+        "\nThis project has been returned to you for verification after further work by the post-processor.\n";
+
+    maybe_mail(
+        $PPVer_email_addr,
+        "$site_abbreviation: Book returned to PPVer",
         $body_blurb);
 }
 
@@ -1220,7 +1269,7 @@ new ProjectTransition(
         'action_name'           => '[default]',
         'confirmation_question' => _('Someone currently has this project checked out. Are you sure you want to make it unavailable?'),
         'detour'                => null,
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', smoothread_deadline='0'",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier='', smoothread_deadline='0'",
         'collateral_actions'    => null,
         'disabled_during_SR'    => true,
     )
@@ -1276,7 +1325,7 @@ new ProjectTransition(
         'action_name'           => '[default]',
         'confirmation_question' => $post_complete_question,
         'detour'                => null,
-        'settings_template'     => '',
+        'settings_template'     => "ppverifier=''",
         'collateral_actions'    => null,
         'disabled_during_SR'    => true,
     )

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1145,7 +1145,22 @@ new ProjectTransition(
     PROJ_POST_SECOND_AVAILABLE,
     'holder',
     array(
-        'project_restriction'   => null,
+        'project_restriction'   => "project_was_not_returned_from_PPV",
+        'action_name'           => _("Upload to the PPV pool for verification"),
+        'confirmation_question' => null,
+        'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
+        'collateral_actions'    => 'PP_to_PPV_collateral',
+        'disabled_during_SR'    => true,
+    )
+);
+
+new ProjectTransition(
+    PROJ_POST_FIRST_CHECKED_OUT,
+    PROJ_POST_SECOND_AVAILABLE,
+    'manager',
+    array(
+        'project_restriction'   => "project_was_returned_from_PPV",
         'action_name'           => _("Upload to the PPV pool for verification"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
@@ -1214,6 +1229,12 @@ function project_was_returned_from_PPV($project, $transition )
 {
     assert( $project->state == $transition->from_state );
     return $project->ppverifier != NULL;
+}
+
+function project_was_not_returned_from_PPV($project, $transition )
+{
+    assert( $project->state == $transition->from_state );
+    return $project->ppverifier == NULL;
 }
 
 function return_from_PP_to_PPV_collateral( $old_project, $project, $transition, $who )

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1155,6 +1155,21 @@ new ProjectTransition(
     )
 );
 
+new ProjectTransition(
+    PROJ_POST_FIRST_CHECKED_OUT,
+    PROJ_POST_SECOND_AVAILABLE,
+    'proj_facilitator',
+    array(
+        'project_restriction'   => "project_was_returned_from_PPV",
+        'action_name'           => _("Upload for Verification"),
+        'confirmation_question' => null,
+        'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
+        'collateral_actions'    => 'PP_to_PPV_collateral',
+        'disabled_during_SR'    => true,
+    )
+);
+
 function PP_to_PPV_collateral( $old_project, $project, $transition, $who )
 {
     notify_project_event_subscribers( $project, 'ppv_enter' );

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1145,23 +1145,8 @@ new ProjectTransition(
     PROJ_POST_SECOND_AVAILABLE,
     'holder',
     array(
-        'project_restriction'   => "project_was_not_returned_from_PPV",
-        'action_name'           => _("Upload for Verification"),
-        'confirmation_question' => null,
-        'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
-        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
-        'collateral_actions'    => 'PP_to_PPV_collateral',
-        'disabled_during_SR'    => true,
-    )
-);
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_SECOND_AVAILABLE,
-    'site_manager',
-    array(
-        'project_restriction'   => "project_was_returned_from_PPV",
-        'action_name'           => _("Upload for Verification"),
+        'project_restriction'   => null,
+        'action_name'           => _("Upload to the PPV pool for verification"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
         'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
@@ -1216,7 +1201,7 @@ new ProjectTransition(
     'holder',
     array(
         'project_restriction'   => "project_was_returned_from_PPV",
-        'action_name'           => _("Return to Post Processing Verifier"),
+        'action_name'           => _("Return to your current PPVer for further checking"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=re_post_1",
         'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, checkedoutby=ppverifier, ppverifier=NULL",
@@ -1224,12 +1209,6 @@ new ProjectTransition(
         'disabled_during_SR'    => true,
     )
 );
-
-function project_was_not_returned_from_PPV($project, $transition )
-{
-    assert( $project->state == $transition->from_state );
-    return $project->ppverifier == NULL;
-}
 
 function project_was_returned_from_PPV($project, $transition )
 {

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1158,7 +1158,7 @@ new ProjectTransition(
 new ProjectTransition(
     PROJ_POST_FIRST_CHECKED_OUT,
     PROJ_POST_SECOND_AVAILABLE,
-    'manager',
+    'site_manager',
     array(
         'project_restriction'   => "project_was_returned_from_PPV",
         'action_name'           => _("Upload to the PPV pool for verification"),

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1158,7 +1158,7 @@ new ProjectTransition(
 new ProjectTransition(
     PROJ_POST_FIRST_CHECKED_OUT,
     PROJ_POST_SECOND_AVAILABLE,
-    'proj_facilitator',
+    'site_manager',
     array(
         'project_restriction'   => "project_was_returned_from_PPV",
         'action_name'           => _("Upload for Verification"),
@@ -1186,9 +1186,9 @@ new ProjectTransition(
         'detour'                => null,
         // formerly ppverifier was only set when the project was uploaded to PG
         // it is set here so the PPer can return it to the same PPVer
-        // any transition out of PROJ_POST_FIRST_CHECKED_OUT sets it to ''
+        // any transition out of PROJ_POST_FIRST_CHECKED_OUT sets it to NULL
         // this will not affect how the PPVer is ultimately set.
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=postproofer, postproofer='', ppverifier=checkedoutby",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', ppverifier=checkedoutby, checkedoutby=postproofer, postproofer=''",
         'collateral_actions'    => "return_to_PP_collateral",
     )
 );
@@ -1219,7 +1219,7 @@ new ProjectTransition(
         'action_name'           => _("Return to Post Processing Verifier"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=re_post_1",
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=ppverifier, postproofer=checkedoutby, ppverifier=NULL",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, checkedoutby=ppverifier, ppverifier=NULL",
         'collateral_actions'    => "return_from_PP_to_PPV_collateral",
         'disabled_during_SR'    => true,
     )

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1097,7 +1097,7 @@ new ProjectTransition(
         'action_name'           => _("Return to Available"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=return_1",
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier='', smoothread_deadline='0', postcomments=CONCAT(postcomments,'<G:postcomments>')",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier=NULL, smoothread_deadline='0', postcomments=CONCAT(postcomments,'<G:postcomments>')",
         'collateral_actions'    => null,
         'disabled_during_SR'    => true,
     )
@@ -1149,7 +1149,7 @@ new ProjectTransition(
         'action_name'           => _("Upload for Verification"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
-        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier='', postcomments=CONCAT(postcomments,'<G:postcomments>')",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
         'collateral_actions'    => 'PP_to_PPV_collateral',
         'disabled_during_SR'    => true,
     )
@@ -1205,7 +1205,7 @@ new ProjectTransition(
         'action_name'           => _("Return to Post Processing Verifier"),
         'confirmation_question' => null,
         'detour'                => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=re_post_1",
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=ppverifier, postproofer=checkedoutby, ppverifier=''",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby=ppverifier, postproofer=checkedoutby, ppverifier=NULL",
         'collateral_actions'    => "return_from_PP_to_PPV_collateral",
         'disabled_during_SR'    => true,
     )
@@ -1214,13 +1214,13 @@ new ProjectTransition(
 function project_was_not_returned_from_PPV($project, $transition )
 {
     assert( $project->state == $transition->from_state );
-    return $project->ppverifier == "";
+    return $project->ppverifier == NULL;
 }
 
 function project_was_returned_from_PPV($project, $transition )
 {
     assert( $project->state == $transition->from_state );
-    return $project->ppverifier != "";
+    return $project->ppverifier != NULL;
 }
 
 function return_from_PP_to_PPV_collateral( $old_project, $project, $transition, $who )
@@ -1269,7 +1269,7 @@ new ProjectTransition(
         'action_name'           => '[default]',
         'confirmation_question' => _('Someone currently has this project checked out. Are you sure you want to make it unavailable?'),
         'detour'                => null,
-        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier='', smoothread_deadline='0'",
+        'settings_template'     => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier=NULL, smoothread_deadline='0'",
         'collateral_actions'    => null,
         'disabled_during_SR'    => true,
     )
@@ -1325,7 +1325,7 @@ new ProjectTransition(
         'action_name'           => '[default]',
         'confirmation_question' => $post_complete_question,
         'detour'                => null,
-        'settings_template'     => "ppverifier=''",
+        'settings_template'     => "ppverifier=NULL",
         'collateral_actions'    => null,
         'disabled_during_SR'    => true,
     )

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -16,7 +16,7 @@ detect_too_large();
 require_login();
 
 $projectid = get_projectID_param($_REQUEST, 'project');
-$valid_stages = array('post_1', 'in_prog_1', 'return_1', 'in_prog_2', 'return_2', 'correct', 'smooth_avail', 'smooth_done');
+$valid_stages = array('post_1', 're_post_1', 'in_prog_1', 'return_1', 'in_prog_2', 'return_2', 'correct', 'smooth_avail', 'smooth_done');
 $stage = get_enumerated_param($_REQUEST, 'stage', NULL, $valid_stages, TRUE);
 // $stage==smooth_avail controls sr, 2 cases:
 // days given: upload a file & make sr available first time or after finished for days from now.
@@ -51,6 +51,18 @@ if ($stage == 'post_1')
     $project_is_in_valid_state = PROJ_POST_FIRST_CHECKED_OUT == $project->state;
     $user_is_able_to_perform_action = $project->PPer_is_current_user || user_is_a_sitemanager();
     $new_state = PROJ_POST_SECOND_AVAILABLE;
+    $back_url = "$code_url/tools/pool.php?pool_id=PP";
+    $back_blurb = _("Post-Processing Page");
+}
+else if ($stage == 're_post_1')
+{
+    $title = _("Upload post-processed file for verification");
+    $intro_blurb = _("This page allows you to upload a post-processed file for verification.");
+    $submit_label = _("Upload file");
+    $indicator = "_second";
+    $project_is_in_valid_state = PROJ_POST_FIRST_CHECKED_OUT == $project->state;
+    $user_is_able_to_perform_action = $project->PPer_is_current_user || user_is_a_sitemanager();
+    $new_state = PROJ_POST_SECOND_CHECKED_OUT;
     $back_url = "$code_url/tools/pool.php?pool_id=PP";
     $back_blurb = _("Post-Processing Page");
 }


### PR DESCRIPTION
This allows a PPer to return a project to the original PPVer after further work.
See task 1917. [https://www.pgdp.net/c/tasks.php?action=show&task_id=1917](url).
An email is sent to the PPer when the PPver returns the project for further work.
An email is sent to the PPVer when the PPer uploads the project to him after further work.
There was some discussion of how the return to PPVer should work. This is one possible way: If the project had been returned to the PPer from a PPVer then the PPer only sees the "Return to PPverifier" button but a project facilitator can upload the project from PP to the PPV pool.
The PPV statistics will be unchanged because the statistics for PPVer does not use the ppverifier field.
The project search and myprojects will show PPVer when the project is in PP stage and the project has been returned from PPV as well as "posted to PG" stage.