### PR TITLE
Explicitly set the standard interface colors

### DIFF
--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -35,6 +35,7 @@
 
         input, select, button {
             background-color: @text-pane-background;
+            color: @text-pane-text;
             .solid-border;
         }
 
@@ -55,7 +56,7 @@
 /* ------------------------------------------------------------------------ */
 /* Standard Editing Interface */
 
-#standard_interface {
+#standard_interface_image {
     .no-padding;
     .no-margin;
     .page-interface;
@@ -65,7 +66,26 @@
     }
 }
 
+#standard_interface_text {
+    .no-margin;
+    background-color: white;
+    color: black;
+    #editform {
+        input {
+            background-color: white;
+            color: black;
+            border: thin solid black;
+        }
+        button, input[type=submit], input[type=button] {
+            box-shadow: 1px 1px grey;
+            margin: 2px;
+        }
+    }
+}
+
 #text_data, #text_data:focus {
+    background-color: white;
+    color: black;
     outline: none;
 }
 

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -180,6 +180,7 @@
 .page-interface .control-pane select,
 .page-interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .page-interface .control-pane button,
@@ -195,42 +196,61 @@
 }
 /* ------------------------------------------------------------------------ */
 /* Standard Editing Interface */
-#standard_interface {
+#standard_interface_image {
   padding: 0;
   margin: 0;
   background-color: #CDCDC1;
   color: black;
 }
-#standard_interface .text-pane {
+#standard_interface_image .text-pane {
   background-color: #FFF8DC;
   color: black;
 }
-#standard_interface .control-pane {
+#standard_interface_image .control-pane {
   background-color: #CDC0B0;
   color: black;
 }
-#standard_interface .control-pane input,
-#standard_interface .control-pane select,
-#standard_interface .control-pane button {
+#standard_interface_image .control-pane input,
+#standard_interface_image .control-pane select,
+#standard_interface_image .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
-#standard_interface .control-pane button,
-#standard_interface .control-pane input[type=submit],
-#standard_interface .control-pane input[type=button] {
+#standard_interface_image .control-pane button,
+#standard_interface_image .control-pane input[type=submit],
+#standard_interface_image .control-pane input[type=button] {
   box-shadow: 1px 1px grey;
 }
-#standard_interface .control-pane input[type=image] {
+#standard_interface_image .control-pane input[type=image] {
   border: none;
 }
-#standard_interface .control-pane .menu {
+#standard_interface_image .control-pane .menu {
   background-color: Bisque;
 }
-#standard_interface #imagedisplay {
+#standard_interface_image #imagedisplay {
   text-align: center;
+}
+#standard_interface_text {
+  margin: 0;
+  background-color: white;
+  color: black;
+}
+#standard_interface_text #editform input {
+  background-color: white;
+  color: black;
+  border: thin solid black;
+}
+#standard_interface_text #editform button,
+#standard_interface_text #editform input[type=submit],
+#standard_interface_text #editform input[type=button] {
+  box-shadow: 1px 1px grey;
+  margin: 2px;
 }
 #text_data,
 #text_data:focus {
+  background-color: white;
+  color: black;
   outline: none;
 }
 /* ------------------------------------------------------------------------ */
@@ -253,6 +273,7 @@
 #enhanced_interface .control-pane select,
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface .control-pane button,
@@ -284,6 +305,7 @@
 #enhanced_interface #tdtop select,
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface #tdtop button,
@@ -319,6 +341,7 @@
 #enhanced_interface #tdtext .control-pane select,
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface #tdtext .control-pane button,
@@ -365,6 +388,7 @@
 #wordcheck_interface .control-pane select,
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #wordcheck_interface .control-pane button,
@@ -394,6 +418,7 @@
 #wordcheck_interface #tdtop select,
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #wordcheck_interface #tdtop button,
@@ -443,6 +468,7 @@
 #format_preview .control-pane select,
 #format_preview .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #format_preview .control-pane button,
@@ -466,6 +492,7 @@
 .ilb select,
 .ilb button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .ilb button,
@@ -496,6 +523,7 @@
 .fixedbox select,
 .fixedbox button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .fixedbox button,
@@ -537,6 +565,7 @@
 .control-frame select,
 .control-frame button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .control-frame button,
@@ -563,6 +592,7 @@
 #toolbox select,
 #toolbox button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #toolbox button,
