### PR TITLE
Allow retrieval of all round stats in one call

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -425,6 +425,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/site_stats'
 
+  /stats/site/rounds:
+    get:
+      tags:
+      - stats
+      description: Gets the site statistics for all rounds
+      responses:
+        200:
+          description: Requested round statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/round_stats'
+
   /stats/site/rounds/{roundid}:
     get:
       tags:

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -30,4 +30,5 @@ $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
+$router->add_route("GET", "v1/stats/site/rounds", "api_v1_stats_site_rounds");
 $router->add_route("GET", "v1/stats/site/rounds/:roundid", "api_v1_stats_site_round");

--- a/api/v1_stats.inc
+++ b/api/v1_stats.inc
@@ -18,13 +18,11 @@ function api_v1_stats_site($method, $data, $query_params)
 }
 
 //---------------------------------------------------------------------------
-// stats/site/:roundid
+// stats/site/rounds
 
-function api_v1_stats_site_round($method, $data, $query_params)
+function render_round_stats($round_id)
 {
-    $round = $data[":roundid"];
-
-    $stats = get_site_page_tally_summary($round->id);
+    $stats = get_site_page_tally_summary($round_id);
     return [
         "today_goal" => $stats->curr_day_goal,
         "today_actual" => $stats->curr_day_actual,
@@ -33,4 +31,27 @@ function api_v1_stats_site_round($method, $data, $query_params)
         "month_goal" => $stats->curr_month_goal,
         "month_actual" => $stats->curr_month_actual,
     ];
+}
+
+function api_v1_stats_site_rounds($method, $data, $query_params)
+{
+    global $Round_for_round_id_;
+
+    $return = [];
+    foreach(array_keys($Round_for_round_id_) as $round_id)
+    {
+        $return[$round_id] = render_round_stats($round_id);
+    }
+
+    return $return;
+}
+
+//---------------------------------------------------------------------------
+// stats/site/rounds/:roundid
+
+function api_v1_stats_site_round($method, $data, $query_params)
+{
+    $round = $data[":roundid"];
+
+    return render_round_stats($round->id);
 }


### PR DESCRIPTION
Allow requesting all site statistics in one API call in addition to the per-round calls.

```bash
curl -i -g -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
    'https://www.pgdp.org/~cpeel/c.branch/api-round-stats/api/index.php?url=v1/stats/site/rounds'
```

Returns:
```json
{
    "P1": {
        "today_goal": 50,
        "today_actual": 0,
        "yesterday_goal": 50,
        "yesterday_actual": 1,
        "month_goal": 1550,
        "month_actual": -3
    },
    "P2": {
        "today_goal": 50,
        "today_actual": 0,
        "yesterday_goal": 50,
        "yesterday_actual": 0,
        "month_goal": 1550,
        "month_actual": 0
    },
    ...
```