### PR TITLE
Preview font fix

### DIFF
--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -114,13 +114,6 @@ $( function() {
         win.style.color = previewStyles.t.fg;
     }
 
-    $fontSelector.change( function() {
-        let fontIndex = this.value;
-        prevWin.style.fontFamily = fontFamilies[fontIndex];
-        previewStyles.defFontIndex = fontIndex;
-        saveStyle();
-    });
-
     // this makes a copy of the style data
     // js assignment of objects just makes a reference to the old object
     // so we need to copy each primitive value and construct new objects
@@ -160,6 +153,13 @@ $( function() {
         }
     }
 
+    function setSelectedFont() {
+        let fontIndex = $fontSelector.val();
+        prevWin.style.fontFamily = fontFamilies[fontIndex];
+        previewStyles.defFontIndex = fontIndex;
+        saveStyle();
+    }
+
     function setupFont() {
         Object.keys(fontStyles).forEach(function(index) {
             let fontStyle = fontStyles[index];
@@ -169,8 +169,12 @@ $( function() {
         });
         // use value from selector incase the user defined option has been
         // removed and value has changed from 1 to 0
-        prevWin.style.fontFamily = fontFamilies[$fontSelector.val()];
+        setSelectedFont();
     }
+
+    $fontSelector.change( function() {
+        setSelectedFont();
+    });
 
     function initView() {
         enableColorCheckbox.checked = previewStyles.color;
@@ -312,7 +316,7 @@ $( function() {
             // make a copy of the styles so that if we cancel we can go back
             // to how it was before.
             tempStyle = deepCopy(tempStyle, previewStyles, false);
-            testDiv.style.fontFamily = tempStyle.defFont;
+            testDiv.style.fontFamily = fontFamilies[previewStyles.defFontIndex];
             testDiv.style.fontSize = font_size.toFixed(1) + "px";
             testDraw();
             selTag = "t";   // always start with t (plain text) selected

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -55,8 +55,6 @@ $( function() {
     // the foreground and background colours for plain text, italic, bold,
     // gesperrt, smallcaps, font change, other tags, highlighting issues
     // and possible issues
-    // font names are stored as fontSet properties,
-    // the values have no significance
     var previewStyles = {
         t: {bg: "#fffcf4", fg: "#000000"},
         i: {bg: "", fg: "#0000ff"},
@@ -134,8 +132,6 @@ $( function() {
     // construct new empty objects or arrays. If an element becomes obsolete
     // the destination will not then exist, so check before copying.
     // If keep is false then an exact copy is made.
-    // This implies that if one of the default font options is deleted
-    // it will re-appear next time
     function deepCopy(dest, source, keep) {
         if (source && typeof source === 'object') {
             if (!keep) {
@@ -164,8 +160,7 @@ $( function() {
         }
     }
 
-    function initView() {
-        // set up the font selector
+    function setupFont() {
         Object.keys(fontStyles).forEach(function(index) {
             let fontStyle = fontStyles[index];
             let selected = (index === previewStyles.defFontIndex);
@@ -175,7 +170,9 @@ $( function() {
         // use value from selector incase the user defined option has been
         // removed and value has changed from 1 to 0
         prevWin.style.fontFamily = fontFamilies[$fontSelector.val()];
+    }
 
+    function initView() {
         enableColorCheckbox.checked = previewStyles.color;
         setViewColors(outerPrev);
         viewMode = previewStyles.initialViewMode;
@@ -184,6 +181,7 @@ $( function() {
 
     initStyle();
     initView();
+    setupFont();
 
     $("[name='viewSel']").click(function () {
         viewMode = this.id;


### PR DESCRIPTION
This fixes two bugs which appeared after the change to font selection in format preview:
The fonts in the selector were duplicated each time the configuration was changed - now the selector is only set up once at start.
The example text in the configuration now uses the selected font.
Some comments have been deleted which referred to the previous way of selecting preview fonts.