@@ -676,6 +706,7 @@
 #page-browser .control-pane select,
 #page-browser .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #page-browser .control-pane button,

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -180,6 +180,7 @@
 .page-interface .control-pane select,
 .page-interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .page-interface .control-pane button,
@@ -195,42 +196,61 @@
 }
 /* ------------------------------------------------------------------------ */
 /* Standard Editing Interface */
-#standard_interface {
+#standard_interface_image {
   padding: 0;
   margin: 0;
   background-color: #CDCDC1;
   color: black;
 }
-#standard_interface .text-pane {
+#standard_interface_image .text-pane {
   background-color: #FFF8DC;
   color: black;
 }
-#standard_interface .control-pane {
+#standard_interface_image .control-pane {
   background-color: #CDC0B0;
   color: black;
 }
-#standard_interface .control-pane input,
-#standard_interface .control-pane select,
-#standard_interface .control-pane button {
+#standard_interface_image .control-pane input,
+#standard_interface_image .control-pane select,
+#standard_interface_image .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
-#standard_interface .control-pane button,
-#standard_interface .control-pane input[type=submit],
-#standard_interface .control-pane input[type=button] {
+#standard_interface_image .control-pane button,
+#standard_interface_image .control-pane input[type=submit],
+#standard_interface_image .control-pane input[type=button] {
   box-shadow: 1px 1px grey;
 }
-#standard_interface .control-pane input[type=image] {
+#standard_interface_image .control-pane input[type=image] {
   border: none;
 }
-#standard_interface .control-pane .menu {
+#standard_interface_image .control-pane .menu {
   background-color: Bisque;
 }
-#standard_interface #imagedisplay {
+#standard_interface_image #imagedisplay {
   text-align: center;
+}
+#standard_interface_text {
+  margin: 0;
+  background-color: white;
+  color: black;
+}
+#standard_interface_text #editform input {
+  background-color: white;
+  color: black;
+  border: thin solid black;
+}
+#standard_interface_text #editform button,
+#standard_interface_text #editform input[type=submit],
+#standard_interface_text #editform input[type=button] {
+  box-shadow: 1px 1px grey;
+  margin: 2px;
 }
 #text_data,
 #text_data:focus {
+  background-color: white;
+  color: black;
   outline: none;
 }
 /* ------------------------------------------------------------------------ */
@@ -253,6 +273,7 @@
 #enhanced_interface .control-pane select,
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface .control-pane button,
@@ -284,6 +305,7 @@
 #enhanced_interface #tdtop select,
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface #tdtop button,
@@ -319,6 +341,7 @@
 #enhanced_interface #tdtext .control-pane select,
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface #tdtext .control-pane button,
@@ -365,6 +388,7 @@
 #wordcheck_interface .control-pane select,
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #wordcheck_interface .control-pane button,
@@ -394,6 +418,7 @@
 #wordcheck_interface #tdtop select,
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #wordcheck_interface #tdtop button,
@@ -443,6 +468,7 @@
 #format_preview .control-pane select,
 #format_preview .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #format_preview .control-pane button,
@@ -466,6 +492,7 @@
 .ilb select,
 .ilb button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .ilb button,
@@ -496,6 +523,7 @@
 .fixedbox select,
 .fixedbox button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .fixedbox button,
@@ -537,6 +565,7 @@
 .control-frame select,
 .control-frame button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .control-frame button,
@@ -563,6 +592,7 @@
 #toolbox select,
 #toolbox button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #toolbox button,
@@ -676,6 +706,7 @@
 #page-browser .control-pane select,
 #page-browser .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #page-browser .control-pane button,

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -180,6 +180,7 @@
 .page-interface .control-pane select,
 .page-interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .page-interface .control-pane button,
@@ -195,42 +196,61 @@
 }
 /* ------------------------------------------------------------------------ */
 /* Standard Editing Interface */
-#standard_interface {
+#standard_interface_image {
   padding: 0;
   margin: 0;
   background-color: #CDCDC1;
   color: black;
 }
-#standard_interface .text-pane {
+#standard_interface_image .text-pane {
   background-color: #FFF8DC;
   color: black;
 }
-#standard_interface .control-pane {
+#standard_interface_image .control-pane {
   background-color: #CDC0B0;
   color: black;
 }
