### PR TITLE
Allow news entries to have a header and a type

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -176,6 +176,8 @@ CREATE TABLE `news_items` (
   `ordering` smallint(6) NOT NULL default '0',
   `content` text NOT NULL,
   `locale` varchar(8) NOT NULL DEFAULT '',
+  `header` varchar(256) NOT NULL DEFAULT '',
+  `item_type` varchar(16) NOT NULL DEFAULT '',
   PRIMARY KEY  (`id`),
   KEY `pageid_locale` (`news_page_id`,`locale`)
 );

--- a/SETUP/upgrade/15/20200925_alter_news_items.php
+++ b/SETUP/upgrade/15/20200925_alter_news_items.php
@@ -1,0 +1,24 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding columns to news_items..\n";
+$sql = "
+    ALTER TABLE news_items
+        ADD COLUMN header varchar(256) NOT NULL DEFAULT '',
+        ADD COLUMN item_type varchar(16) NOT NULL DEFAULT ''
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -67,7 +67,7 @@ function show_news_for_page( $news_page_id )
     // Get the set of 'current' news items
     // defined for the given page.
     $sql = sprintf("
-        SELECT date_posted, content
+        SELECT date_posted, header, content, item_type
         FROM news_items
         WHERE status = 'current'
             AND (news_page_id = '%s' OR news_page_id = 'GLOBAL')
@@ -80,7 +80,7 @@ function show_news_for_page( $news_page_id )
     // Get a randomly selected news item from the set of
     // 'recent' news items defined for the given page.
     $sql = sprintf("
-        SELECT content
+        SELECT header, content, item_type
         FROM news_items
         WHERE status = 'recent'
             AND (news_page_id = '%s' OR news_page_id = 'GLOBAL')
@@ -100,9 +100,7 @@ function show_news_for_page( $news_page_id )
 
         echo "<div class='news'>";
 
-
         echo "<div class='newsupdated'>";
-
         echo "<small>";
         if ( user_is_a_sitemanager() or user_is_site_news_editor())
         {
@@ -124,11 +122,8 @@ function show_news_for_page( $news_page_id )
         }
         echo "</small>";
         echo "</div>";
-        echo "<div class='newsheader'>";
 
         echo "<h2>" . _('News') . "</h2>";
-
-        echo "</div>"; // div.newsheader
 
         // -------------------------------------------
         // Output the 'current' news items, if any.
@@ -136,7 +131,18 @@ function show_news_for_page( $news_page_id )
         while ($news_item = mysqli_fetch_assoc($res_current))
         {
             echo "<div class='newsitem'>";
+
+            if($news_item['header'])
+            {
+                echo "<div class='news-header news-{$news_item['item_type']}'>";
+                echo $news_item['header'];
+                echo "</div>";
+            }
+
+            echo "<div class='news-content'>";
             echo $news_item['content'];
+            echo "</div>";
+
             echo "</div>";
         }
 
@@ -147,7 +153,18 @@ function show_news_for_page( $news_page_id )
         if($news_item)
         {
             echo "<div class='newsitem'>";
+
+            if($news_item['header'])
+            {
+                echo "<div class='news-header news-{$news_item['item_type']}'>";
+                echo $news_item['header'];
+                echo "</div>";
+            }
+
+            echo "<div class='news-content'>";
             echo $news_item['content'];
+            echo "</div>";
+
             $url = "$code_url/pastnews.php?news_page_id=$news_page_id";
             $linktext = _("See all random news items");
             echo "<p><small><a href='$url'>$linktext</a></small></p>";

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -211,6 +211,29 @@ h6 {
 div.newsitem {
   box-shadow: -5px -5px 5px lightgrey;
 }
+.news-header {
+  font-size: 1.5em;
+  font-weight: bold;
+  padding-bottom: 0.5em;
+}
+.news-normal {
+  color: black;
+}
+.news-announcement1 {
+  color: maroon;
+}
+.news-announcement2 {
+  color: orange;
+}
+.news-announcement3 {
+  color: darkblue;
+}
+.news-celebration {
+  color: green;
+}
+.news-maintenance {
+  color: red;
+}
 /* ------------------------------------------------------------------------ */
 /* FAQ */
 div.faqheader {

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -211,6 +211,29 @@ h6 {
 div.newsitem {
   box-shadow: -5px -5px 5px lightgrey;
 }
+.news-header {
+  font-size: 1.5em;
+  font-weight: bold;
+  padding-bottom: 0.5em;
+}
+.news-normal {
+  color: black;
+}
+.news-announcement1 {
+  color: maroon;
+}
+.news-announcement2 {
+  color: orange;
+}
+.news-announcement3 {
+  color: darkblue;
+}
+.news-celebration {
+  color: green;
+}
+.news-maintenance {
+  color: red;
+}
 /* ------------------------------------------------------------------------ */
 /* FAQ */
 div.faqheader {

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -211,6 +211,29 @@ h6 {
 div.newsitem {
   box-shadow: -5px -5px 5px lightgrey;
 }
+.news-header {
+  font-size: 1.5em;
+  font-weight: bold;
+  padding-bottom: 0.5em;
+}
+.news-normal {
+  color: black;
+}
+.news-announcement1 {
+  color: maroon;
+}
+.news-announcement2 {
+  color: orange;
+}
+.news-announcement3 {
+  color: darkblue;
+}
+.news-celebration {
+  color: green;
+}
+.news-maintenance {
+  color: red;
+}
 /* ------------------------------------------------------------------------ */
 /* FAQ */
 div.faqheader {

--- a/styles/themes/theme.less
+++ b/styles/themes/theme.less
@@ -164,6 +164,40 @@ div.newsitem {
     box-shadow: -5px -5px 5px lightgrey;
 }
 
+.news-header {
+    font-size: 1.5em;
+    font-weight: bold;
+    padding-bottom: 0.5em;
+}
+
+.news-format(@color: black) {
+    color: @color;
+}
+
+.news-normal {
+    .news-format();
+}
+
+.news-announcement1 {
+    .news-format(maroon);
+}
+
+.news-announcement2 {
+    .news-format(orange);
+}
+
+.news-announcement3 {
+    .news-format(darkblue);
+}
+
+.news-celebration {
+    .news-format(green);
+}
+
+.news-maintenance {
+    .news-format(red);
+}
+
 /* ------------------------------------------------------------------------ */
 /* FAQ */
 


### PR DESCRIPTION
Currently news items are a single blob of text. Admins have gotten in the habit of adding formatted header-lines (larger and with color) over the years. This MR pulls the header out into a proper field and allows the news item to have a type that influences the styling. This enables the header to be styled with the theme rather than hard-coded.

The header is optional and if not present won't show up at all so this is backwards compatible with all existing news items.

The item types and colors are mostly adhoc and I'm looking to @lhamilton1, @wf49670, and @srjfoo for recommendations on what these should be.

This also converts the news admin code to use the new DPDatabase functions. It's in a separate commit though so if it is preferable for it to be in a separate MR I can easily do so.

Viewable in the [news-headers](https://www.pgdp.org/~cpeel/c.branch/news-headers/) sandbox.