### PR TITLE
Move quiz colors into layout.less

### DIFF
--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -138,7 +138,7 @@ class Quiz
         if ($this->description != "" || count($stage_required_for) > 0)
         {
             echo "
-                <tr><td colspan='$n_columns' class='info'>";
+                <tr><td colspan='$n_columns'>";
             if (count($stage_required_for) > 0)
             {
                 echo "<p>" . _("Passing this quiz is required for:") . " ";
@@ -168,18 +168,27 @@ class Quiz
             {
                 $passed = user_has_passed_quiz_page($username, $quiz_page_id);
                 $text = $passed ? _("Passed") : _("Not passed");
-                $bgcolor = $passed ? '#ccffcc' : '#ffcccc';
-                echo "<td style='background-color: $bgcolor'>$text</td>";
+                $class = $passed ? 'quiz-passed' : 'quiz-not-passed';
+                echo "<td class='$class'>$text</td>";
+
                 $date = get_last_attempt_date_for_quiz_page($username, $quiz_page_id);
                 $text = ($date != 0) ? strftime("%d-%b-%y", $date) : _("Not attempted");
                 $max = $this->pass_requirements['maximum_age'];
                 $date_ok = ((time() - $date) < $max) || empty($max);
-                $bgcolor = $date_ok ? '#ccffcc' : '#ffcccc';
-                echo "<td style='background-color: $bgcolor'>$text</td>";
-                $text = ($passed && $date_ok) ?	"<span style='font-size: 1.5em' title='Quiz page passed!'>&check;</span>"
-                    : "<span style='font-size: 1.5em' title='Quiz page not passed'>&#x2717;</span>";
-                $bgcolor = ($passed && $date_ok) ? '#88ff88' : '#ff8888';
-                echo "<td style='background-color: $bgcolor'>$text</td>";
+                $class = $date_ok ? 'quiz-date-ok' : 'quiz-date-not-ok';
+                echo "<td class='$class'>$text</td>";
+
+                if($passed && $date_ok)
+                {
+                    $text = "<span class='x-large' title='" . attr_safe(_("Quiz page passed!")) . "'>✓</span>";
+                    $class = 'quiz-ok';
+                }
+                else
+                {
+                    $text = "<span class='x-large' title='" . attr_safe(_("Quiz page not passed!")) . "'>✗</span>";
+                    $class = 'quiz-not-ok';
+                }
+                echo "<td class='$class'>$text</td>";
             }
             echo "</tr>";
         }
@@ -187,9 +196,9 @@ class Quiz
         {
             $total_pass = $this->user_has_passed($username);
             $text = $total_pass ? _("Quiz passed") : _("Quiz not passed");
-            $bgcolor = $total_pass ? '#88ff88' : '#ff8888';
+            $class = $total_pass ? 'quiz-ok' : 'quiz-not-ok';
             echo "
-                <tr><td colspan='$n_columns' style='background-color: $bgcolor; font-weight: bold; text-align: center;'>$text</td></tr>";
+                <tr><td colspan='$n_columns' class='$class center-align bold'>$text</td></tr>";
         }
         echo "</table>\n";
     }

--- a/styles/global.less
+++ b/styles/global.less
@@ -36,6 +36,10 @@
     text-decoration: underline;
 }
 
+.x-large {
+    font-size: x-large;
+}
+
 .large {
     font-size: large;
 }

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1045,6 +1045,40 @@ table.dirlist {
 }
 
 /* ------------------------------------------------------------------------ */
+/* Quizzes */
+
+@quiz-passed: #ccffcc;
+@quiz-not-passed: #ffcccc;
+@quiz-date-ok: #ccffcc;
+@quiz-date-not-ok: #ffcccc;
+@quiz-all-ok: #88ff88;
+@quiz-all-not-ok: #ff8888;
+
+.quiz-passed {
+    background-color: @quiz-passed;
+}
+
+.quiz-not-passed {
+    background-color: @quiz-not-passed;
+}
+
+.quiz-date-ok {
+    background-color: @quiz-date-ok;
+}
+
+.quiz-date-not-ok {
+    background-color: @quiz-date-not-ok;
+}
+
+.quiz-ok {
+    background-color: @quiz-all-ok;
+}
+
+.quiz-not-ok {
+    background-color: @quiz-all-not-ok;
+}
+
+/* ------------------------------------------------------------------------ */
 /* Special days tables */
 
 table.list_special_days {

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -29,6 +29,9 @@
 .underlined {
   text-decoration: underline;
 }
+.x-large {
+  font-size: x-large;
+}
 .large {
   font-size: large;
 }
@@ -1811,6 +1814,26 @@ table.dirlist caption {
   font-size: 111%;
   margin-top: 0.5em;
   padding: 5px;
+}
+/* ------------------------------------------------------------------------ */
+/* Quizzes */
+.quiz-passed {
+  background-color: #ccffcc;
+}
+.quiz-not-passed {
+  background-color: #ffcccc;
+}
+.quiz-date-ok {
+  background-color: #ccffcc;
+}
+.quiz-date-not-ok {
+  background-color: #ffcccc;
+}
+.quiz-ok {
+  background-color: #88ff88;
+}
+.quiz-not-ok {
+  background-color: #ff8888;
 }
 /* ------------------------------------------------------------------------ */
 /* Special days tables */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -29,6 +29,9 @@
 .underlined {
   text-decoration: underline;
 }
+.x-large {
+  font-size: x-large;
+}
 .large {
   font-size: large;
 }
@@ -1811,6 +1814,26 @@ table.dirlist caption {
   font-size: 111%;
   margin-top: 0.5em;
   padding: 5px;
+}
+/* ------------------------------------------------------------------------ */
+/* Quizzes */
+.quiz-passed {
+  background-color: #ccffcc;
+}
+.quiz-not-passed {
+  background-color: #ffcccc;
+}
+.quiz-date-ok {
+  background-color: #ccffcc;
+}
+.quiz-date-not-ok {
+  background-color: #ffcccc;
+}
+.quiz-ok {
+  background-color: #88ff88;
+}
+.quiz-not-ok {
+  background-color: #ff8888;
 }
 /* ------------------------------------------------------------------------ */
 /* Special days tables */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -29,6 +29,9 @@
 .underlined {
   text-decoration: underline;
 }
+.x-large {
+  font-size: x-large;
+}
 .large {
   font-size: large;
 }
@@ -1811,6 +1814,26 @@ table.dirlist caption {
   font-size: 111%;
   margin-top: 0.5em;
   padding: 5px;
+}
+/* ------------------------------------------------------------------------ */
+/* Quizzes */
+.quiz-passed {
+  background-color: #ccffcc;
+}
+.quiz-not-passed {
+  background-color: #ffcccc;
+}
+.quiz-date-ok {
+  background-color: #ccffcc;
+}
+.quiz-date-not-ok {
+  background-color: #ffcccc;
+}
+.quiz-ok {
+  background-color: #88ff88;
+}
+.quiz-not-ok {
+  background-color: #ff8888;
 }
 /* ------------------------------------------------------------------------ */
 /* Special days tables */


### PR DESCRIPTION
We need to be able to theme the passed/not passed colors for the quizzes. This moves them out of `Quiz.inc` into `layout.less`. I also removed an unused class reference from `Quiz.inc` and added a mixin for `x-large` text to `global.less`.

Testable here: [quiz-color-to-layout](https://www.pgdp.org/~srjfoo/c.branch/quiz-color-to-layout/quiz/start.php).