-#standard_interface .control-pane input,
-#standard_interface .control-pane select,
-#standard_interface .control-pane button {
+#standard_interface_image .control-pane input,
+#standard_interface_image .control-pane select,
+#standard_interface_image .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
-#standard_interface .control-pane button,
-#standard_interface .control-pane input[type=submit],
-#standard_interface .control-pane input[type=button] {
+#standard_interface_image .control-pane button,
+#standard_interface_image .control-pane input[type=submit],
+#standard_interface_image .control-pane input[type=button] {
   box-shadow: 1px 1px grey;
 }
-#standard_interface .control-pane input[type=image] {
+#standard_interface_image .control-pane input[type=image] {
   border: none;
 }
-#standard_interface .control-pane .menu {
+#standard_interface_image .control-pane .menu {
   background-color: Bisque;
 }
-#standard_interface #imagedisplay {
+#standard_interface_image #imagedisplay {
   text-align: center;
+}
+#standard_interface_text {
+  margin: 0;
+  background-color: white;
+  color: black;
+}
+#standard_interface_text #editform input {
+  background-color: white;
+  color: black;
+  border: thin solid black;
+}
+#standard_interface_text #editform button,
+#standard_interface_text #editform input[type=submit],
+#standard_interface_text #editform input[type=button] {
+  box-shadow: 1px 1px grey;
+  margin: 2px;
 }
 #text_data,
 #text_data:focus {
+  background-color: white;
+  color: black;
   outline: none;
 }
 /* ------------------------------------------------------------------------ */
@@ -253,6 +273,7 @@
 #enhanced_interface .control-pane select,
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface .control-pane button,
@@ -284,6 +305,7 @@
 #enhanced_interface #tdtop select,
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface #tdtop button,
@@ -319,6 +341,7 @@
 #enhanced_interface #tdtext .control-pane select,
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #enhanced_interface #tdtext .control-pane button,
@@ -365,6 +388,7 @@
 #wordcheck_interface .control-pane select,
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #wordcheck_interface .control-pane button,
@@ -394,6 +418,7 @@
 #wordcheck_interface #tdtop select,
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #wordcheck_interface #tdtop button,
@@ -443,6 +468,7 @@
 #format_preview .control-pane select,
 #format_preview .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #format_preview .control-pane button,
@@ -466,6 +492,7 @@
 .ilb select,
 .ilb button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .ilb button,
@@ -496,6 +523,7 @@
 .fixedbox select,
 .fixedbox button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .fixedbox button,
@@ -537,6 +565,7 @@
 .control-frame select,
 .control-frame button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 .control-frame button,
@@ -563,6 +592,7 @@
 #toolbox select,
 #toolbox button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #toolbox button,
@@ -676,6 +706,7 @@
 #page-browser .control-pane select,
 #page-browser .control-pane button {
   background-color: #FFF8DC;
+  color: black;
   border: thin solid black;
 }
 #page-browser .control-pane button,

--- a/tools/proofers/image_frame_std.php
+++ b/tools/proofers/image_frame_std.php
@@ -9,7 +9,7 @@ require_login();
 
 $ppage = get_requested_PPage($_GET);
 
-slim_header("Image Frame", array('body_attributes' => 'id="standard_interface"'));
+slim_header("Image Frame", array('body_attributes' => 'id="standard_interface_image"'));
 
 $user = User::load_current();
 if ($user->profile->i_layout == 1)

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -33,7 +33,7 @@ function echo_text_frame_std( $ppage )
         var switchConfirm = '$switch_confirm';
         var revertConfirm = '$revert_confirm';
         ",
-        "body_attributes" => "onload='ldAll()' class='no-margin'",
+        "body_attributes" => "id='standard_interface_text' onload='ldAll()'",
         );
     slim_header(_("Text Frame"), $header_args);
     ?>


### PR DESCRIPTION
Rather than rely on the standard interface inheriting from the site style, explicitly set the colors. This is a stepping stone to before we have themes that apply just to the proofreading interface. This is in prep for theming work that @srjfoo is doing.

Note that one downside to this is that buttons in the standard proofreading interface are now styled rather than simply whatever the browser agent is using.

Testable in the [set-std-interface-colors](https://www.pgdp.org/~cpeel/c.branch/set-std-interface-colors/) sandbox.