### PR TITLE
Add an user's guide for the API 

### DIFF
--- a/SETUP/API.md
+++ b/SETUP/API.md
@@ -26,7 +26,7 @@ This can be achieved by adding a stanza such as this one to your Apache
 config:
 ```
 RewriteEngine On
-RewriteRule ^api/(.*)$ /c/api/index.php?url=$1 [L,QSA]
+RewriteRule ^/api/(.*)$ %{DOCUMENT_ROOT}/c/api/index.php?url=$1 [L,QSA]
 ```
 
 ## Access Control

--- a/api/README.md
+++ b/api/README.md
@@ -1,7 +1,11 @@
 # API Development
 
-This documentation is for developers to extend the current APIs. For the
-administrative documentation on the APIs, see [SETUP/API.md](SETUP/API.md).
+This documentation is for developers to extend the current APIs.
+
+For the API user's guide, see [USERS_GUIDE.md](USERS_GUIDE.md).
+
+For the administrative documentation on the APIs, see
+[SETUP/API.md](../SETUP/API.md).
 
 ## Design
 

--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -1,0 +1,154 @@
+# API User's Guide
+
+The DP code provides a RESTful API for accessing various its of data
+programmatically using a well-defined structure instead of HTML scraping.
+
+## RESTful API
+
+The DP API is a RESTful API. Among other things, this means that all requests
+to the API will be via URL (possibly with JSON request body) and all responses
+-- including error messages -- will be JSON objects.
+
+## Documentation
+
+The `dp-openapi.yaml` file should always contain the definitive OpenAPI on what
+is currently implemented. This file is best edited via
+[Swagger Editor](https://editor.swagger.io/). Indeed, that's a great place
+to test out the APIs as well.
+
+## Access
+
+The API can be enabled or disabled independently of the main UI. If the API is
+not enabled, the server will return a `400 Bad Request` HTTP status code with
+the following message:
+
+```json
+{
+    "error": "API is not enabled"
+}
+```
+
+Similarly, if the site is in maintenance mode, the server will return a
+`400 Bad Request` HTTP status code with the message:
+
+```json
+{
+    "error": "Site is in maintenance mode"
+}
+```
+
+## Authentication
+
+API authentication and authorization is provided via an API key. The API key
+is associated with your user account and restricts the data you can get from
+the API to the same data you would have access to via the web UI.
+
+To request an API key, contact a site administrator.
+
+Attempts to access the API with a missing or invalid API key will return a
+`401 Unauthorized` HTTP status code with the JSON body:
+
+```json
+{
+    "error": "Unauthorized"
+}
+```
+
+## Rate Limiting
+
+Your site may have API rate limiting enabled. This prevents overwhelming the
+system by limiting the number of API requests per unit of time. API responses
+will include three HTTP headers to let the caller know how many more requests
+they have remaining in the limit window.
+
+* `X-Rate-Limit-Limit` - total number of requests allowed within the window
+* `X-Rate-Limit-Remaining` - number of requests remaining in the window
+* `X-Rate-Limit-Reset` - number of seconds before the limit window restarts
+
+When the rate limit is reached, the server will return a `429 Too Many Requests`
+HTTP status code with the JSON body:
+
+```json
+{
+    "error": "Rate limit exceeded, resets in 2383 seconds"
+}
+```
+
+## Pagination
+
+Some requests, like project searches, may return paginated results. Paginated
+responses will include the following HTTP headers to assist with navigating the
+result set:
+
+* `X-Results-Total` - total number of entries available in the query set
+* `Link` - links to walk through the paginated results.
+
+The `Link` format looks like (lines wrapped here for readability):
+```
+Link: <https://www.pgdp.org/api/v1/projects?per_page=20&page=1>; rel="first",
+      <https://www.pgdp.org/api/v1/projects?per_page=20&page=2>; rel="next",
+      <https://www.pgdp.org/api/v1/projects?per_page=20&page=20>; rel="last"
+```
+
+You should use the links provided to navigate through the pages.
+
+Some endpoints allow increasing the page size by passing in the `per_page`
+parameter on the URL. These endpoints have a maximum number of entries per page,
+usually 100.
+
+## Examples
+
+Here are some examples using `curl`. See the `dp-openapi.yaml` file for all
+available endpoints and their parameters and return values.
+
+### Project searches
+
+Search for all projects with genre `Other`:
+
+```bash
+curl -i -g -X GET "https://www.pgdp.org/api/v1/projects?genre=Other" \
+    -H "accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
+Search for all projects with the word `Monster` in their title:
+
+```bash
+curl -i -g -X GET "https://www.pgdp.org/api/v1/projects?title=Monster" \
+    -H "accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
+### Project details
+
+Load details about a specific project:
+
+```bash
+curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
+    -H "accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
+See all pages in a project:
+
+```bash
+curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages" \
+    -H "accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
+Get the P1 text for a project page:
+
+```bash
+curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages/001.png/pagerounds/P1" \
+    -H "accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
+Get the good wordlist for a project:
+
+```bash
+curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
+    -H "accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```


### PR DESCRIPTION
Add a basic user's guide for the API to help developers get started using it.

You can view this rendered at https://github.com/cpeel/dproofreaders/blob/api-users-guide/api/USERS_GUIDE.md