### PR TITLE
Pull page interface styling out into theme.less

### DIFF
--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -193,7 +193,7 @@ var imageControl = function() {
 
 // Construct the font-face, font-size and wrap controls
 var textControl = function() {
-    let textArea = $("<textarea>", {class: "full-text"});
+    let textArea = $("<textarea>", {class: "text-pane"});
     textArea.val(pageBrowserData.text);
     let fontFaceSelector = document.createElement("select");
     fontFaceSelector.title = proofIntData.strings.changeFontFace;

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -742,7 +742,6 @@ table.dirlist caption {
 #standard_interface {
   padding: 0;
   margin: 0;
-  background-color: #CDC0B0;
 }
 #standard_interface #imagedisplay {
   text-align: center;
@@ -756,76 +755,52 @@ table.dirlist caption {
 #enhanced_interface {
   text-align: center;
   overflow: hidden;
-  background-color: #CDCDC1;
 }
 #enhanced_interface #tbtext {
   margin-left: auto;
   margin-right: auto;
   border-collapse: collapse;
-  border: 1px solid #000000;
   overflow: auto;
 }
 #enhanced_interface #tdtop {
   vertical-align: middle;
-  border: 1px solid #000000;
-  background-color: #CDC0B0;
   padding: 2px;
 }
-#enhanced_interface #tdtext {
-  vertical-align: top;
-  border: 1px solid #000000;
-  background-color: #CDCDC1;
-  padding: 2px;
-}
+#enhanced_interface #tdtext,
 #enhanced_interface #tdbottom {
   vertical-align: top;
-  border: 1px solid #000000;
-  background-color: #EEDFCC;
   padding: 2px;
 }
 #enhanced_interface #text_data,
 #enhanced_interface #text_data:focus {
-  background-color: #FFF8DC;
-  color: #000000;
   padding: 2px;
   outline: none;
 }
 #enhanced_interface .dropsmall {
   font-size: 75%;
-  background-color: #FFF8DC;
-}
-#enhanced_interface .boxnormal {
-  background-color: #FFF8DC;
 }
 /* ------------------------------------------------------------------------ */
 /* WordCheck Interface */
 #wordcheck_interface {
   text-align: center;
-  background-color: #CDCDC1;
   overflow: auto;
 }
 #wordcheck_interface #tbtext {
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid #000000;
   padding: 10px;
 }
 #wordcheck_interface #tdtop {
-  border: 1px solid #000000;
-  background-color: #CDC0B0;
   padding: 2px;
 }
 #wordcheck_interface #tdtext {
   vertical-align: top;
   text-align: left;
-  border: 1px solid #000000;
-  background-color: #FFF8DC;
   padding: 0.5em;
 }
 /* ------------------------------------------------------------------------ */
-/* control frame */
+/* Proofreading control frame */
 .control-frame {
-  background-color: #CDC0B0;
   padding: 0;
   margin: 0;
 }
@@ -840,7 +815,6 @@ table.dirlist caption {
   margin-top: 1px;
   font-size: 1em;
   padding: 0.1em 0.15em 0 0.15em;
-  border: 1px solid black;
   margin-right: 2px;
   min-width: 1em;
 }
@@ -1079,23 +1053,18 @@ li.spaced {
 }
 .fixedbox {
   flex: 0 0 auto;
-  background-color: #CDC0B0;
   padding: 2px;
 }
 .stretchbox {
   flex: auto;
   min-height: 10px;
   overflow: auto;
-  background-color: HoneyDew;
 }
 .ws-pre {
   white-space: pre;
   padding-left: 0.5em;
   text-align: left;
   font-family: monospace;
-}
-.bad-char {
-  background: #ff99cc;
 }
 /* ------------------------------------------------------------------------ */
 /* CharSuite Explorer */
@@ -1113,38 +1082,58 @@ li.spaced {
   border: 1px solid black;
 }
 /* ------------------------------------------------------------------------ */
-/* view_page_text_image */
-.control-form {
+/* Page Browser */
+#page-browser {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+#page-browser .fixed-box {
+  flex: 0 0 auto;
+}
+#page-browser .stretch-box {
+  flex: 1 1 100vh;
+  min-height: 10px;
+}
+#page-browser .control-pane {
   padding: 0 1em;
   overflow: auto;
 }
-.control-form p {
+#page-browser .control-pane p {
   margin: 0.2em 0;
 }
-.control-form input {
-  border-width: 2px;
+#page-browser .control-pane input {
   margin: 1px 0.2em;
 }
-.control-form select {
+#page-browser .control-pane select {
   margin-right: 0.4em;
 }
-.control-form .img-button {
+#page-browser .control-pane .img-button {
   vertical-align: middle;
-  border: 0;
   padding: 0;
 }
-.control-form img {
+#page-browser .control-pane img {
   display: block;
 }
-.control-form input[type=checkbox] {
+#page-browser .control-pane input[type=checkbox] {
   vertical-align: middle;
 }
-.control-form input[type=number] {
+#page-browser .control-pane input[type=number] {
   width: 5em;
 }
-.control-form a {
+#page-browser .control-pane a {
   margin-right: 0.4em;
   margin-left: 0.4em;
+}
+#page-browser .text-pane {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding-left: 0.25em;
+  resize: none;
+  border: 0;
+  margin: 0;
+  display: block;
 }
 .flex_100vh {
   height: 100vh;
@@ -1157,16 +1146,6 @@ li.spaced {
 .flex_100vh .stretch-box {
   flex: 1 1 100vh;
   min-height: 10px;
-}
-.full-text {
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  padding-left: 0.25em;
-  resize: none;
-  border: 0;
-  margin: 0;
-  display: block;
 }
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -759,7 +759,6 @@ table.dirlist {
 #standard_interface {
     .no-padding;
     .no-margin;
-    background-color: #CDC0B0;
 
     #imagedisplay {
         .center-align;
@@ -776,45 +775,27 @@ table.dirlist {
 #enhanced_interface {
     .center-align;
     overflow: hidden;
-    background-color: #CDCDC1;
 
     #tbtext {
         margin-left: auto;
         margin-right: auto;
         border-collapse: collapse;
-        border: 1px solid #000000;
         overflow: auto;
     }
     #tdtop {
         .middle-align;
-        border: 1px solid #000000;
-        background-color: #CDC0B0;
         padding: 2px;
     }
-    #tdtext {
+    #tdtext, #tdbottom {
         .top-align;
-        border: 1px solid #000000;
-        background-color: #CDCDC1;
-        padding: 2px;
-    }
-    #tdbottom {
-        .top-align;
-        border: 1px solid #000000;
-        background-color: #EEDFCC;
         padding: 2px;
     }
     #text_data, #text_data:focus {
