### PR TITLE
Always rebuild CSS from .less files

### DIFF
--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -11,11 +11,12 @@ security_checks:
 	$(SELF_DIR)check_require_login.php
 
 #----------------------------------------------------------------------------
-# PHP file linting
+# File linting
 lint:
 	$(SELF_DIR)lint_php_files.sh $(SELF_DIR)..
 	$(SELF_DIR)lint_json_files.sh $(SELF_DIR)..
 	$(SELF_DIR)lint_charsuites.php $(SELF_DIR)..
+	$(SELF_DIR)generate_css_from_less.sh --check $(SELF_DIR)../styles
 
 #----------------------------------------------------------------------------
 # CSS compilation

--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -19,21 +19,9 @@ lint:
 
 #----------------------------------------------------------------------------
 # CSS compilation
-LESSC := lessc
-SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-STYLE_DIR := $(SELF_DIR)../styles
 
-BASE_CSS := $(wildcard $(STYLE_DIR)/*.css)
-THEME_CSS := $(wildcard $(STYLE_DIR)/themes/*.css)
-
-all: less lint
-
-less: $(BASE_CSS) $(THEME_CSS)
-
-$(THEME_CSS): $(STYLE_DIR)/themes/theme.less
-
-%.css: %.less $(STYLE_DIR)/global.less
-	$(LESSC) $< $@
+less:
+	$(SELF_DIR)generate_css_from_less.sh $(SELF_DIR)../styles
 
 #----------------------------------------------------------------------------
 # Unit tests

--- a/SETUP/generate_css_from_less.sh
+++ b/SETUP/generate_css_from_less.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ "_$1" != "_" ]; then
+    STYLE_DIR=$1
+elif [ -d styles ]; then
+    STYLE_DIR=styles
+elif [ -d ../styles ]; then
+    STYLE_DIR=../styles
+else
+    echo "Unable to determine styles directory"
+    exit 1
+fi
+
+# Array of .less files that should not turn into a .css file
+NON_CSS_LESS_FILES=("theme.less")
+
+function run_less {
+    less_file=$1
+
+    # skip files in NON_CSS_LESS_FILES that shouldn't generate a .css
+    less_basename=$(basename -- "$less_file")
+    if [[ " ${NON_CSS_LESS_FILES[@]} " =~ " ${less_basename} " ]]; then
+        echo "Skipping $less_file"
+        return;
+    fi
+
+    css_file="${less_file%.*}.css"
+    echo "Generating $css_file"
+    lessc $less_file $css_file
+}
+
+# run over every .less file in our style directory
+for file in $(find $STYLE_DIR -name "*.less"); do
+    run_less $file
+done
+
+# now the themes

--- a/package-lock.json
+++ b/package-lock.json
@@ -334,6 +334,16 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -642,6 +652,13 @@
         "url-parse-lax": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true,
+      "optional": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -683,6 +700,13 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "dev": true,
+      "optional": true
     },
     "immediate": {
       "version": "3.0.6",
@@ -898,6 +922,31 @@
         "set-immediate-shim": "~1.0.1"
       }
     },
+    "less": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.12.2.tgz",
+      "integrity": "sha512-+1V2PCMFkL+OIj2/HrtrvZw0BC0sYLMICJfbQjuj/K8CEnlrFX6R5cKKgzzttsZDHyxQNL1jqMREjKN3ja/E3Q==",
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
+        "native-request": "^1.0.5",
+        "source-map": "~0.6.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "lessc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lessc/-/lessc-1.0.2.tgz",
+      "integrity": "sha512-cv7EXQRiD3Cu2Vsy3S9C89G01kOv0TrLQMoWHxscCgkMYdhEvknhaINeQkZbPmUlJ87AEzjPm0y/14Cg9j7/ug==",
+      "dev": true,
+      "requires": {
+        "less": "^3.9.0"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -928,6 +977,33 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "optional": true
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -989,6 +1065,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "native-request": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.0.7.tgz",
+      "integrity": "sha512-9nRjinI9bmz+S7dgNtf4A70+/vPhnd+2krGpy4SUlADuOuSa24IDkNaZ+R/QT1wQ6S8jBdi6wE7fLekFZNfUpQ==",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -1082,6 +1165,13 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "optional": true
+    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -1120,6 +1210,13 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true,
+      "optional": true
     },
     "punycode": {
       "version": "2.1.1",
@@ -1292,6 +1389,13 @@
           "dev": true
         }
       }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "eslint": "^7.1.0",
     "geckodriver": "^1.19.1",
+    "lessc": "^1.0.2",
     "selenium-webdriver": "^4.0.0-alpha.7"
   }
 }

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -663,16 +663,6 @@ table.pagedetail th,
 table.pagedetail td {
   text-align: center;
   font-weight: normal;
-  border: 1px solid black;
-}
-table.pagedetail td.in_progress {
-  background-color: #FC6;
-}
-table.pagedetail td.done_current {
-  background-color: #9F6;
-}
-table.pagedetail td.done_previous {
-  background-color: #F36;
 }
 /* ------------------------------------------------------------------------ */
 /* Remote File Manager */
@@ -836,7 +826,6 @@ table.list_special_days {
 }
 table.list_special_days td,
 table.list_special_days th {
-  border: 1px solid #999;
   padding: 3px;
 }
 table.list_special_days td.codecell {
@@ -846,26 +835,14 @@ table.list_special_days td.codecell {
 table.list_special_days th.headers {
   padding: 0.5em;
 }
-table.list_special_days tr.e {
-  background-color: #eee;
-}
-table.list_special_days tr.o {
-  background-color: #ddd;
-}
 table.list_special_days td.enabled {
-  background-color: #9f9;
   text-align: center;
 }
 table.list_special_days td.disabled {
-  background-color: #ddd;
   text-align: center;
 }
 table.list_special_days td.center {
   text-align: center;
-}
-table.list_special_days tr.month > * {
-  border: none;
-  border-bottom: solid 2px black;
 }
 table.list_special_days td.right,
 table.list_special_days th.right {
@@ -876,18 +853,13 @@ table.list_special_days h2 {
   margin: 1em auto auto auto;
   text-align: left;
 }
-table.show_special_days th {
-  background-color: #eeeeee;
-}
 table.edit_special_day {
   width: 90%;
   margin: auto;
 }
 table.edit_special_day th,
 table.edit_special_day td {
-  border: 1px solid black;
   padding: 5px;
-  background-color: #eeeeee;
 }
 /* ------------------------------------------------------------------------ */
 /* Search Form */
@@ -927,11 +899,8 @@ table.search-column tr th {
   position: absolute;
   top: 1.5em;
   right: 0;
-  background-color: #f9f9f9;
-  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.5);
   padding: 0.3em;
   margin: 0 0 0 -15em;
-  border-radius: 0.3em;
   z-index: 1;
 }
 /* button looking like a link */
@@ -956,7 +925,6 @@ table.search-column tr th {
   float: right;
   margin-left: 0.5em;
   margin-bottom: 0.5em;
-  border: 1px solid black;
 }
 #pm_links ul {
   padding: 0;
@@ -1030,7 +998,6 @@ li.spaced {
 .replace_check {
   height: 20em;
   width: 50em;
-  border: 1px solid black;
 }
 /* ------------------------------------------------------------------------ */
 /* Page Browser */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -230,18 +230,18 @@ table.preferences th.longlabel {
   color: #000000;
 }
 .tabs {
-  border-bottom: thin solid gray;
+  border-bottom: thin solid grey;
 }
 .tabs li {
   background-color: #dddddd;
-  border: thin solid gray;
+  border: thin solid grey;
 }
 .tabs li a {
   color: #000000;
 }
 .tabs .current-tab {
   background-color: #ffffff;
-  border: thin solid gray;
+  border: thin solid grey;
 }
 .tabs .current-tab a {
   color: #000000;
@@ -384,9 +384,6 @@ table.ppv_reportcard td {
 }
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
-table.image_source_listing td.title {
-  background-color: #dddddd;
-}
 table.image_source th {
   background-color: #eee;
   border: thin solid #999;
@@ -411,6 +408,21 @@ table.image_source td.pending {
 }
 div.perms_wrapper {
   border-bottom: dotted black 1px;
+}
+/* ------------------------------------------------------------------------ */
+/* Page Detail */
+table.pagedetail th,
+table.pagedetail td {
+  border: thin solid black;
+}
+table.pagedetail td.in_progress {
+  background-color: #FC6;
+}
+table.pagedetail td.done_current {
+  background-color: #9F6;
+}
+table.pagedetail td.done_previous {
+  background-color: #F36;
 }
 /* ------------------------------------------------------------------------ */
 /* Registration table */
@@ -441,6 +453,48 @@ div.progressbar {
   border: thin solid black;
 }
 /* ------------------------------------------------------------------------ */
+/* Special days tables */
+table.list_special_days td,
+table.list_special_days th {
+  border: thin solid #999;
+}
+table.list_special_days tr.e {
+  background-color: #eee;
+}
+table.list_special_days tr.o {
+  background-color: #ddd;
+}
+table.list_special_days td.enabled {
+  background-color: #9f9;
+}
+table.list_special_days td.disabled {
+  background-color: #ddd;
+}
+table.list_special_days tr.month > * {
+  border: none;
+  border-bottom: solid 2px black;
+}
+table.show_special_days th {
+  background-color: #eeeeee;
+}
+table.edit_special_day th,
+table.edit_special_day td {
+  border: thin solid black;
+  background-color: #eeeeee;
+}
+/* ------------------------------------------------------------------------ */
+/* Search Results drop-down */
+.dropdown-content {
+  background-color: #f9f9f9;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.5);
+  border-radius: 0.3em;
+}
+/* ------------------------------------------------------------------------ */
+/* PM link box */
+#pm_links {
+  border: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
 /* WordCheck pages */
 .preWC {
   background-color: #c2c2c2;
@@ -451,6 +505,11 @@ div.progressbar {
 }
 .WC {
   background-color: #97fc9e;
+}
+/* ------------------------------------------------------------------------ */
+/* replace text validator */
+.replace_check {
+  border: thin solid black;
 }
 /* ======================================================================== */
 /* Page Interface Structures */
@@ -478,7 +537,7 @@ div.progressbar {
 .page-interface .control-pane select,
 .page-interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .page-interface .control-pane button,
 .page-interface .control-pane input[type=submit],
@@ -501,7 +560,7 @@ div.progressbar {
 .control-frame select,
 .control-frame button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .control-frame button,
 .control-frame input[type=submit],
@@ -525,7 +584,7 @@ div.progressbar {
 #toolbox select,
 #toolbox button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #toolbox button,
 #toolbox input[type=submit],
@@ -567,7 +626,7 @@ div.progressbar {
 #format_preview .control-pane select,
 #format_preview .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #format_preview .control-pane button,
 #format_preview .control-pane input[type=submit],
@@ -581,7 +640,7 @@ div.progressbar {
   background-color: Bisque;
 }
 .ilb {
-  border: 1px solid #404040;
+  border: thin solid #404040;
   border-radius: 2px;
   background-color: #CDC0B0;
   color: black;
@@ -590,7 +649,7 @@ div.progressbar {
 .ilb select,
 .ilb button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .ilb button,
 .ilb input[type=submit],
@@ -621,7 +680,7 @@ div.progressbar {
 #page-browser .control-pane select,
 #page-browser .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #page-browser .control-pane button,
 #page-browser .control-pane input[type=submit],
@@ -635,7 +694,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #page-browser .control-pane {
-  border-bottom: 1px solid #999;
+  border-bottom: thin solid #999;
 }
 #page-browser .control-pane .img-button {
   border: 0;
@@ -659,7 +718,7 @@ div.progressbar {
 #standard_interface .control-pane select,
 #standard_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #standard_interface .control-pane button,
 #standard_interface .control-pane input[type=submit],
@@ -690,7 +749,7 @@ div.progressbar {
 #enhanced_interface .control-pane select,
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface .control-pane button,
 #enhanced_interface .control-pane input[type=submit],
@@ -704,10 +763,10 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tbtext {
-  border: 1px solid black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtop {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDC0B0;
   color: black;
 }
@@ -715,7 +774,7 @@ div.progressbar {
 #enhanced_interface #tdtop select,
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtop button,
 #enhanced_interface #tdtop input[type=submit],
@@ -729,7 +788,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tdtext {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDCDC1;
   color: black;
 }
@@ -745,7 +804,7 @@ div.progressbar {
 #enhanced_interface #tdtext .control-pane select,
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtext .control-pane button,
 #enhanced_interface #tdtext .control-pane input[type=submit],
@@ -759,7 +818,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tdbottom {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #EEDFCC;
 }
 #enhanced_interface #text_data,
@@ -788,7 +847,7 @@ div.progressbar {
 #wordcheck_interface .control-pane select,
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #wordcheck_interface .control-pane button,
 #wordcheck_interface .control-pane input[type=submit],
@@ -802,10 +861,10 @@ div.progressbar {
   background-color: Bisque;
 }
 #wordcheck_interface #tbtext {
-  border: 1px solid black;
+  border: thin solid black;
 }
 #wordcheck_interface #tdtop {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDC0B0;
   color: black;
 }
@@ -813,7 +872,7 @@ div.progressbar {
 #wordcheck_interface #tdtop select,
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #wordcheck_interface #tdtop button,
 #wordcheck_interface #tdtop input[type=submit],
@@ -827,7 +886,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #wordcheck_interface #tdtext {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #FFF8DC;
   color: black;
 }
@@ -845,7 +904,7 @@ div.progressbar {
 .fixedbox select,
 .fixedbox button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .fixedbox button,
 .fixedbox input[type=submit],

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -230,18 +230,18 @@ table.preferences th.longlabel {
   color: #000000;
 }
 .tabs {
-  border-bottom: thin solid gray;
+  border-bottom: thin solid grey;
 }
 .tabs li {
   background-color: #e3e3e3;
-  border: thin solid gray;
+  border: thin solid grey;
 }
 .tabs li a {
   color: #000000;
 }
 .tabs .current-tab {
   background-color: #ffffff;
-  border: thin solid gray;
+  border: thin solid grey;
 }
 .tabs .current-tab a {
   color: #000000;
@@ -384,9 +384,6 @@ table.ppv_reportcard td {
 }
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
-table.image_source_listing td.title {
-  background-color: #e0e8dd;
-}
 table.image_source th {
   background-color: #eee;
   border: thin solid #999;
@@ -411,6 +408,21 @@ table.image_source td.pending {
 }
 div.perms_wrapper {
   border-bottom: dotted black 1px;
+}
+/* ------------------------------------------------------------------------ */
+/* Page Detail */
+table.pagedetail th,
+table.pagedetail td {
+  border: thin solid black;
+}
+table.pagedetail td.in_progress {
+  background-color: #FC6;
+}
+table.pagedetail td.done_current {
+  background-color: #9F6;
+}
+table.pagedetail td.done_previous {
+  background-color: #F36;
 }
 /* ------------------------------------------------------------------------ */
 /* Registration table */
@@ -441,6 +453,48 @@ div.progressbar {
   border: thin solid black;
 }
 /* ------------------------------------------------------------------------ */
+/* Special days tables */
+table.list_special_days td,
+table.list_special_days th {
+  border: thin solid #999;
+}
+table.list_special_days tr.e {
+  background-color: #eee;
+}
+table.list_special_days tr.o {
+  background-color: #ddd;
+}
+table.list_special_days td.enabled {
+  background-color: #9f9;
+}
+table.list_special_days td.disabled {
+  background-color: #ddd;
+}
+table.list_special_days tr.month > * {
+  border: none;
+  border-bottom: solid 2px black;
+}
+table.show_special_days th {
+  background-color: #eeeeee;
+}
+table.edit_special_day th,
+table.edit_special_day td {
+  border: thin solid black;
+  background-color: #eeeeee;
+}
+/* ------------------------------------------------------------------------ */
+/* Search Results drop-down */
+.dropdown-content {
+  background-color: #f9f9f9;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.5);
+  border-radius: 0.3em;
+}
+/* ------------------------------------------------------------------------ */
+/* PM link box */
+#pm_links {
+  border: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
 /* WordCheck pages */
 .preWC {
   background-color: #c2c2c2;
@@ -451,6 +505,11 @@ div.progressbar {
 }
 .WC {
   background-color: #97fc9e;
+}
+/* ------------------------------------------------------------------------ */
+/* replace text validator */
+.replace_check {
+  border: thin solid black;
 }
 /* ======================================================================== */
 /* Page Interface Structures */
@@ -478,7 +537,7 @@ div.progressbar {
 .page-interface .control-pane select,
 .page-interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .page-interface .control-pane button,
 .page-interface .control-pane input[type=submit],
@@ -501,7 +560,7 @@ div.progressbar {
 .control-frame select,
 .control-frame button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .control-frame button,
 .control-frame input[type=submit],
@@ -525,7 +584,7 @@ div.progressbar {
 #toolbox select,
 #toolbox button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #toolbox button,
 #toolbox input[type=submit],
@@ -567,7 +626,7 @@ div.progressbar {
 #format_preview .control-pane select,
 #format_preview .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #format_preview .control-pane button,
 #format_preview .control-pane input[type=submit],
@@ -581,7 +640,7 @@ div.progressbar {
   background-color: Bisque;
 }
 .ilb {
-  border: 1px solid #404040;
+  border: thin solid #404040;
   border-radius: 2px;
   background-color: #CDC0B0;
   color: black;
@@ -590,7 +649,7 @@ div.progressbar {
 .ilb select,
 .ilb button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .ilb button,
 .ilb input[type=submit],
@@ -621,7 +680,7 @@ div.progressbar {
 #page-browser .control-pane select,
 #page-browser .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #page-browser .control-pane button,
 #page-browser .control-pane input[type=submit],
@@ -635,7 +694,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #page-browser .control-pane {
-  border-bottom: 1px solid #999;
+  border-bottom: thin solid #999;
 }
 #page-browser .control-pane .img-button {
   border: 0;
@@ -659,7 +718,7 @@ div.progressbar {
 #standard_interface .control-pane select,
 #standard_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #standard_interface .control-pane button,
 #standard_interface .control-pane input[type=submit],
@@ -690,7 +749,7 @@ div.progressbar {
 #enhanced_interface .control-pane select,
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface .control-pane button,
 #enhanced_interface .control-pane input[type=submit],
@@ -704,10 +763,10 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tbtext {
-  border: 1px solid black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtop {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDC0B0;
   color: black;
 }
@@ -715,7 +774,7 @@ div.progressbar {
 #enhanced_interface #tdtop select,
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtop button,
 #enhanced_interface #tdtop input[type=submit],
@@ -729,7 +788,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tdtext {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDCDC1;
   color: black;
 }
@@ -745,7 +804,7 @@ div.progressbar {
 #enhanced_interface #tdtext .control-pane select,
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtext .control-pane button,
 #enhanced_interface #tdtext .control-pane input[type=submit],
@@ -759,7 +818,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tdbottom {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #EEDFCC;
 }
 #enhanced_interface #text_data,
@@ -788,7 +847,7 @@ div.progressbar {
 #wordcheck_interface .control-pane select,
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #wordcheck_interface .control-pane button,
 #wordcheck_interface .control-pane input[type=submit],
@@ -802,10 +861,10 @@ div.progressbar {
   background-color: Bisque;
 }
 #wordcheck_interface #tbtext {
-  border: 1px solid black;
+  border: thin solid black;
 }
 #wordcheck_interface #tdtop {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDC0B0;
   color: black;
 }
@@ -813,7 +872,7 @@ div.progressbar {
 #wordcheck_interface #tdtop select,
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #wordcheck_interface #tdtop button,
 #wordcheck_interface #tdtop input[type=submit],
@@ -827,7 +886,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #wordcheck_interface #tdtext {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #FFF8DC;
   color: black;
 }
@@ -845,7 +904,7 @@ div.progressbar {
 .fixedbox select,
 .fixedbox button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .fixedbox button,
 .fixedbox input[type=submit],

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -230,18 +230,18 @@ table.preferences th.longlabel {
   color: #000000;
 }
 .tabs {
-  border-bottom: thin solid gray;
+  border-bottom: thin solid grey;
 }
 .tabs li {
   background-color: #b3cce6;
-  border: thin solid gray;
+  border: thin solid grey;
 }
 .tabs li a {
   color: #000000;
 }
 .tabs .current-tab {
   background-color: #ffffff;
-  border: thin solid gray;
+  border: thin solid grey;
 }
 .tabs .current-tab a {
   color: #000000;
@@ -384,9 +384,6 @@ table.ppv_reportcard td {
 }
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
-table.image_source_listing td.title {
-  background-color: #99ccff;
-}
 table.image_source th {
   background-color: #eee;
   border: thin solid #999;
@@ -411,6 +408,21 @@ table.image_source td.pending {
 }
 div.perms_wrapper {
   border-bottom: dotted black 1px;
+}
+/* ------------------------------------------------------------------------ */
+/* Page Detail */
+table.pagedetail th,
+table.pagedetail td {
+  border: thin solid black;
+}
+table.pagedetail td.in_progress {
+  background-color: #FC6;
+}
+table.pagedetail td.done_current {
+  background-color: #9F6;
+}
+table.pagedetail td.done_previous {
+  background-color: #F36;
 }
 /* ------------------------------------------------------------------------ */
 /* Registration table */
@@ -441,6 +453,48 @@ div.progressbar {
   border: thin solid black;
 }
 /* ------------------------------------------------------------------------ */
+/* Special days tables */
+table.list_special_days td,
+table.list_special_days th {
+  border: thin solid #999;
+}
+table.list_special_days tr.e {
+  background-color: #eee;
+}
+table.list_special_days tr.o {
+  background-color: #ddd;
+}
+table.list_special_days td.enabled {
+  background-color: #9f9;
+}
+table.list_special_days td.disabled {
+  background-color: #ddd;
+}
+table.list_special_days tr.month > * {
+  border: none;
+  border-bottom: solid 2px black;
+}
+table.show_special_days th {
+  background-color: #eeeeee;
+}
+table.edit_special_day th,
+table.edit_special_day td {
+  border: thin solid black;
+  background-color: #eeeeee;
+}
+/* ------------------------------------------------------------------------ */
+/* Search Results drop-down */
+.dropdown-content {
+  background-color: #f9f9f9;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.5);
+  border-radius: 0.3em;
+}
+/* ------------------------------------------------------------------------ */
+/* PM link box */
+#pm_links {
+  border: thin solid black;
+}
+/* ------------------------------------------------------------------------ */
 /* WordCheck pages */
 .preWC {
   background-color: #c2c2c2;
@@ -451,6 +505,11 @@ div.progressbar {
 }
 .WC {
   background-color: #97fc9e;
+}
+/* ------------------------------------------------------------------------ */
+/* replace text validator */
+.replace_check {
+  border: thin solid black;
 }
 /* ======================================================================== */
 /* Page Interface Structures */
@@ -478,7 +537,7 @@ div.progressbar {
 .page-interface .control-pane select,
 .page-interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .page-interface .control-pane button,
 .page-interface .control-pane input[type=submit],
@@ -501,7 +560,7 @@ div.progressbar {
 .control-frame select,
 .control-frame button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .control-frame button,
 .control-frame input[type=submit],
@@ -525,7 +584,7 @@ div.progressbar {
 #toolbox select,
 #toolbox button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #toolbox button,
 #toolbox input[type=submit],
@@ -567,7 +626,7 @@ div.progressbar {
 #format_preview .control-pane select,
 #format_preview .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #format_preview .control-pane button,
 #format_preview .control-pane input[type=submit],
@@ -581,7 +640,7 @@ div.progressbar {
   background-color: Bisque;
 }
 .ilb {
-  border: 1px solid #404040;
+  border: thin solid #404040;
   border-radius: 2px;
   background-color: #CDC0B0;
   color: black;
@@ -590,7 +649,7 @@ div.progressbar {
 .ilb select,
 .ilb button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .ilb button,
 .ilb input[type=submit],
@@ -621,7 +680,7 @@ div.progressbar {
 #page-browser .control-pane select,
 #page-browser .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #page-browser .control-pane button,
 #page-browser .control-pane input[type=submit],
@@ -635,7 +694,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #page-browser .control-pane {
-  border-bottom: 1px solid #999;
+  border-bottom: thin solid #999;
 }
 #page-browser .control-pane .img-button {
   border: 0;
@@ -659,7 +718,7 @@ div.progressbar {
 #standard_interface .control-pane select,
 #standard_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #standard_interface .control-pane button,
 #standard_interface .control-pane input[type=submit],
@@ -690,7 +749,7 @@ div.progressbar {
 #enhanced_interface .control-pane select,
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface .control-pane button,
 #enhanced_interface .control-pane input[type=submit],
@@ -704,10 +763,10 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tbtext {
-  border: 1px solid black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtop {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDC0B0;
   color: black;
 }
@@ -715,7 +774,7 @@ div.progressbar {
 #enhanced_interface #tdtop select,
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtop button,
 #enhanced_interface #tdtop input[type=submit],
@@ -729,7 +788,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tdtext {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDCDC1;
   color: black;
 }
@@ -745,7 +804,7 @@ div.progressbar {
 #enhanced_interface #tdtext .control-pane select,
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #enhanced_interface #tdtext .control-pane button,
 #enhanced_interface #tdtext .control-pane input[type=submit],
@@ -759,7 +818,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #enhanced_interface #tdbottom {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #EEDFCC;
 }
 #enhanced_interface #text_data,
@@ -788,7 +847,7 @@ div.progressbar {
 #wordcheck_interface .control-pane select,
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #wordcheck_interface .control-pane button,
 #wordcheck_interface .control-pane input[type=submit],
@@ -802,10 +861,10 @@ div.progressbar {
   background-color: Bisque;
 }
 #wordcheck_interface #tbtext {
-  border: 1px solid black;
+  border: thin solid black;
 }
 #wordcheck_interface #tdtop {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #CDC0B0;
   color: black;
 }
@@ -813,7 +872,7 @@ div.progressbar {
 #wordcheck_interface #tdtop select,
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 #wordcheck_interface #tdtop button,
 #wordcheck_interface #tdtop input[type=submit],
@@ -827,7 +886,7 @@ div.progressbar {
   background-color: Bisque;
 }
 #wordcheck_interface #tdtext {
-  border: 1px solid black;
+  border: thin solid black;
   background-color: #FFF8DC;
   color: black;
 }
@@ -845,7 +904,7 @@ div.progressbar {
 .fixedbox select,
 .fixedbox button {
   background-color: #FFF8DC;
-  border: solid thin black;
+  border: thin solid black;
 }
 .fixedbox button,
 .fixedbox input[type=submit],


### PR DESCRIPTION
9a43fc8 had a mismatch between the `.less` files and the `.css` that should have come from them. This is possibly the result of an incorrect rebase, but it could have easily been exacerbated by the Makefile not regenerating `.css` files if they had a newer timestamp than the `.less` files.

Makefiles don't mesh well with git because the timestamps from the generated files might be newer than the source files but still out of date. Change to a shell script which is less "magical" than a Makefile and always rebuild every CSS file.