### PR TITLE
Math preview 4

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -21,6 +21,11 @@ QUnit.module("Format preview test", function() {
         allowUnderline: false,
     };
 
+    let mathConfig = {
+        suppress: {},
+        allowMathPreview: true
+    };
+
     let text;
     let issArray;
 
@@ -391,5 +396,31 @@ QUnit.module("Format preview test", function() {
         issueTest(assert, 2, 3, 3, "multipleAnchors", 0);
         issueTest(assert, 1, 10, 3, "multipleAnchors", 0);
         issueTest(assert, 0, 17, 3, "multipleAnchors", 0);
+    });
+
+    QUnit.test("missing maths start tag in non-math mode", function (assert) {
+        text = "e=mc^2\\\]";
+        issArray = analyse(text, configuration);
+        noIssueTest(assert);
+    });
+
+    QUnit.test("missing maths start tag", function (assert) {
+        text = "e=mc^2\\\]";
+        issArray = analyse(text, mathConfig);
+        issueTest(assert, 0, 6, 2, "noStartTag", 1);
+    });
+
+    QUnit.test("mismatched maths tags", function (assert) {
+        text = "\\\(e=mc^2\\\]";
+        issArray = analyse(text, mathConfig);
+        issueTest(assert, 1, 0, 2, "misMatchTag", 1);
+        issueTest(assert, 0, 8, 2, "misMatchTag", 1);
+    });
+
+    QUnit.test("missing maths end tag", function (assert) {
+        text = "\\\[e=mc^2\\\(";
+        issArray = analyse(text, mathConfig);
+        issueTest(assert, 1, 0, 2, "noEndTag", 1);
+        issueTest(assert, 0, 8, 2, "noEndTag", 1);
     });
 });

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -97,8 +97,8 @@ QUnit.module("Format preview test", function() {
     QUnit.test("unrecognised tag, u not enabled", function (assert) {
         text = "ab <u>cd</u>";
         issArray = analyse(text, configuration);
-        issueTest(assert, 1, 3, 1, "unRecTag", 0);
-        issueTest(assert, 0, 8, 1, "unRecTag", 0);
+        issueTest(assert, 1, 3, 3, "unRecTag", 0);
+        issueTest(assert, 0, 8, 4, "unRecTag", 0);
     });
 
     QUnit.test("u tag enabled", function (assert) {

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -1,4 +1,4 @@
-/* global QUnit analyse */
+/* global QUnit analyse processExMath */
 
 QUnit.module("Format preview test", function() {
     let configuration = {
@@ -399,28 +399,39 @@ QUnit.module("Format preview test", function() {
     });
 
     QUnit.test("missing maths start tag in non-math mode", function (assert) {
-        text = "e=mc^2\\\]";
+        text = "e=mc^2\\]";
         issArray = analyse(text, configuration);
         noIssueTest(assert);
     });
 
     QUnit.test("missing maths start tag", function (assert) {
-        text = "e=mc^2\\\]";
+        text = "e=mc^2\\]";
         issArray = analyse(text, mathConfig);
         issueTest(assert, 0, 6, 2, "noStartTag", 1);
     });
 
     QUnit.test("mismatched maths tags", function (assert) {
-        text = "\\\(e=mc^2\\\]";
+        text = "\\(e=mc^2\\]";
         issArray = analyse(text, mathConfig);
         issueTest(assert, 1, 0, 2, "misMatchTag", 1);
         issueTest(assert, 0, 8, 2, "misMatchTag", 1);
     });
 
     QUnit.test("missing maths end tag", function (assert) {
-        text = "\\\[e=mc^2\\\(";
+        text = "\\[e=mc^2\\(";
         issArray = analyse(text, mathConfig);
         issueTest(assert, 1, 0, 2, "noEndTag", 1);
         issueTest(assert, 0, 8, 2, "noEndTag", 1);
+    });
+
+    QUnit.test("process outside math markup", function (assert) {
+        let text = "abc\\[d\nef\\]ghi\\(jkl\\)mno";
+        function toUpper(txt) {
+            return txt.toUpperCase();
+        }
+        let procText = processExMath(text, toUpper, true);
+        assert.strictEqual(procText, "ABC\\[d\nef\\]GHI\\(jkl\\)MNO");
+        procText = processExMath(text, toUpper, false);
+        assert.strictEqual(procText, "ABC\\[D\nEF\\]GHI\\(JKL\\)MNO");
     });
 });

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -60,22 +60,15 @@ function get_preview_messages()
 
 function get_preview_js_vars()
 {
-    global $charset, $utf8_site;
-
-    $messages = get_preview_messages();
     $plain = _("Plain text");
     $superscript = _("superscript");
     $subscript = _("subscript");
     $styles = get_style_strings();
 
     $demo_string = javascript_safe("$plain _{{$subscript}} <i>$styles[italic]</i> ^{{$superscript}} <b>$styles[bold]</b> <g>$styles[gesperrt]</g> <sc>$styles[small_caps]</sc> <f>$styles[font_change]</f>");
-    $ie_warn = javascript_safe(_("This function is not available for Internet Explorer versions less than 9"), $charset);
+    $ie_warn = javascript_safe(_("This function is not available for Internet Explorer versions less than 9"));
 
-    if(!$utf8_site)
-    {
-        array_walk($messages, function(&$item) { $item = utf8_encode($item);} );
-    }
-    $preview_msg = json_encode($messages);
+    $preview_msg = json_encode(get_preview_messages());
 
     return "var previewMessages = $preview_msg; var previewDemo = '$demo_string'; var ieWarn = '$ie_warn';";
 }
@@ -105,6 +98,7 @@ function output_preview_div()
     $other_tags = html_safe(_("Other tags"));
     $background = html_safe(_("Background"));
     $allow_underine = html_safe(_("Allow <u> for underline"));
+    $math_preview = html_safe(_("Preview Math"));
     $suppress_warnings = html_safe(_('Suppress warnings'));
     $choose_colors = html_safe(_("Choose Colors"));
     $initial_mode = html_safe(_("Initial view mode"));
@@ -182,6 +176,7 @@ function output_preview_div()
   </fieldset>
   <div class="box2">
     <span class='ilb'><label for="id_underline">$allow_underine</label><input type="checkbox" id="id_underline"></span>
+    <span class='ilb'><label for="id_math_preview">$math_preview</label><input type="checkbox" id="id_math_preview"></span>
   </div>
   <fieldset>
     <legend>$suppress_warnings</legend>

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -333,14 +333,27 @@ $(function () {
 
         // check for an unrecognised tag
         function unRecog() {
-            var re = new RegExp("<(?!(?:\\/?(?:" + ILTags + ")|tb)>)", "g");
-            var result;
-            while (true) {
-                result = re.exec(txt);
-                if (null === result) {
-                    break;
+            let reMaybeTag = /<(\/?)(\w{1,3})>/g;
+            let reGoodTag = new RegExp("^(?:" + ILTags + ")$");
+            let result;
+            // find all possible tags and check if valid
+            while((result = reMaybeTag.exec(txt)) !== null) {
+                let tagString = result[2];
+                let tagLen = result[0].length;
+
+                if(tagString === "tb") {
+                    if(result[1]) {
+                        // found </tb>
+                        reportIssue(result.index, tagLen, "unRecTag");
+                    }
+                    // ignore thought break
+                    continue;
                 }
-                reportIssue(result.index, 1, "unRecTag");
+
+                if(!reGoodTag.test(tagString)) {
+                    reportIssue(result.index, tagLen, "unRecTag");
+                    continue;
+                }
             }
         }
 

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define, camelcase */
 /* exported previewControl, initPrev */
-/* global $ previewDemo, makePreview, ieWarn fontStyles fontFamilies */
+/* global $ previewDemo, makePreview, ieWarn fontStyles fontFamilies MathJax */
 /*
 This file controls the user interface functions. Initially nothing is displayed
 because "prevdiv" has diplay:none; which means it is not displayed and the page
@@ -37,6 +37,7 @@ $( function() {
     var issBox = document.getElementById("id_iss");
     var possIssBox = document.getElementById("id_poss_iss");
     var allowUnderlineCheckbox = document.getElementById("id_underline");
+    var allowMathPreviewCheckbox = document.getElementById("id_math_preview");
     var someSupp = document.getElementById("id_some_supp");
     var proofFrameSet = top.document.getElementById("proof_frames");
 
@@ -72,7 +73,8 @@ $( function() {
         allowUnderline: false,
         defFontIndex: 0,
         suppress: {},
-        initialViewMode: "no_tags"
+        initialViewMode: "no_tags",
+        allowMathPreview: false
     };
     supp_set.forEach(function (msg, i) {
         previewStyles.suppress[msg] = false;
@@ -92,6 +94,13 @@ $( function() {
                 : "pre"
         );
         prevWin.innerHTML = preview.txtout;
+        if (preview.ok && previewStyles.allowMathPreview) {
+            try {
+                MathJax.typeset([prevWin]);
+            } catch(exception) {
+                alert("MathJax error: " + exception);
+            }
+        }
         issBox.value = preview.issues;
         possIssBox.value = preview.possIss;
         // if there are any issues the tags will be shown
@@ -180,6 +189,15 @@ $( function() {
         setViewColors(outerPrev);
         viewMode = previewStyles.initialViewMode;
         $("#" + viewMode).prop("checked", true);
+        // check if MathJax already loaded. Will break if load more than once
+        if(previewStyles.allowMathPreview && (typeof(MathJax) === 'undefined')) {
+            // allow caching which getScript() by default does not
+            return $.ajax({
+                dataType: "script",
+                cache: true,
+                url: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js",
+            });
+        }
     }
 
     initStyle();
@@ -321,6 +339,7 @@ $( function() {
             defaultTextRadio.checked = true;
             initPicker();
             allowUnderlineCheckbox.checked = tempStyle.allowUnderline;
+            allowMathPreviewCheckbox.checked = tempStyle.allowMathPreview;
 
             supp_set.forEach(function (msg, i) {
                 suppCheckBox[i].checked = tempStyle.suppress[msg];
@@ -344,12 +363,15 @@ $( function() {
                 tempStyle.suppress[msg] = suppCheckBox[i].checked;
             });
             tempStyle.allowUnderline = allowUnderlineCheckbox.checked;
+            tempStyle.allowMathPreview = allowMathPreviewCheckbox.checked;
             tempStyle.initialViewMode = $("#id_init_mode").val();
             previewStyles = deepCopy(previewStyles, tempStyle, false);
             saveStyle();
-            initView();
-            writePreviewText();
-            hideConfig();
+            // if loading MathJax, wait for it to finish
+            $.when(initView()).done(function() {
+                writePreviewText();
+                hideConfig();
+            });
         },
 
         cancelConfig: function () { // don't change anything


### PR DESCRIPTION
This enables preview of Latex math markup using MathJax. Much the same as math_preview_3 but reworked with commits indicating purpose of each change and incorporating improvements suggested by @chrismiceli.
(preview.js still has many stylistic shortcomings beyond the scope of this MR).