-        background-color: #FFF8DC;
-        color: #000000;
         padding: 2px;
         outline: none;
     }
     .dropsmall {
         font-size: 75%;
-        background-color: #FFF8DC;
-    }
-    .boxnormal {
-        background-color: #FFF8DC;
     }
 }
 
@@ -823,33 +804,26 @@ table.dirlist {
 
 #wordcheck_interface {
     .center-align;
-    background-color: #CDCDC1;
     overflow: auto;
 
     #tbtext {
         margin-left: auto;
         margin-right: auto;
-        border: 1px solid #000000;
         padding: 10px;
     }
     #tdtop {
-        border: 1px solid #000000;
-        background-color: #CDC0B0;
         padding: 2px;
     }
     #tdtext {
         .top-align;
         .left-align;
-        border: 1px solid #000000;
-        background-color: #FFF8DC;
         padding: 0.5em;
     }
 }
 
 /* ------------------------------------------------------------------------ */
-/* control frame */
+/* Proofreading control frame */
 .control-frame {
-    background-color: #CDC0B0;
     padding: 0;
     margin: 0;
 }
@@ -864,7 +838,6 @@ table.dirlist {
         margin-top: 1px;
         font-size: 1em;
         padding: 0.1em 0.15em 0 0.15em;
-        border: 1px solid black;
         margin-right: 2px;
         min-width: 1em;
     }
@@ -1134,7 +1107,6 @@ li.spaced {
 
 .fixedbox {
     flex: 0 0 auto;
-    background-color: #CDC0B0;
     padding: 2px;
 }
 
@@ -1142,7 +1114,6 @@ li.spaced {
     flex: auto;
     min-height: 10px;
     overflow: auto;
-    background-color: HoneyDew;
 }
 
 .ws-pre {
@@ -1150,10 +1121,6 @@ li.spaced {
     padding-left: 0.5em;
     text-align: left;
     font-family: monospace;
-}
-
-.bad-char {
-    background: #ff99cc;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -1177,38 +1144,51 @@ li.spaced {
 }
 
 /* ------------------------------------------------------------------------ */
-/* view_page_text_image */
+/* Page Browser */
 
-.control-form {
-    padding: 0 1em;
-    overflow: auto;
-    p {
-        margin: 0.2em 0;
+#page-browser {
+    .flex_100vh;
+
+    .control-pane {
+        padding: 0 1em;
+        overflow: auto;
+        p {
+            margin: 0.2em 0;
+        }
+        input {
+            margin: 1px 0.2em;
+        }
+        select {
+            margin-right: 0.4em;
+        }
+        .img-button {
+            vertical-align: middle;
+            padding: 0;
+        }
+        img {
+            display: block;
+        }
+        input[type=checkbox] {
+            vertical-align: middle;
+        }
+        input[type=number] {
+            width: 5em;
+        }
+        a {
+            margin-right: 0.4em;
+            margin-left: 0.4em;
+        }
     }
-    input {
-        border-width: 2px;
-        margin: 1px 0.2em;
-    }
-    select {
-        margin-right: 0.4em;
-    }
-    .img-button {
-        vertical-align: middle;
+
+    .text-pane {
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
+        padding-left: .25em;
+        resize: none;
         border: 0;
-        padding: 0;
-    }
-    img {
+        margin: 0;
         display: block;
-    }
-    input[type=checkbox] {
-        vertical-align: middle;
-    }
-    input[type=number] {
-        width: 5em;
-    }
-    a {
-        margin-right: 0.4em;
-        margin-left: 0.4em;
     }
 }
 
@@ -1225,16 +1205,6 @@ li.spaced {
     }
 }
 
-.full-text {
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    padding-left: .25em;
-    resize: none;
-    border: 0;
-    margin: 0;
-    display: block;
-}
 
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/preview.css
+++ b/styles/preview.css
@@ -22,21 +22,15 @@
 
 /* control panel */
 #id_controls {
-    border-left: 1px solid black;
-    border-right: 1px solid black;
     padding-left: 2px;
     padding-right: 2px;
-    background-color: #f1d1b4
 }
 
 /* inline block for grouped controls */
 .ilb {
     display: inline-block;
-    border: 1px solid #404040;
     margin: 1px;
-    padding: 1px 2px 1px 2px;
-    border-radius: 2px;
-    background-color:#ffe1c4
+    padding: 2px 3px;
 }
 
 /* configure divs */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -341,41 +341,414 @@ table.snapshottable th {
 .WC {
   background-color: #97fc9e;
 }
+/* ======================================================================== */
+/* Page Interface Structures */
+/*
+ * The following classes all relate to various page interfaces, such as the
+ * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
+ * toolbox, code point validator, display image interface, etc.
+ */
+/* Base layer for page interface */
+/* Text pane */
+/* Control panes */
+.page-interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+.page-interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+.page-interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+.page-interface .control-pane input,
+.page-interface .control-pane select,
+.page-interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.page-interface .control-pane button,
+.page-interface .control-pane input[type=submit],
+.page-interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.page-interface .control-pane input[type=image] {
+  border: none;
+}
+.page-interface .control-pane .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Proofreading control frame */
+.control-frame {
+  background-color: #CDC0B0;
+  color: black;
+}
+.control-frame input,
+.control-frame select,
+.control-frame button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.control-frame button,
+.control-frame input[type=submit],
+.control-frame input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.control-frame input[type=image] {
+  border: none;
+}
+.control-frame .menu {
+  background-color: Bisque;
+}
 /* ------------------------------------------------------------------------ */
 /* Proofreading Toolbox */
 #toolbox {
   font-family: Verdana, Helvetica, sans-serif;
   background-color: #CDC0B0;
+  color: black;
+}
+#toolbox input,
+#toolbox select,
+#toolbox button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#toolbox button,
+#toolbox input[type=submit],
+#toolbox input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#toolbox input[type=image] {
+  border: none;
+}
+#toolbox .menu {
+  background-color: Bisque;
 }
 #toolbox .selector_button {
   background-color: Bisque;
 }
