### PR TITLE
Add styling for Random Rules to layout.less

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -563,6 +563,36 @@ table.filter {
 }
 
 /* ------------------------------------------------------------------------ */
+/* Random Rules */
+/* Because the guidelines are in the wiki, we have to jump through
+   some hoops to get any tables used there to be displayed properly
+   if they are included in a random rule. A random_rule class has been
+   created in https://www.pgdp.net/wiki/MediaWiki:Common.css to allow
+   a class to be added to the tables that are in a random rule. The
+   CSS defined here in layout.less is not used directly anywhere in
+   the code, but only used to theme random rules imported from the
+   pgdp.net wiki.
+ */
+
+@random-rule-header: cornsilk;
+
+table.random_rule {
+    .default-border();
+    border-collapse: collapse;
+    tr td {
+        .default-border(); 
+        padding: 0.25em 0.5em;
+    }
+    tr th {
+        .default-border();
+        padding: 0.25em 0.5em;
+        .top-align;
+        .left-align;
+        background-color: @random-rule-header;
+    }
+}
+
+/* ------------------------------------------------------------------------ */
 /* Registration table */
 
 table.register {

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1363,6 +1363,32 @@ table.filter td select {
   width: 100%;
 }
 /* ------------------------------------------------------------------------ */
+/* Random Rules */
+/* Because the guidelines are in the wiki, we have to jump through
+   some hoops to get any tables used there to be displayed properly
+   if they are included in a random rule. A random_rule class has been
+   created in https://www.pgdp.net/wiki/MediaWiki:Common.css to allow
+   a class to be added to the tables that are in a random rule. The
+   CSS defined here in layout.less is not used directly anywhere in
+   the code, but only used to theme random rules imported from the
+   pgdp.net wiki.
+ */
+table.random_rule {
+  border: thin solid black;
+  border-collapse: collapse;
+}
+table.random_rule tr td {
+  border: thin solid black;
+  padding: 0.25em 0.5em;
+}
+table.random_rule tr th {
+  border: thin solid black;
+  padding: 0.25em 0.5em;
+  vertical-align: top;
+  text-align: left;
+  background-color: cornsilk;
+}
+/* ------------------------------------------------------------------------ */
 /* Registration table */
 table.register {
   width: auto;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1363,6 +1363,32 @@ table.filter td select {
   width: 100%;
 }
 /* ------------------------------------------------------------------------ */
+/* Random Rules */
+/* Because the guidelines are in the wiki, we have to jump through
+   some hoops to get any tables used there to be displayed properly
+   if they are included in a random rule. A random_rule class has been
+   created in https://www.pgdp.net/wiki/MediaWiki:Common.css to allow
+   a class to be added to the tables that are in a random rule. The
+   CSS defined here in layout.less is not used directly anywhere in
+   the code, but only used to theme random rules imported from the
+   pgdp.net wiki.
+ */
+table.random_rule {
+  border: thin solid black;
+  border-collapse: collapse;
+}
+table.random_rule tr td {
+  border: thin solid black;
+  padding: 0.25em 0.5em;
+}
+table.random_rule tr th {
+  border: thin solid black;
+  padding: 0.25em 0.5em;
+  vertical-align: top;
+  text-align: left;
+  background-color: cornsilk;
+}
+/* ------------------------------------------------------------------------ */
 /* Registration table */
 table.register {
   width: auto;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1363,6 +1363,32 @@ table.filter td select {
   width: 100%;
 }
 /* ------------------------------------------------------------------------ */
+/* Random Rules */
+/* Because the guidelines are in the wiki, we have to jump through
+   some hoops to get any tables used there to be displayed properly
+   if they are included in a random rule. A random_rule class has been
+   created in https://www.pgdp.net/wiki/MediaWiki:Common.css to allow
+   a class to be added to the tables that are in a random rule. The
+   CSS defined here in layout.less is not used directly anywhere in
+   the code, but only used to theme random rules imported from the
+   pgdp.net wiki.
+ */
+table.random_rule {
+  border: thin solid black;
+  border-collapse: collapse;
+}
+table.random_rule tr td {
+  border: thin solid black;
+  padding: 0.25em 0.5em;
+}
+table.random_rule tr th {
+  border: thin solid black;
+  padding: 0.25em 0.5em;
+  vertical-align: top;
+  text-align: left;
+  background-color: cornsilk;
+}
+/* ------------------------------------------------------------------------ */
 /* Registration table */
 table.register {
   width: auto;


### PR DESCRIPTION
Create a set of styles that will allow tables that are used in Random Rules to be themed properly.

Test by opening a round page in the [style-random-rules](https://www.pgdp.org/~srjfoo/c.branch/style-random-rules) sandbox, as well as one on the regular test site or even one on the production site. Scroll down to the Random Rule section and refresh the page until a rule with a table shows up. Also can be compared against the corresponding section of the Proofreading or Formatting guidelines.

If you compare against the corresponding tables in the wiki on PROD, you will notice a border line weight difference. The only other visible change should be that the Random Rule tables that had a `width: 100%` style on them no longer do.