### PR TITLE
Name text and border colors

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -295,7 +295,7 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects=FALSE,
     {
         $round_stats = get_site_page_tally_summary($stage->id);
 
-        list($progress_bar_width, $progress_bar_color, $percent_complete) =
+        list($progress_bar_width, $progress_bar_class, $percent_complete) =
             calculate_progress_bar_properties($round_stats->curr_day_actual, $round_stats->curr_day_goal);
     }
 
@@ -412,7 +412,7 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects=FALSE,
     {
         echo "<td class='pages-goal'>{$round_stats->curr_day_goal}</td>";
         echo "<td class='pages-completed'>{$round_stats->curr_day_actual}</td>";
-        echo "<td><div class='progressbar' style='background-color: $progress_bar_color; width: $progress_bar_width%;'>&nbsp;</div><p style='clear: both; margin: 0;'>$percent_complete%</p></td>";
+        echo "<td><div class='progressbar $progress_bar_class' style='width: $progress_bar_width%;'>&nbsp;</div><p style='clear: both; margin: 0;'>$percent_complete%</p></td>";
     }
     else
     {

--- a/pinc/mentorbanner.inc
+++ b/pinc/mentorbanner.inc
@@ -33,21 +33,17 @@ function mentor_banner($round)
         case 0:
         case 1:
         case 2:
-            $font_boost = "1em";
-            $font_col = '#339933';
+            $class = 'mentor-recent';
             break;
         case 3:
         case 4:
-            $font_boost = "large";
-            $font_col = "#FF6600";
+            $class = 'mentor-older';
             break;
         default:
-            $font_boost = "x-large";
-            $font_col = "#FF0000";
+            $class = 'mentor-oldest';
             break;
     }