-#toolbox .selected-tab,
-#toolbox .big_text,
-#toolbox .picker {
-  background-color: Beige;
+#toolbox .selected-tab {
+  font-weight: bold;
+  background-color: #FFF8DC;
+  box-shadow: -1px -1px grey;
 }
-#toolbox .proofbutton {
-  border: 1px solid black;
-  background: #FFF8DC;
+#toolbox #hide-picker {
+  box-shadow: -1px -1px grey;
 }
 /* ------------------------------------------------------------------------ */
-/* view_page_text_image */
-.control-form {
+/* Format Preview */
+#format_preview {
+  background-color: #CDCDC1;
+  color: black;
+}
+#format_preview .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#format_preview .control-pane {
   background-color: #CDC0B0;
+  color: black;
+}
+#format_preview .control-pane input,
+#format_preview .control-pane select,
+#format_preview .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#format_preview .control-pane button,
+#format_preview .control-pane input[type=submit],
+#format_preview .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#format_preview .control-pane input[type=image] {
+  border: none;
+}
+#format_preview .control-pane .menu {
+  background-color: Bisque;
+}
+.ilb {
+  border: 1px solid #404040;
+  border-radius: 2px;
+  background-color: #CDC0B0;
+  color: black;
+}
+.ilb input,
+.ilb select,
+.ilb button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.ilb button,
+.ilb input[type=submit],
+.ilb input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.ilb input[type=image] {
+  border: none;
+}
+.ilb .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Page Browser */
+#page-browser {
+  background-color: #CDCDC1;
+  color: black;
+}
+#page-browser .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#page-browser .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#page-browser .control-pane input,
+#page-browser .control-pane select,
+#page-browser .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#page-browser .control-pane button,
+#page-browser .control-pane input[type=submit],
+#page-browser .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#page-browser .control-pane input[type=image] {
+  border: none;
+}
+#page-browser .control-pane .menu {
+  background-color: Bisque;
+}
+#page-browser .control-pane {
   border-bottom: 1px solid #999;
 }
-.control-form input {
-  background-color: #FFF8DC;
+#page-browser .control-pane .img-button {
+  border: 0;
+  box-shadow: none;
 }
-.control-form select {
-  background-color: #FFF8DC;
-}
-.image-back {
+/* ------------------------------------------------------------------------ */
+/* Standard Editing Interface */
+#standard_interface {
   background-color: #CDCDC1;
+  color: black;
 }
