### PR TITLE
Separate round images from their titles

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -30,7 +30,9 @@ $title = _("Activity Hub");
 
 output_header($title);
 
-echo "<h1>" . get_translated_graphic_or_text("page_header", "HUB", $title) . "</h1>";
+echo "<h1>$title</h1>";
+
+echo get_page_header_image("HUB");
 
 echo "<p>\n";
 echo sprintf(_('Welcome to the %1$s Activity Hub. From this page you can view the phases of %1$s production.'),$site_abbreviation);

--- a/default.php
+++ b/default.php
@@ -11,6 +11,10 @@ include_once($relPath.'walkthrough.inc');
 output_header(_("Welcome"), True);
 $etext_limit = 10;
 
+$image = get_page_header_image("FRONT");
+if($image)
+    echo "<div style='margin-top: 1em;'>$image</div>";
+
 show_news_for_page("FRONT");
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -56,9 +56,7 @@ class Stage extends Activity
     // Display a page-header, either an image (if available) or a textual title
     // for this stage.
     {
-        $header_string = get_translated_graphic_or_text(
-            "page_header", $this->id, $title);
-        echo "<h1>$header_string</h1>\n";
+        echo "<h1>$title</h1>\n" . get_page_header_image($this->id);
     }
 
     function page_top( $uao )

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -1039,18 +1039,23 @@ function get_dyn_image_url_for_file($filename)
     return NULL;
 }
 
-// Given an image, see if we have a version that is in the current
-// user's locale. If so, return the <img> tag with $text as alt text.
-// If not, return $text.
-function get_translated_graphic_or_text($directory, $image, $text)
+// Given a page basename, see if we have a header image for the page.
+// If so, return the <img>. If not, return "";
+function get_page_header_image($image)
 {
-    $locale = get_desired_language();
-    $dyn_url = get_dyn_image_url_for_file("$directory/$locale/$image");
-
+    # Try a locale-less image first
+    $dyn_url = get_dyn_image_url_for_file("page_header/$image");
     if($dyn_url)
-        return sprintf("<img style='max-width: 100%%' src='$dyn_url' alt='%s'>", attr_safe($text));
-    else
-        return $text;
+        return "<img style='max-width: 100%;' src='$dyn_url'>";
+
+    # Now try a locale-based one
+    $locale = get_desired_language();
+    $dyn_url = get_dyn_image_url_for_file("page_header/$locale/$image");
+    if($dyn_url)
+        return "<img style='max-width: 100%;' src='$dyn_url'>";
+
+    # Fall back to nothing
+    return "";
 }
 
 // vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
Some history: before the site was translatable into something besides English, each round page had a graphic at the top for its header. The graphics (the same ones we have today) have English text in them that we can't easily translate. During the effort to provide a translatable site, the compromise was to pull the images out of the codebase but make them accessible via `code_images`. If these images-with-English are present we show them  if the user's locale was English and otherwise we output the translated round title.

The downside is that this presents two very different versions of the Activity Hub and round pages for English and non-English speakers. It also means that we have a weird thing where the Activity Hub header is in a font distinctly different from everything else and it has a white background which limits our ability to theme the site.

This MR allows us to have proper page text for the round headers and also display some graphics for each round. This way we get some header consistency and still have some more eye-catching images. The MR also introduces a way to have images for the front page without putting them in a news item which I think @lhamilton1 will appreciate.

This is a stepping stone to us pulling in an interesting font to use for the headers in a later MR.

Viewable in the [separate-page-header-images](https://www.pgdp.org/~cpeel/c.branch/separate-page-header-images/) sandbox.