-
-    echo "<p style='color: $font_col; font-weight: bold; font-size: $font_boost; text-align: center'>";
+    echo "<p class='$class'>";
     printf(ngettext(
             /* TRANSLATORS: %4 is the name of the user's UI language in their language;
             %1 is a URL; %2 is the round ID; %3 is the number of days. */

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -671,7 +671,7 @@ function echo_cells_for_round( $round_num, $diff_round_num, // <- These are the 
     }
     else if ($R_username == "[none]")
     {
-        echo "<td>" . html_safe($R_username) . "</td>\n";
+        echo "<td class='text-link-disabled'>" . html_safe($R_username) . "</td>\n";
     }
     else if ($can_see_names_for_this_page)
     {

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -937,11 +937,12 @@ function show_key_help_links()
 
 function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_color=TRUE, $color_thresholds=NULL)
 // A simple progress bar can be created by using the following HTML:
-//   <div class='progressbar' style='background-color: $color; width: $width%;'>&nbsp;</div>
+//   <div class='progressbar $progress_bar_class' style='width: $width%;'>&nbsp;</div>
 // The <div> can be placed inside another container used to control
 // the total width. This function assists in calculating the $color and $width
 // values used above in addition to returning the actual percentage of the
-// goal achieved.
+// goal achieved. In order for the progress bars to be themable, a class name
+// is returned, instead of an actual color.
 // Arguments:
 //   actual           - actual value obtained
 //   goal             - goal
@@ -951,21 +952,23 @@ function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_col
 //                      the color will be based on how much of the month has passed.
 //                      This is useful so that at the beginning of a new timefram the
 //                      bar isn't at the low color.
-//   color_thresholds - associative array containing the colors to use for
+//   color_thresholds - associative array containing the class names to use for
 //                      each percentage completed range
-//                      eg: array(100 => "lightgreen", 75 => "orange", 0 => "red");
+//                      eg: array(100 => "goal-on-target", 75 => "goal-maybe", 0 => "goal-unlikely");
 //
 // Returns three values via a non-associative array():
 //   progress_bar_width - percentage width of the progress bar in range [0-100]
-//   progress_bar_color - color of progress bar using step-wise colors
+//   progress_bar_class - class for color of progress bar using step-wise colors.
+//                        The classes will need to be defined in layout.less
+//                        for them to be applied to the progress bar.
 //   percent_complete   - actual percentage complete in whole numbers
 {
-    // Define the colors used for the status bar graph
+    // Define the color classes used for the status bar graph
     if(!is_array($color_thresholds))
     {
         // Thresholds defined here are assumed to be highest to
         // lowest. Thresholds passed into this function are sorted.
-        $color_thresholds = array(100 => "lightgreen", 75 => "orange", 0 => "red");
+        $color_thresholds = array(100 => "goal-on-target", 75 => "goal-maybe", 0 => "goal-unlikely");
     }
     else
     {
@@ -1005,16 +1008,16 @@ function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_col
         $fraction_of_time_passed = 1;
     }
 
-    foreach($color_thresholds as $threshold => $color)
+    foreach($color_thresholds as $threshold => $class)
     {
         if($percent_complete >= ($threshold * $fraction_of_time_passed))
         {
-            $progress_bar_color = $color;
+            $progress_bar_class = $class;
             break;
         }
     }
 
-    return array($progress_bar_width, $progress_bar_color, $percent_complete);
+    return array($progress_bar_width, $progress_bar_class, $percent_complete);
 }
 
 // -----------------------------------------------------------------------------

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -87,7 +87,7 @@ function user_can_modify_access_of($subject_username)
         static $shown = FALSE;
         if  (!$shown)
         {
-            echo "<p style='color:red'>";
+            echo "<p class='test_warning'>";
             echo _("You would not normally be able to grant+revoke access, but because this is a test site, you are permitted to do so <i>for yourself</i>.");
             echo "</p>";
             $shown = TRUE;

--- a/project.php
+++ b/project.php
@@ -2254,7 +2254,7 @@ function do_change_state()
 
             // Gray out the original text and add an explanation why it is disabled
             $reason = $transition->why_disabled($project);
-            $text_next_to_btn = "<span style='color: #A9A9A9'>$text_next_to_btn</span> [$reason]";
+            $text_next_to_btn = "<span class='transition-disabled'>$text_next_to_btn</span> [$reason]";
         }
 
         echo "<form method='POST' action='$code_url/tools/changestate.php'>";

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -4,19 +4,26 @@
 
 /* ------------------------------------------------------------------------ */
 /* Common color definitions
-   Where a particular color family has multiple shades available, a
-   suffix indicates relative contrast as compared with the default
-   @page-background color. */
+ * Where a particular color family has multiple shades available, a
+ * suffix indicates relative contrast as compared with the default
+ * @page-background color.
+ * All of the color names defined in this file are the default colors
+ * for themes with a white page-background with black page-text, but
+ * for themes that have other than a white page-background with black
+ * page-text, the colors can be overridden in that theme's .less file
+ */
 
 /* Shades based on @page-background. Various contrast levels, commonly
-   used for table rows or other containers that should stand out from
-   the page background */
+ * used for table rows or other containers that should stand out from
+ * the page background
+ */
 @table-cell-base-highc: #cccccc;
 @table-cell-base-mediumc: #dddddd;
 @table-cell-base-lowc: #eeeeee;
 
 /* Background colors with various meanings, some needing two different
-   contrast levels */
+ * contrast levels
+ */
 @table-cell-ok-highc: #88ff88;     // high contrast, green family
 @table-cell-ok-lowc: #ccffcc;      // low contrast, green family
 @table-cell-alert: #ffff66;        // yellow family
@@ -24,15 +31,39 @@
 @table-cell-not-ok-lowc: #ffcccc;  // low contrast, red family
 @table-cell-pending: #ffcc66;      // orange family
 
+/* Special text colors that have a particular meaning that are not
+ * related to the theme colors but nonetheless may need to be
+ * adjusted depending on the theme. Also, needed variation on
+ * theme default page-text color
+ */
+@text-error: red;            // red family
+@text-alert: #ff6600;        // orange family
+@text-warning: blue;         // blue family
+@text-ok: green;             // green family
+@text-mono: #cc0000;         // red family, different from error
+@text-base-mediumc: #666666; // medium contrast theme page-text color
+@text-base-lowc: #9a9a9a;    // low contrast theme page-text color
+
+/* Border colors. Based on the basic theme background and text
+ * colors, various levels of contrast. For themes with white
+ * page-background and black page-text, the default border color
+ * is black. Define that, and work from there for the lower-contrast
+ * border colors. It needn't be based on the page-text color,
+ * but for the original three themes, it is.
+ */
+
+@border-color-base: @page-text;
+@border-color-base-mediumc: #999999;
+@border-color-base-lowc: #d3d3d3;    // lightgrey
 
 /* ------------------------------------------------------------------------ */
 /* mixins with color */
 
-.solid-border(@color: black) {
+.solid-border(@color: @border-color-base) {
     border: thin solid @color;
 }
 
-.solid-border-bottom(@color: black) {
+.solid-border-bottom(@color: @border-color-base) {
     border-bottom: thin solid @color;
 }
 
@@ -48,6 +79,10 @@
 
 .default-border-bottom {
     .solid-border-bottom;
+}
+
+.text-link-disabled {
+    color: @text-base-mediumc;
 }
 
 .sidebar-color {
@@ -258,7 +293,7 @@ nav, #navbar-outer {
         @table-cell-alert 100%,
     );
     color: @page-text;
-    .solid-border-bottom;
+    .solid-border-bottom();
     .unicolor-link(lighten(black, 30%));
 }
 
@@ -443,6 +478,14 @@ hr.divider {
 /* ------------------------------------------------------------------------ */
 /* News items */
 
+@news-border: @border-color-base-lowc;
+@news-normal: @page-text;
+@news-announce-high: maroon;
+@news-announce-medium: orange;
+@news-announce-low: darkblue;
+@news-celebrate: green;
+@news-maintain: red;
+
 div.news {
     margin: 1em 0;
 }
@@ -457,8 +500,8 @@ div.newsitem {
     padding: 0.75em;
     margin-top: 1em;
     overflow: auto;
-    border-left: thick solid lightgrey;
-    border-bottom: thin solid lightgrey;
+    border-left: thick solid @news-border;
+    border-bottom: thin solid @news-border;
     p {
         margin: 0 0.5em 0.5em 0;
     }
@@ -473,32 +516,32 @@ div.newsitem {
     padding-bottom: 0.5em;
 }
 
-.news-format(@color: black) {
+.news-format(@color: @news-normal) {
     color: @color;
 }
 
 .news-normal {
-    .news-format(inherit);
+    .news-format(@news-normal);
 }
 
 .news-announcement1 {
-    .news-format(maroon);
+    .news-format(@news-announce-high);
 }
 
 .news-announcement2 {
-    .news-format(orange);
+    .news-format(@news-announce-medium);
 }
 
 .news-announcement3 {
-    .news-format(darkblue);
+    .news-format(@news-announce-low);
 }
 
 .news-celebration {
-    .news-format(green);
+    .news-format(@news-celebrate);
 }
 
 .news-maintenance {
-    .news-format(red);
+    .news-format(@news-maintain);
 }
 
 /* ------------------------------------------------------------------------ */
@@ -549,11 +592,11 @@ div.calloutheader {
 }
 
 .error, .test_warning {
-    color: red;
+    color: @text-error;
 }
 
 .warning {
-    color: blue;
+    color: @text-warning;
 }
 
 .highlight {
@@ -563,7 +606,8 @@ div.calloutheader {
 
 kbd {
     font-family: DejaVu Sans Mono, monospace;
-    color: #cc0000;
+    color: @text-mono;
+    font-size: .95em;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -676,7 +720,7 @@ table.snapshottable {
     }
 }
 
-.stage-access(@color: black) {
+.stage-access(@color: @page-text) {
     padding-left: 5px;
     float: right;
     display: inline-block;
@@ -694,18 +738,21 @@ table.snapshottable {
     }
 }
 
+@access-yes: green;
+@access-no: red;
+@access-eligible: blue;
+
 .access-yes {
-    .stage-access(green);
+    .stage-access(@access-yes);
 }
 
 .access-no {
-    .stage-access(red);
+    .stage-access(@access-no);
 }
 
 .access-eligible {
-    .stage-access(blue);
+    .stage-access(@access-eligible);
 }
-
 
 @media only screen and (max-width: 768px) {
     .stage-name,
@@ -719,10 +766,26 @@ table.snapshottable {
 /* ------------------------------------------------------------------------ */
 /* Progress bar */
 
+@progress-high: lightgreen;
+@progress-medium: orange;
+@progress-low: red;
+
 div.progressbar {
     font-size: 0.5em;
     float: left;
     .solid-border;
+}
+
+div.goal-on-target {
+    background-color: @progress-high;
+}
+
+div.goal-maybe {
+    background-color: @progress-medium;
+}
+
+div.goal-unlikely {
+    background-color: @progress-low;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -759,13 +822,13 @@ table.availprojectlisting {
         th {
             .bold;
             .left-align;
-            .solid-border-bottom;
+            .solid-border-bottom();
             img {
                 border: 0;
             }
         }
         td {
-            .solid-border-bottom(#888);
+            .solid-border-bottom(@border-color-base-mediumc);
         }
     }
     tr:nth-child(even) {
@@ -865,10 +928,13 @@ table.preferences {
     }
 }
 
+@background-tab-disabled: desaturate(@header-background, 50%);
+@text-tab-disabled: @text-base-mediumc;
+
 .tabs {
     float: left;
     width: 90%;
-    .solid-border-bottom(grey);
+    .solid-border-bottom(@border-color-base-mediumc);
     ul {
         margin: 0;
         padding: 0 20px 0 10px;
@@ -880,10 +946,10 @@ table.preferences {
         padding: 0 0 0 4px;
         border-radius: 5px 5px 0 0;
         margin-bottom: -2px;
-        background-color: desaturate(@header-background, 50%);
-        .solid-border(grey);
+        background-color: @background-tab-disabled;
+        .solid-border(@border-color-base-mediumc);
         a {
-            color: desaturate(@header-text, 50%);
+            color: @text-tab-disabled;
         }
     }
     a {
@@ -1043,11 +1109,11 @@ table.image_source {
         .center-align;
         padding: 5px;
         background-color: @table-cell-base-lowc;
-        .solid-border(#999);
+        .solid-border(@border-color-base-mediumc);
     }
     td {
         padding: 5px;
-        .solid-border(#999);
+        .solid-border(@border-color-base-mediumc);
         a.sourcelink {
             font-size: 90%;
             margin: 10px 0px 3px 25px;
@@ -1165,18 +1231,18 @@ table.list_special_days {
     }
     tr.month > * {
         border: none;
-        border-bottom: solid 2px black;
+        border-bottom: solid 2px @border-color-base;
     }
     td, th {
         padding: 3px;
-        .solid-border(#999);
+        .solid-border(@border-color-base-mediumc);
     }
     td.codecell {
-        vertical-align:middle;
-        text-align:center;
+        vertical-align: middle;
+        text-align: center;
     }
     th.headers {
-        padding:0.5em;
+        padding: 0.5em;
     }
     td.enabled {
         text-align: center;
@@ -1269,7 +1335,7 @@ table.search-column {
 .dropdown-button {
     border: none;
     padding: 1px;
-    background-color: transparent;
+    background-color: inherit;
     cursor: pointer;
     font-family: initial;
     font-size: initial;
@@ -1360,6 +1426,10 @@ li.spaced {
     background-color: @table-cell-ok-lowc;
 }
 
+.transition-disabled {
+    color: @text-base-lowc;
+}
+
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 
@@ -1428,4 +1498,28 @@ table.task-detail-block {
             width: 100%;
         }
     }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Mentoring */
+/* Text colors and sizes for the message mentors see on the P2 round page */
+
+p.mentor-recent {
+    color: #339933;
+    .bold;
+    .center-align;
+}
+
+p.mentor-older {
+    color: #ff6600;
+    .large;
+    .bold;
+    .center-align;
+}
+
+p.mentor-oldest {
+    color: #ff0000;
+    .x-large;
+    .bold;
+    .center-align;
 }

--- a/styles/style_demo.php
+++ b/styles/style_demo.php
@@ -39,61 +39,61 @@ output_header("Style Demos");
 <h2 id='links'>Links</h2>
 <p><a href='../activity_hub.php'>Activity Hub</a></p>
 
-<h2 id='table-formats'>Table formats<h2>
+<h2 id='table-formats'>Table formats</h2>
 <h3>Un-styled table</h3>
 <table>
 <tr> <th>Column 1</th> <th>Column 2</th> <th>Column 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
 </table>
 
 <h3>Basic table</h3>
 <table class='basic'>
 <tr> <th>Column 1</th> <th>Column 2</th> <th>Column 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
 </table>
 
 <h3>Striped table</h3>
 <table class='striped'>
 <tr> <th>Column 1</th> <th>Column 2</th> <th>Column 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
 </table>
 
 <h3>Basic striped table</h3>
 <table class='basic striped'>
 <tr> <th>Column 1</th> <th>Column 2</th> <th>Column 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
 </table>
 
 <h3>Themed table</h3>
 <table class='themed'>
 <tr> <th>Column 1</th> <th>Column 2</th> <th>Column 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
 </table>
 
 <h3>Theme-striped table</h3>
 <table class='theme_striped'>
 <tr> <th>Column 1</th> <th>Column 2</th> <th>Column 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
 </table>
 
 <h3>Themed & themed-striped table</h3>
 <table class='themed theme_striped'>
 <tr> <th>Column 1</th> <th>Column 2</th> <th>Column 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
-<tr> <td>Data 1</th> <td>Data 2</th> <td>Data 3</th> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
+<tr> <td>Data 1</td> <td>Data 2</td> <td>Data 3</td> </tr>
 </table>
 
 

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -181,7 +181,7 @@
 .page-interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .page-interface .control-pane input[type=submit]:disabled,
 .page-interface .control-pane input[type=button]:disabled,
@@ -221,7 +221,7 @@
 #standard_interface_image .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #standard_interface_image .control-pane input[type=submit]:disabled,
 #standard_interface_image .control-pane input[type=button]:disabled,
@@ -288,7 +288,7 @@
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface .control-pane input[type=submit]:disabled,
 #enhanced_interface .control-pane input[type=button]:disabled,
@@ -312,12 +312,12 @@
   margin-right: auto;
   border-collapse: collapse;
   overflow: auto;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtop {
   vertical-align: middle;
   padding: 2px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #CDC0B0;
   color: black;
 }
@@ -326,7 +326,7 @@
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtop input[type=submit]:disabled,
 #enhanced_interface #tdtop input[type=button]:disabled,
@@ -348,7 +348,7 @@
 #enhanced_interface #tdtext,
 #enhanced_interface #tdbottom {
   vertical-align: top;
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 2px;
 }
 #enhanced_interface #tdtext {
@@ -368,7 +368,7 @@
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtext .control-pane input[type=submit]:disabled,
 #enhanced_interface #tdtext .control-pane input[type=button]:disabled,
@@ -421,7 +421,7 @@
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface .control-pane input[type=submit]:disabled,
 #wordcheck_interface .control-pane input[type=button]:disabled,
@@ -444,11 +444,11 @@
   margin-left: auto;
   margin-right: auto;
   padding: 10px;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface #tdtop {
   padding: 2px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #CDC0B0;
   color: black;
 }
@@ -457,7 +457,7 @@
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface #tdtop input[type=submit]:disabled,
 #wordcheck_interface #tdtop input[type=button]:disabled,
@@ -480,7 +480,7 @@
   vertical-align: top;
   text-align: left;
   padding: 0.5em;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #FFF8DC;
   color: black;
 }
@@ -513,7 +513,7 @@
 #format_preview .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #format_preview .control-pane input[type=submit]:disabled,
 #format_preview .control-pane input[type=button]:disabled,
@@ -543,7 +543,7 @@
 .ilb button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .ilb input[type=submit]:disabled,
 .ilb input[type=button]:disabled,
@@ -580,7 +580,7 @@
 .fixedbox button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .fixedbox input[type=submit]:disabled,
 .fixedbox input[type=button]:disabled,
@@ -628,7 +628,7 @@
 .control-frame button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .control-frame input[type=submit]:disabled,
 .control-frame input[type=button]:disabled,
@@ -661,7 +661,7 @@
 #toolbox button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #toolbox input[type=submit]:disabled,
 #toolbox input[type=button]:disabled,
@@ -781,7 +781,7 @@
 #page-browser .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #page-browser .control-pane input[type=submit]:disabled,
 #page-browser .control-pane input[type=button]:disabled,
@@ -859,14 +859,33 @@
 }
 /* ------------------------------------------------------------------------ */
 /* Common color definitions
-   Where a particular color family has multiple shades available, a
-   suffix indicates relative contrast as compared with the default
-   @page-background color. */
+ * Where a particular color family has multiple shades available, a
+ * suffix indicates relative contrast as compared with the default
+ * @page-background color.
+ * All of the color names defined in this file are the default colors
+ * for themes with a white page-background with black page-text, but
+ * for themes that have other than a white page-background with black
+ * page-text, the colors can be overridden in that theme's .less file
+ */
 /* Shades based on @page-background. Various contrast levels, commonly
-   used for table rows or other containers that should stand out from
-   the page background */
+ * used for table rows or other containers that should stand out from
+ * the page background
+ */
 /* Background colors with various meanings, some needing two different
-   contrast levels */
+ * contrast levels
+ */
+/* Special text colors that have a particular meaning that are not
+ * related to the theme colors but nonetheless may need to be
+ * adjusted depending on the theme. Also, needed variation on
+ * theme default page-text color
+ */
+/* Border colors. Based on the basic theme background and text
+ * colors, various levels of contrast. For themes with white
+ * page-background and black page-text, the default border color
+ * is black. Define that, and work from there for the lower-contrast
+ * border colors. It needn't be based on the page-text color,
+ * but for the original three themes, it is.
+ */
 /* ------------------------------------------------------------------------ */
 /* mixins with color */
 /* standalone classes that can be used as mixins, but that should not
@@ -875,10 +894,13 @@
  * sort out
  */
 .default-border {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .default-border-bottom {
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
+}
+.text-link-disabled {
+  color: #666666;
 }
 .sidebar-color {
   background-color: #dddddd;
@@ -1158,7 +1180,7 @@ nav,
   background-color: #ffffff;
   background: repeating-linear-gradient(to right, #ffff66, #ffffff 24%, #ffffff 75%, #ffff66 100%);
   color: #000000;
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
 }
 #testbar a:link,
 #testbar-outer a:link,
@@ -1346,8 +1368,8 @@ div.newsitem {
   padding: 0.75em;
   margin-top: 1em;
   overflow: auto;
-  border-left: thick solid lightgrey;
-  border-bottom: thin solid lightgrey;
+  border-left: thick solid #d3d3d3;
+  border-bottom: thin solid #d3d3d3;
 }
 div.newsitem p {
   margin: 0 0.5em 0.5em 0;
@@ -1361,7 +1383,7 @@ div.newsitem img {
   padding-bottom: 0.5em;
 }
 .news-normal {
-  color: inherit;
+  color: #000000;
 }
 .news-announcement1 {
   color: maroon;
@@ -1404,7 +1426,7 @@ table.newsedit td.items {
 /* ------------------------------------------------------------------------ */
 /* Attention-getting structures */
 div.callout {
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #eeeeee;
   margin-right: 2em;
   margin-left: 2em;
@@ -1434,6 +1456,7 @@ div.calloutheader {
 kbd {
   font-family: DejaVu Sans Mono, monospace;
   color: #cc0000;
+  font-size: 0.95em;
 }
 /* ------------------------------------------------------------------------ */
 /* Round and Pool filter table */
@@ -1464,15 +1487,15 @@ table.filter td select {
    pgdp.net wiki.
  */
 table.random_rule {
-  border: thin solid black;
+  border: thin solid #000000;
   border-collapse: collapse;
 }
 table.random_rule tr td {
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 0.25em 0.5em;
 }
 table.random_rule tr th {
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 0.25em 0.5em;
   vertical-align: top;
   text-align: left;
@@ -1483,7 +1506,7 @@ table.random_rule tr th {
 table.register {
   width: auto;
   border-collapse: separate;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.register th,
 table.register td {
@@ -1518,7 +1541,7 @@ table.snapshottable th {
   padding: 2px;
   margin: 0;
   text-align: center;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.snapshottable th {
   font-weight: normal;
@@ -1600,7 +1623,16 @@ table.snapshottable td.nocell {
 div.progressbar {
   font-size: 0.5em;
   float: left;
-  border: thin solid black;
+  border: thin solid #000000;
+}
+div.goal-on-target {
+  background-color: lightgreen;
+}
+div.goal-maybe {
+  background-color: orange;
+}
+div.goal-unlikely {
+  background-color: red;
 }
 /* ------------------------------------------------------------------------ */
 /* Statistics table */
@@ -1622,7 +1654,7 @@ table.translation th {
 table.availprojectlisting {
   width: 100%;
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.availprojectlisting tr td,
 table.availprojectlisting tr th {
@@ -1632,13 +1664,13 @@ table.availprojectlisting tr th {
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
 }
 table.availprojectlisting tr th img {
   border: 0;
 }
 table.availprojectlisting tr td {
-  border-bottom: thin solid #888;
+  border-bottom: thin solid #999999;
 }
 table.availprojectlisting tr:nth-child(even) {
   background-color: #dddddd;
@@ -1736,7 +1768,7 @@ table.preferences {
 }
 table.preferences td,
 table.preferences th {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.preferences th.longlabel {
   text-align: center;
@@ -1749,7 +1781,7 @@ table.preferences th.longlabel {
 .tabs {
   float: left;
   width: 90%;
-  border-bottom: thin solid grey;
+  border-bottom: thin solid #999999;
 }
 .tabs ul {
   margin: 0;
@@ -1763,10 +1795,10 @@ table.preferences th.longlabel {
   border-radius: 5px 5px 0 0;
   margin-bottom: -2px;
   background-color: #dddddd;
-  border: thin solid grey;
+  border: thin solid #999999;
 }
 .tabs li a {
-  color: #000000;
+  color: #666666;
 }
 .tabs a {
   float: left;
@@ -1788,7 +1820,7 @@ table.preferences th.longlabel {
 table.themed {
   width: 100%;
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.themed tr {
   background-color: #dddddd;
@@ -1822,14 +1854,14 @@ table.theme_striped tr:nth-child(odd) {
 }
 table.basic {
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.basic th {
   background-color: #cccccc;
 }
 table.basic td,
 table.basic th {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.basic th.label {
   text-align: left;
@@ -1880,11 +1912,11 @@ p.form_problem:before {
 }
 table.ppv_reportcard {
   width: 95%;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.ppv_reportcard th {
   font-weight: bold;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.ppv_reportcard th.major_section {
   background-color: #dddddd;
@@ -1893,7 +1925,7 @@ table.ppv_reportcard th.heading {
   background-color: #cccccc;
 }
 table.ppv_reportcard td {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
@@ -1912,11 +1944,11 @@ table.image_source th {
   text-align: center;
   padding: 5px;
   background-color: #eeeeee;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.image_source td {
   padding: 5px;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.image_source td a.sourcelink {
   font-size: 90%;
@@ -1946,7 +1978,7 @@ table.pagedetail th,
 table.pagedetail td {
   text-align: center;
   font-weight: normal;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .in_progress {
   background-color: #ffcc66;
@@ -2016,12 +2048,12 @@ table.list_special_days tr.o {
 }
 table.list_special_days tr.month > * {
   border: none;
-  border-bottom: solid 2px black;
+  border-bottom: solid 2px #000000;
 }
 table.list_special_days td,
 table.list_special_days th {
   padding: 3px;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.list_special_days td.codecell {
   vertical-align: middle;
@@ -2060,7 +2092,7 @@ table.edit_special_day {
 table.edit_special_day th,
 table.edit_special_day td {
   padding: 5px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #eeeeee;
 }
 /* ------------------------------------------------------------------------ */
@@ -2112,7 +2144,7 @@ table.search-column tr th {
 .dropdown-button {
   border: none;
   padding: 1px;
-  background-color: transparent;
+  background-color: inherit;
   cursor: pointer;
   font-family: initial;
   font-size: initial;
@@ -2129,7 +2161,7 @@ table.search-column tr th {
   padding: 0 1em;
   float: right;
   margin: 0.5em auto 0.5em 0.5em;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #dddddd;
 }
 #linkbox ul {
@@ -2192,6 +2224,9 @@ li.spaced {
   text-align: center;
   background-color: #ccffcc;
 }
+.transition-disabled {
+  color: #9a9a9a;
+}
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 td.has-diff {
@@ -2210,7 +2245,7 @@ td.has-diff {
 .replace_check {
   height: 20em;
   width: 50em;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Completed Project Listings */
@@ -2231,7 +2266,7 @@ div.task-comment .task-comment-body {
   margin-left: 1em;
 }
 table.task-detail-block {
-  border: thin solid black;
+  border: thin solid #000000;
   width: 100%;
 }
 table.task-detail-block tr th,
@@ -2246,4 +2281,24 @@ table.task-detail-block tr th {
 table.task-detail-block tr td {
   background-color: #ffffff;
   width: 100%;
+}
+/* ------------------------------------------------------------------------ */
+/* Mentoring */
+/* Text colors and sizes for the message mentors see on the P2 round page */
+p.mentor-recent {
+  color: #339933;
+  font-weight: bold;
+  text-align: center;
+}
+p.mentor-older {
+  color: #ff6600;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}
+p.mentor-oldest {
+  color: #ff0000;
+  font-size: x-large;
+  font-weight: bold;
+  text-align: center;
 }

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -181,7 +181,7 @@
 .page-interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .page-interface .control-pane input[type=submit]:disabled,
 .page-interface .control-pane input[type=button]:disabled,
@@ -221,7 +221,7 @@
 #standard_interface_image .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #standard_interface_image .control-pane input[type=submit]:disabled,
 #standard_interface_image .control-pane input[type=button]:disabled,
@@ -288,7 +288,7 @@
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface .control-pane input[type=submit]:disabled,
 #enhanced_interface .control-pane input[type=button]:disabled,
@@ -312,12 +312,12 @@
   margin-right: auto;
   border-collapse: collapse;
   overflow: auto;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtop {
   vertical-align: middle;
   padding: 2px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #CDC0B0;
   color: black;
 }
@@ -326,7 +326,7 @@
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtop input[type=submit]:disabled,
 #enhanced_interface #tdtop input[type=button]:disabled,
@@ -348,7 +348,7 @@
 #enhanced_interface #tdtext,
 #enhanced_interface #tdbottom {
   vertical-align: top;
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 2px;
 }
 #enhanced_interface #tdtext {
@@ -368,7 +368,7 @@
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtext .control-pane input[type=submit]:disabled,
 #enhanced_interface #tdtext .control-pane input[type=button]:disabled,
@@ -421,7 +421,7 @@
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface .control-pane input[type=submit]:disabled,
 #wordcheck_interface .control-pane input[type=button]:disabled,
@@ -444,11 +444,11 @@
   margin-left: auto;
   margin-right: auto;
   padding: 10px;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface #tdtop {
   padding: 2px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #CDC0B0;
   color: black;
 }
@@ -457,7 +457,7 @@
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface #tdtop input[type=submit]:disabled,
 #wordcheck_interface #tdtop input[type=button]:disabled,
@@ -480,7 +480,7 @@
   vertical-align: top;
   text-align: left;
   padding: 0.5em;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #FFF8DC;
   color: black;
 }
@@ -513,7 +513,7 @@
 #format_preview .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #format_preview .control-pane input[type=submit]:disabled,
 #format_preview .control-pane input[type=button]:disabled,
@@ -543,7 +543,7 @@
 .ilb button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .ilb input[type=submit]:disabled,
 .ilb input[type=button]:disabled,
@@ -580,7 +580,7 @@
 .fixedbox button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .fixedbox input[type=submit]:disabled,
 .fixedbox input[type=button]:disabled,
@@ -628,7 +628,7 @@
 .control-frame button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .control-frame input[type=submit]:disabled,
 .control-frame input[type=button]:disabled,
@@ -661,7 +661,7 @@
 #toolbox button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #toolbox input[type=submit]:disabled,
 #toolbox input[type=button]:disabled,
@@ -781,7 +781,7 @@
 #page-browser .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #page-browser .control-pane input[type=submit]:disabled,
 #page-browser .control-pane input[type=button]:disabled,
@@ -859,14 +859,33 @@
 }
 /* ------------------------------------------------------------------------ */
 /* Common color definitions
-   Where a particular color family has multiple shades available, a
-   suffix indicates relative contrast as compared with the default
-   @page-background color. */
+ * Where a particular color family has multiple shades available, a
+ * suffix indicates relative contrast as compared with the default
+ * @page-background color.
+ * All of the color names defined in this file are the default colors
+ * for themes with a white page-background with black page-text, but
+ * for themes that have other than a white page-background with black
+ * page-text, the colors can be overridden in that theme's .less file
+ */
 /* Shades based on @page-background. Various contrast levels, commonly
-   used for table rows or other containers that should stand out from
-   the page background */
+ * used for table rows or other containers that should stand out from
+ * the page background
+ */
 /* Background colors with various meanings, some needing two different
-   contrast levels */
+ * contrast levels
+ */
+/* Special text colors that have a particular meaning that are not
+ * related to the theme colors but nonetheless may need to be
+ * adjusted depending on the theme. Also, needed variation on
+ * theme default page-text color
+ */
+/* Border colors. Based on the basic theme background and text
+ * colors, various levels of contrast. For themes with white
+ * page-background and black page-text, the default border color
+ * is black. Define that, and work from there for the lower-contrast
+ * border colors. It needn't be based on the page-text color,
+ * but for the original three themes, it is.
+ */
 /* ------------------------------------------------------------------------ */
 /* mixins with color */
 /* standalone classes that can be used as mixins, but that should not
@@ -875,10 +894,13 @@
  * sort out
  */
 .default-border {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .default-border-bottom {
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
+}
+.text-link-disabled {
+  color: #666666;
 }
 .sidebar-color {
   background-color: #e0e8dd;
@@ -1158,7 +1180,7 @@ nav,
   background-color: #ffffff;
   background: repeating-linear-gradient(to right, #ffff66, #ffffff 24%, #ffffff 75%, #ffff66 100%);
   color: #000000;
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
 }
 #testbar a:link,
 #testbar-outer a:link,
@@ -1346,8 +1368,8 @@ div.newsitem {
   padding: 0.75em;
   margin-top: 1em;
   overflow: auto;
-  border-left: thick solid lightgrey;
-  border-bottom: thin solid lightgrey;
+  border-left: thick solid #d3d3d3;
+  border-bottom: thin solid #d3d3d3;
 }
 div.newsitem p {
   margin: 0 0.5em 0.5em 0;
@@ -1361,7 +1383,7 @@ div.newsitem img {
   padding-bottom: 0.5em;
 }
 .news-normal {
-  color: inherit;
+  color: #000000;
 }
 .news-announcement1 {
   color: maroon;
@@ -1404,7 +1426,7 @@ table.newsedit td.items {
 /* ------------------------------------------------------------------------ */
 /* Attention-getting structures */
 div.callout {
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #eeeeee;
   margin-right: 2em;
   margin-left: 2em;
@@ -1434,6 +1456,7 @@ div.calloutheader {
 kbd {
   font-family: DejaVu Sans Mono, monospace;
   color: #cc0000;
+  font-size: 0.95em;
 }
 /* ------------------------------------------------------------------------ */
 /* Round and Pool filter table */
@@ -1464,15 +1487,15 @@ table.filter td select {
    pgdp.net wiki.
  */
 table.random_rule {
-  border: thin solid black;
+  border: thin solid #000000;
   border-collapse: collapse;
 }
 table.random_rule tr td {
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 0.25em 0.5em;
 }
 table.random_rule tr th {
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 0.25em 0.5em;
   vertical-align: top;
   text-align: left;
@@ -1483,7 +1506,7 @@ table.random_rule tr th {
 table.register {
   width: auto;
   border-collapse: separate;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.register th,
 table.register td {
@@ -1518,7 +1541,7 @@ table.snapshottable th {
   padding: 2px;
   margin: 0;
   text-align: center;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.snapshottable th {
   font-weight: normal;
@@ -1600,7 +1623,16 @@ table.snapshottable td.nocell {
 div.progressbar {
   font-size: 0.5em;
   float: left;
-  border: thin solid black;
+  border: thin solid #000000;
+}
+div.goal-on-target {
+  background-color: lightgreen;
+}
+div.goal-maybe {
+  background-color: orange;
+}
+div.goal-unlikely {
+  background-color: red;
 }
 /* ------------------------------------------------------------------------ */
 /* Statistics table */
@@ -1622,7 +1654,7 @@ table.translation th {
 table.availprojectlisting {
   width: 100%;
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.availprojectlisting tr td,
 table.availprojectlisting tr th {
@@ -1632,13 +1664,13 @@ table.availprojectlisting tr th {
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
 }
 table.availprojectlisting tr th img {
   border: 0;
 }
 table.availprojectlisting tr td {
-  border-bottom: thin solid #888;
+  border-bottom: thin solid #999999;
 }
 table.availprojectlisting tr:nth-child(even) {
   background-color: #dddddd;
@@ -1736,7 +1768,7 @@ table.preferences {
 }
 table.preferences td,
 table.preferences th {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.preferences th.longlabel {
   text-align: center;
@@ -1749,7 +1781,7 @@ table.preferences th.longlabel {
 .tabs {
   float: left;
   width: 90%;
-  border-bottom: thin solid grey;
+  border-bottom: thin solid #999999;
 }
 .tabs ul {
   margin: 0;
@@ -1763,10 +1795,10 @@ table.preferences th.longlabel {
   border-radius: 5px 5px 0 0;
   margin-bottom: -2px;
   background-color: #e3e3e3;
-  border: thin solid grey;
+  border: thin solid #999999;
 }
 .tabs li a {
-  color: #000000;
+  color: #666666;
 }
 .tabs a {
   float: left;
@@ -1788,7 +1820,7 @@ table.preferences th.longlabel {
 table.themed {
   width: 100%;
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.themed tr {
   background-color: #e0e8dd;
@@ -1822,14 +1854,14 @@ table.theme_striped tr:nth-child(odd) {
 }
 table.basic {
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.basic th {
   background-color: #cccccc;
 }
 table.basic td,
 table.basic th {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.basic th.label {
   text-align: left;
@@ -1880,11 +1912,11 @@ p.form_problem:before {
 }
 table.ppv_reportcard {
   width: 95%;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.ppv_reportcard th {
   font-weight: bold;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.ppv_reportcard th.major_section {
   background-color: #e0e8dd;
@@ -1893,7 +1925,7 @@ table.ppv_reportcard th.heading {
   background-color: #cccccc;
 }
 table.ppv_reportcard td {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
@@ -1912,11 +1944,11 @@ table.image_source th {
   text-align: center;
   padding: 5px;
   background-color: #eeeeee;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.image_source td {
   padding: 5px;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.image_source td a.sourcelink {
   font-size: 90%;
@@ -1946,7 +1978,7 @@ table.pagedetail th,
 table.pagedetail td {
   text-align: center;
   font-weight: normal;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .in_progress {
   background-color: #ffcc66;
@@ -2016,12 +2048,12 @@ table.list_special_days tr.o {
 }
 table.list_special_days tr.month > * {
   border: none;
-  border-bottom: solid 2px black;
+  border-bottom: solid 2px #000000;
 }
 table.list_special_days td,
 table.list_special_days th {
   padding: 3px;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.list_special_days td.codecell {
   vertical-align: middle;
@@ -2060,7 +2092,7 @@ table.edit_special_day {
 table.edit_special_day th,
 table.edit_special_day td {
   padding: 5px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #eeeeee;
 }
 /* ------------------------------------------------------------------------ */
@@ -2112,7 +2144,7 @@ table.search-column tr th {
 .dropdown-button {
   border: none;
   padding: 1px;
-  background-color: transparent;
+  background-color: inherit;
   cursor: pointer;
   font-family: initial;
   font-size: initial;
@@ -2129,7 +2161,7 @@ table.search-column tr th {
   padding: 0 1em;
   float: right;
   margin: 0.5em auto 0.5em 0.5em;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #e0e8dd;
 }
 #linkbox ul {
@@ -2192,6 +2224,9 @@ li.spaced {
   text-align: center;
   background-color: #ccffcc;
 }
+.transition-disabled {
+  color: #9a9a9a;
+}
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 td.has-diff {
@@ -2210,7 +2245,7 @@ td.has-diff {
 .replace_check {
   height: 20em;
   width: 50em;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Completed Project Listings */
@@ -2231,7 +2266,7 @@ div.task-comment .task-comment-body {
   margin-left: 1em;
 }
 table.task-detail-block {
-  border: thin solid black;
+  border: thin solid #000000;
   width: 100%;
 }
 table.task-detail-block tr th,
@@ -2246,4 +2281,24 @@ table.task-detail-block tr th {
 table.task-detail-block tr td {
   background-color: #ffffff;
   width: 100%;
+}
+/* ------------------------------------------------------------------------ */
+/* Mentoring */
+/* Text colors and sizes for the message mentors see on the P2 round page */
+p.mentor-recent {
+  color: #339933;
+  font-weight: bold;
+  text-align: center;
+}
+p.mentor-older {
+  color: #ff6600;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}
+p.mentor-oldest {
+  color: #ff0000;
+  font-size: x-large;
+  font-weight: bold;
+  text-align: center;
 }

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -181,7 +181,7 @@
 .page-interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .page-interface .control-pane input[type=submit]:disabled,
 .page-interface .control-pane input[type=button]:disabled,
@@ -221,7 +221,7 @@
 #standard_interface_image .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #standard_interface_image .control-pane input[type=submit]:disabled,
 #standard_interface_image .control-pane input[type=button]:disabled,
@@ -288,7 +288,7 @@
 #enhanced_interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface .control-pane input[type=submit]:disabled,
 #enhanced_interface .control-pane input[type=button]:disabled,
@@ -312,12 +312,12 @@
   margin-right: auto;
   border-collapse: collapse;
   overflow: auto;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtop {
   vertical-align: middle;
   padding: 2px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #CDC0B0;
   color: black;
 }
@@ -326,7 +326,7 @@
 #enhanced_interface #tdtop button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtop input[type=submit]:disabled,
 #enhanced_interface #tdtop input[type=button]:disabled,
@@ -348,7 +348,7 @@
 #enhanced_interface #tdtext,
 #enhanced_interface #tdbottom {
   vertical-align: top;
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 2px;
 }
 #enhanced_interface #tdtext {
@@ -368,7 +368,7 @@
 #enhanced_interface #tdtext .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #enhanced_interface #tdtext .control-pane input[type=submit]:disabled,
 #enhanced_interface #tdtext .control-pane input[type=button]:disabled,
@@ -421,7 +421,7 @@
 #wordcheck_interface .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface .control-pane input[type=submit]:disabled,
 #wordcheck_interface .control-pane input[type=button]:disabled,
@@ -444,11 +444,11 @@
   margin-left: auto;
   margin-right: auto;
   padding: 10px;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface #tdtop {
   padding: 2px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #CDC0B0;
   color: black;
 }
@@ -457,7 +457,7 @@
 #wordcheck_interface #tdtop button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #wordcheck_interface #tdtop input[type=submit]:disabled,
 #wordcheck_interface #tdtop input[type=button]:disabled,
@@ -480,7 +480,7 @@
   vertical-align: top;
   text-align: left;
   padding: 0.5em;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #FFF8DC;
   color: black;
 }
@@ -513,7 +513,7 @@
 #format_preview .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #format_preview .control-pane input[type=submit]:disabled,
 #format_preview .control-pane input[type=button]:disabled,
@@ -543,7 +543,7 @@
 .ilb button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .ilb input[type=submit]:disabled,
 .ilb input[type=button]:disabled,
@@ -580,7 +580,7 @@
 .fixedbox button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .fixedbox input[type=submit]:disabled,
 .fixedbox input[type=button]:disabled,
@@ -628,7 +628,7 @@
 .control-frame button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .control-frame input[type=submit]:disabled,
 .control-frame input[type=button]:disabled,
@@ -661,7 +661,7 @@
 #toolbox button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #toolbox input[type=submit]:disabled,
 #toolbox input[type=button]:disabled,
@@ -781,7 +781,7 @@
 #page-browser .control-pane button {
   background-color: #FFF8DC;
   color: black;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 #page-browser .control-pane input[type=submit]:disabled,
 #page-browser .control-pane input[type=button]:disabled,
@@ -859,14 +859,33 @@
 }
 /* ------------------------------------------------------------------------ */
 /* Common color definitions
-   Where a particular color family has multiple shades available, a
-   suffix indicates relative contrast as compared with the default
-   @page-background color. */
+ * Where a particular color family has multiple shades available, a
+ * suffix indicates relative contrast as compared with the default
+ * @page-background color.
+ * All of the color names defined in this file are the default colors
+ * for themes with a white page-background with black page-text, but
+ * for themes that have other than a white page-background with black
+ * page-text, the colors can be overridden in that theme's .less file
+ */
 /* Shades based on @page-background. Various contrast levels, commonly
-   used for table rows or other containers that should stand out from
-   the page background */
+ * used for table rows or other containers that should stand out from
+ * the page background
+ */
 /* Background colors with various meanings, some needing two different
-   contrast levels */
+ * contrast levels
+ */
+/* Special text colors that have a particular meaning that are not
+ * related to the theme colors but nonetheless may need to be
+ * adjusted depending on the theme. Also, needed variation on
+ * theme default page-text color
+ */
+/* Border colors. Based on the basic theme background and text
+ * colors, various levels of contrast. For themes with white
+ * page-background and black page-text, the default border color
+ * is black. Define that, and work from there for the lower-contrast
+ * border colors. It needn't be based on the page-text color,
+ * but for the original three themes, it is.
+ */
 /* ------------------------------------------------------------------------ */
 /* mixins with color */
 /* standalone classes that can be used as mixins, but that should not
@@ -875,10 +894,13 @@
  * sort out
  */
 .default-border {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .default-border-bottom {
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
+}
+.text-link-disabled {
+  color: #666666;
 }
 .sidebar-color {
   background-color: #99ccff;
@@ -1158,7 +1180,7 @@ nav,
   background-color: #ffffff;
   background: repeating-linear-gradient(to right, #ffff66, #ffffff 24%, #ffffff 75%, #ffff66 100%);
   color: #000000;
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
 }
 #testbar a:link,
 #testbar-outer a:link,
@@ -1346,8 +1368,8 @@ div.newsitem {
   padding: 0.75em;
   margin-top: 1em;
   overflow: auto;
-  border-left: thick solid lightgrey;
-  border-bottom: thin solid lightgrey;
+  border-left: thick solid #d3d3d3;
+  border-bottom: thin solid #d3d3d3;
 }
 div.newsitem p {
   margin: 0 0.5em 0.5em 0;
@@ -1361,7 +1383,7 @@ div.newsitem img {
   padding-bottom: 0.5em;
 }
 .news-normal {
-  color: inherit;
+  color: #000000;
 }
 .news-announcement1 {
   color: maroon;
@@ -1404,7 +1426,7 @@ table.newsedit td.items {
 /* ------------------------------------------------------------------------ */
 /* Attention-getting structures */
 div.callout {
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #eeeeee;
   margin-right: 2em;
   margin-left: 2em;
@@ -1434,6 +1456,7 @@ div.calloutheader {
 kbd {
   font-family: DejaVu Sans Mono, monospace;
   color: #cc0000;
+  font-size: 0.95em;
 }
 /* ------------------------------------------------------------------------ */
 /* Round and Pool filter table */
@@ -1464,15 +1487,15 @@ table.filter td select {
    pgdp.net wiki.
  */
 table.random_rule {
-  border: thin solid black;
+  border: thin solid #000000;
   border-collapse: collapse;
 }
 table.random_rule tr td {
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 0.25em 0.5em;
 }
 table.random_rule tr th {
-  border: thin solid black;
+  border: thin solid #000000;
   padding: 0.25em 0.5em;
   vertical-align: top;
   text-align: left;
@@ -1483,7 +1506,7 @@ table.random_rule tr th {
 table.register {
   width: auto;
   border-collapse: separate;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.register th,
 table.register td {
@@ -1518,7 +1541,7 @@ table.snapshottable th {
   padding: 2px;
   margin: 0;
   text-align: center;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.snapshottable th {
   font-weight: normal;
@@ -1600,7 +1623,16 @@ table.snapshottable td.nocell {
 div.progressbar {
   font-size: 0.5em;
   float: left;
-  border: thin solid black;
+  border: thin solid #000000;
+}
+div.goal-on-target {
+  background-color: lightgreen;
+}
+div.goal-maybe {
+  background-color: orange;
+}
+div.goal-unlikely {
+  background-color: red;
 }
 /* ------------------------------------------------------------------------ */
 /* Statistics table */
@@ -1622,7 +1654,7 @@ table.translation th {
 table.availprojectlisting {
   width: 100%;
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.availprojectlisting tr td,
 table.availprojectlisting tr th {
@@ -1632,13 +1664,13 @@ table.availprojectlisting tr th {
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: thin solid black;
+  border-bottom: thin solid #000000;
 }
 table.availprojectlisting tr th img {
   border: 0;
 }
 table.availprojectlisting tr td {
-  border-bottom: thin solid #888;
+  border-bottom: thin solid #999999;
 }
 table.availprojectlisting tr:nth-child(even) {
   background-color: #dddddd;
@@ -1736,7 +1768,7 @@ table.preferences {
 }
 table.preferences td,
 table.preferences th {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.preferences th.longlabel {
   text-align: center;
@@ -1749,7 +1781,7 @@ table.preferences th.longlabel {
 .tabs {
   float: left;
   width: 90%;
-  border-bottom: thin solid grey;
+  border-bottom: thin solid #999999;
 }
 .tabs ul {
   margin: 0;
@@ -1763,10 +1795,10 @@ table.preferences th.longlabel {
   border-radius: 5px 5px 0 0;
   margin-bottom: -2px;
   background-color: #b3cce6;
-  border: thin solid grey;
+  border: thin solid #999999;
 }
 .tabs li a {
-  color: #000000;
+  color: #666666;
 }
 .tabs a {
   float: left;
@@ -1788,7 +1820,7 @@ table.preferences th.longlabel {
 table.themed {
   width: 100%;
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.themed tr {
   background-color: #99ccff;
@@ -1822,14 +1854,14 @@ table.theme_striped tr:nth-child(odd) {
 }
 table.basic {
   border-collapse: collapse;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.basic th {
   background-color: #cccccc;
 }
 table.basic td,
 table.basic th {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.basic th.label {
   text-align: left;
@@ -1880,11 +1912,11 @@ p.form_problem:before {
 }
 table.ppv_reportcard {
   width: 95%;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.ppv_reportcard th {
   font-weight: bold;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 table.ppv_reportcard th.major_section {
   background-color: #99ccff;
@@ -1893,7 +1925,7 @@ table.ppv_reportcard th.heading {
   background-color: #cccccc;
 }
 table.ppv_reportcard td {
-  border: thin solid black;
+  border: thin solid #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
@@ -1912,11 +1944,11 @@ table.image_source th {
   text-align: center;
   padding: 5px;
   background-color: #eeeeee;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.image_source td {
   padding: 5px;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.image_source td a.sourcelink {
   font-size: 90%;
@@ -1946,7 +1978,7 @@ table.pagedetail th,
 table.pagedetail td {
   text-align: center;
   font-weight: normal;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 .in_progress {
   background-color: #ffcc66;
@@ -2016,12 +2048,12 @@ table.list_special_days tr.o {
 }
 table.list_special_days tr.month > * {
   border: none;
-  border-bottom: solid 2px black;
+  border-bottom: solid 2px #000000;
 }
 table.list_special_days td,
 table.list_special_days th {
   padding: 3px;
-  border: thin solid #999;
+  border: thin solid #999999;
 }
 table.list_special_days td.codecell {
   vertical-align: middle;
@@ -2060,7 +2092,7 @@ table.edit_special_day {
 table.edit_special_day th,
 table.edit_special_day td {
   padding: 5px;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #eeeeee;
 }
 /* ------------------------------------------------------------------------ */
@@ -2112,7 +2144,7 @@ table.search-column tr th {
 .dropdown-button {
   border: none;
   padding: 1px;
-  background-color: transparent;
+  background-color: inherit;
   cursor: pointer;
   font-family: initial;
   font-size: initial;
@@ -2129,7 +2161,7 @@ table.search-column tr th {
   padding: 0 1em;
   float: right;
   margin: 0.5em auto 0.5em 0.5em;
-  border: thin solid black;
+  border: thin solid #000000;
   background-color: #99ccff;
 }
 #linkbox ul {
@@ -2192,6 +2224,9 @@ li.spaced {
   text-align: center;
   background-color: #ccffcc;
 }
+.transition-disabled {
+  color: #9a9a9a;
+}
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 td.has-diff {
@@ -2210,7 +2245,7 @@ td.has-diff {
 .replace_check {
   height: 20em;
   width: 50em;
-  border: thin solid black;
+  border: thin solid #000000;
 }
 /* ------------------------------------------------------------------------ */
 /* Completed Project Listings */
@@ -2231,7 +2266,7 @@ div.task-comment .task-comment-body {
   margin-left: 1em;
 }
 table.task-detail-block {
-  border: thin solid black;
+  border: thin solid #000000;
   width: 100%;
 }
 table.task-detail-block tr th,
@@ -2246,4 +2281,24 @@ table.task-detail-block tr th {
 table.task-detail-block tr td {
   background-color: #ffffff;
   width: 100%;
+}
+/* ------------------------------------------------------------------------ */
+/* Mentoring */
+/* Text colors and sizes for the message mentors see on the P2 round page */
+p.mentor-recent {
+  color: #339933;
+  font-weight: bold;
+  text-align: center;
+}
+p.mentor-older {
+  color: #ff6600;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}
+p.mentor-oldest {
+  color: #ff0000;
+  font-size: x-large;
+  font-weight: bold;
+  text-align: center;
 }

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -185,7 +185,7 @@ class PPage
                 if ( $username == '' || $user_id == NULL )
                 {
                     // Grey, because it's not the link expected by the user.
-                    echo "<span style='color: #666;'>";
+                    echo "<span class='text-link-disabled'>";
                     if ($username == '')
                     {
                         // e.g., the project might have skipped $other_round,


### PR DESCRIPTION
In `layout.less`, name text and border colors. Changed a few more isolated instances of inline styles controlling color to use classes.

In a separate commit, fixed some improperly closed elements in `styles/style_demo.php`.

sandbox: [text-border-colors](https://www.pgdp.org/~srjfoo/c.branch/text-border-colors/)