### PR TITLE
Show WordCheck page in user's proofreading font

### DIFF
--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -53,13 +53,13 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
         $font_size = "font-size: $font_size";
     // define the styles used for the interface (highlight for the punctuation, AW button, etc)
     $returnString.="<style>" .
-                   " pre { $font_size }".
+                   "  pre { line-height: 2.25; }".
                    "  .proofingfont { font-family: $font_family; $font_size }" .
                    "  .hl { background-color: yellow; color: black; }" .
                    "  img.aw { border: 0; margin-left: 5px; }" .
                    "  span.aw { background-color: white; color: black; }" .
                    "</style>";
-    $returnString.="<pre>\n";
+    $returnString.="<pre class='proofingfont'>\n";
 
     $puncArray = utf8_split($puncCharacters);
 
@@ -169,7 +169,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
         }
 
         // output the final line
-        $returnString.=$newLine . "<br>\n";
+        $returnString.=$newLine . "\n";
     }
 
     $returnString.="</pre>";


### PR DESCRIPTION
This updates WordCheck so that the page text is shown in the user's proofreading font. [Task 1928](https://www.pgdp.net/c/tasks.php?action=show&task_id=1928)

While I was here I used CSS for the line spacing instead of a `<br>`. This makes the lines with an input box appear uniformly spaced apart like all the other lines. And yes, I made it a smidge closer than they were before.

Available in the [wordcheck-proofreading-font](https://www.pgdp.org/~cpeel/c.branch/wordcheck-proofreading-font/) sandbox.