### PR TITLE
Allow theming for blurb boxes on Project Page

### DIFF
--- a/project.php
+++ b/project.php
@@ -732,7 +732,8 @@ function do_project_info_table()
     {
         if ( $available_for_SR )
         {
-            echo_row_b( _("Instructions for Smooth Reading"), '' );
+            $class = 'sr-instructions';
+            echo_row_b( _("Instructions for Smooth Reading"), '', $class );
             echo_row_c( $postcomments );
         }
         // Postcomments should always be shown to those directly involved with the project (the
@@ -746,7 +747,8 @@ function do_project_info_table()
                  $state==PROJ_POST_FIRST_AVAILABLE && user_can_work_in_stage($pguser,'PP') ||
                  $state==PROJ_POST_SECOND_AVAILABLE && user_can_work_in_stage($pguser,'PPV') )
         {
-            echo_row_b( _("Post Processor's Comments"), '' );
+            $class = 'post-processor-comments';
+            echo_row_b( _("Post Processor's Comments"), '', $class );
             echo_row_c( $postcomments );
         }
     }
@@ -795,7 +797,8 @@ function do_project_info_table()
         {
             $comments_blurb = "";
         }
-        echo_row_b( _("Project Comments"), $comments_blurb );
+        $class = 'project-comments';
+        echo_row_b( _("Project Comments"), $comments_blurb, $class );
 
         echo_row_c( $comments );
     }

--- a/project.php
+++ b/project.php
@@ -377,8 +377,7 @@ function do_blurb_box( $blurb )
     if ( is_null($blurb) ) return;
 
 //    echo "<br>";
-    $class = 'blurb-box';
-    echo "<table class=$class>";
+    echo "<table class='blurb-box'>";
     echo "<tr><td class='center-align'>";
     echo $blurb;
     echo "</td></tr>";

--- a/project.php
+++ b/project.php
@@ -377,7 +377,8 @@ function do_blurb_box( $blurb )
     if ( is_null($blurb) ) return;
 
 //    echo "<br>";
-    echo "<table style='width: 100%; max-width: 630px; background-color: #DDDDDD;'>";
+    $class = 'blurb-box';
+    echo "<table class=$class>";
     echo "<tr><td class='center-align'>";
     echo $blurb;
     echo "</td></tr>";

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1256,6 +1256,7 @@ table.search-column {
 
 @blurb-box: #ddd;
 @subscr-hold-selected: #cfc;
+@comments-background: #ccc;
 
 li.spaced {
     margin: 1em 0;
@@ -1279,6 +1280,12 @@ li.spaced {
     width: 100%;
     max-width: 630px;
     background-color: @blurb-box;
+}
+
+.project-comments,
+.post-processor-comments,
+.sr-instructions {
+    background-color: @comments-background;
 }
 
 #event_subscriptions,

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1254,6 +1254,9 @@ table.search-column {
 /* ------------------------------------------------------------------------ */
 /* Project Page */
 
+@blurb-box: #ddd;
+@subscr-hold-selected: #cfc;
+
 li.spaced {
     margin: 1em 0;
 }
@@ -1272,6 +1275,12 @@ li.spaced {
     margin-bottom: 0.5em;
 }
 
+.blurb-box {
+    width: 100%;
+    max-width: 630px;
+    background-color: @blurb-box;
+}
+
 #event_subscriptions,
 #project_holds {
     th, td {
@@ -1285,7 +1294,7 @@ li.spaced {
 
 .checkbox-cell-selected {
     .center-align;
-    background-color: #cfc;
+    background-color: @subscr-hold-selected;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2044,6 +2044,11 @@ li.spaced {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
 }
+.blurb-box {
+  width: 100%;
+  max-width: 630px;
+  background-color: #ddd;
+}
 #event_subscriptions th,
 #project_holds th,
 #event_subscriptions td,

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2049,6 +2049,11 @@ li.spaced {
   max-width: 630px;
   background-color: #ddd;
 }
+.project-comments,
+.post-processor-comments,
+.sr-instructions {
+  background-color: #ccc;
+}
 #event_subscriptions th,
 #project_holds th,
 #event_subscriptions td,

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2044,6 +2044,11 @@ li.spaced {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
 }
+.blurb-box {
+  width: 100%;
+  max-width: 630px;
+  background-color: #ddd;
+}
 #event_subscriptions th,
 #project_holds th,
 #event_subscriptions td,

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2049,6 +2049,11 @@ li.spaced {
   max-width: 630px;
   background-color: #ddd;
 }
+.project-comments,
+.post-processor-comments,
+.sr-instructions {
+  background-color: #ccc;
+}
 #event_subscriptions th,
 #project_holds th,
 #event_subscriptions td,

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2044,6 +2044,11 @@ li.spaced {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
 }
+.blurb-box {
+  width: 100%;
+  max-width: 630px;
+  background-color: #ddd;
+}
 #event_subscriptions th,
 #project_holds th,
 #event_subscriptions td,

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2049,6 +2049,11 @@ li.spaced {
   max-width: 630px;
   background-color: #ddd;
 }
+.project-comments,
+.post-processor-comments,
+.sr-instructions {
+  background-color: #ccc;
+}
 #event_subscriptions th,
 #project_holds th,
 #event_subscriptions td,


### PR DESCRIPTION
Allows theming of blurb boxes on the project page (the borderless boxes above and below the project table that include the `Start Proofreading` link (the top blurb box includes that link only if a proofer has saved at least one page since the project comments were last saved).

Also adds color classes for comment row headers for PP/PPV, SR and Project Comments.

Available for testing: [style-blurb-box](https://www.pgdp.org/~srjfoo/c.branch/style-blurb-box/)