### PR TITLE
Use EB Garamond for page headers

### DIFF
--- a/faq/faq_central.php
+++ b/faq/faq_central.php
@@ -220,7 +220,7 @@ class FAQ
                 echo "<td class='column'>";
                 continue;
             }
-            echo "\n<div class='faqheader'>$section->title</div>\n";
+            echo "\n<h2>" . html_safe($section->title) . "</h2>\n";
 
             $section->output();
         }

--- a/styles/global.less
+++ b/styles/global.less
@@ -190,3 +190,8 @@
     font-weight: normal;
     font-style: oblique;
 }
+
+
+/* EB Garamond
+   https://fonts.google.com/specimen/EB+Garamond */
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:wght@700&display=swap');

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -446,7 +446,7 @@ div.newsitem {
 }
 
 .news-header {
-    font-size: 1.5em;
+    font-size: 1.25em;
     font-weight: bold;
     padding-bottom: 0.5em;
 }
@@ -456,7 +456,7 @@ div.newsitem {
 }
 
 .news-normal {
-    .news-format();
+    .news-format(inherit);
 }
 
 .news-announcement1 {

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -242,11 +242,9 @@ nav, #navbar-outer {
 /* Statsbar */
 
 #sidebar, #statsbar {
+    .sans-serif;
     background-color: @sidebar-background;
     color: @sidebar-text;
-    p, li, td, th {
-        .sans-serif;
-    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -768,15 +766,6 @@ table.faqtable {
             padding-right: 1em;
         }
     }
-}
-
-div.faqheader {
-    .bold;
-    .middle-align;
-    padding: 0.25em 0.5em;
-    .sans-serif;
-    background-color: @navbar-background;
-    color: @navbar-text;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -89,7 +89,32 @@ section, footer, aside, main, article, figure {
 
 h1, h2, h3, h4, h5, h6 {
     color: @heading-color;
-    .sans-serif;
+    font-family: 'EB Garamond', serif;
+    margin: 0.5em auto;
+}
+
+h1 {
+    font-size: 2.2em;
+}
+
+h2 {
+    font-size: 1.8em;
+}
+
+h3 {
+    font-size: 1.5em;
+}
+
+h4 {
+    font-size: 1.3em;
+}
+
+h5 {
+    font-size: 1.2em;
+}
+
+h5 {
+    font-size: 1em;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -1220,7 +1245,7 @@ table.search-column {
     .sidebar-color;
     h2 {
         .center-align;
-        font-size: 1em;
+        font-size: 1.5em;
     }
     li {
         margin-top: 3px;

--- a/styles/statsbar.css
+++ b/styles/statsbar.css
@@ -11,7 +11,7 @@
 }
 #statsbar h2 {
   text-align: center;
-  font-size: 1.25em;
+  font-size: 1.5em;
 }
 #statsbar .more-link {
   text-align: center;

--- a/styles/statsbar.less
+++ b/styles/statsbar.less
@@ -13,7 +13,7 @@
     .small;
     h2 {
         .center-align;
-        font-size: 1.25em;
+        font-size: 1.5em;
     }
     .more-link {
         .center-align;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1051,18 +1051,9 @@ nav,
 /* Statsbar */
 #sidebar,
 #statsbar {
+  font-family: Verdana, Helvetica, sans-serif;
   background-color: #dddddd;
   color: #000000;
-}
-#sidebar p,
-#statsbar p,
-#sidebar li,
-#statsbar li,
-#sidebar td,
-#statsbar td,
-#sidebar th,
-#statsbar th {
-  font-family: Verdana, Helvetica, sans-serif;
 }
 /* ------------------------------------------------------------------------ */
 /* Footer */
@@ -1565,14 +1556,6 @@ table.faqtable tr td.column {
   vertical-align: top;
   width: 50%;
   padding-right: 1em;
-}
-div.faqheader {
-  font-weight: bold;
-  vertical-align: middle;
-  padding: 0.25em 0.5em;
-  font-family: Verdana, Helvetica, sans-serif;
-  background-color: #444444;
-  color: #ffffff;
 }
 /* ------------------------------------------------------------------------ */
 /* User Preferences */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -145,6 +145,15 @@
   font-weight: normal;
   font-style: oblique;
 }
+/* EB Garamond
+   https://fonts.google.com/specimen/EB+Garamond */
+@font-face {
+  font-family: 'EB Garamond';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v14/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+}
 /* ======================================================================== */
 /* Page Interface Structures */
 /*
@@ -813,7 +822,26 @@ h4,
 h5,
 h6 {
   color: #333333;
-  font-family: Verdana, Helvetica, sans-serif;
+  font-family: 'EB Garamond', serif;
+  margin: 0.5em auto;
+}
+h1 {
+  font-size: 2.2em;
+}
+h2 {
+  font-size: 1.8em;
+}
+h3 {
+  font-size: 1.5em;
+}
+h4 {
+  font-size: 1.3em;
+}
+h5 {
+  font-size: 1.2em;
+}
+h5 {
+  font-size: 1em;
 }
 /* ------------------------------------------------------------------------ */
 /* Header */
@@ -1973,7 +2001,7 @@ table.search-column tr th {
 }
 #linkbox h2 {
   text-align: center;
-  font-size: 1em;
+  font-size: 1.5em;
 }
 #linkbox li {
   margin-top: 3px;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1244,12 +1244,12 @@ div.newsitem img {
   max-width: 100%;
 }
 .news-header {
-  font-size: 1.5em;
+  font-size: 1.25em;
   font-weight: bold;
   padding-bottom: 0.5em;
 }
 .news-normal {
-  color: black;
+  color: inherit;
 }
 .news-announcement1 {
   color: maroon;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1244,12 +1244,12 @@ div.newsitem img {
   max-width: 100%;
 }
 .news-header {
-  font-size: 1.5em;
+  font-size: 1.25em;
   font-weight: bold;
   padding-bottom: 0.5em;
 }
 .news-normal {
-  color: black;
+  color: inherit;
 }
 .news-announcement1 {
   color: maroon;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1051,18 +1051,9 @@ nav,
 /* Statsbar */
 #sidebar,
 #statsbar {
+  font-family: Verdana, Helvetica, sans-serif;
   background-color: #e0e8dd;
   color: #000000;
-}
-#sidebar p,
-#statsbar p,
-#sidebar li,
-#statsbar li,
-#sidebar td,
-#statsbar td,
-#sidebar th,
-#statsbar th {
-  font-family: Verdana, Helvetica, sans-serif;
 }
 /* ------------------------------------------------------------------------ */
 /* Footer */
