### PR TITLE
API updates: correct project fields; page details; more info in pages index

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -332,7 +332,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: string
+                  $ref: '#/components/schemas/project_page_index'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -496,6 +496,22 @@ components:
         includes a great deal of information, some fields of which are calculated
         and not directly modifyable. Not all fields are available to all users. Fields
         the user does not have access to will not be returned.
+
+    project_page_index:
+      required:
+      - image
+      - image_url
+      - image_size
+      type: object
+      properties:
+        image:
+          type: string
+        image_url:
+          type: string
+          format: url
+        image_size:
+          type: integer
+          description: Image size in bytes
 
     project_page:
       required:

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -342,6 +342,36 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/{projectid}/pagedetails:
+    get:
+      tags:
+      - project
+      description: Gets all details about a project's pages
+      parameters:
+      - name: projectid
+        in: path
+        description: ID of project
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Page details
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/project_page_detail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/{projectid}/pages/{pagename}/pagerounds/{pageroundid}:
     get:
       tags:
@@ -512,6 +542,53 @@ components:
         image_size:
           type: integer
           description: Image size in bytes
+
+    project_page_detail:
+      required:
+      - image
+      - image_url
+      - image_size
+      - state
+      type: object
+      properties:
+        image:
+          type: string
+        image_url:
+          type: string
+          format: url
+        image_size:
+          type: integer
+          description: Image size in bytes
+        state:
+          type: string
+        pagerounds:
+          type: array
+          items:
+            $ref: '#/components/schemas/project_page_round_detail'
+
+    project_page_round_detail:
+      type: object
+      required:
+      - page_round
+      - page_size
+      properties:
+        pageround:
+          type: string
+        page_size:
+          type: integer
+          description: Page size in bytes
+        is_diff:
+          type: boolean
+          description: Is there a diff between this and the prior round
+        user_page_tally:
+          type: integer
+          description: Number of pages proofer has proofed in this round
+        wordcheck_ran:
+          type: boolean
+          description: Was WordCheck run on the page
+        last_modified:
+          type: string
+          format: dateTime
 
     project_page:
       required:

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -475,50 +475,36 @@ components:
           type: string
         special_day:
           type: string
-        clearance_line:
-          type: string
         project_manager:
           type: string
         post_processor:
+          type: string
+        post_process_verifier:
+          type: string
+        image_preparer:
+          type: string
+        text_preparer:
           type: string
         image_source:
           type: string
         pages_available:
           type: integer
-        page_total:
+        pages_total:
           type: integer
-        text_preparer:
-          type: string
         pg_ebook_number:
           type: integer
-        comments:
-          type: string
-        credits_so_far:
-          type: string
-          readOnly: true
-        modified:
-          type: string
-          format: dateTime
-          readOnly: true
         state:
           type: string
           readOnly: true
-        state_last_modified:
+        last_state_change_time:
           type: string
           format: dateTime
           readOnly: true
-        page_last_modified:
+        last_page_done_time:
           type: string
           format: dateTime
           readOnly: true
-        forum_url:
-          type: string
-          format: url
-          readOnly: true
-        forum_replies:
-          type: integer
-          readOnly: true
-        forum_last_updated:
+        last_edit_time:
           type: string
           format: dateTime
           readOnly: true

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -293,7 +293,7 @@ paths:
           type: string
           enum: [good, bad]
       requestBody:
-        description: Words to replace
+        description: List of replacement words
         content:
           application/json:
             schema:
@@ -316,7 +316,7 @@ paths:
     get:
       tags:
       - project
-      description: Gets a list of a project's page names
+      description: Gets a list of project pages
       parameters:
       - name: projectid
         in: path
@@ -376,7 +376,7 @@ paths:
     get:
       tags:
       - project
-      description: Gets a list of a project's page names
+      description: Gets a project page text in a given pageround
       parameters:
       - name: projectid
         in: path
@@ -510,7 +510,7 @@ components:
           readOnly: true
       description: A project represents a unique project object in the system. It
         includes a great deal of information, some fields of which are calculated
-        and not directly modifyable. Not all fields are available to all users. Fields
+        and not directly modifiable. Not all fields are available to all users. Fields
         the user does not have access to will not be returned.
 
     project_page_index:

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -26,6 +26,7 @@ $router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
 $router->add_route("GET", "v1/projects/states", "api_v1_projects_states");
 $router->add_route("GET", "v1/projects/pagerounds", "api_v1_projects_pagerounds");
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
+$router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -2,6 +2,7 @@
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'ProjectSearchForm.inc');
+include_once($relPath.'page_table.inc');
 include_once("exceptions.inc");
 
 // DP API v1 -- Projects
