### PR TITLE
Update ppv report

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -958,8 +958,6 @@ table.no-border {
 /* ------------------------------------------------------------------------ */
 /* PPV Report */
 
-@ppv-report-minor: #99ff99; 
-
 p.inline_input {
     .no-margin;
     .no-padding;
@@ -974,8 +972,7 @@ p.hanging_indent_long {
 }
 p.form_problem {
     margin-bottom: 0;
-    color: red;
-    font-weight: bold;
+    .error();
 }
 p.form_problem:before {
     content: '↓'; /* down-arrow */
@@ -984,16 +981,11 @@ table.ppv_reportcard {
     width: 95%;
     .solid-border;
     th {
-        //.left-align;
         .bold;
         .solid-border;
-        // background-color: @header-background;
     }
     th.major_section {
         background-color: @header-background;
-    }
-    th.minor_section {
-        background-color: teal; // @ppv-report-minor;
     }
     th.heading {
         background-color: @basic-column-header;

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -880,6 +880,8 @@ table.preferences {
 /* ------------------------------------------------------------------------ */
 /* Themed tables */
 
+@basic-column-header: #cccccc;
+
 table.themed {
     width: 100%;
     border-collapse: collapse;
@@ -918,7 +920,7 @@ table.basic {
     border-collapse: collapse;
     .solid-border;
     th {
-        background-color: #CCC;
+        background-color: @basic-column-header;
     }
     td, th {
         .solid-border;
@@ -956,6 +958,8 @@ table.no-border {
 /* ------------------------------------------------------------------------ */
 /* PPV Report */
 
+@ppv-report-minor: #99ff99; 
+
 p.inline_input {
     .no-margin;
     .no-padding;
@@ -974,24 +978,25 @@ p.form_problem {
     font-weight: bold;
 }
 p.form_problem:before {
-    content: '\\002193 '; /* down-arrow */
+    content: '↓'; /* down-arrow */
 }
 table.ppv_reportcard {
     width: 95%;
     .solid-border;
     th {
-        .center-align;
+        //.left-align;
         .bold;
         .solid-border;
+        // background-color: @header-background;
     }
     th.major_section {
         background-color: @header-background;
     }
     th.minor_section {
-        background-color: #99ff99;
+        background-color: teal; // @ppv-report-minor;
     }
     th.heading {
-        background-color: #e0e8dd;
+        background-color: @basic-column-header;
     }
     td {
         .solid-border;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1809,7 +1809,7 @@ table.basic {
   border: thin solid black;
 }
 table.basic th {
-  background-color: #CCC;
+  background-color: #cccccc;
 }
 table.basic td,
 table.basic th {
@@ -1856,7 +1856,7 @@ p.form_problem {
   font-weight: bold;
 }
 p.form_problem:before {
-  content: '\\002193 ';
+  content: '↓';
   /* down-arrow */
 }
 table.ppv_reportcard {
@@ -1864,7 +1864,6 @@ table.ppv_reportcard {
   border: thin solid black;
 }
 table.ppv_reportcard th {
-  text-align: center;
   font-weight: bold;
   border: thin solid black;
 }
@@ -1872,10 +1871,10 @@ table.ppv_reportcard th.major_section {
   background-color: #dddddd;
 }
 table.ppv_reportcard th.minor_section {
-  background-color: #99ff99;
+  background-color: teal;
 }
 table.ppv_reportcard th.heading {
-  background-color: #e0e8dd;
+  background-color: #cccccc;
 }
 table.ppv_reportcard td {
   border: thin solid black;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1852,8 +1852,8 @@ p.hanging_indent_long {
 }
 p.form_problem {
   margin-bottom: 0;
-  color: red;
   font-weight: bold;
+  color: red;
 }
 p.form_problem:before {
   content: '↓';
@@ -1869,9 +1869,6 @@ table.ppv_reportcard th {
 }
 table.ppv_reportcard th.major_section {
   background-color: #dddddd;
-}
-table.ppv_reportcard th.minor_section {
-  background-color: teal;
 }
 table.ppv_reportcard th.heading {
   background-color: #cccccc;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1852,8 +1852,8 @@ p.hanging_indent_long {
 }
 p.form_problem {
   margin-bottom: 0;
-  color: red;
   font-weight: bold;
+  color: red;
 }
 p.form_problem:before {
   content: '↓';
@@ -1869,9 +1869,6 @@ table.ppv_reportcard th {
 }
 table.ppv_reportcard th.major_section {
   background-color: #e0e8dd;
-}
-table.ppv_reportcard th.minor_section {
-  background-color: teal;
 }
 table.ppv_reportcard th.heading {
   background-color: #cccccc;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1809,7 +1809,7 @@ table.basic {
   border: thin solid black;
 }
 table.basic th {
-  background-color: #CCC;
+  background-color: #cccccc;
 }
 table.basic td,
 table.basic th {
@@ -1856,7 +1856,7 @@ p.form_problem {
   font-weight: bold;
 }
 p.form_problem:before {
-  content: '\\002193 ';
+  content: '↓';
   /* down-arrow */
 }
 table.ppv_reportcard {
@@ -1864,7 +1864,6 @@ table.ppv_reportcard {
   border: thin solid black;
 }
 table.ppv_reportcard th {
-  text-align: center;
   font-weight: bold;
   border: thin solid black;
 }
@@ -1872,10 +1871,10 @@ table.ppv_reportcard th.major_section {
   background-color: #e0e8dd;
 }
 table.ppv_reportcard th.minor_section {
-  background-color: #99ff99;
+  background-color: teal;
 }
 table.ppv_reportcard th.heading {
-  background-color: #e0e8dd;
+  background-color: #cccccc;
 }
 table.ppv_reportcard td {
   border: thin solid black;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1809,7 +1809,7 @@ table.basic {
   border: thin solid black;
 }
 table.basic th {
-  background-color: #CCC;
+  background-color: #cccccc;
 }
 table.basic td,
 table.basic th {
@@ -1856,7 +1856,7 @@ p.form_problem {
   font-weight: bold;
 }
 p.form_problem:before {
-  content: '\\002193 ';
+  content: '↓';
   /* down-arrow */
 }
 table.ppv_reportcard {
@@ -1864,7 +1864,6 @@ table.ppv_reportcard {
   border: thin solid black;
 }
 table.ppv_reportcard th {
-  text-align: center;
   font-weight: bold;
   border: thin solid black;
 }
@@ -1872,10 +1871,10 @@ table.ppv_reportcard th.major_section {
   background-color: #99ccff;
 }
 table.ppv_reportcard th.minor_section {
-  background-color: #99ff99;
+  background-color: teal;
 }
 table.ppv_reportcard th.heading {
-  background-color: #e0e8dd;
+  background-color: #cccccc;
 }
 table.ppv_reportcard td {
   border: thin solid black;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1852,8 +1852,8 @@ p.hanging_indent_long {
 }
 p.form_problem {
   margin-bottom: 0;
-  color: red;
   font-weight: bold;
+  color: red;
 }
 p.form_problem:before {
   content: '↓';
@@ -1869,9 +1869,6 @@ table.ppv_reportcard th {
 }
 table.ppv_reportcard th.major_section {
   background-color: #99ccff;
-}
-table.ppv_reportcard th.minor_section {
-  background-color: teal;
 }
 table.ppv_reportcard th.heading {
   background-color: #cccccc;

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -17,15 +17,9 @@ require_login();
 
 // -------------------------------------
 
-$theme_args['css_data'] = "
-input[type='text'], textarea {
-     background-color: #E2F2E1;
-}
-";
-
 $page_title = _('Post-Processing Verification Reporting');
 
-output_header($page_title, SHOW_STATSBAR, $theme_args);
+output_header($page_title);
 
 echo "\n<h1>$page_title</h1>\n";
 
@@ -103,6 +97,11 @@ mysqli_free_result($result);
 //
 // So, the date we are looking for is the latest transition to PPV.avail
 // before the earliest transition from PPV.avail to PPV.checked out...
+//
+// Note that the following queries do not take into accout the case where
+// the PPer, after having the project returned to them, returns the project
+// to the PP pool, after which it is checked out by another PPer who has
+// to submit for PPV.
 
 $pp_date = "";
 
@@ -156,7 +155,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         global $i4, $i5;
         return ""
             . "\n$i4<tr>"
-            . "\n$i5<th colspan='2' class='$class'>$content</th>"
+            . "\n$i5<th colspan='2' class='$class center-align'>$content</th>"
             . "\n$i4</tr>";
     }
 
@@ -176,7 +175,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         global $i4, $i5;
         return ""
             . "\n$i4<tr>"
-            . "\n$i5<td style='background-color: #CCCCCC; width: 40%;'><b>$left_content</b></td>"
+            . "\n$i5<th class='label' style='width: 25%;'><b>$left_content</b></td>"
             . "\n$i5<td>"
             . $right_content
             . "\n$i5</td>"
@@ -387,7 +386,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
 
     $entry_form = "<br>
           <form action='{$code_url}/tools/post_proofers/ppv_report.php?project=$projectid&amp;confirm=1' name='ppvform' method='post'>
-          <table class='ppv_reportcard' id='report_card'>
+          <table class='basic ppv_reportcard' id='report_card'>
 "
         . tr_w_one_cell_centered('major_section', _("Project Information"))
         . tr_w_two_cells(

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -98,10 +98,10 @@ mysqli_free_result($result);
 // So, the date we are looking for is the latest transition to PPV.avail
 // before the earliest transition from PPV.avail to PPV.checked out...
 //
-// Note that the following queries do not take into accout the case where
-// the PPer, after having the project returned to them, returns the project
-// to the PP pool, after which it is checked out by another PPer who has
-// to submit for PPV.
+// The following queries do not take into account the case where the PPer,
+// after having the project returned to them, returns the project to the
+// PP pool, after which it is checked out by another PPer who has to
+// submit for PPV.
 
 $pp_date = "";
 
@@ -156,17 +156,6 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         return ""
             . "\n$i4<tr>"
             . "\n$i5<th colspan='2' class='$class center-align'>$content</th>"
-            . "\n$i4</tr>";
-    }
-
-    function tr_w_one_cell($content)
-    {
-        global $i4, $i5;
-        return ""
-            . "\n$i4<tr>"
-            . "\n$i5<td colspan='2'>"
-            . $content
-            . "\n$i5</td>"
             . "\n$i4</tr>";
     }
 
@@ -383,6 +372,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
     // ---------------------------------
 
     $ppv_guidelines_url = get_faq_url("ppv.php");
+    $pp_faq_url = get_faq_url("post_proof.php");
 
     $entry_form = "<br>
           <form action='{$code_url}/tools/post_proofers/ppv_report.php?project=$projectid&amp;confirm=1' name='ppvform' method='post'>
@@ -425,8 +415,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
             $pp_date
         )
 
-        . tr_w_one_cell_centered('major_section', _("General Information"))
-        . tr_w_one_cell_centered("heading", _("Difficulty Details"))
+        . tr_w_one_cell_centered('major_section', "<a href='$ppv_guidelines_url#difficulty'>" . _("Post-Processing Difficulty") . "</a>")
         . tr_w_two_cells(
             "File Information",
             number_box('kb_size', _("Text File Size in kb (Please do not insert commas. For example, you should input 1450 instead of 1,450 and, if you use commas as decimal marks, 1450.5 instead of 1450,5)"), array('size'=>5))
@@ -444,15 +433,15 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
                 . some_sig_combo('some_index',    _("Small"), 'sig_index',  _("Significant Size"),   _("Index"))
                 . some_num_combo('some_illos', _("Illustrations (other than minor decorations or logos)"), 'num_illos')
                 . check_box('sig_illos',     _("Illustrations requiring advanced preparation and/or difficult placement"))
-                . check_box('sig_multilang', _("Multiple Languages") . " <a href='$ppv_guidelines_url#mult'>*</a>")
+                . check_box('sig_multilang', "<a href='$ppv_guidelines_url#mult'>" . _("Multiple Languages") . "</a>")
                 . check_box('sig_spell',     _("Extensive Spellcheck/Gutcheck"))
                 . check_box('sig_englifh',   _("Engliſh"))
                 . check_box('sig_music',     _("Musical Notation and Files"))
                 . check_box('sig_math',      _("Extensive mathematical/chemical notation"))
         )
-        . tr_w_one_cell_centered("minor_section", _("ERRORS") . " <a href='$ppv_guidelines_url#errors'>**</a>")
-        . tr_w_one_cell_centered("minor_section", _("LEVEL 1 (Minor Errors)"))
-        . tr_w_one_cell_centered("heading", _("All Versions"))
+        . tr_w_one_cell_centered("major_section", "<a href='$ppv_guidelines_url#errors'>" . _("ERRORS") . "</a>")
+        . tr_w_one_cell_centered("major_section", _("Level 1 (Minor Errors)"))
+        . tr_w_one_cell_centered("heading", "<a href='$ppv_guidelines_url#errors_minor_all'>" . _("All Versions") . "</a>")
         . tr_w_two_cells(
             _("Approximate number of errors <br>(Please enter only numbers)"),
             ""
@@ -468,17 +457,17 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
                 . comment_box('level1_general_comments')
         )
         . tr_w_one_cell_centered("heading", _("HTML Version Only"))
-        . tr_w_one_cell_centered("heading", _("Images"))
+        . tr_w_one_cell_centered("heading", "<a href='$ppv_guidelines_url#errors_minor_images'>" . _("Images") . "</a>")
         . tr_w_two_cells(
             _("Approximate number of errors <br>(Please enter only numbers)"),
             ""
                 . number_box('e1_unused_num',    _("Unused files in images folder (Thumbs.db is not counted toward rating)"))
-                . number_box('e1_imagesize_num', sprintf(_("Appropriate image size not used for thumbnail, inline and linked-to images. Image sizes should not normally exceed <a href='%s'>these described limits</a>, but exceptions may be made if warranted by the type of image or book (provided the PPer explains the exception)."), "http://www.pgdp.net/wiki/Guide_to_Image_Processing#Image_Display_Dimensions:_Considerations"))
+                . number_box('e1_imagesize_num', sprintf(_("Appropriate image size not used for thumbnail, inline and linked-to images. Image sizes should not normally exceed <a href='%s'>these described limits</a>, but exceptions may be made if warranted by the type of image or book (provided the PPer explains the exception)."), "$pp_faq_url#imagesizes"))
                 . number_box('e1_blemish_num',   _("Images with major blemishes, uncorrected rotation/distortion or without appropriate cropping"))
                 . number_box('e1_distort_num',   _("Failure to enter image size appropriately via HTML attribute or CSS such that the image is distorted in HTML, epub or mobi"))
                 . number_box('e1_alt_num',       _("Failure to use appropriate \"alt\" tags for images that have no caption and to include empty \"alt\" tags if captions exist"))
         )
-        . tr_w_one_cell_centered("heading", _("HTML Code"))
+        . tr_w_one_cell_centered("heading", "<a href='$ppv_guidelines_url#errors_minor_html'>" . _("HTML Code") . "</a>")
         . tr_w_two_cells(
             _("Approximate number of errors <br>(Please enter only numbers)"),
             ""
@@ -494,15 +483,15 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
                 . "\n"
                 . comment_box('level1_html_comments')
         )
-        . tr_w_one_cell_centered("minor_section", _("LEVEL 2 (Major Errors)"))
-        . tr_w_one_cell_centered("heading", _("All Versions"))
+        . tr_w_one_cell_centered("major_section", _("Level 2 (Major Errors)"))
+        . tr_w_one_cell_centered("heading", "<a href='$ppv_guidelines_url#errors_major_all'>" . _("All Versions") . "</a>")
         . tr_w_two_cells(
             _("Approximate number of errors <br>(Please enter only numbers)"),
             ""
                 . number_box('e2_markup_num',   _("Markup not handled (e.g. blockquotes, poetry indentation, or widespread failure to mark italics)"))
                 . number_box('e2_poetry_num',   _("Poetry indentation does not match original"))
                 . number_box('e2_foot_num',     _("Footnotes/footnote markers missing or incorrectly placed"))
-                . number_box('e2_printers_num', _("Printers' errors not addressed") . " <a href='$ppv_guidelines_url#printers'>***</a>")
+                . number_box('e2_printers_num', "<a href='$ppv_guidelines_url#printers'>" . _("Printers' errors not addressed") . "</a>")
                 . number_box('e2_missing_num',  _("Missing page(s) or substantial sections of missing text"))
                 . number_box('e2_rewrap_num',   _("Substantial rewrapping errors, e.g., poetry has been rewrapped or text version generally not rewrapped to required length (not exceeding 75 characters or falling below 55 characters) except where unavoidable, e.g., some tables though the aim should be 72 characters"))
                 . number_box('e2_hyphen_num',   _("Widespread/general occurrences of hyphenated/non-hyphenated, spelling and punctuation variants and other inconsistencies not addressed (may be addressed by note in the TN)"))
@@ -510,7 +499,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
                 . "\n"
                 . comment_box('level2_general_comments')
         )
-        . tr_w_one_cell_centered("heading", _("HTML Version Only"))
+        . tr_w_one_cell_centered("heading", "<a href='$ppv_guidelines_url#errors_major_html'>" . _("HTML Version Only") . "</a>")
         . tr_w_two_cells(
             _("Approximate number of errors <br>(Please enter only numbers)"),
             ""
@@ -518,11 +507,12 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
                 . number_box('e2_csscheck_num', sprintf(_("The W3C CSS Validation Service generates errors or warning messages other than for the dropcap \"transparent\" element and other CSS 3 code permitted by <a href='%s'>PGLAF</a> (Please enter number of errors)"), 'http://upload.pglaf.org/'))
                 . number_box('e2_links_num',    _("Non-working links within HTML or to images. (Either broken or link to wrong place/file)"))
                 . number_box('e2_file_num',     _("File and folder names not in lowercase or contain spaces, images not in \"images\" folder, etc."))
-                . number_box('e2_cover_num',    sprintf(_("Cover image has not been included and/or has not been coded for e-reader use. (The cover should meet <a href='%s'>current DP guidelines</a>.)"), "https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/Post-Processing_FAQ#Cover_image"))
-                . number_box('e2_epub_num',     _("Project not presentable/useable when put through epubmaker") . " <a href='$ppv_guidelines_url#reader'>****</a>")
+                . number_box('e2_cover_num',    sprintf(_("Cover image has not been included and/or has not been coded for e-reader use. (The cover should meet <a href='%s'>current DP guidelines</a>.)"), "$pp_faq_url#covers"))
+                . number_box('e2_epub_num',     sprintf(_("Project not presentable/useable when put through <a href='%s'>ebookmaker</a>"), "$ppv_guidelines_url#reader"))
                 . number_box('e2_heading_num',  _("Heading elements used for things that are not headings and failure to use hierarchical headings for book, chapter and section headings (single h1, appropriate h2s and h3s etc.)"))
         )
-        . tr_w_one_cell_centered("minor_section", _("STRONGLY RECOMMENDED<br>(Failure to follow these guidelines will not be tabulated as errors, but the PPer should be counselled to correct any problems)"))
+        . tr_w_one_cell_centered("major_section", "<a href='$ppv_guidelines_url#strongly_recommended'>" . _("Strongly Recommended") . "</a>")
+        . tr_w_one_cell_centered("heading", _("(Failure to follow these guidelines will not be tabulated as errors, but the PPer should be counselled to correct any problems)"))
         . tr_w_two_cells(
             _("Occurrence"),
             ""
@@ -536,7 +526,8 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
                 . check_box('s_thumbs',  _("Remove thumbs.db file from the images folder"))
                 . check_box('s_ereader', _("E-reader version, although without major flaws, should also look as good as possible"))
         )
-        . tr_w_one_cell_centered("minor_section", _("MILDLY RECOMMENDED<br>(Failure to follow these guidelines will not be tabulated as errors, and any corrections are solely at the discretion of the PPVer and PPer)"))
+        . tr_w_one_cell_centered("major_section", "<a href='$ppv_guidelines_url#mildly_recommended'>" . _("Mildly Recommended") . "</a>")
+        . tr_w_one_cell_centered("heading", _("(Failure to follow these guidelines will not be tabulated as errors, and any corrections are solely at the discretion of the PPVer and PPer)"))
         . tr_w_two_cells(
             _("Occurrence"),
             ""
@@ -544,9 +535,9 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
                 . check_box('m_space',     _("Include space before the slash in self-closing tags (e.g. &lt;br /&gt;)"))
                 . check_box('m_unusedcss', _("Ensure that there are no unused elements in the CSS (other than the base HTML headings)"))
         )
-        . tr_w_one_cell_centered("minor_section", _("GENERAL COMMENTS"))
+        . tr_w_one_cell_centered("major_section", _("General Comments"))
         . tr_w_two_cells(
-            _("Did you have to return the project again because the PPer failed to make requested corrections on the second submission? (If so, please explain)"),
+            sprintf(_("<a href='%s'>Did you have to return</a> the project again because the PPer failed to make requested corrections on the second submission? (If so, please explain)"), "$ppv_guidelines_url#rr"),
             comment_box('reason_returned')
         )
         . tr_w_two_cells(
@@ -555,13 +546,13 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         )
         . tr_w_one_cell_centered('major_section', _("Copies"))
         . tr_w_two_cells(
-            _("Send to"),
+            sprintf(_("<a href='%s'>Send to</a>"), "$ppv_guidelines_url#summary"),
             ""
                 . check_box('cc_ppv', _("Me"))
                 . check_box('cc_pp', $project->postproofer, TRUE) ."
                         <p class='inline_input hanging_indent'><input type='checkbox' name='foo' checked disabled>"._("PPV Summary (mailing list)") ."</p>"
         )
-        . tr_w_one_cell_centered("", "<input type='submit' value='".attr_safe(_("Submit"))."'>") ."
+        . tr_w_one_cell_centered("", "<input type='submit' value='".attr_safe(_("Preview"))."'>") ."
         </table>
     </form>";
 }
@@ -787,7 +778,7 @@ else if ($action == HANDLE_ENTRY_FORM_SUBMISSION)
             'e2_links_num'      => "Non-working links within HTML or to images. (Either broken or link to wrong place/file)",
             'e2_file_num'       => "File and folder names not in lowercase or contain spaces, images not in \"images\" folder, etc.",
             'e2_cover_num'      => "Cover image has not been included and/or has not been coded for e-reader use. (The cover should meet current DP guidelines.)",
-            'e2_epub_num'       => "Project not presentable/useable when put through epubmaker",
+            'e2_epub_num'       => "Project not presentable/useable when put through ebookmaker",
             'e2_heading_num'    => "Heading elements used for things that are not headings and failure to use hierarchical headings for book, chapter and section headings (single h1, appropriate h2s and h3s etc.)",
         ))
 
@@ -825,8 +816,9 @@ else if ($action == HANDLE_ENTRY_FORM_SUBMISSION)
 
         . "\n";
 
-    echo _("Please check the information below to make sure everything is correct.
-        To return to the form, simply use your browser's back button.") . "<br>\n";
+    echo "<p>" . _("Please check the information below to make sure everything is correct.
+        To return to the form, simply use your browser's back button.") . "</p>\n";
+    echo "<p>" . sprintf(_("The PPV Guidelines describe how the <a href='%s'>PPing Difficulty</a> and <a href='%s'>Overall evaluation of PPers' work</a> are calculated."), "$ppv_guidelines_url#difficulty", "$ppv_guidelines_url#allowable") . "</p>";
     echo "<pre>" . $reportcard . "</pre>";
     echo "<form action='{$code_url}/tools/post_proofers/ppv_report.php?project=$projectid&amp;send=1' name='ppvform' method='post'>
                 <input type='hidden' name='reportcard' value='" . attr_safe($reportcard) . "'>


### PR DESCRIPTION
The initial focus of this branch was to pull inline styles for colors out of the form and set it up to use site-wide styling. I've tried to keep that part of it in the first commit. This involved changing some content, as well.

The second commit updates more content and adds/corrects links from the form to the appropriate sections in the guidelines, and adds dummy `id`s to the PP FAQ and PPV Guidelines documents in the code for use as redirects to the wiki.

To test, you'll need to grant yourself PPV access. Probably easiest if you just use [this link](https://www.pgdp.org/~srjfoo/c.branch/update-ppv-report/tools/post_proofers/ppv_report.php?project=projectID5771f9753c0c7) to go directly to a project.