-.full-text {
+#standard_interface .text-pane {
   background-color: #FFF8DC;
+  color: black;
+}
+#standard_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#standard_interface .control-pane input,
+#standard_interface .control-pane select,
+#standard_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#standard_interface .control-pane button,
+#standard_interface .control-pane input[type=submit],
+#standard_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#standard_interface .control-pane input[type=image] {
+  border: none;
+}
+#standard_interface .control-pane .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Enhanced Editing Interface */
+#enhanced_interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+#enhanced_interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface .control-pane input,
+#enhanced_interface .control-pane select,
+#enhanced_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface .control-pane button,
+#enhanced_interface .control-pane input[type=submit],
+#enhanced_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface .control-pane input[type=image] {
+  border: none;
+}
+#enhanced_interface .control-pane .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tbtext {
+  border: 1px solid black;
+}
+#enhanced_interface #tdtop {
+  border: 1px solid black;
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface #tdtop input,
+#enhanced_interface #tdtop select,
+#enhanced_interface #tdtop button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface #tdtop button,
+#enhanced_interface #tdtop input[type=submit],
+#enhanced_interface #tdtop input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface #tdtop input[type=image] {
+  border: none;
+}
+#enhanced_interface #tdtop .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tdtext {
+  border: 1px solid black;
+  background-color: #CDCDC1;
+  color: black;
+}
+#enhanced_interface #tdtext .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface #tdtext .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface #tdtext .control-pane input,
+#enhanced_interface #tdtext .control-pane select,
+#enhanced_interface #tdtext .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface #tdtext .control-pane button,
+#enhanced_interface #tdtext .control-pane input[type=submit],
+#enhanced_interface #tdtext .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface #tdtext .control-pane input[type=image] {
+  border: none;
+}
+#enhanced_interface #tdtext .control-pane .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tdbottom {
+  border: 1px solid black;
+  background-color: #EEDFCC;
+}
+#enhanced_interface #text_data,
+#enhanced_interface #text_data:focus {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface .dropsmall {
+  font-size: 75%;
+}
+/* ------------------------------------------------------------------------ */
+/* WordCheck Interface */
+#wordcheck_interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+#wordcheck_interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#wordcheck_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#wordcheck_interface .control-pane input,
+#wordcheck_interface .control-pane select,
+#wordcheck_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#wordcheck_interface .control-pane button,
+#wordcheck_interface .control-pane input[type=submit],
+#wordcheck_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#wordcheck_interface .control-pane input[type=image] {
+  border: none;
+}
+#wordcheck_interface .control-pane .menu {
+  background-color: Bisque;
+}
+#wordcheck_interface #tbtext {
+  border: 1px solid black;
+}
+#wordcheck_interface #tdtop {
+  border: 1px solid black;
+  background-color: #CDC0B0;
+  color: black;
+}
+#wordcheck_interface #tdtop input,
+#wordcheck_interface #tdtop select,
+#wordcheck_interface #tdtop button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#wordcheck_interface #tdtop button,
+#wordcheck_interface #tdtop input[type=submit],
+#wordcheck_interface #tdtop input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#wordcheck_interface #tdtop input[type=image] {
+  border: none;
+}
+#wordcheck_interface #tdtop .menu {
+  background-color: Bisque;
+}
+#wordcheck_interface #tdtext {
+  border: 1px solid black;
+  background-color: #FFF8DC;
+  color: black;
+}
+/* ------------------------------------------------------------------------ */
+/* Codepoint Validator */
+.stretchbox {
+  background-color: #FFF8DC;
+  color: black;
+}
+.fixedbox {
+  background-color: #CDC0B0;
+  color: black;
+}
+.fixedbox input,
+.fixedbox select,
+.fixedbox button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.fixedbox button,
+.fixedbox input[type=submit],
+.fixedbox input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.fixedbox input[type=image] {
+  border: none;
+}
+.fixedbox .menu {
+  background-color: Bisque;
+}
+.bad-char {
+  background: #ff99cc;
 }
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -341,41 +341,414 @@ table.snapshottable th {
 .WC {
   background-color: #97fc9e;
 }
+/* ======================================================================== */
+/* Page Interface Structures */
+/*
+ * The following classes all relate to various page interfaces, such as the
+ * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
+ * toolbox, code point validator, display image interface, etc.
+ */
+/* Base layer for page interface */
+/* Text pane */
+/* Control panes */
+.page-interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+.page-interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+.page-interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+.page-interface .control-pane input,
+.page-interface .control-pane select,
+.page-interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.page-interface .control-pane button,
+.page-interface .control-pane input[type=submit],
+.page-interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.page-interface .control-pane input[type=image] {
+  border: none;
+}
+.page-interface .control-pane .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Proofreading control frame */
+.control-frame {
+  background-color: #CDC0B0;
+  color: black;
+}
+.control-frame input,
+.control-frame select,
+.control-frame button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.control-frame button,
+.control-frame input[type=submit],
+.control-frame input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.control-frame input[type=image] {
+  border: none;
+}
+.control-frame .menu {
+  background-color: Bisque;
+}
 /* ------------------------------------------------------------------------ */
 /* Proofreading Toolbox */
 #toolbox {
   font-family: Verdana, Helvetica, sans-serif;
   background-color: #CDC0B0;
+  color: black;
+}
+#toolbox input,
+#toolbox select,
+#toolbox button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#toolbox button,
+#toolbox input[type=submit],
+#toolbox input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#toolbox input[type=image] {
+  border: none;
+}
+#toolbox .menu {
+  background-color: Bisque;
 }
 #toolbox .selector_button {
   background-color: Bisque;
 }
-#toolbox .selected-tab,
-#toolbox .big_text,
-#toolbox .picker {
-  background-color: Beige;
+#toolbox .selected-tab {
+  font-weight: bold;
+  background-color: #FFF8DC;
+  box-shadow: -1px -1px grey;
 }
-#toolbox .proofbutton {
-  border: 1px solid black;
-  background: #FFF8DC;
+#toolbox #hide-picker {
+  box-shadow: -1px -1px grey;
 }
 /* ------------------------------------------------------------------------ */
-/* view_page_text_image */
-.control-form {
+/* Format Preview */
+#format_preview {
+  background-color: #CDCDC1;
+  color: black;
+}
+#format_preview .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#format_preview .control-pane {
   background-color: #CDC0B0;
+  color: black;
+}
+#format_preview .control-pane input,
+#format_preview .control-pane select,
+#format_preview .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#format_preview .control-pane button,
+#format_preview .control-pane input[type=submit],
+#format_preview .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#format_preview .control-pane input[type=image] {
+  border: none;
+}
+#format_preview .control-pane .menu {
+  background-color: Bisque;
+}
+.ilb {
+  border: 1px solid #404040;
+  border-radius: 2px;
+  background-color: #CDC0B0;
+  color: black;
+}
+.ilb input,
+.ilb select,
+.ilb button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.ilb button,
+.ilb input[type=submit],
+.ilb input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.ilb input[type=image] {
+  border: none;
+}
+.ilb .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Page Browser */
+#page-browser {
+  background-color: #CDCDC1;
+  color: black;
+}
+#page-browser .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#page-browser .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#page-browser .control-pane input,
+#page-browser .control-pane select,
+#page-browser .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#page-browser .control-pane button,
+#page-browser .control-pane input[type=submit],
+#page-browser .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#page-browser .control-pane input[type=image] {
+  border: none;
+}
+#page-browser .control-pane .menu {
+  background-color: Bisque;
+}
+#page-browser .control-pane {
   border-bottom: 1px solid #999;
 }
-.control-form input {
-  background-color: #FFF8DC;
+#page-browser .control-pane .img-button {
+  border: 0;
+  box-shadow: none;
 }
-.control-form select {
-  background-color: #FFF8DC;
-}
-.image-back {
+/* ------------------------------------------------------------------------ */
+/* Standard Editing Interface */
+#standard_interface {
   background-color: #CDCDC1;
+  color: black;
 }
