### PR TITLE
Condense the news headers and remove the images

### DIFF
--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -100,18 +100,14 @@ function show_news_for_page( $news_page_id )
 
         echo "<div class='news'>";
 
-        echo "<div class='newsheader'>";
-        $header_title = sprintf( _('News for %s'), $news_subject );
 
-        // Show header-title as an image, if available.
-        $header_string = get_translated_graphic_or_text("news_header", $news_page_id, $header_title);
-        echo "<h2>$header_string</h2>";
+        echo "<div class='newsupdated'>";
 
         echo "<small>";
         if ( user_is_a_sitemanager() or user_is_site_news_editor())
         {
             $url = "$code_url/tools/site_admin/sitenews.php?news_page_id=$news_page_id";
-            $linktext = sprintf( _("Update News for %s"), $news_subject );
+            $linktext = _("Update News");
             echo "<a href='$url'>$linktext</a> - ";
         }
 
@@ -127,6 +123,11 @@ function show_news_for_page( $news_page_id )
             echo sprintf( _("last changed %s"), $formatted_date );
         }
         echo "</small>";
+        echo "</div>";
+        echo "<div class='newsheader'>";
+
+        echo "<h2>" . _('News') . "</h2>";
+
         echo "</div>"; // div.newsheader
 
         // -------------------------------------------

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -292,6 +292,10 @@ hr.divider {
 div.news {
   margin: 1em 0;
 }
+div.newsupdated {
+  margin-top: 0.7em;
+  float: right;
+}
 div.newsitem {
   border-radius: 5px;
   padding: 0.75em;

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -260,6 +260,12 @@ hr.divider {
 div.news {
     margin: 1em 0;
 }
+div.newsupdated {
+    // margin-top is a _horrible_ hack to force this lower and closer
+    // to the baseline of newsheader
+    margin-top: 0.7em;
+    float: right;
+}
 div.newsitem {
     border-radius: 5px;
     padding: 0.75em;


### PR DESCRIPTION
Condense the news header and remove the images for the news title.

See the [condense-news-header](https://www.pgdp.org/~cpeel/c.branch/condense-news-header/) sandbox.