### PR TITLE
Tweak news layout

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -65,10 +65,6 @@ foreach ( $Round_for_round_id_ as $round )
 
 // =============================================================================
 
-echo "\n<hr>\n";
-
-// ----------------------------------
-
 // Get the project transitions for the number of projects completed today
 // set the timestamp representing the start of today
 $t_start_of_today = mktime(0,0,0,date('m'),date('d'),date('y'));

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -431,10 +431,10 @@ div.newsupdated {
 div.newsitem {
     border-radius: 5px;
     padding: 0.75em;
-    margin-left: 0.5em;
     margin-top: 1em;
     overflow: auto;
-    box-shadow: -5px -5px 5px lightgrey;
+    border-left: thick solid lightgrey;
+    border-bottom: thin solid lightgrey;
     p {
         margin: 0 0.5em 0.5em 0;
     }

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1223,10 +1223,10 @@ div.newsupdated {
 div.newsitem {
   border-radius: 5px;
   padding: 0.75em;
-  margin-left: 0.5em;
   margin-top: 1em;
   overflow: auto;
-  box-shadow: -5px -5px 5px lightgrey;
+  border-left: thick solid lightgrey;
+  border-bottom: thin solid lightgrey;
 }
 div.newsitem p {
   margin: 0 0.5em 0.5em 0;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1223,10 +1223,10 @@ div.newsupdated {
 div.newsitem {
   border-radius: 5px;
   padding: 0.75em;
-  margin-left: 0.5em;
   margin-top: 1em;
   overflow: auto;
-  box-shadow: -5px -5px 5px lightgrey;
+  border-left: thick solid lightgrey;
+  border-bottom: thin solid lightgrey;
 }
 div.newsitem p {
   margin: 0 0.5em 0.5em 0;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1223,10 +1223,10 @@ div.newsupdated {
 div.newsitem {
   border-radius: 5px;
   padding: 0.75em;
-  margin-left: 0.5em;
   margin-top: 1em;
   overflow: auto;
-  box-shadow: -5px -5px 5px lightgrey;
+  border-left: thick solid lightgrey;
+  border-bottom: thin solid lightgrey;
 }
 div.newsitem p {
   margin: 0 0.5em 0.5em 0;

--- a/tools/pool.php
+++ b/tools/pool.php
@@ -32,20 +32,9 @@ if ( !$uao->can_access )
     show_user_access_object( $uao );
 }
 
-
-
 show_news_for_page($pool->id);
 
-
-echo "<hr class='divider'>\n";
-
-echo "<br>\n";
-echo implode( "\n", $pool->blather );
-
-
-echo "<br><p>" . _("If there's a project you're interested in, you can get to a page about that project by clicking on the title of the work. (We strongly recommend you right-click and open this project-specific page in a new window or tab.) The page will let you see the project comments and check the project in or out as well as download the associated text and image files.") . "</p>";
-
-
+echo "<p style='padding-top: 1em'>" . implode( "\n", $pool->blather ) . "</p>";
 
 // --------------------------------------------------------------
 


### PR DESCRIPTION
Remove the drop-shadow from the news items and use vertical and horizontal borders to separate them. This creates a cleaner interface (and also looks better in the upcoming charcoal theme).

I also removed some unnecessary `<hr>`s and a paragraph on the pool pages that doesn't need to be there (we don't put that on the round pages, why do we do it on the pool pages?).

Testable in the [tweak-news-layout](https://www.pgdp.org/~cpeel/c.branch/tweak-news-layout/) sandbox.