-.full-text {
+#standard_interface .text-pane {
   background-color: #FFF8DC;
+  color: black;
+}
+#standard_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#standard_interface .control-pane input,
+#standard_interface .control-pane select,
+#standard_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#standard_interface .control-pane button,
+#standard_interface .control-pane input[type=submit],
+#standard_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#standard_interface .control-pane input[type=image] {
+  border: none;
+}
+#standard_interface .control-pane .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Enhanced Editing Interface */
+#enhanced_interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+#enhanced_interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface .control-pane input,
+#enhanced_interface .control-pane select,
+#enhanced_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface .control-pane button,
+#enhanced_interface .control-pane input[type=submit],
+#enhanced_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface .control-pane input[type=image] {
+  border: none;
+}
+#enhanced_interface .control-pane .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tbtext {
+  border: 1px solid black;
+}
+#enhanced_interface #tdtop {
+  border: 1px solid black;
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface #tdtop input,
+#enhanced_interface #tdtop select,
+#enhanced_interface #tdtop button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface #tdtop button,
+#enhanced_interface #tdtop input[type=submit],
+#enhanced_interface #tdtop input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface #tdtop input[type=image] {
+  border: none;
+}
+#enhanced_interface #tdtop .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tdtext {
+  border: 1px solid black;
+  background-color: #CDCDC1;
+  color: black;
+}
+#enhanced_interface #tdtext .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface #tdtext .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface #tdtext .control-pane input,
+#enhanced_interface #tdtext .control-pane select,
+#enhanced_interface #tdtext .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface #tdtext .control-pane button,
+#enhanced_interface #tdtext .control-pane input[type=submit],
+#enhanced_interface #tdtext .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface #tdtext .control-pane input[type=image] {
+  border: none;
+}
+#enhanced_interface #tdtext .control-pane .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tdbottom {
+  border: 1px solid black;
+  background-color: #EEDFCC;
+}
+#enhanced_interface #text_data,
+#enhanced_interface #text_data:focus {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface .dropsmall {
+  font-size: 75%;
+}
+/* ------------------------------------------------------------------------ */
+/* WordCheck Interface */
+#wordcheck_interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+#wordcheck_interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#wordcheck_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#wordcheck_interface .control-pane input,
+#wordcheck_interface .control-pane select,
+#wordcheck_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#wordcheck_interface .control-pane button,
+#wordcheck_interface .control-pane input[type=submit],
+#wordcheck_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#wordcheck_interface .control-pane input[type=image] {
+  border: none;
+}
+#wordcheck_interface .control-pane .menu {
+  background-color: Bisque;
+}
+#wordcheck_interface #tbtext {
+  border: 1px solid black;
+}
+#wordcheck_interface #tdtop {
+  border: 1px solid black;
+  background-color: #CDC0B0;
+  color: black;
+}
+#wordcheck_interface #tdtop input,
+#wordcheck_interface #tdtop select,
+#wordcheck_interface #tdtop button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#wordcheck_interface #tdtop button,
+#wordcheck_interface #tdtop input[type=submit],
+#wordcheck_interface #tdtop input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#wordcheck_interface #tdtop input[type=image] {
+  border: none;
+}
+#wordcheck_interface #tdtop .menu {
+  background-color: Bisque;
+}
+#wordcheck_interface #tdtext {
+  border: 1px solid black;
+  background-color: #FFF8DC;
+  color: black;
+}
+/* ------------------------------------------------------------------------ */
+/* Codepoint Validator */
+.stretchbox {
+  background-color: #FFF8DC;
+  color: black;
+}
+.fixedbox {
+  background-color: #CDC0B0;
+  color: black;
+}
+.fixedbox input,
+.fixedbox select,
+.fixedbox button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.fixedbox button,
+.fixedbox input[type=submit],
+.fixedbox input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.fixedbox input[type=image] {
+  border: none;
+}
+.fixedbox .menu {
+  background-color: Bisque;
+}
+.bad-char {
+  background: #ff99cc;
 }
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -341,41 +341,414 @@ table.snapshottable th {
 .WC {
   background-color: #97fc9e;
 }
+/* ======================================================================== */
+/* Page Interface Structures */
+/*
+ * The following classes all relate to various page interfaces, such as the
+ * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
+ * toolbox, code point validator, display image interface, etc.
+ */
+/* Base layer for page interface */
+/* Text pane */
+/* Control panes */
+.page-interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+.page-interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+.page-interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+.page-interface .control-pane input,
+.page-interface .control-pane select,
+.page-interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.page-interface .control-pane button,
+.page-interface .control-pane input[type=submit],
+.page-interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.page-interface .control-pane input[type=image] {
+  border: none;
+}
+.page-interface .control-pane .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Proofreading control frame */
+.control-frame {
+  background-color: #CDC0B0;
+  color: black;
+}
+.control-frame input,
+.control-frame select,
+.control-frame button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.control-frame button,
+.control-frame input[type=submit],
+.control-frame input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.control-frame input[type=image] {
+  border: none;
+}
+.control-frame .menu {
+  background-color: Bisque;
+}
 /* ------------------------------------------------------------------------ */
 /* Proofreading Toolbox */
 #toolbox {
   font-family: Verdana, Arial, sans-serif;
   background-color: #CDC0B0;
+  color: black;
+}
+#toolbox input,
+#toolbox select,
+#toolbox button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#toolbox button,
+#toolbox input[type=submit],
+#toolbox input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#toolbox input[type=image] {
+  border: none;
+}
+#toolbox .menu {
+  background-color: Bisque;
 }
 #toolbox .selector_button {
   background-color: Bisque;
 }
-#toolbox .selected-tab,
-#toolbox .big_text,
-#toolbox .picker {
-  background-color: Beige;
+#toolbox .selected-tab {
+  font-weight: bold;
+  background-color: #FFF8DC;
+  box-shadow: -1px -1px grey;
 }
-#toolbox .proofbutton {
-  border: 1px solid black;
-  background: #FFF8DC;
+#toolbox #hide-picker {
+  box-shadow: -1px -1px grey;
 }
 /* ------------------------------------------------------------------------ */
-/* view_page_text_image */
-.control-form {
+/* Format Preview */
+#format_preview {
+  background-color: #CDCDC1;
+  color: black;
+}
+#format_preview .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#format_preview .control-pane {
   background-color: #CDC0B0;