@@ -1565,14 +1556,6 @@ table.faqtable tr td.column {
   vertical-align: top;
   width: 50%;
   padding-right: 1em;
-}
-div.faqheader {
-  font-weight: bold;
-  vertical-align: middle;
-  padding: 0.25em 0.5em;
-  font-family: Verdana, Helvetica, sans-serif;
-  background-color: #336633;
-  color: #ffffff;
 }
 /* ------------------------------------------------------------------------ */
 /* User Preferences */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -145,6 +145,15 @@
   font-weight: normal;
   font-style: oblique;
 }
+/* EB Garamond
+   https://fonts.google.com/specimen/EB+Garamond */
+@font-face {
+  font-family: 'EB Garamond';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v14/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+}
 /* ======================================================================== */
 /* Page Interface Structures */
 /*
@@ -813,7 +822,26 @@ h4,
 h5,
 h6 {
   color: #234523;
-  font-family: Verdana, Helvetica, sans-serif;
+  font-family: 'EB Garamond', serif;
+  margin: 0.5em auto;
+}
+h1 {
+  font-size: 2.2em;
+}
+h2 {
+  font-size: 1.8em;
+}
+h3 {
+  font-size: 1.5em;
+}
+h4 {
+  font-size: 1.3em;
+}
+h5 {
+  font-size: 1.2em;
+}
+h5 {
+  font-size: 1em;
 }
 /* ------------------------------------------------------------------------ */
 /* Header */
@@ -1973,7 +2001,7 @@ table.search-column tr th {
 }
 #linkbox h2 {
   text-align: center;
-  font-size: 1em;
+  font-size: 1.5em;
 }
 #linkbox li {
   margin-top: 3px;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1051,18 +1051,9 @@ nav,
 /* Statsbar */
 #sidebar,
 #statsbar {
+  font-family: Verdana, Arial, sans-serif;
   background-color: #99ccff;
   color: #000000;
-}
-#sidebar p,
-#statsbar p,
-#sidebar li,
-#statsbar li,
-#sidebar td,
-#statsbar td,
-#sidebar th,
-#statsbar th {
-  font-family: Verdana, Arial, sans-serif;
 }
 /* ------------------------------------------------------------------------ */
 /* Footer */
@@ -1565,14 +1556,6 @@ table.faqtable tr td.column {
   vertical-align: top;
   width: 50%;
   padding-right: 1em;
-}
-div.faqheader {
-  font-weight: bold;
-  vertical-align: middle;
-  padding: 0.25em 0.5em;
-  font-family: Verdana, Arial, sans-serif;
-  background-color: #000099;
-  color: #ffffff;
 }
 /* ------------------------------------------------------------------------ */
 /* User Preferences */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1244,12 +1244,12 @@ div.newsitem img {
   max-width: 100%;
 }
 .news-header {
-  font-size: 1.5em;
+  font-size: 1.25em;
   font-weight: bold;
   padding-bottom: 0.5em;
 }
 .news-normal {
-  color: black;
+  color: inherit;
 }
 .news-announcement1 {
   color: maroon;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -145,6 +145,15 @@
   font-weight: normal;
   font-style: oblique;
 }
+/* EB Garamond
+   https://fonts.google.com/specimen/EB+Garamond */
+@font-face {
+  font-family: 'EB Garamond';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v14/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+}
 /* ======================================================================== */
 /* Page Interface Structures */
 /*
@@ -813,7 +822,26 @@ h4,
 h5,
 h6 {
   color: #000066;
-  font-family: Verdana, Arial, sans-serif;
+  font-family: 'EB Garamond', serif;
+  margin: 0.5em auto;
+}
+h1 {
+  font-size: 2.2em;
+}
+h2 {
+  font-size: 1.8em;
+}
+h3 {
+  font-size: 1.5em;
+}
+h4 {
+  font-size: 1.3em;
+}
+h5 {
+  font-size: 1.2em;
+}
+h5 {
+  font-size: 1em;
 }
 /* ------------------------------------------------------------------------ */
 /* Header */
@@ -1973,7 +2001,7 @@ table.search-column tr th {
 }
 #linkbox h2 {
   text-align: center;
-  font-size: 1em;
+  font-size: 1.5em;
 }
 #linkbox li {
   margin-top: 3px;


### PR DESCRIPTION
Use EB Garamond for page headers, providing a bit more visual pizzaz to them.

This is viewable in the [eb-garamond-headers](https://www.pgdp.org/~cpeel/c.branch/eb-garamond-headers/) sandbox.