### PR TITLE
Properly escape <meta>-refreshed URLs

### DIFF
--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -59,12 +59,13 @@ function metarefresh($seconds, $url, $title="", $body="", $allow_external=FALSE)
     // If we can't do the redirection using HTTP headers (which is the common
     // case), fall back to using a <meta> tag.
 
-    // See if ambersands are present and if not escaped, escape them
-    if(strpos($url, '&') !== FALSE && strpos($url, '&amp;') === FALSE) {
-        $url = str_replace('&', '&amp;', $url);
+    // If ampersands are present and already escaped, unescape them so
+    // attr_safe() will re-escape them along with anything else
+    if(strpos($absolute_url, '&amp;') !== FALSE) {
+        $absolute_url = str_replace('&amp;', '&', $absolute_url);
     }
 
-    $meta_tag_refresh = "<meta http-equiv=\"refresh\" content=\"$sec ;URL=$url\">";
+    $meta_tag_refresh = "<meta http-equiv='refresh' content='$sec ;URL=" . attr_safe($absolute_url) . "'>";
 
     global $relPath;
     include_once($relPath."slim_header.inc");
@@ -74,9 +75,9 @@ function metarefresh($seconds, $url, $title="", $body="", $allow_external=FALSE)
 
     if ($testing)
     {
-    	echo "\n<hr>\n<i>";
-    	echo sprintf(_('Normally, you would be directed to the next page in %1$d seconds. However, as we are in testing mode, this has been increased to %2$d seconds. If you don\'t want to wait that long, or if you want this page inserted into your browser history, <a href="%3$s">click here</a>.'), $seconds, $sec, $url);
-    	echo "</i>";
+        echo "\n<hr>\n<i>";
+        echo sprintf(_('Normally, you would be directed to the next page in %1$d seconds. However, as we are in testing mode, this has been increased to %2$d seconds. If you don\'t want to wait that long, or if you want this page inserted into your browser history, <a href="%3$s">click here</a>.'), $seconds, $sec, attr_safe($absolute_url));
+        echo "</i>";
     }
 
     exit;


### PR DESCRIPTION
Properly escape redirect URLs in `metarefresh()` that use the `<meta>` tag. Also ensure we disallow redirects off-site when using the `<meta>` tag unless explicitly allowed. This addresses a XSS vulnerability.

This can be played with using the https://www.pgdp.org/~cpeel/c.branch/escape-metarefresh-urls/pinc/test.php page and passing in a URL, eg:
https://www.pgdp.org/~cpeel/c.branch/escape-metarefresh-urls/pinc/test.php?url=../project.php?id=projectID45c225f598e32