### PR TITLE
Add search forms to the Members and Team listings

### DIFF
--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -23,7 +23,7 @@ show_news_for_page("STATS");
 <table style='width: 95%; margin: 2em auto;'>
 <tr>
     <td>
-    <form action='<?php echo $code_url; ?>/stats/members/mbr_list.php' method='post'>
+    <form action='<?php echo $code_url; ?>/stats/members/mbr_list.php' method='get'>
         <input type='text' name='uname' size='20' style='margin-left: 0;' required>
         <input type='submit' value='<?php echo attr_safe(_("Member Search")); ?>'>
         <br>
@@ -33,7 +33,7 @@ show_news_for_page("STATS");
     </form>
     </td>
     <td>
-    <form action='<?php echo $code_url; ?>/stats/teams/tlist.php' method='post'>
+    <form action='<?php echo $code_url; ?>/stats/teams/tlist.php' method='get'>
         <input type='text' name='tname' size='20' style='margin-left: 0;' required>
         <input type='submit' value='<?php echo attr_safe(_("Team Search")); ?>'>
         <br>


### PR DESCRIPTION
This adds a search form the to Members and Team listings. In a separate commit I styled the search forms on the Stats Central page. I'm not enamored with that one so I'm happy if folks think we should just drop that commit. [Task 1926](https://www.pgdp.net/c/tasks.php?action=show&task_id=1926)

See the [member-team-search](https://www.pgdp.org/~cpeel/c.branch/member-team-search/) sandbox.