### PR TITLE
Rename structure used for links

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -905,26 +905,25 @@ table.search-column tr th {
   display: block;
 }
 /* ------------------------------------------------------------------------ */
-/* PM link box */
-#pm_links {
+/* Link box */
+#linkbox {
   text-align: left;
   vertical-align: top;
   padding: 0 1em;
   float: right;
-  margin-left: 0.5em;
-  margin-bottom: 0.5em;
+  margin: 0.5em auto 0.5em 0.5em;
 }
-#pm_links ul {
+#linkbox ul {
   padding: 0;
 }
-#pm_links li {
+#linkbox li {
   list-style-type: none;
 }
-#pm_links h2 {
+#linkbox h2 {
   text-align: center;
   font-size: 1em;
 }
-#pm_links li {
+#linkbox li {
   margin-top: 3px;
 }
 /* ------------------------------------------------------------------------ */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -952,16 +952,15 @@ table.search-column {
 }
 
 /* ------------------------------------------------------------------------ */
-/* PM link box */
+/* Link box */
 
-#pm_links {
+#linkbox{
     .plain-list;
     .left-align;
     .top-align;
     padding: 0 1em;
     float:right;
-    margin-left: 0.5em;
-    margin-bottom: 0.5em;
+    margin: 0.5em auto 0.5em 0.5em;
     h2 {
         .center-align;
         font-size: 1em;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -490,9 +490,10 @@ table.edit_special_day td {
   border-radius: 0.3em;
 }
 /* ------------------------------------------------------------------------ */
-/* PM link box */
-#pm_links {
+/* Link box */
+#linkbox {
   border: thin solid black;
+  background-color: #dddddd;
 }
 .access-yes {
   display: inline-block;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -490,9 +490,10 @@ table.edit_special_day td {
   border-radius: 0.3em;
 }
 /* ------------------------------------------------------------------------ */
-/* PM link box */
-#pm_links {
+/* Link box */
+#linkbox {
   border: thin solid black;
+  background-color: #e0e8dd;
 }
 .access-yes {
   display: inline-block;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -490,9 +490,10 @@ table.edit_special_day td {
   border-radius: 0.3em;
 }
 /* ------------------------------------------------------------------------ */
-/* PM link box */
-#pm_links {
+/* Link box */
+#linkbox {
   border: thin solid black;
+  background-color: #99ccff;
 }
 .access-yes {
   display: inline-block;

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -475,10 +475,11 @@ table.edit_special_day {
 }
 
 /* ------------------------------------------------------------------------ */
-/* PM link box */
+/* Link box */
 
-#pm_links {
+#linkbox{
     .solid-border;
+    .sidebar-color;
 }
 
 .stage-access(@color: black) {

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -43,7 +43,7 @@ output_header($title, NO_STATSBAR);
 
 if ( user_is_a_sitemanager() || user_is_proj_facilitator() )
 {
-    echo "<div id='pm_links' class='sidebar-color'>";
+    echo "<div id='linkbox'>";
     echo "<form action='#' method='get'><p>";
     echo _("See projects for another user") . "<br>";
     echo "<input type='text' name='username' value='$username' required>";

--- a/tools/project_manager/projectmgr.inc
+++ b/tools/project_manager/projectmgr.inc
@@ -27,7 +27,7 @@ function echo_manager_links()
                            ? "$code_url/tools/project_manager/editproject.php?action=createnew"
                            : "$code_url/tools/project_manager/external_catalog_search.php?action=show_query_form");
 
-    echo "<div id='pm_links' class='sidebar-color'>\n";
+    echo "<div id='linkbox'>\n";
     // TRANSLATORS: PM = project manager
     echo "<h2>", _("PM Links"), "</h2>\n";
     echo "<p>", _("Server Time"), ": <span id='server-time'></span></p>\n";

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -342,7 +342,7 @@ else
 
 function output_link_box($username)
 {
-    echo "<div id='pm_links' class='sidebar-color'>";
+    echo "<div id='linkbox'>";
     if ( user_is_a_sitemanager() || user_is_proj_facilitator() )
     {
         echo "<form action='#' method='get'><p>";


### PR DESCRIPTION
The "pm_links" box is used on more pages than just the PM page now so rename it as "linkbox" and pull the color definition into the CSS instead of in the 3 separate pages.

This also introduces a very small margin at the top to separate it out from the navbar.

Viewable in the [rename-pm-links](https://www.pgdp.org/~cpeel/c.branch/rename-pm-links) sanbox.