+  color: black;
+}
+#format_preview .control-pane input,
+#format_preview .control-pane select,
+#format_preview .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#format_preview .control-pane button,
+#format_preview .control-pane input[type=submit],
+#format_preview .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#format_preview .control-pane input[type=image] {
+  border: none;
+}
+#format_preview .control-pane .menu {
+  background-color: Bisque;
+}
+.ilb {
+  border: 1px solid #404040;
+  border-radius: 2px;
+  background-color: #CDC0B0;
+  color: black;
+}
+.ilb input,
+.ilb select,
+.ilb button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.ilb button,
+.ilb input[type=submit],
+.ilb input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.ilb input[type=image] {
+  border: none;
+}
+.ilb .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Page Browser */
+#page-browser {
+  background-color: #CDCDC1;
+  color: black;
+}
+#page-browser .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#page-browser .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#page-browser .control-pane input,
+#page-browser .control-pane select,
+#page-browser .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#page-browser .control-pane button,
+#page-browser .control-pane input[type=submit],
+#page-browser .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#page-browser .control-pane input[type=image] {
+  border: none;
+}
+#page-browser .control-pane .menu {
+  background-color: Bisque;
+}
+#page-browser .control-pane {
   border-bottom: 1px solid #999;
 }
-.control-form input {
-  background-color: #FFF8DC;
+#page-browser .control-pane .img-button {
+  border: 0;
+  box-shadow: none;
 }
-.control-form select {
-  background-color: #FFF8DC;
-}
-.image-back {
+/* ------------------------------------------------------------------------ */
+/* Standard Editing Interface */
+#standard_interface {
   background-color: #CDCDC1;
+  color: black;
 }
-.full-text {
+#standard_interface .text-pane {
   background-color: #FFF8DC;
+  color: black;
+}
+#standard_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#standard_interface .control-pane input,
+#standard_interface .control-pane select,
+#standard_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#standard_interface .control-pane button,
+#standard_interface .control-pane input[type=submit],
+#standard_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#standard_interface .control-pane input[type=image] {
+  border: none;
+}
+#standard_interface .control-pane .menu {
+  background-color: Bisque;
+}
+/* ------------------------------------------------------------------------ */
+/* Enhanced Editing Interface */
+#enhanced_interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+#enhanced_interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface .control-pane input,
+#enhanced_interface .control-pane select,
+#enhanced_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface .control-pane button,
+#enhanced_interface .control-pane input[type=submit],
+#enhanced_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface .control-pane input[type=image] {
+  border: none;
+}
+#enhanced_interface .control-pane .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tbtext {
+  border: 1px solid black;
+}
+#enhanced_interface #tdtop {
+  border: 1px solid black;
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface #tdtop input,
+#enhanced_interface #tdtop select,
+#enhanced_interface #tdtop button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface #tdtop button,
+#enhanced_interface #tdtop input[type=submit],
+#enhanced_interface #tdtop input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface #tdtop input[type=image] {
+  border: none;
+}
+#enhanced_interface #tdtop .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tdtext {
+  border: 1px solid black;
+  background-color: #CDCDC1;
+  color: black;
+}
+#enhanced_interface #tdtext .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface #tdtext .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#enhanced_interface #tdtext .control-pane input,
+#enhanced_interface #tdtext .control-pane select,
+#enhanced_interface #tdtext .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#enhanced_interface #tdtext .control-pane button,
+#enhanced_interface #tdtext .control-pane input[type=submit],
+#enhanced_interface #tdtext .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#enhanced_interface #tdtext .control-pane input[type=image] {
+  border: none;
+}
+#enhanced_interface #tdtext .control-pane .menu {
+  background-color: Bisque;
+}
+#enhanced_interface #tdbottom {
+  border: 1px solid black;
+  background-color: #EEDFCC;
+}
+#enhanced_interface #text_data,
+#enhanced_interface #text_data:focus {
+  background-color: #FFF8DC;
+  color: black;
+}
+#enhanced_interface .dropsmall {
+  font-size: 75%;
+}
+/* ------------------------------------------------------------------------ */
+/* WordCheck Interface */
+#wordcheck_interface {
+  background-color: #CDCDC1;
+  color: black;
+}
+#wordcheck_interface .text-pane {
+  background-color: #FFF8DC;
+  color: black;
+}
+#wordcheck_interface .control-pane {
+  background-color: #CDC0B0;
+  color: black;
+}
+#wordcheck_interface .control-pane input,
+#wordcheck_interface .control-pane select,
+#wordcheck_interface .control-pane button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#wordcheck_interface .control-pane button,
+#wordcheck_interface .control-pane input[type=submit],
+#wordcheck_interface .control-pane input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#wordcheck_interface .control-pane input[type=image] {
+  border: none;
+}
+#wordcheck_interface .control-pane .menu {
+  background-color: Bisque;
+}
+#wordcheck_interface #tbtext {
+  border: 1px solid black;
+}
+#wordcheck_interface #tdtop {
+  border: 1px solid black;
+  background-color: #CDC0B0;
+  color: black;
+}
+#wordcheck_interface #tdtop input,
+#wordcheck_interface #tdtop select,
+#wordcheck_interface #tdtop button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+#wordcheck_interface #tdtop button,
+#wordcheck_interface #tdtop input[type=submit],
+#wordcheck_interface #tdtop input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+#wordcheck_interface #tdtop input[type=image] {
+  border: none;
+}
+#wordcheck_interface #tdtop .menu {
+  background-color: Bisque;
+}
+#wordcheck_interface #tdtext {
+  border: 1px solid black;
+  background-color: #FFF8DC;
+  color: black;
+}
+/* ------------------------------------------------------------------------ */
+/* Codepoint Validator */
+.stretchbox {
+  background-color: #FFF8DC;
+  color: black;
+}
+.fixedbox {
+  background-color: #CDC0B0;
+  color: black;
+}
+.fixedbox input,
+.fixedbox select,
+.fixedbox button {
+  background-color: #FFF8DC;
+  border: solid thin black;
+}
+.fixedbox button,
+.fixedbox input[type=submit],
+.fixedbox input[type=button] {
+  box-shadow: 1px 1px grey;
+}
+.fixedbox input[type=image] {
+  border: none;
+}
+.fixedbox .menu {
+  background-color: Bisque;
+}
+.bad-char {
+  background: #ff99cc;
 }
 /* vim: sw=4 ts=4 expandtab
 */

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -304,46 +304,181 @@ table.snapshottable {
     background-color: #97fc9e;
 }
 
