### PR TITLE
Move color CSS from layout.less to theme.less

### DIFF
--- a/faq/doc-copy.php
+++ b/faq/doc-copy.php
@@ -74,7 +74,7 @@ and also some common guidelines.
 
 <li>
 <b>Example:</b>
-<table style="width: 50%; border: 1px solid black">
+<table class="default-border" style="width: 50%">
   <tbody>
     <tr>
       <td>
@@ -135,7 +135,7 @@ BENNETT, MARIE MARGUERITE                                        <br>
 <li>
 <b>Example:</b>
 (for <a href="<?php echo $projects_url; ?>/projectID3f5be9a8c1685/269.png">this image</a>)
-<table style="width: 50%; border: 1px solid black">
+<table class="default-border" style="width: 50%">
   <tbody>
     <tr>
       <td>

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -293,7 +293,6 @@ div.news {
   margin: 1em 0;
 }
 div.newsitem {
-  box-shadow: -5px -5px 5px lightgrey;
   border-radius: 5px;
   padding: 0.75em;
   margin-left: 0.5em;
@@ -335,8 +334,6 @@ div.callout {
   margin-right: 2em;
   margin-left: 2em;
   padding: 1em;
-  background-color: #EEE;
-  border: solid thin black;
 }
 div.callout p {
   margin-bottom: 0;
@@ -373,7 +370,6 @@ table.filter td select {
 table.register {
   width: auto;
   border-collapse: separate;
-  border: 1px solid black;
 }
 table.register th,
 table.register td {
@@ -403,7 +399,6 @@ table.snapshottable {
 }
 table.snapshottable td,
 table.snapshottable th {
-  border: 1px solid black;
   padding: 2px;
   margin: 0;
   text-align: center;
@@ -424,7 +419,6 @@ table.snapshottable td.nocell {
 }
 table.snapshottable th.activity-icon-header {
   border: none;
-  background-color: #ffffff;
 }
 .stage-icon {
   display: inline-block;
@@ -455,7 +449,6 @@ table.snapshottable th.activity-icon-header {
 /* ------------------------------------------------------------------------ */
 /* Progress bar */
 div.progressbar {
-  border: 1px solid black;
   font-size: 0.5em;
   float: left;
 }
@@ -478,19 +471,14 @@ table.translation th {
 /* Available Project Listings */
 table.availprojectlisting {
   width: 100%;
-  border: 1px solid black;
   border-collapse: collapse;
 }
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: 1px solid black;
 }
 table.availprojectlisting tr th img {
   border: 0;
-}
-table.availprojectlisting tr td {
-  border-bottom: 1px solid #888;
 }
 table.availprojectlisting tr td,
 table.availprojectlisting tr th {
@@ -542,17 +530,12 @@ Quote http://www.alistapart.com/copyright/:
 table.preferences {
   border-collapse: collapse;
 }
-table.preferences td,
-table.preferences th {
-  border: solid thin black;
-}
 table.preferences th.longlabel {
   text-align: center;
 }
 .tabs {
   float: left;
   width: 90%;
-  border-bottom: solid thin gray;
 }
 .tabs ul {
   margin: 0;
@@ -563,7 +546,6 @@ table.preferences th.longlabel {
   float: left;
   margin: 0;
   padding: 0 0 0 4px;
-  border: solid thin gray;
   border-radius: 5px 5px 0 0;
   margin-bottom: -2px;
 }
@@ -575,7 +557,6 @@ table.preferences th.longlabel {
   min-width: 8em;
 }
 .tabs .current-tab {
-  border: solid thin gray;
   border-bottom: none;
 }
 .tabs .current-tab a {
@@ -585,7 +566,6 @@ table.preferences th.longlabel {
 /* Themed tables */
 table.themed {
   width: 100%;
-  border: 1px solid black;
   border-collapse: collapse;
 }
 table.themed tr th,
@@ -598,25 +578,15 @@ table.theme_striped tr td {
 }
 table.basic {
   border-collapse: collapse;
-  border: 1px solid black;
-}
-table.basic th {
-  background-color: #CCC;
 }
 table.basic th.label {
   text-align: left;
 }
-table.basic td,
-table.basic th {
-  border: 1px solid black;
-}
 table.basic td.satisfied {
   text-align: right;
-  background-color: #ccffcc;
 }
 table.basic td.not_satisfied {
   text-align: right;
-  background-color: #ffcccc;
 }
 table.basic textarea {
   width: 100%;
@@ -640,8 +610,6 @@ p.hanging_indent_long {
   margin-left: 3em;
 }
 p.form_problem {
-  color: red;
-  font-weight: bold;
   margin-bottom: 0;
 }
 p.form_problem:before {
@@ -649,11 +617,7 @@ p.form_problem:before {
   /* down-arrow */
 }
 table.ppv_reportcard {
-  border: solid thin black;
   width: 95%;
-}
-table.ppv_reportcard td {
-  border: solid thin black;
 }
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
@@ -663,44 +627,31 @@ table.image_source {
   margin: auto;
 }
 table.image_source th {
-  background-color: #eee;
-  border: 1px solid #999;
   text-align: center;
   padding: 5px;
 }
 table.image_source td {
-  border: 1px solid #999;
   padding: 5px;
 }
 table.image_source td a.sourcelink {
   font-size: 90%;
   margin: 10px 0px 3px 25px;
 }
-table.image_source tr.e {
-  background-color: #eee;
-}
-table.image_source tr.o {
-  background-color: #ddd;
-}
 table.image_source th.label {
   text-align: left;
 }
 table.image_source td.enabled {
-  background-color: #9f9;
   text-align: center;
 }
 table.image_source td.disabled {
-  background-color: #ddd;
   text-align: center;
 }
 table.image_source td.pending {
-  background-color: #ff8;
   text-align: center;
 }
 div.perms_wrapper {
   width: 40%;
   display: inline-block;
-  border-bottom: dotted black 1px;
   padding: 2px;
 }
 /* ------------------------------------------------------------------------ */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -260,10 +260,7 @@ hr.divider {
 div.news {
     margin: 1em 0;
 }
-div.newsheader {
-}
 div.newsitem {
-    box-shadow: -5px -5px 5px lightgrey;
     border-radius: 5px;
     padding: 0.75em;
     margin-left: 0.5em;
@@ -309,8 +306,6 @@ div.callout {
     margin-right: 2em;
     margin-left: 2em;
     padding: 1em;
-    background-color: #EEE;
-    border: solid thin black;
     p {
         margin-bottom: 0;
     }
@@ -353,7 +348,6 @@ table.filter {
 table.register {
     width: auto;
     border-collapse: separate;
-    border: 1px solid black;
     th, td {
         padding: 3px;
     }
@@ -382,7 +376,6 @@ table.snapshottable {
     padding: 0;
     border-collapse: collapse;
     td, th {
-        border: 1px solid black;
         padding: 2px;
         margin: 0;
         .center-align;
@@ -403,7 +396,6 @@ table.snapshottable {
     }
     th.activity-icon-header {
         border: none;
-        background-color: #ffffff;
     }
 }
 
@@ -439,7 +431,6 @@ table.snapshottable {
 /* Progress bar */
 
 div.progressbar {
-    border: 1px solid black;
     font-size: 0.5em;
     float: left;
 }
@@ -468,19 +459,14 @@ table.translation {
 
 table.availprojectlisting {
     width: 100%;
-    border: 1px solid black;
     border-collapse: collapse;
     tr {
         th {
             .bold;
             .left-align;
-            border-bottom: 1px solid black;
             img {
                 border: 0;
             }
-        }
-        td {
-            border-bottom: 1px solid #888;
         }
         td, th {
             padding-left: 0.5em;
@@ -540,9 +526,6 @@ Quote http://www.alistapart.com/copyright/:
 
 table.preferences {
     border-collapse: collapse;
-    td, th {
-        border: solid thin black;
-    }
     th.longlabel {
         .center-align;
     }
@@ -551,7 +534,6 @@ table.preferences {
 .tabs {
     float: left;
     width: 90%;
-    border-bottom: solid thin gray;
     ul {
         margin: 0;
         padding: 0 20px 0 10px;
@@ -561,7 +543,6 @@ table.preferences {
         float: left;
         margin: 0;
         padding: 0 0 0 4px;
-        border: solid thin gray;
         border-radius: 5px 5px 0 0;
         margin-bottom: -2px;
     }
@@ -573,7 +554,6 @@ table.preferences {
         min-width: 8em;
     }
     .current-tab {
-        border: solid thin gray;
         border-bottom: none;
         a {
             .bold;
@@ -586,7 +566,6 @@ table.preferences {
 
 table.themed {
     width: 100%;
-    border: 1px solid black;
     border-collapse: collapse;
     tr {
         th, td {
@@ -605,23 +584,14 @@ table.theme_striped {
 
 table.basic {
     border-collapse: collapse;
-    border: 1px solid black;
-    th {
-        background-color: #CCC;
-    }
     th.label {
         .left-align;
     }
-    td, th {
-        border: 1px solid black;
-    }
     td.satisfied {
         .right-align;
-        background-color: #ccffcc;
     }
     td.not_satisfied {
         .right-align;
-        background-color: #ffcccc;
     }
     textarea {
         width: 100%;
@@ -650,19 +620,13 @@ p.hanging_indent_long {
     margin-left: 3em;
 }
 p.form_problem {
-    color: red;
-    font-weight: bold;
     margin-bottom: 0;
 }
 p.form_problem:before {
     content: '\\002193 '; /* down-arrow */
 }
 table.ppv_reportcard {
-    border: solid thin black;
     width: 95%;
-    td {
-        border: solid thin black;
-    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -673,38 +637,26 @@ table.image_source {
     width: 90%;
     margin: auto;
     th {
-        background-color: #eee;
-        border: 1px solid #999;
         .center-align;
         padding: 5px;
     }
     td {
-        border: 1px solid #999;
         padding: 5px;
         a.sourcelink {
             font-size: 90%;
             margin: 10px 0px 3px 25px;
         }
     }
-    tr.e {
-        background-color: #eee;
-    }
-    tr.o {
-        background-color: #ddd;
-    }
     th.label {
         .left-align;
     }
     td.enabled {
-        background-color: #9f9;
         .center-align;
         }
     td.disabled {
-        background-color: #ddd;
         .center-align;
     }
     td.pending {
-        background-color: #ff8;
         .center-align;
     }
 }
@@ -712,7 +664,6 @@ table.image_source {
 div.perms_wrapper {
     width: 40%;
     display: inline-block;
-    border-bottom: dotted black 1px;
     padding: 2px;
 }
 
@@ -724,16 +675,6 @@ table.pagedetail {
     th, td {
         .center-align;
         font-weight: normal;
-        border: 1px solid black;
-    }
-    td.in_progress {
-        background-color: #FC6;
-    }
-    td.done_current {
-        background-color: #9F6;
-    }
-    td.done_previous {
-        background-color: #F36;
     }
 }
 
@@ -833,7 +774,7 @@ table.dirlist {
 
 #toolbox {
     padding: 2px;
-/* default buttons have small text = 83% */
+    /* default buttons have small text = 83% */
     .selector_button {
         margin-top: 1px;
         font-size: 1em;
@@ -922,7 +863,6 @@ table.dirlist {
 table.list_special_days {
     width: 90%; margin: auto;
     td,th {
-        border: 1px solid #999;
         padding: 3px;
         }
     td.codecell {
@@ -932,26 +872,14 @@ table.list_special_days {
     th.headers {
         padding:0.5em;
     }
-    tr.e {
-        background-color: #eee;
-    }
-    tr.o {
-        background-color: #ddd;
-    }
     td.enabled {
-        background-color: #9f9;
         text-align: center;
     }
     td.disabled {
-        background-color: #ddd;
         text-align: center;
     }
     td.center {
         text-align: center;
-    }
-    tr.month > * {
-        border: none;
-        border-bottom: solid 2px black;
     }
     td.right, th.right {
         text-align: right; font-weight: normal;
@@ -961,19 +889,11 @@ table.list_special_days {
     }
 }
 
-table.show_special_days {
-    th {
-        background-color: #eeeeee;
-    }
-}
-
 table.edit_special_day {
     width: 90%;
     margin: auto;
     th, td {
-        border: 1px solid black;
         padding: 5px;
-        background-color: #eeeeee;
     }
 }
 
@@ -1021,11 +941,8 @@ table.search-column {
     position: absolute;
     top: 1.5em;
     right: 0;
-    background-color: #f9f9f9;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.5);
     padding: 0.3em;
     margin: 0 0 0 -15em;
-    border-radius: 0.3em;
     z-index: 1;
 }
 
@@ -1055,7 +972,6 @@ table.search-column {
     float:right;
     margin-left: 0.5em;
     margin-bottom: 0.5em;
-    border: 1px solid black;
     h2 {
         .center-align;
         font-size: 1em;
@@ -1140,7 +1056,6 @@ li.spaced {
 .replace_check {
     height: 20em;
     width: 50em;
-    border: 1px solid black;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1,5 +1,42 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Classic Grey */
+/* ------------------------------------------------------------------------ */
+/* mixins with color */
+/* standalone classes that can be used as mixins, but that should not
+ * be given parameters, as they can't be used as classes in the code
+ * directly if they have parameters that the lessc compiler has to 
+ * sort out
+ */
+.default-border {
+  border: thin solid black;
+}
+.default-border-bottom {
+  border-bottom: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
+/* Attention-getting structures */
+.error,
+.test_warning {
+  color: red;
+}
+.warning {
+  color: blue;
+}
+.highlight {
+  background-color: yellow;
+  color: black;
+}
+.button {
+  font-family: Verdana, Helvetica, sans-serif;
+}
+kbd {
+  color: #cc0000;
+}
+div.callout {
+  background-color: #EEE;
+  border: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
 body {
   background-color: #ffffff;
   color: #000000;
@@ -106,7 +143,7 @@ nav input,
   background-color: #ffffff;
   background: repeating-linear-gradient(to right, yellow, #ffffff 24%, #ffffff 75%, yellow 100%);
   color: black;
-  border-bottom: solid thin black;
+  border-bottom: thin solid black;
 }
 #testbar a:link,
 #testbar-outer a:link,
@@ -169,23 +206,10 @@ h6 {
 .sidebar-color {
   background-color: #dddddd;
 }
-/* Attention-getting structures */
-.error,
-.test_warning {
-  color: red;
-}
-.warning {
-  color: blue;
-}
-.highlight {
-  background-color: yellow;
-  color: black;
-}
-.button {
-  font-family: Verdana, Helvetica, sans-serif;
-}
-kbd {
-  color: #cc0000;
+/* ------------------------------------------------------------------------ */
+/* News items */
+div.newsitem {
+  box-shadow: -5px -5px 5px lightgrey;
 }
 /* ------------------------------------------------------------------------ */
 /* FAQ */
@@ -196,25 +220,37 @@ div.faqheader {
 }
 /* ------------------------------------------------------------------------ */
 /* User Preferences */
+table.preferences td,
+table.preferences th {
+  border: thin solid black;
+}
 table.preferences th.label,
 table.preferences th.longlabel {
   background-color: #dddddd;
   color: #000000;
 }
+.tabs {
+  border-bottom: thin solid gray;
+}
 .tabs li {
   background-color: #dddddd;
+  border: thin solid gray;
 }
 .tabs li a {
   color: #000000;
 }
 .tabs .current-tab {
   background-color: #ffffff;
+  border: thin solid gray;
 }
 .tabs .current-tab a {
   color: #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Themed tables */
+table.themed {
+  border: thin solid black;
+}
 table.themed tr {
   background-color: #dddddd;
   color: #000000;
@@ -236,8 +272,33 @@ table.theme_striped tr:nth-child(odd) {
 table.striped tr:nth-child(even) td {
   background-color: #ddd;
 }
+table.basic {
+  border: thin solid black;
+}
+table.basic th {
+  background-color: #CCC;
+}
+table.basic td,
+table.basic th {
+  border: thin solid black;
+}
+table.basic td.satisfied {
+  background-color: #ccffcc;
+}
+table.basic td.not_satisfied {
+  background-color: #ffcccc;
+}
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
+table.availprojectlisting {
+  border: thin solid black;
+}
+table.availprojectlisting tr th {
+  border-bottom: thin solid black;
+}
+table.availprojectlisting tr td {
+  border-bottom: thin solid #888;
+}
 table.availprojectlisting tr:nth-child(even) {
   background-color: #ddd;
 }
@@ -297,10 +358,17 @@ table.stage_SR tr:nth-child(odd) {
 }
 /* ------------------------------------------------------------------------ */
 /* PPV Report */
+p.form_problem {
+  color: red;
+  font-weight: bold;
+}
+table.ppv_reportcard {
+  border: thin solid black;
+}
 table.ppv_reportcard th {
   text-align: center;
   font-weight: bold;
-  border: solid thin black;
+  border: thin solid black;
 }
 table.ppv_reportcard th.major_section {
   background-color: #dddddd;
@@ -311,13 +379,44 @@ table.ppv_reportcard th.minor_section {
 table.ppv_reportcard th.heading {
   background-color: #e0e8dd;
 }
+table.ppv_reportcard td {
+  border: thin solid black;
+}
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
 table.image_source_listing td.title {
   background-color: #dddddd;
 }
+table.image_source th {
+  background-color: #eee;
+  border: thin solid #999;
+}
+table.image_source td {
+  border: thin solid #999;
+}
+table.image_source tr.e {
+  background-color: #eee;
+}
+table.image_source tr.o {
+  background-color: #ddd;
+}
+table.image_source td.enabled {
+  background-color: #9f9;
+}
+table.image_source td.disabled {
+  background-color: #ddd;
+}
+table.image_source td.pending {
+  background-color: #ff8;
+}
+div.perms_wrapper {
+  border-bottom: dotted black 1px;
+}
 /* ------------------------------------------------------------------------ */
 /* Registration table */
+table.register {
+  border: thin solid black;
+}
 table.register td.bar {
   background-color: #444444;
 }
@@ -326,8 +425,20 @@ table.register th {
 }
 /* ------------------------------------------------------------------------ */
 /* Site Progress Snapshot table on Activity Hub */
+table.snapshottable td,
+table.snapshottable th {
+  border: thin solid black;
+}
 table.snapshottable th {
   background-color: #dddddd;
+}
+table.snapshottable th.activity-icon-header {
+  background-color: #ffffff;
+}
+/* ------------------------------------------------------------------------ */
+/* Progress bar */
+div.progressbar {
+  border: thin solid black;
 }
 /* ------------------------------------------------------------------------ */
 /* WordCheck pages */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1,5 +1,42 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Project Gutenberg */
+/* ------------------------------------------------------------------------ */
+/* mixins with color */
+/* standalone classes that can be used as mixins, but that should not
+ * be given parameters, as they can't be used as classes in the code
+ * directly if they have parameters that the lessc compiler has to 
+ * sort out
+ */
+.default-border {
+  border: thin solid black;
+}
+.default-border-bottom {
+  border-bottom: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
+/* Attention-getting structures */
+.error,
+.test_warning {
+  color: red;
+}
+.warning {
+  color: blue;
+}
+.highlight {
+  background-color: yellow;
+  color: black;
+}
+.button {
+  font-family: Verdana, Helvetica, sans-serif;
+}
+kbd {
+  color: #cc0000;
+}
+div.callout {
+  background-color: #EEE;
+  border: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
 body {
   background-color: #ffffff;
   color: #000000;
@@ -106,7 +143,7 @@ nav input,
   background-color: #ffffff;
   background: repeating-linear-gradient(to right, yellow, #ffffff 24%, #ffffff 75%, yellow 100%);
   color: black;
-  border-bottom: solid thin black;
+  border-bottom: thin solid black;
 }
 #testbar a:link,
 #testbar-outer a:link,
@@ -169,23 +206,10 @@ h6 {
 .sidebar-color {
   background-color: #e0e8dd;
 }
-/* Attention-getting structures */
-.error,
-.test_warning {
-  color: red;
-}
-.warning {
-  color: blue;
-}
-.highlight {
-  background-color: yellow;
-  color: black;
-}
-.button {
-  font-family: Verdana, Helvetica, sans-serif;
-}
-kbd {
-  color: #cc0000;
+/* ------------------------------------------------------------------------ */
+/* News items */
+div.newsitem {
+  box-shadow: -5px -5px 5px lightgrey;
 }
 /* ------------------------------------------------------------------------ */
 /* FAQ */
@@ -196,25 +220,37 @@ div.faqheader {
 }
 /* ------------------------------------------------------------------------ */
 /* User Preferences */
+table.preferences td,
+table.preferences th {
+  border: thin solid black;
+}
 table.preferences th.label,
 table.preferences th.longlabel {
   background-color: #e0e8dd;
   color: #000000;
 }
+.tabs {
+  border-bottom: thin solid gray;
+}
 .tabs li {
   background-color: #e3e3e3;
+  border: thin solid gray;
 }
 .tabs li a {
   color: #000000;
 }
 .tabs .current-tab {
   background-color: #ffffff;
+  border: thin solid gray;
 }
 .tabs .current-tab a {
   color: #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Themed tables */
+table.themed {
+  border: thin solid black;
+}
 table.themed tr {
   background-color: #e0e8dd;
   color: #000000;
@@ -236,8 +272,33 @@ table.theme_striped tr:nth-child(odd) {
 table.striped tr:nth-child(even) td {
   background-color: #ddd;
 }
+table.basic {
+  border: thin solid black;
+}
+table.basic th {
+  background-color: #CCC;
+}
+table.basic td,
+table.basic th {
+  border: thin solid black;
+}
+table.basic td.satisfied {
+  background-color: #ccffcc;
+}
+table.basic td.not_satisfied {
+  background-color: #ffcccc;
+}
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
+table.availprojectlisting {
+  border: thin solid black;
+}
+table.availprojectlisting tr th {
+  border-bottom: thin solid black;
+}
+table.availprojectlisting tr td {
+  border-bottom: thin solid #888;
+}
 table.availprojectlisting tr:nth-child(even) {
   background-color: #ddd;
 }
@@ -297,10 +358,17 @@ table.stage_SR tr:nth-child(odd) {
 }
 /* ------------------------------------------------------------------------ */
 /* PPV Report */
+p.form_problem {
+  color: red;
+  font-weight: bold;
+}
+table.ppv_reportcard {
+  border: thin solid black;
+}
 table.ppv_reportcard th {
   text-align: center;
   font-weight: bold;
-  border: solid thin black;
+  border: thin solid black;
 }
 table.ppv_reportcard th.major_section {
   background-color: #e0e8dd;
@@ -311,13 +379,44 @@ table.ppv_reportcard th.minor_section {
 table.ppv_reportcard th.heading {
   background-color: #e0e8dd;
 }
+table.ppv_reportcard td {
+  border: thin solid black;
+}
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
 table.image_source_listing td.title {
   background-color: #e0e8dd;
 }
+table.image_source th {
+  background-color: #eee;
+  border: thin solid #999;
+}
+table.image_source td {
+  border: thin solid #999;
+}
+table.image_source tr.e {
+  background-color: #eee;
+}
+table.image_source tr.o {
+  background-color: #ddd;
+}
+table.image_source td.enabled {
+  background-color: #9f9;
+}
+table.image_source td.disabled {
+  background-color: #ddd;
+}
+table.image_source td.pending {
+  background-color: #ff8;
+}
+div.perms_wrapper {
+  border-bottom: dotted black 1px;
+}
 /* ------------------------------------------------------------------------ */
 /* Registration table */
+table.register {
+  border: thin solid black;
+}
 table.register td.bar {
   background-color: #336633;
 }
@@ -326,8 +425,20 @@ table.register th {
 }
 /* ------------------------------------------------------------------------ */
 /* Site Progress Snapshot table on Activity Hub */
+table.snapshottable td,
+table.snapshottable th {
+  border: thin solid black;
+}
 table.snapshottable th {
   background-color: #e0e8dd;
+}
+table.snapshottable th.activity-icon-header {
+  background-color: #ffffff;
+}
+/* ------------------------------------------------------------------------ */
+/* Progress bar */
+div.progressbar {
+  border: thin solid black;
 }
 /* ------------------------------------------------------------------------ */
 /* WordCheck pages */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1,5 +1,42 @@
 /* ------------------------------------------------------------------------ */
 /* Theme coloring for Royal Blues */
+/* ------------------------------------------------------------------------ */
+/* mixins with color */
+/* standalone classes that can be used as mixins, but that should not
+ * be given parameters, as they can't be used as classes in the code
+ * directly if they have parameters that the lessc compiler has to 
+ * sort out
+ */
+.default-border {
+  border: thin solid black;
+}
+.default-border-bottom {
+  border-bottom: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
+/* Attention-getting structures */
+.error,
+.test_warning {
+  color: red;
+}
+.warning {
+  color: blue;
+}
+.highlight {
+  background-color: yellow;
+  color: black;
+}
+.button {
+  font-family: Verdana, Arial, sans-serif;
+}
+kbd {
+  color: #cc0000;
+}
+div.callout {
+  background-color: #EEE;
+  border: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
 body {
   background-color: #ffffff;
   color: #000000;
@@ -106,7 +143,7 @@ nav input,
   background-color: #ffffff;
   background: repeating-linear-gradient(to right, yellow, #ffffff 24%, #ffffff 75%, yellow 100%);
   color: black;
-  border-bottom: solid thin black;
+  border-bottom: thin solid black;
 }
 #testbar a:link,
 #testbar-outer a:link,
@@ -169,23 +206,10 @@ h6 {
 .sidebar-color {
   background-color: #99ccff;
 }
-/* Attention-getting structures */
-.error,
-.test_warning {
-  color: red;
-}
-.warning {
-  color: blue;
-}
-.highlight {
-  background-color: yellow;
-  color: black;
-}
-.button {
-  font-family: Verdana, Arial, sans-serif;
-}
-kbd {
-  color: #cc0000;
+/* ------------------------------------------------------------------------ */
+/* News items */
+div.newsitem {
+  box-shadow: -5px -5px 5px lightgrey;
 }
 /* ------------------------------------------------------------------------ */
 /* FAQ */
@@ -196,25 +220,37 @@ div.faqheader {
 }
 /* ------------------------------------------------------------------------ */
 /* User Preferences */
+table.preferences td,
+table.preferences th {
+  border: thin solid black;
+}
 table.preferences th.label,
 table.preferences th.longlabel {
   background-color: #99ccff;
   color: #000000;
 }
+.tabs {
+  border-bottom: thin solid gray;
+}
 .tabs li {
   background-color: #b3cce6;
+  border: thin solid gray;
 }
 .tabs li a {
   color: #000000;
 }
 .tabs .current-tab {
   background-color: #ffffff;
+  border: thin solid gray;
 }
 .tabs .current-tab a {
   color: #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Themed tables */
+table.themed {
+  border: thin solid black;
+}
 table.themed tr {
   background-color: #99ccff;
   color: #000000;
@@ -236,8 +272,33 @@ table.theme_striped tr:nth-child(odd) {
 table.striped tr:nth-child(even) td {
   background-color: #ddd;
 }
+table.basic {
+  border: thin solid black;
+}
+table.basic th {
+  background-color: #CCC;
+}
+table.basic td,
+table.basic th {
+  border: thin solid black;
+}
+table.basic td.satisfied {
+  background-color: #ccffcc;
+}
+table.basic td.not_satisfied {
+  background-color: #ffcccc;
+}
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
+table.availprojectlisting {
+  border: thin solid black;
+}
+table.availprojectlisting tr th {
+  border-bottom: thin solid black;
+}
+table.availprojectlisting tr td {
+  border-bottom: thin solid #888;
+}
 table.availprojectlisting tr:nth-child(even) {
   background-color: #ddd;
 }
@@ -297,10 +358,17 @@ table.stage_SR tr:nth-child(odd) {
 }
 /* ------------------------------------------------------------------------ */
 /* PPV Report */
+p.form_problem {
+  color: red;
+  font-weight: bold;
+}
+table.ppv_reportcard {
+  border: thin solid black;
+}
 table.ppv_reportcard th {
   text-align: center;
   font-weight: bold;
-  border: solid thin black;
+  border: thin solid black;
 }
 table.ppv_reportcard th.major_section {
   background-color: #99ccff;
@@ -311,13 +379,44 @@ table.ppv_reportcard th.minor_section {
 table.ppv_reportcard th.heading {
   background-color: #e0e8dd;
 }
+table.ppv_reportcard td {
+  border: thin solid black;
+}
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
 table.image_source_listing td.title {
   background-color: #99ccff;
 }
+table.image_source th {
+  background-color: #eee;
+  border: thin solid #999;
+}
+table.image_source td {
+  border: thin solid #999;
+}
+table.image_source tr.e {
+  background-color: #eee;
+}
+table.image_source tr.o {
+  background-color: #ddd;
+}
+table.image_source td.enabled {
+  background-color: #9f9;
+}
+table.image_source td.disabled {
+  background-color: #ddd;
+}
+table.image_source td.pending {
+  background-color: #ff8;
+}
+div.perms_wrapper {
+  border-bottom: dotted black 1px;
+}
 /* ------------------------------------------------------------------------ */
 /* Registration table */
+table.register {
+  border: thin solid black;
+}
 table.register td.bar {
   background-color: #000099;
 }
@@ -326,8 +425,20 @@ table.register th {
 }
 /* ------------------------------------------------------------------------ */
 /* Site Progress Snapshot table on Activity Hub */
+table.snapshottable td,
+table.snapshottable th {
+  border: thin solid black;
+}
 table.snapshottable th {
   background-color: #99ccff;
+}
+table.snapshottable th.activity-icon-header {
+  background-color: #ffffff;
+}
+/* ------------------------------------------------------------------------ */
+/* Progress bar */
+div.progressbar {
+  border: thin solid black;
 }
 /* ------------------------------------------------------------------------ */
 /* WordCheck pages */

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -1,5 +1,61 @@
 @import (reference) "../global.less";
 
+/* ------------------------------------------------------------------------ */
+/* mixins with color */
+
+.solid-border(@color: black) {
+    border: thin solid @color;
+}
+
+.solid-border-bottom(@color: black) {
+    border-bottom: thin solid @color;
+}
+
+/* standalone classes that can be used as mixins, but that should not
+ * be given parameters, as they can't be used as classes in the code
+ * directly if they have parameters that the lessc compiler has to 
+ * sort out
+ */
+
+.default-border {
+    .solid-border;
+}
+
+.default-border-bottom {
+    .solid-border-bottom;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Attention-getting structures */
+.error, .test_warning {
+    color: red;
+}
+
+.warning {
+    color: blue;
+}
+
+.highlight {
+    background-color: yellow;
+    color: black;
+}
+
+.button {
+    .sans-serif;
+}
+
+kbd {
+    color: #cc0000;
+}
+
+
+div.callout {
+    background-color: #EEE;
+    .solid-border;
+}
+
+/* ------------------------------------------------------------------------ */
+
 body {
     background-color: @page-background;
     color: @page-text;
@@ -58,7 +114,7 @@ nav, #navbar-outer, #navbar, #navbar-left, #navbar-right, #navbar-login {
         yellow 100%,
     );
     color: black;
-    border-bottom: solid thin black;
+    .solid-border-bottom;
     .unicolor-link(lighten(black, 30%));
 }
 
@@ -101,26 +157,11 @@ h1, h2, h3, h4, h5, h6 {
     background-color: @sidebar-background;
 }
 
-/* Attention-getting structures */
-.error, .test_warning {
-    color: red;
-}
 
-.warning {
-    color: blue;
-}
-
-.highlight {
-    background-color: yellow;
-    color: black;
-}
-
-.button {
-    .sans-serif;
-}
-
-kbd {
-    color: #cc0000;
+/* ------------------------------------------------------------------------ */
+/* News items */
+div.newsitem {
+    box-shadow: -5px -5px 5px lightgrey; //srj: moved from layout
 }
 
 /* ------------------------------------------------------------------------ */
@@ -136,6 +177,9 @@ div.faqheader {
 /* User Preferences */
 
 table.preferences {
+    td, th {
+        .solid-border;
+    }
     th.label, th.longlabel {
         background-color: @header-background;
         color: @header-text;
@@ -143,14 +187,17 @@ table.preferences {
 }
 
 .tabs {
+    .solid-border-bottom(grey);
     li {
         background-color: desaturate(@header-background, 50%);
+        .solid-border(grey);
         a {
             color: desaturate(@header-text, 50%);
         }
     }
     .current-tab {
         background-color: @page-background;
+        .solid-border(grey);
         a {
             color: @page-text;
         }
@@ -161,6 +208,7 @@ table.preferences {
 /* Themed tables */
 
 table.themed {
+    .solid-border;
     tr {
         th {
             background-color: @navbar-background;
@@ -191,10 +239,35 @@ table.striped {
     }
 }
 
+table.basic {
+    .solid-border;
+    th {
+        background-color: #CCC;
+    }
+    td, th {
+        .solid-border;
+    }
+    td.satisfied {
+        background-color: #ccffcc;
+    }
+    td.not_satisfied {
+        background-color: #ffcccc;
+    }
+}
+
 /* ------------------------------------------------------------------------ */
 /* Available Project Listings */
 
 table.availprojectlisting {
+    .solid-border;
+    tr {
+        th {
+            .solid-border-bottom;
+        }
+        td {
+            .solid-border-bottom(#888);
+        }
+    }
     tr:nth-child(even) {
         background-color: #ddd;
     }
@@ -243,11 +316,16 @@ each(@stages, {
 /* ------------------------------------------------------------------------ */
 /* PPV Report */
 
+p.form_problem {
+    color: red;
+    font-weight: bold;
+}
 table.ppv_reportcard {
+    .solid-border;
     th {
         .center-align;
         .bold;
-        border: solid thin black;
+        .solid-border;
     }
     th.major_section {
         background-color: @header-background;
@@ -258,14 +336,59 @@ table.ppv_reportcard {
     th.heading {
         background-color: #e0e8dd;
     }
+    td {
+        .solid-border;
+    }
+
 }
 
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
 
-table.image_source_listing {
-    td.title {
-        background-color: @header-background;
+table.image_source {
+    th {
+        background-color: #eee;
+        .solid-border(#999);
+    }
+    td {
+        .solid-border(#999);
+    }
+    tr.e {
+        background-color: #eee;
+    }
+    tr.o {
+        background-color: #ddd;
+    }
+    td.enabled {
+        background-color: #9f9;
+        }
+    td.disabled {
+        background-color: #ddd;
+    }
+    td.pending {
+        background-color: #ff8;
+    }
+}
+
+div.perms_wrapper {
+    border-bottom: dotted black 1px;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Page Detail */
+
+table.pagedetail {
+    th, td {
+        .solid-border;
+    }
+    td.in_progress {
+        background-color: #FC6;
+    }
+    td.done_current {
+        background-color: #9F6;
+    }
+    td.done_previous {
+        background-color: #F36;
     }
 }
 
@@ -273,6 +396,7 @@ table.image_source_listing {
 /* Registration table */
 
 table.register {
+    .solid-border;
     td.bar {
         background-color: @navbar-background;
     }
@@ -285,9 +409,76 @@ table.register {
 /* Site Progress Snapshot table on Activity Hub */
 
 table.snapshottable {
+    td, th {
+        .solid-border;
+    }
     th {
         background-color: @header-background;
     }
+    th.activity-icon-header {
+        background-color: @page-background;  // moved from layout
+    }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Progress bar */
+
+div.progressbar {
+    .solid-border;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Special days tables */
+
+table.list_special_days {
+    td,th {
+        .solid-border(#999);
+        }
+    tr.e {
+        background-color: #eee;
+    }
+    tr.o {
+        background-color: #ddd;
+    }
+    td.enabled {
+        background-color: #9f9;
+    }
+    td.disabled {
+        background-color: #ddd;
+    }
+    tr.month > * {
+        border: none;
+        border-bottom: solid 2px black;
+    }
+}
+
+table.show_special_days {
+    th {
+        background-color: #eeeeee;
+    }
+}
+
+table.edit_special_day {
+    th, td {
+        .solid-border;
+        background-color: #eeeeee;
+    }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Search Results drop-down */
+
+.dropdown-content {
+    background-color: #f9f9f9;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.5);
+    border-radius: 0.3em;
+}
+
+/* ------------------------------------------------------------------------ */
+/* PM link box */
+
+#pm_links {
+    .solid-border;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -302,6 +493,13 @@ table.snapshottable {
 }
 .WC {
     background-color: #97fc9e;
+}
+
+/* ------------------------------------------------------------------------ */
+/* replace text validator */
+
+.replace_check {
+    .solid-border;
 }
 
 /* ======================================================================== */
@@ -341,7 +539,7 @@ table.snapshottable {
 
         input, select, button {
             background-color: @text-pane-background;
-            border: solid thin black;
+            .solid-border;
         }
 
         button, input[type=submit], input[type=button] {
@@ -391,7 +589,7 @@ table.snapshottable {
 }
 
 .ilb {
-    border: 1px solid #404040;
+   .solid-border(#404040);
     border-radius: 2px;
     .page-interface .control-pane;
 }
@@ -402,7 +600,7 @@ table.snapshottable {
 #page-browser {
     .page-interface;
     .control-pane {
-        border-bottom: 1px solid #999;
+        .solid-border-bottom(#999);
         .img-button {
             border: 0;
             box-shadow: none;
@@ -424,18 +622,18 @@ table.snapshottable {
     .page-interface;
 
     #tbtext {
-        border: 1px solid black;
+        .solid-border;
     }
     #tdtop {
-        border: 1px solid black;
+        .solid-border;
         .page-interface .control-pane;
     }
     #tdtext {
-        border: 1px solid black;
+        .solid-border;
         .page-interface;
     }
     #tdbottom {
-        border: 1px solid black;
+        .solid-border;
         background-color: #EEDFCC;
     }
     #text_data, #text_data:focus {
@@ -453,14 +651,14 @@ table.snapshottable {
     .page-interface;
 
     #tbtext {
-        border: 1px solid black;
+        .solid-border;
     }
     #tdtop {
-        border: 1px solid black;
+        .solid-border;
         .page-interface .control-pane;
     }
     #tdtext {
-        border: 1px solid black;
+        .solid-border;
         .page-interface .text-pane;
     }
 }

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -161,7 +161,7 @@ h1, h2, h3, h4, h5, h6 {
 /* ------------------------------------------------------------------------ */
 /* News items */
 div.newsitem {
-    box-shadow: -5px -5px 5px lightgrey; //srj: moved from layout
+    box-shadow: -5px -5px 5px lightgrey;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -416,7 +416,7 @@ table.snapshottable {
         background-color: @header-background;
     }
     th.activity-icon-header {
-        background-color: @page-background;  // moved from layout
+        background-color: @page-background;
     }
 }
 

--- a/tools/authors/harvest.php
+++ b/tools/authors/harvest.php
@@ -194,7 +194,7 @@ else {
             ", DPDatabase::escape($last_name),
                 DPDatabase::escape($other_names));
             if ($simulating) {
-                echo "<span style='color: red'>    " . _("The following query would have been run:") . "\n      " .
+                echo "<span class='error'>    " . _("The following query would have been run:") . "\n      " .
                      str_replace("\n", "\n      ", html_safe($query)) . "</span>\n";
                 $author_id='#new author id#';
             }
@@ -209,7 +209,7 @@ else {
                 VALUES(%d, '%s')
             ", $author_id, DPDatabase::escape($bio));
             if ($simulating)
-                echo "<span style='color: blue'>    " . _("The following query would have been run:") . "\n      " .
+                echo "<span class='warning'>    " . _("The following query would have been run:") . "\n      " .
                      str_replace("\n", "\n      ", html_safe($query)) . "</span>\n";
             else {
                 $store_result = DPDatabase::query($query);

--- a/tools/post_proofers/smooth_reading.php
+++ b/tools/post_proofers/smooth_reading.php
@@ -40,15 +40,15 @@ echo "<h2>" . _("Smooth Reading") . "</h2>";
 if (!$logged_in)
 {
 
-    echo  "<p style='font-size: 120%;'>" . _("This Preview page shows which books are currently available for Smooth Reading. Click on a book's title to view more information about it or to download the text.") . "</p>";
+    echo  "<p>" . _("This Preview page shows which books are currently available for Smooth Reading. Click on a book's title to view more information about it or to download the text.") . "</p>";
 
     echo "<p>" . _("Please note that while unregistered guests are welcome to download texts for Smooth Reading, only registered volunteers are able to upload annotated texts. A registration link is available at the top of this page.") . "</p>";
 
 }
 
-echo "<p style='font-size: 120%;'>" . _("The goal of Smooth Reading is to read the text attentively, as for pleasure, with just a little more attention than usual to punctuation, etc. This is NOT full scale proofreading, and comparison with the scans is not needed. Just read it as your normal, sensitized-to-proofreading-errors self, and report any problem that disrupts the sense or the flow of the book. Note that some of these will be due to the author and/or publisher.") . "</p>";
+echo "<p>" . _("The goal of Smooth Reading is to read the text attentively, as for pleasure, with just a little more attention than usual to punctuation, etc. This is NOT full scale proofreading, and comparison with the scans is not needed. Just read it as your normal, sensitized-to-proofreading-errors self, and report any problem that disrupts the sense or the flow of the book. Note that some of these will be due to the author and/or publisher.") . "</p>";
 
-echo "<p>" . _("Errors are reported by adding a comment of the form <blockquote style='color: red; background-color: inherit;'> [**correction or query] <br> </blockquote> immediately after the problem spot. Do not correct or change the problem, just note it in the above format.") . "</p>";
+echo "<p>" . _("Errors are reported by adding a comment of the form <blockquote><kbd>[**correction or query]</kbd></blockquote> immediately after the problem spot. Do not correct or change the problem, just note it in the above format.") . "</p>";
 
 echo "<h2>" . _("Examples") . "</h2>";
 echo "<ul>";

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -336,7 +336,7 @@ class SpecialDay
         if ($errmsgs)
         {
             output_header('', NO_STATSBAR);
-            echo "<p style='font-weight: bold; color: red;'>" . $errmsgs . "</p>";
+            echo "<p class='error bold'>" . $errmsgs . "</p>";
             $this->show_edit_form();
             die;
         }

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -329,7 +329,7 @@ function show_all_news_items_for_page( $news_page_id )
                 echo "<a href='$url' $onclick>$label</a><br>";
             }
             echo "</td>";
-            echo "<td class='items' style='border-bottom: solid thin black;'>";
+            echo "<td class='items default-border-bottom'>";
             echo "\n";
             echo $news_item['content']."<br><br>";
             echo "\n";


### PR DESCRIPTION
This moves almost everything that can take a color out of `layout.less` and into `theme.less`. This includes border*, color and background-color. After experimenting with just breaking out the border color, I came to the conclusion that it was better to move the whole border property instead of breaking it up.  There are still a few border: none; and background-color: transparent; declarations that should probably be moved. The purpose is to make it easier to build additional site themes.

Instead of moving the stragglers, we might want to consider merging `layout.less` into `theme.less`: the problem with the current setup is that many structures have declaration blocks in both files, which can be confusing.

None of the class/mixin names I've choses are set in stone -- more logical suggestions are welcome.

If I've done what I should, there should be no user visible changes (except for a small one on the SR pool page). Compare [move-color-to-theme](https://www.pgdp.org/~srjfoo/c.branch/move-color-to-theme/) with the main test site.