@@ -198,6 +199,33 @@ function api_v1_project_pages($method, $data, $query_params)
             "image_url" => "{$project->dir}/$image",
             "image_size" => $project->get_image_file_size($image),
         ];
+    }
+    return $return_data;
+}
+
+//---------------------------------------------------------------------------
+// projects/:projectid/pagedetails
+
+function api_v1_project_pagedetails($method, $data, $query_params)
+{
+    $return_data = [];
+    foreach(fetch_page_table_data($data[":projectid"]) as $image)
+    {
+        $page_rounds_data = [];
+        // Remove proofer names and adjust timestamp format
+        foreach($image["pagerounds"] as $round_id => $round_data)
+        {
+            $round_data["pageround"] = $round_id;
+            if(isset($round_data["modified_timestamp"]))
+            {
+                $round_data["last_modified"] = date(DATE_ATOM, $round_data["modified_timestamp"]);
+                unset($round_data["modified_timestamp"]);
+            }
+            unset($round_data["username"]);
+            $page_rounds_data[] = $round_data;
+        }
+        $image["pagerounds"] = $page_rounds_data;
+        $return_data[] = $image;
     }
     return $return_data;
 }

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -143,9 +143,9 @@ function render_project_json($project)
         "pages_available" => $project->n_available_pages,
         "pages_total" => $project->n_pages,
         "pg_ebook_number" => $project->postednum,
-        "last_modified" => date(DATE_ATOM, $project->modifieddate),
-        "last_page_done" => date(DATE_ATOM, $project->t_last_page_done),
-        "last_edit" => date(DATE_ATOM, $project->t_last_edit),
+        "last_state_change_time" => date(DATE_ATOM, $project->modifieddate),
+        "last_page_done_time" => date(DATE_ATOM, $project->t_last_page_done),
+        "last_edit_time" => date(DATE_ATOM, $project->t_last_edit),
     ];
 }
 

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -188,7 +188,18 @@ function api_v1_project_wordlists($method, $data, $query_params)
 
 function api_v1_project_pages($method, $data, $query_params)
 {
-    return $data[":projectid"]->get_page_names_from_db();
+    $project = $data[":projectid"];
+
+    $return_data = [];
+    foreach($project->get_page_names_from_db() as $image)
+    {
+        $return_data[] = [
+            "image" => $image,
+            "image_url" => "{$project->dir}/$image",
+            "image_size" => $project->get_image_file_size($image),
+        ];
+    }
+    return $return_data;
 }
 
 //---------------------------------------------------------------------------

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -564,6 +564,20 @@ class Project
         return array_intersect($db_names, $disk_names);
     }
 
+    // Given a project image, return the file size in bytes. If the image
+    // doesn't exist on disk, return NULL.
+    // TODO: This function would be better in a ProjectPage object, but we
+    // don't have one of those.
+    function get_image_file_size($image)
+    {
+        $image_path = realpath("{$this->dir}/$image");
+        if (file_exists($image_path)) {
+            return filesize($image_path);
+        } else {
+            return NULL;
+        }
+    }
+
     function get_illustrations()
     {
         // Illustrations are the set of files in the project directory that

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -175,14 +175,9 @@ function fetch_page_table_data($project, $page_selector = NULL, $proofed_in_roun
         $data = [
             "image" => $row['image'],
             "image_url" => "{$project->url}/{$row['image']}",
+            "image_size" => $project->get_image_file_size($row['image']),
             "state" => $row['state'],
         ];
-
-        if (file_exists("{$project->dir}/{$row['image']}")) {
-            $data['image_size'] = filesize(realpath("{$project->dir}/{$row['image']}"));
-        } else {
-            $data['image_size'] = NULL;
-        }
 
         $pagerounds = [
             "OCR" => [


### PR DESCRIPTION
This updates the API with the following changes:
* corrects project fields so the OpenAPI docs match the fields returned for a project
* updates the `/pages` endpoint to include more information about the page instead of just a listing of names
* adds a `/pagedetails` endpoint that returns largely the same data as the UI page with the same name

Testable via:
```bash
curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/api-updates/api/index.php?url=v1/projects/projectID45c225f598e32" \
    -H "accept: application/json" \
    -H "X-API-KEY: review"

curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/api-updates/api/index.php?url=v1/projects/projectID45c225f598e32/pagedetails" \
    -H "accept: application/json" \
    -H "X-API-KEY: review"

curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/api-updates/api/index.php?url=v1/projects/projectID45c225f598e32/pages" \
    -H "accept: application/json" \
    -H "X-API-KEY: review"
```

The updates to the `/pages` and project endpoints break compatibility with what was out there before, but currently we have no consumers and the API is not included in any DP code release, so this seems entirely reasonable at this time.