+/* ======================================================================== */
+/* Page Interface Structures */
+
+/*
+ * The following classes all relate to various page interfaces, such as the
+ * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
+ * toolbox, code point validator, display image interface, etc.
+ */
+
+/* Base layer for page interface */
+@page-interface-background: #CDCDC1;
+@page-interface-text: black;
+
+/* Text pane */
+@text-pane-background: #FFF8DC;
+@text-pane-text: black;
+
+/* Control panes */
+@control-pane-background: #CDC0B0;
+@control-pane-text: black;
+@control-pane-menu: Bisque;
+
+.page-interface {
+    background-color: @page-interface-background;
+    color: @page-interface-text;
+
+    .text-pane {
+        background-color: @text-pane-background;
+        color: @text-pane-text;
+    }
+
+    .control-pane {
+        background-color: @control-pane-background;
+        color: @control-pane-text;
+
+        input, select, button {
+            background-color: @text-pane-background;
+            border: solid thin black;
+        }
+
+        button, input[type=submit], input[type=button] {
+            box-shadow: 1px 1px grey;
+        }
+
+        input[type=image] {
+            border: none;
+        }
+
+        .menu {
+            background-color: @control-pane-menu;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Proofreading control frame */
+.control-frame {
+    .page-interface .control-pane;
+}
+
 /* ------------------------------------------------------------------------ */
 /* Proofreading Toolbox */
 
 #toolbox {
     .sans-serif;
-    background-color: #CDC0B0;
+    .page-interface .control-pane;
     .selector_button {
-        background-color: Bisque;
+        .page-interface .control-pane .menu;
     }
-    .selected-tab, .big_text, .picker {
-        background-color: Beige;
+    .selected-tab {
+        .bold;
+        background-color: @text-pane-background;
+        box-shadow: -1px -1px grey;
     }
-    .proofbutton {
-        border: 1px solid black;
-        background: #FFF8DC;
+    #hide-picker {
+        box-shadow: -1px -1px grey;
     }
 }
 
 /* ------------------------------------------------------------------------ */
-/* view_page_text_image */
+/* Format Preview */
 
-.control-form {
-    background-color: #CDC0B0;
-    border-bottom: 1px solid #999;
-    input {
-        background-color: #FFF8DC;
+#format_preview {
+    .page-interface;
+}
+
+.ilb {
+    border: 1px solid #404040;
+    border-radius: 2px;
+    .page-interface .control-pane;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Page Browser */
+
+#page-browser {
+    .page-interface;
+    .control-pane {
+        border-bottom: 1px solid #999;
+        .img-button {
+            border: 0;
+            box-shadow: none;
+        }
     }
-    select {
-        background-color: #FFF8DC;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Standard Editing Interface */
+
+#standard_interface {
+    .page-interface;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Enhanced Editing Interface */
+
+#enhanced_interface {
+    .page-interface;
+
+    #tbtext {
+        border: 1px solid black;
+    }
+    #tdtop {
+        border: 1px solid black;
+        .page-interface .control-pane;
+    }
+    #tdtext {
+        border: 1px solid black;
+        .page-interface;
+    }
+    #tdbottom {
+        border: 1px solid black;
+        background-color: #EEDFCC;
+    }
+    #text_data, #text_data:focus {
+        .page-interface .text-pane;
+    }
+    .dropsmall {
+        font-size: 75%;
     }
 }
 
-.image-back {
-    background-color: #CDCDC1;
+/* ------------------------------------------------------------------------ */
+/* WordCheck Interface */
+
+#wordcheck_interface {
+    .page-interface;
+
+    #tbtext {
+        border: 1px solid black;
+    }
+    #tdtop {
+        border: 1px solid black;
+        .page-interface .control-pane;
+    }
+    #tdtext {
+        border: 1px solid black;
+        .page-interface .text-pane;
+    }
 }
 
