### PR TITLE
Remove selected tab bottom border

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -870,7 +870,6 @@ table.preferences {
     .current-tab {
         border-bottom: none;
         background-color: @page-background;
-        .solid-border(grey);
         a {
             .bold;
             color: @page-text;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1766,7 +1766,6 @@ table.preferences th.longlabel {
 .tabs .current-tab {
   border-bottom: none;
   background-color: #ffffff;
-  border: thin solid grey;
 }
 .tabs .current-tab a {
   font-weight: bold;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1766,7 +1766,6 @@ table.preferences th.longlabel {
 .tabs .current-tab {
   border-bottom: none;
   background-color: #ffffff;
-  border: thin solid grey;
 }
 .tabs .current-tab a {
   font-weight: bold;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1766,7 +1766,6 @@ table.preferences th.longlabel {
 .tabs .current-tab {
   border-bottom: none;
   background-color: #ffffff;
-  border: thin solid grey;
 }
 .tabs .current-tab a {
   font-weight: bold;


### PR DESCRIPTION
Somewhere among the recent style reshuffle, the selected tabs got a bottom border when they don't need one.

Check it out in the [fix-tab-bottom-border](https://www.pgdp.org/~cpeel/c.branch/fix-tab-bottom-border/) sandbox.