### PR TITLE
Create and use a func for loading a task

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -552,7 +552,7 @@ CREATE TABLE `tasks` (
   `edited_by` mediumint(9) NOT NULL default '0',
   `percent_complete` tinyint(3) NOT NULL default '0',
   `related_postings` mediumtext NOT NULL,
-  KEY `task_id` (`task_id`)
+  PRIMARY KEY (`task_id`)
 );
 # --------------------------------------------------------
 

--- a/SETUP/upgrade/15/20201023_alter_tasks.php
+++ b/SETUP/upgrade/15/20201023_alter_tasks.php
@@ -1,0 +1,32 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adjusting indexes on tasks..\n";
+$sql = "
+    ALTER TABLE tasks
+        ADD PRIMARY KEY (task_id)
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+$sql = "
+    ALTER TABLE tasks
+        DROP KEY `task_id`
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
Create a function for loading a task instead of sprinkling that logic around. This also adds a migration script to correctly treat task_id as a primary key. This is a stepping stone to updating tasks to use proper escaping and the new DPDatabase functions.

Note that due to the 2-level de-indenting in `TaskDetails()` there are a lot of changes to that function that are mostly just whitespace changes. Consider adjusting the view to hide whitespace changes when reviewing it.

Testable in the [consolidate-task-queries](https://www.pgdp.org/~cpeel/c.branch/consolidate-task-queries/tasks.php) sandbox.