### PR TITLE
Preview adjust

### DIFF
--- a/SETUP/tests/jsTests/characterValidation.js
+++ b/SETUP/tests/jsTests/characterValidation.js
@@ -51,7 +51,6 @@ QUnit.module("Character validation test", function() {
     // (which IE doesn't do) in regex constructor in character_test.js
     /* QUnit.test("Astral plane", function (assert) {
         validCharRegex = makeValidCharRegex("^(?:[\n\r 𓀀-𓀂])$");
-        validCharRegex = makeValidCharRegex("[\n\r 𓀀𓀁𓀂]");
         assert.strictEqual(testText("𓀀"), true);
         assert.strictEqual(testText("\u{13000}"), true);
         assert.strictEqual(testText("𓀂"), true);

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -112,12 +112,6 @@ QUnit.module("Format preview test", function() {
         noIssueTest(assert);
     });
 
-    QUnit.test("tabulate character", function (assert) {
-        text = "ab\tcd";
-        issArray = analyse(text, configuration);
-        issueTest(assert, 0, 2, 1, "tabChar", 1);
-    });
-
     QUnit.test("character before footnote", function (assert) {
         text = "xy[1]\n\nz[Footnote 1: ab]";
         issArray = analyse(text, configuration);

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -46,6 +46,10 @@ $(function () {
     }
 
     function _validateText() {
+        // IE HACK - xregexp causes problems in IE11, return true if IE
+        if(document.documentMode) {
+            return true;
+        }
         var text = textArea.value;
         // IE HACK - IE11 does not support string normalization
         if(String.prototype.normalize) {

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -46,10 +46,6 @@ $(function () {
     }
 
     function _validateText() {
-        // IE HACK - xregexp causes problems in IE11, return true if IE
-        if(document.documentMode) {
-            return true;
-        }
         var text = textArea.value;
         // IE HACK - IE11 does not support string normalization
         if(String.prototype.normalize) {

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -2,18 +2,6 @@
 $relPath="./../../pinc/";
 include_once($relPath.'misc.inc');
 
-function get_style_strings()
-{
-    return array(
-        "plain" => _("Plain text"),
-        "italic" => _("Italic"),
-        "bold" => _("Bold"),
-        "gesperrt" => _("Gesperrt"),
-        "small_caps" => _("Small caps"),
-        "font_change" => _("Font change"),
-    );
-}
-
 function get_preview_messages()
 {
     return array(
@@ -62,13 +50,32 @@ function get_preview_js_vars()
 {
     $superscript = _("superscript");
     $subscript = _("subscript");
-    $styles = get_style_strings();
 
-    $demo_string = javascript_safe("{$styles['plain']} _{{$subscript}} <i>{$styles['italic']}</i> ^{{$superscript}} <b>{$styles['bold']}</b> <g>{$styles['gesperrt']}</g> <sc>{$styles['small_caps']}</sc> <f>{$styles['font_change']}</f>");
-    $ie_warn = javascript_safe(_("This function is not available for Internet Explorer versions less than 9"));
+    $tag_names = [
+        "t" => _("Plain text"),
+        "i" => _("Italic"),
+        "b" => _("Bold"),
+        "g" => _("Gesperrt"),
+        "sc" => _("Small caps"),
+        "f" => _("Font change"),
+        "etc" => _("Other tags"),
+        "err" => _("Issues"),
+        "hlt" => _("Poss. Issues")
+    ];
+
+    $demo_string = "{$tag_names['t']} _{{$subscript}} <i>{$tag_names['i']}</i> ^{{$superscript}} <b>{$tag_names['b']}</b> <g>{$tag_names['g']}</g> <sc>{$tag_names['sc']}</sc> <f>{$tag_names['f']}</f>";
+
+    $preview_strings = json_encode([
+        "background" => _("Background"),
+        "text" => _("Text"),
+        "previewDemo" => $demo_string,
+        "ieWarn" => _("This function is not available for Internet Explorer versions less than 9"),
+    ]);
+
     $preview_msg = json_encode(get_preview_messages());
+    $tag_names = json_encode($tag_names);
 
-    return "var previewMessages = $preview_msg; var previewDemo = '$demo_string'; var ieWarn = '$ie_warn';";
+    return "var previewMessages = $preview_msg; var tagNames = $tag_names; var previewStrings = $preview_strings; ";
 }
 
 function output_preview_div()
@@ -93,7 +100,6 @@ function output_preview_div()
     $issues = html_safe(_("Issues"));
     $poss_iss = html_safe(_("Poss. Issues"));
     $other_tags = html_safe(_("Other tags"));
-    $background = html_safe(_("Background"));
     $allow_underine = html_safe(_("Allow <u> for underline"));
     $math_preview = html_safe(_("Preview Math"));
     $suppress_warnings = html_safe(_('Suppress warnings'));
@@ -101,8 +107,6 @@ function output_preview_div()
     $select = html_safe(_("Select"));
     $options = html_safe(_("Options"));
     $initial_mode = html_safe(_("Initial view mode"));
-    $styles = get_style_strings();
-    array_walk($styles, function(&$item) { $item = html_safe($item);} );
 
     $supp_set = array('charBeforeStart', 'sideNoteBlank');
     $supp_item_string = "";
@@ -151,39 +155,10 @@ function output_preview_div()
 END;
 
     // draw the configuration panel
-    $tag_style = [
-        "t" => $styles['plain'],
-        "i" => $styles['italic'],
-        "b" => $styles['bold'],
-        "g" => $styles['gesperrt'],
-        "sc" => $styles['small_caps'],
-        "f" => $styles['font_change'],
-        "etc" => $other_tags,
-        "err" => $issues,
-        "hlt" => $poss_iss
-    ];
-    $fore_back_ground = ["fg", "bg"];
     echo "<div id='id_config_panel' class='no_display'>
 <div id='color_test'></div>\n";
 
-    // draw the color selector table
-    echo "<fieldset><legend>$choose_colors</legend>\n<table id='color_table'>
-<tr><th></th><th colspan='2'>$text</th><th colspan='2'>$background</th></tr>";
-
-    // draw the rows for each style
-    foreach($tag_style as $tag => $style)
-    {
-        echo "<tr><td>$style</td>";
-        foreach($fore_back_ground as $ground)
-        {
-            // draw the plain row with no checkboxes
-            $check_box = ($tag == 't') ? "" : "<input type='checkbox' id='{$tag}_$ground'>";
-            echo "<td>$check_box</td>";
-            echo "<td><input type='color' id='col_{$tag}_$ground'></td>";
-        }
-        echo "</tr>\n";
-    }
-    echo "</table>\n</fieldset>\n";
+    echo "<fieldset><legend>$choose_colors</legend>\n<table id='color_table'></table>\n</fieldset>\n";
 
     echo <<<END1
     <fieldset>

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -5,6 +5,7 @@ include_once($relPath.'misc.inc');
 function get_style_strings()
 {
     return array(
+        "plain" => _("Plain text"),
         "italic" => _("Italic"),
         "bold" => _("Bold"),
         "gesperrt" => _("Gesperrt"),
@@ -59,14 +60,12 @@ function get_preview_messages()
 
 function get_preview_js_vars()
 {
-    $plain = _("Plain text");
     $superscript = _("superscript");
     $subscript = _("subscript");
     $styles = get_style_strings();
 
-    $demo_string = javascript_safe("$plain _{{$subscript}} <i>$styles[italic]</i> ^{{$superscript}} <b>$styles[bold]</b> <g>$styles[gesperrt]</g> <sc>$styles[small_caps]</sc> <f>$styles[font_change]</f>");
+    $demo_string = javascript_safe("{$styles['plain']} _{{$subscript}} <i>{$styles['italic']}</i> ^{{$superscript}} <b>{$styles['bold']}</b> <g>{$styles['gesperrt']}</g> <sc>{$styles['small_caps']}</sc> <f>{$styles['font_change']}</f>");
     $ie_warn = javascript_safe(_("This function is not available for Internet Explorer versions less than 9"));
-
     $preview_msg = json_encode(get_preview_messages());
 
     return "var previewMessages = $preview_msg; var previewDemo = '$demo_string'; var ieWarn = '$ie_warn';";
@@ -93,7 +92,6 @@ function output_preview_div()
     $re_wrap = html_safe(_("Re-wrap"));
     $issues = html_safe(_("Issues"));
     $poss_iss = html_safe(_("Poss. Issues"));
-    $default = html_safe(_("Default"));
     $other_tags = html_safe(_("Other tags"));
     $background = html_safe(_("Background"));
     $allow_underine = html_safe(_("Allow <u> for underline"));
@@ -113,6 +111,7 @@ function output_preview_div()
         $supp_item_string .= ("<label><input type='checkbox' id='$supp_item'>" . html_safe($messages[$supp_item]) . "</label><br>\n");
     }
 
+    // draw the format preview and controls
     echo <<<END
 <div id='prevdiv' class='no_display'>
     <div id='format_preview' class='flex_container'>
@@ -149,35 +148,44 @@ function output_preview_div()
         </div>
     </div>
 </div>
+END;
 
-<div id="id_config_panel" class='no_display'>
-    <div id='color_test'>
-    </div>
-    <div class="display-flex">
-        <div id="id_markmenu">
-            <fieldset>
-                <legend>$select</legend>
-                <input type="radio" name="mSel" id="id_default_radio" onclick="previewControl.setTagColors('t')"> $default<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('i')"> $styles[italic]<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('b')"> $styles[bold]<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('g')"> $styles[gesperrt]<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('sc')"> $styles[small_caps]<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('f')"> $styles[font_change]<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('etc')"> $other_tags<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('err')"> $issues<br>
-                <input type="radio" name="mSel" onclick="previewControl.setTagColors('hlt')"> $poss_iss<br>
-            </fieldset>
-        </div>
-        <div id="color_selector">
-            <fieldset>
-                <legend>$choose_colors</legend>
-                <input type="color" id="id_forecol" onchange="previewControl.setForegroundColor()"> $text
-                <span id="span_foreground"><input type="checkbox" id="foreground_checkbox" onchange="previewControl.setForegroundColor()" checked> $default</span><br>
-                <input type="color" id="id_backcol" onchange="previewControl.setBackgroundColor()"> $background
-                <span id="span_background"><input type="checkbox" id="background_checkbox" onchange="previewControl.setBackgroundColor()" checked> $default</span><br>
-            </fieldset>
-        </div>
-    </div>
+    // draw the configuration panel
+    $tag_style = [
+        "t" => $styles['plain'],
+        "i" => $styles['italic'],
+        "b" => $styles['bold'],
+        "g" => $styles['gesperrt'],
+        "sc" => $styles['small_caps'],
+        "f" => $styles['font_change'],
+        "etc" => $other_tags,
+        "err" => $issues,
+        "hlt" => $poss_iss
+    ];
+    $fore_back_ground = ["fg", "bg"];
+    echo "<div id='id_config_panel' class='no_display'>
+<div id='color_test'></div>\n";
+
+    // draw the color selector table
+    echo "<fieldset><legend>$choose_colors</legend>\n<table id='color_table'>
+<tr><th></th><th colspan='2'>$text</th><th colspan='2'>$background</th></tr>";
+
+    // draw the rows for each style
+    foreach($tag_style as $tag => $style)
+    {
+        echo "<tr><td>$style</td>";
+        foreach($fore_back_ground as $ground)
+        {
+            // draw the plain row with no checkboxes
+            $check_box = ($tag == 't') ? "" : "<input type='checkbox' id='{$tag}_$ground'>";
+            echo "<td>$check_box</td>";
+            echo "<td><input type='color' id='col_{$tag}_$ground'></td>";
+        }
+        echo "</tr>\n";
+    }
+    echo "</table>\n</fieldset>\n";
+
+    echo <<<END1
     <fieldset>
         <legend>$options</legend>
         <input type="checkbox" id="id_underline"><label for="id_underline">$allow_underine</label><br>
@@ -200,7 +208,7 @@ function output_preview_div()
         <input type='button' onclick="previewControl.cancelConfig()" value="$cancel">
     </div>
 </div>
-END;
+END1;
 }
 
 function get_preview_font_data_js()

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -100,6 +100,8 @@ function output_preview_div()
     $math_preview = html_safe(_("Preview Math"));
     $suppress_warnings = html_safe(_('Suppress warnings'));
     $choose_colors = html_safe(_("Choose Colors"));
+    $select = html_safe(_("Select"));
+    $options = html_safe(_("Options"));
     $initial_mode = html_safe(_("Initial view mode"));
     $styles = get_style_strings();
     array_walk($styles, function(&$item) { $item = html_safe($item);} );
@@ -113,83 +115,90 @@ function output_preview_div()
 
     echo <<<END
 <div id='prevdiv' class='no_display'>
- <div id='format_preview' class='flex_container'>
-  <div id="id_tp_outer" class='stretchbox text-pane'>
-    <div id="text_preview">
+    <div id='format_preview' class='flex_container'>
+        <div id="id_tp_outer" class='stretchbox text-pane'>
+            <div id="text_preview">
+            </div>
+        </div>
+        <div id="id_controls" class="fixedbox control-pane">
+            <input type='button' onclick="previewControl.hide()" value="$quit">
+            <span class='ilb'><label for="id_color_on">$color_markup</label>
+                <input type="checkbox" id="id_color_on" onchange="previewControl.enableColor(this.checked)" >
+            </span>
+            <span class='ilb'>$image
+                <input type="button" value="-" onclick="top.reSizeRelative(0.91);">
+                <input type="button" value="+" onclick="top.reSizeRelative(1.10);">
+            </span>
+            <span class='ilb'>$text
+                <input type="button" value="-" onclick="previewControl.reSizeText(0.91);">
+                <input type="button" value="+" onclick="previewControl.reSizeText(1.1);">
+            </span>
+            <span class='ilb'>$font <select id="id_font_sel"></select></span>
+            <span class='ilb'>
+                <input type="radio" name="viewSel" id="show_tags"><label for="show_tags">$tags</label>
+                <input type="radio" name="viewSel" id="no_tags"><label for="no_tags">$no_tags</label>
+                <input type="radio" name="viewSel" id="flat"><label for="flat">$text</label>
+            </span>
+            <span class='ilb'>
+                <input type="checkbox" id="re_wrap"><label for="re_wrap">$re_wrap</label>
+            </span>
+            <span class='ilb'>$issues <input type="text" id="id_iss" size="1" readonly></span>
+            <span class='ilb'>$poss_iss <input type="text" id="id_poss_iss" size="1" readonly></span>
+            <img src='$code_url/graphics/exclamation.gif' id='id_some_supp' title='$some_suppressed'>
+            <input type='button' onclick="previewControl.configure()" value="$configure">
+        </div>
     </div>
-  </div>
-  <div id="id_controls" class="fixedbox control-pane">
-    <input type='button' onclick="previewControl.hide()" value="$quit">
-    <span class='ilb'><label for="id_color_on">$color_markup</label>
-        <input type="checkbox" id="id_color_on" onchange="previewControl.enableColor(this.checked)" >
-    </span>
-    <span class='ilb'>$image
-      <input type="button" value="-" onclick="top.reSizeRelative(0.91);">
-      <input type="button" value="+" onclick="top.reSizeRelative(1.10);">
-    </span>
-    <span class='ilb'>$text
-      <input type="button" value="-" onclick="previewControl.reSizeText(0.91);">
-      <input type="button" value="+" onclick="previewControl.reSizeText(1.1);">
-    </span>
-    <span class='ilb'>$font <select id="id_font_sel"></select></span>
-    <span class='ilb'>
-      <input type="radio" name="viewSel" id="show_tags"><label for="show_tags">$tags</label>
-      <input type="radio" name="viewSel" id="no_tags"><label for="no_tags">$no_tags</label>
-      <input type="radio" name="viewSel" id="flat"><label for="flat">$text</label>
-    </span>
-    <span class='ilb'>
-    <input type="checkbox" id="re_wrap"><label for="re_wrap">$re_wrap</label>
-    </span>
-    <span class='ilb'>$issues <input type="text" id="id_iss" size="1" readonly></span>
-    <span class='ilb'>$poss_iss <input type="text" id="id_poss_iss" size="1" readonly></span>
-    <img src='$code_url/graphics/exclamation.gif' id='id_some_supp' title='$some_suppressed'>
-    <input type='button' onclick="previewControl.configure()" value="$configure">
-  </div>
- </div>
 </div>
 
 <div id="id_config_panel" class='no_display'>
-  <div id='color_test'>
-  </div>
-  <fieldset>
-    <legend>$choose_colors</legend>
+    <div id='color_test'>
+    </div>
     <div class="display-flex">
-    <div id="id_markmenu">
-        <input type="radio" name="mSel" id="id_default_radio" onclick="previewControl.setTagColors('t')"> $default<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('i')"> $styles[italic]<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('b')"> $styles[bold]<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('g')"> $styles[gesperrt]<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('sc')"> $styles[small_caps]<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('f')"> $styles[font_change]<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('etc')"> $other_tags<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('err')"> $issues<br>
-        <input type="radio" name="mSel" onclick="previewControl.setTagColors('hlt')"> $poss_iss<br>
+        <div id="id_markmenu">
+            <fieldset>
+                <legend>$select</legend>
+                <input type="radio" name="mSel" id="id_default_radio" onclick="previewControl.setTagColors('t')"> $default<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('i')"> $styles[italic]<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('b')"> $styles[bold]<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('g')"> $styles[gesperrt]<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('sc')"> $styles[small_caps]<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('f')"> $styles[font_change]<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('etc')"> $other_tags<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('err')"> $issues<br>
+                <input type="radio" name="mSel" onclick="previewControl.setTagColors('hlt')"> $poss_iss<br>
+            </fieldset>
+        </div>
+        <div id="color_selector">
+            <fieldset>
+                <legend>$choose_colors</legend>
+                <input type="color" id="id_forecol" onchange="previewControl.setForegroundColor()"> $text
+                <span id="span_foreground"><input type="checkbox" id="foreground_checkbox" onchange="previewControl.setForegroundColor()" checked> $default</span><br>
+                <input type="color" id="id_backcol" onchange="previewControl.setBackgroundColor()"> $background
+                <span id="span_background"><input type="checkbox" id="background_checkbox" onchange="previewControl.setBackgroundColor()" checked> $default</span><br>
+            </fieldset>
+        </div>
     </div>
-    <div id="color_selector">
-        <input type="color" id="id_forecol" onchange="previewControl.setForegroundColor()"> $text
-        <span id="span_foreground"><input type="checkbox" id="foreground_checkbox" onchange="previewControl.setForegroundColor()" checked> $default</span><br>
-        <input type="color" id="id_backcol" onchange="previewControl.setBackgroundColor()"> $background
-        <span id="span_background"><input type="checkbox" id="background_checkbox" onchange="previewControl.setBackgroundColor()" checked> $default</span><br>
+    <fieldset>
+        <legend>$options</legend>
+        <input type="checkbox" id="id_underline"><label for="id_underline">$allow_underine</label><br>
+        <input type="checkbox" id="id_math_preview"><label for="id_math_preview">$math_preview</label>
+    </fieldset>
+    <fieldset>
+        <legend>$suppress_warnings</legend>
+        $supp_item_string
+    </fieldset>
+    <fieldset>
+        <legend>$initial_mode</legend>
+        <select id="id_init_mode">
+            <option value="show_tags">$tags</option>
+            <option value="no_tags">$no_tags</option>
+            <option value="flat">$text</option>
+        </select>
+    </fieldset>
+    <div class="box2">
+        <input type='button' onclick="previewControl.OKConfig()" value="$ok">
+        <input type='button' onclick="previewControl.cancelConfig()" value="$cancel">
     </div>
-    </div>
-  </fieldset>
-  <div class="box2">
-    <span class='ilb'><label for="id_underline">$allow_underine</label><input type="checkbox" id="id_underline"></span>
-    <span class='ilb'><label for="id_math_preview">$math_preview</label><input type="checkbox" id="id_math_preview"></span>
-  </div>
-  <fieldset>
-    <legend>$suppress_warnings</legend>
-    $supp_item_string
-  </fieldset>
-  <br><span class='ilb'><label for='id_init_mode'>$initial_mode</label> <select id="id_init_mode">
-    <option value="show_tags">$tags</option>
-    <option value="no_tags">$no_tags</option>
-    <option value="flat">$text</option>
-  </select></span>
-  <div class="box2">
-    <input type='button' onclick="previewControl.OKConfig()" value="$ok">
-    <input type='button' onclick="previewControl.cancelConfig()" value="$cancel">
-  </div>
 </div>
 END;
 }

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -22,7 +22,6 @@ function get_preview_messages()
         "misMatchTag" => _("End tag does not match start tag"),
         "nestedTag" => _("Tag nested within same tag"),
         "unRecTag" => _("Unrecognized tag"),
-        "tabChar" => _("Tab should not be used"),
         "charBefore" => _("No characters should precede this"),
         "blankBefore" => _("A blank line should precede this"),
         "blankAfter" => _("A blank line should follow %s"),

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -47,7 +47,6 @@ $(function () {
             misMatchTag: 1,
             nestedTag: 1,
             unRecTag: 0,
-            tabChar: 1,
             charBefore: 1,
             blankBefore: 1,
             blankAfter: 0,
@@ -397,15 +396,6 @@ $(function () {
             }
         }
 
-        // find tab characters
-        function checkTab() {
-            var re = /\t/g;
-            var result;
-            while ((result = re.exec(txt)) !== null) {
-                reportIssue(result.index, 1, "tabChar");
-            }
-        }
-
         function checkBlankNumber() { // only 1, 2 or 4 blank lines should appear
             var result;
             var end;
@@ -722,7 +712,6 @@ $(function () {
         parseOol();
         checkFootnotes();
         unRecog();
-        checkTab();
         checkBlankLines();
         if(config.allowMathPreview) {
             checkMath();

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define, camelcase */
 /* exported previewControl, initPrev */
-/* global $ previewDemo, makePreview, ieWarn fontStyles fontFamilies MathJax */
+/* global $ previewDemo, makePreview, ieWarn fontStyles fontFamilies MathJax validateText */
 /*
 This file controls the user interface functions. Initially nothing is displayed
 because "prevdiv" has diplay:none; which means it is not displayed and the page
@@ -310,6 +310,9 @@ $( function() {
         },
 
         show: function () { // called when preview is first shown
+            if(!validateText()) {
+                return;
+            }
             var msie = document.documentMode;
             if (msie < 9) {
                 alert(ieWarn);

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -245,7 +245,9 @@ $( function() {
             dataRow.append($("<td>", {text: tagNames[tag]}));
             foreBackGround.forEach(function(ground) {
                 const color = tempStyle[tag][ground];
-                let colorInput = $("<input>", {type: 'color', value: color}).change({tag: tag, ground: ground}, colorChange);
+                let colorInput = $("<input>", {type: 'color'}).change({tag: tag, ground: ground}, colorChange);
+                // HACK for safari, setting value: color in the constructor doesn't work
+                colorInput.val(color);
                 if(tag == 't') {
                     // no checkbox
                     dataRow.append("<td>");


### PR DESCRIPTION
This does the check for invalid characters before entering preview and removes the check for tab character in preview.

Also improves layout of the configuration panel so the color selection is less confusing (at least to me) and the other options have a more uniform style. The changes made the indenting of the html wrong so I re-indented it all. This makes it seem much more different than it really is. It perhaps would be better to remove all the html indenting.

Can be seen in sandbox https://www.pgdp.org/~rp31/c.branch/preview_adjust