### PR TITLE
Fix PHP warnings for merged projects

### DIFF
--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -146,8 +146,6 @@ else
                 $state = $project->state;
                 $nameofwork = $project->nameofwork;
                 $orig_nameofwork = $row->nameofwork;
-                $n_available_pages = '';
-                $percent_done = '';
                 $days_checkedout = (time() - $project->modifieddate) / (60 * 60 * 24);
             }
             else
@@ -202,7 +200,8 @@ else
 
         if(isset($colspecs['n_available_pages']) && isset($colspecs['percent_done']))
         {
-            if(in_array($state, $avail_states))
+            // Don't show these fields for merged projects
+            if(in_array($state, $avail_states) && $orig_nameofwork == '')
             {
                 echo "<td class='right-align'>";
                 echo $n_available_pages;


### PR DESCRIPTION
Don't output pages available or percent done for merged projects. This fixes the sprintf() warning from trying to force '' into a number.

@srjfoo found this bug on TEST. We don't show warnings on PROD so this isn't visible there.

Testable in the [fix-php-warning](https://www.pgdp.org/~cpeel/c.branch/fix-php-warning/) sandbox.