### PR TITLE
remove-dotted-border: removed dotted bottom border

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1042,13 +1042,6 @@ table.image_source {
     }
 }
 
-div.perms_wrapper {
-    width: 40%;
-    display: inline-block;
-    padding: 2px;
-    border-bottom: dotted black 1px;
-}
-
 /* ------------------------------------------------------------------------ */
 /* Page Detail */
 

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1922,12 +1922,6 @@ table.image_source td.pending {
   text-align: center;
   background-color: #ff8;
 }
-div.perms_wrapper {
-  width: 40%;
-  display: inline-block;
-  padding: 2px;
-  border-bottom: dotted black 1px;
-}
 /* ------------------------------------------------------------------------ */
 /* Page Detail */
 table.pagedetail {

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1922,12 +1922,6 @@ table.image_source td.pending {
   text-align: center;
   background-color: #ff8;
 }
-div.perms_wrapper {
-  width: 40%;
-  display: inline-block;
-  padding: 2px;
-  border-bottom: dotted black 1px;
-}
 /* ------------------------------------------------------------------------ */
 /* Page Detail */
 table.pagedetail {

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1922,12 +1922,6 @@ table.image_source td.pending {
   text-align: center;
   background-color: #ff8;
 }
-div.perms_wrapper {
-  width: 40%;
-  display: inline-block;
-  padding: 2px;
-  border-bottom: dotted black 1px;
-}
 /* ------------------------------------------------------------------------ */
 /* Page Detail */
 table.pagedetail {

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -359,7 +359,7 @@ class ImageSource
                 ? (empty($_REQUEST[$field]) ? '-1' : $_REQUEST[$field])
                 : $this->$field;
 
-            $editing .= "<div class='perms_wrapper'>$col[label]</div>";
+            $editing .= "$col[label]: ";
             $editing .= "<select name='$col[field]'>";
             foreach (array('1' => _('Yes'),'0' => _('No'),'-1' => _('Unknown')) as $val => $opt)
             {
@@ -384,7 +384,9 @@ class ImageSource
             ? (empty($_REQUEST[$field]) ? '2' : $_REQUEST[$field])
             : $this->$field;
 
-        $editing .= "<div class='perms_wrapper'>" . _("Visibility on Info Page") . "</div> <select name='$field'>";
+        $editing .= _("Visibility on Info Page: ");
+        $editing .= "<select name='" . attr_safe($field) . "'>";
+
         foreach (array(
                 // TRANSLATORS: IS = image source
                 '0' => _('IS Managers Only'),


### PR DESCRIPTION
Manage Image Sources (either to propose a new image source or edit an existing one) was the only place that a dotted border was used, and it was used simply as a spacer (Permissions row). Removed bottom border and let the drop-down menus be located next to the labels.

Project Managers and Project Facilitators can use this for proposing new image sources. Only Image Sources Managers, and site admins can edit.

Testable: [remove-dotted-border](https://www.pgdp.org/~srjfoo/c.branch/remove-dotted-border/tools/project_manager/projectmgr.php)