-.full-text {
-    background-color: #FFF8DC;
+/* ------------------------------------------------------------------------ */
+/* Codepoint Validator */
+
+.stretchbox {
+    .page-interface .text-pane;
 }
 
+.fixedbox {
+    .page-interface .control-pane;
+}
+
+.bad-char {
+    background: #ff99cc;
+}
 
 /* vim: sw=4 ts=4 expandtab
 */

--- a/tools/project_manager/display_image.js
+++ b/tools/project_manager/display_image.js
@@ -34,9 +34,9 @@ $(function () {
         return returnValue;
     };
 
-    let topDiv = $("#top-div");
+    let topDiv = $("#page-browser");
     // the non-scrolling area which will contain any error message and the form with controls
-    let fixHead = $("<div>", {class: 'fixed-box control-form'});
+    let fixHead = $("<div>", {class: 'fixed-box control-pane'});
     topDiv.append(fixHead);
 
     if(pageBrowserData.errorMessage) {
@@ -89,7 +89,7 @@ $(function () {
             } else {
                 fixHead.append(theImageControl.controls);
             }
-            stretchDiv.addClass("overflow-auto image-back").append(theImageControl.image);
+            stretchDiv.addClass("overflow-auto image-pane").append(theImageControl.image);
             theImageControl.setZoom();
             break;
         }
@@ -106,11 +106,11 @@ $(function () {
             let theImageControl = imageControl();
             let theTextControl = textControl();
             theTextControl.textArea.prop("readonly", !mentorMode);
-            let imageDiv = $("<div>", {class: 'overflow-auto image-back'}).append(theImageControl.image);
+            let imageDiv = $("<div>", {class: 'overflow-auto image-pane'}).append(theImageControl.image);
             let textDiv = $("<div>").append(theTextControl.textArea);
             if(mentorMode) {
                 let topTextDiv = textDiv;
-                let bottomTextDiv = $("<div>", {class: 'image-back'});
+                let bottomTextDiv = $("<div>", {class: 'image-pane'});
                 textDiv = $("<div>").append(topTextDiv, bottomTextDiv);
             }
             stretchDiv.append(imageDiv, textDiv);

--- a/tools/project_manager/displayimage.php
+++ b/tools/project_manager/displayimage.php
@@ -43,6 +43,6 @@ $header_args = [
 
 slim_header($title, $header_args);
 
-echo "<div class='flex_100vh' id='top-div'></div>";
+echo "<div id='page-browser'></div>";
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/proofers/button_menu.inc
+++ b/tools/proofers/button_menu.inc
@@ -80,7 +80,7 @@ type="text" value="<?php
     } else {
         echo $user->profile->h_zoom;
     }
-?>" name="zmSize" ID="zmSize" class="boxnormal bottom-align" size="3" title="<?php 
+?>" name="zmSize" ID="zmSize" class="bottom-align" size="3" title="<?php
     # xgettext:no-php-format
     echo attr_safe(_("Input Zoom %"));
 ?>" onkeydown="return refuseNonNumeric(event)"><?php

--- a/tools/proofers/image_block_enh.inc
+++ b/tools/proofers/image_block_enh.inc
@@ -63,7 +63,6 @@ function ibe_get_styles()
         width:$textWidth%;
         height:$textHeight%;
         /* clip:rect(0px, 100%, 100%, 0px); -- broken in MS Edge */
-        background-color:#CDCDC1;
         text-align:center;
         z-index:6;
         overflow:auto;
@@ -101,7 +100,6 @@ function ibe_get_styles()
         left:0px;
         top:0px;
         z-index:1;
-        background-color:#EEDFCC;
     }
 STYLES;
 }

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -120,14 +120,16 @@ function output_preview_div()
 
     echo <<<END
 <div id='prevdiv' class='no_display'>
- <div class='flex_container'>
-  <div id="id_tp_outer" class='stretchbox'>
+ <div id='format_preview' class='flex_container'>
+  <div id="id_tp_outer" class='stretchbox text-pane'>
     <div id="text_preview">
     </div>
   </div>
-  <div id="id_controls" class="fixedbox">
+  <div id="id_controls" class="fixedbox control-pane">
     <input type='button' onclick="previewControl.hide()" value="$quit">
-    <span class='ilb'><label>$color_markup<input type="checkbox" id="id_color_on" onchange="previewControl.enableColor(this.checked)" ></label></span>
+    <span class='ilb'><label for="id_color_on">$color_markup</label>
+        <input type="checkbox" id="id_color_on" onchange="previewControl.enableColor(this.checked)" >
+    </span>
     <span class='ilb'>$image
       <input type="button" value="-" onclick="top.reSizeRelative(0.91);">
       <input type="button" value="+" onclick="top.reSizeRelative(1.10);">
@@ -138,12 +140,12 @@ function output_preview_div()
     </span>
     <span class='ilb'>$font <select id="id_font_sel"></select></span>
     <span class='ilb'>
-      <label><input type="radio" name="viewSel" id="show_tags">$tags</label>
-      <label><input type="radio" name="viewSel" id="no_tags">$no_tags</label>
-      <label><input type="radio" name="viewSel" id="flat">$text</label>
+      <input type="radio" name="viewSel" id="show_tags"><label for="show_tags">$tags</label>
+      <input type="radio" name="viewSel" id="no_tags"><label for="no_tags">$no_tags</label>
+      <input type="radio" name="viewSel" id="flat"><label for="flat">$text</label>
     </span>
     <span class='ilb'>
-    <label><input type="checkbox" id="re_wrap">$re_wrap</label>
+    <input type="checkbox" id="re_wrap"><label for="re_wrap">$re_wrap</label>
     </span>
     <span class='ilb'>$issues <input type="text" id="id_iss" size="1" readonly></span>
     <span class='ilb'>$poss_iss <input type="text" id="id_poss_iss" size="1" readonly></span>
@@ -179,13 +181,13 @@ function output_preview_div()
     </div>
   </fieldset>
   <div class="box2">
-    <span class='ilb'><label>$allow_underine<input type="checkbox" id="id_underline"></label></span>
+    <span class='ilb'><label for="id_underline">$allow_underine</label><input type="checkbox" id="id_underline"></span>
   </div>
   <fieldset>
     <legend>$suppress_warnings</legend>
     $supp_item_string
   </fieldset>
-  <br><span class='ilb'>$initial_mode <select id="id_init_mode">
+  <br><span class='ilb'><label for='id_init_mode'>$initial_mode</label> <select id="id_init_mode">
     <option value="show_tags">$tags</option>
     <option value="no_tags">$no_tags</option>
     <option value="flat">$text</option>


### PR DESCRIPTION
Pull page interface styling out of `layout.less` and into `theme.less`. This now centralizes all of the color for the various interfaces that deal with pages (proofreading, WordCheck, image display, format preview) into a single location. This is to enable some theming work that @srjfoo is working on.

This standardizes some of the UI style which makes for some small changes compared to what was there before:
* Buttons in control panes / control panels now all look the same. They have a small drop-shadow to help convey that they are a button. This includes the buttons in WordCheck.
* The background color of the image pane in the standard interface has changed to match the image pane color in the enhanced interface.
* Slight color changes to the control panels of Format Preview.

To review it's best to largely ignore the generated .css and focus on reviewing the other code changes.

This can be played with in the [standardize-proofing-theme](https://www.pgdp.org/~cpeel/c.branch/standardize-proofing-theme/) sandbox.

This does introduce some CSS classes and less variables that use some new nomenclature. Please see, review, and provide feedback on [DP Code - Page Interface Nomenclature](https://www.pgdp.net/wiki/DP_Code_-_Page_Interface_Nomenclature).