### PR TITLE
Minor updates for PHP 7.4

### DIFF
--- a/list_etexts.php
+++ b/list_etexts.php
@@ -54,7 +54,7 @@ foreach(array("g" => _("Gold"), "s" => _("Silver"), "b"=> _("Bronze")) as $key =
     else
         $menu[] = "<a href='list_etexts.php?x=$key$listsuffix'>$type_option</a>";
 }
-echo "<p>" .  implode($menu, " | ") . "</p>";
+echo "<p>" .  implode(" | ", $menu) . "</p>";
 echo "<div class='star-$type' style='float: left; width: 1.5em;'>★</div>";
 echo "<p>$info</p>";
 echo "<p>$boilerplate</p>";

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -515,7 +515,7 @@ function _Page_require(
                 $op_name )
             . "\n"
             . "        "
-            . implode( $allowed_states, ' ' )
+            . implode( ' ', $allowed_states )
             . "\n"
             . "    "
             . sprintf( _("But it is in %s"), $curr_page_state )

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -113,10 +113,11 @@ class Project
 
     private function _load_image_source()
     {
+        $this->image_source_name = '';
+        $this->image_source_credit = '';
+
         if(!isset($this->image_source))
         {
-            $this->image_source_name = '';
-            $this->image_source_credit = '';
             return;
         }
 
@@ -128,8 +129,11 @@ class Project
         );
         $result = DPDatabase::query($sql);
         $imso_res = mysqli_fetch_assoc($result);
-        $this->image_source_name = $imso_res['full_name'];
-        $this->image_source_credit = $imso_res['credit'];
+        if($imso_res)
+        {
+            $this->image_source_name = $imso_res['full_name'];
+            $this->image_source_credit = $imso_res['credit'];
+        }
     }
 
     private function _get_credits_line()

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -797,7 +797,7 @@ EOS;
             VALUES $values
         ";
         DPDatabase::query($sql);
-        log_project_event($this->projectid, $pguser, 'add_holds', join($states, ' '));
+        log_project_event($this->projectid, $pguser, 'add_holds', join(' ', $states));
     }
 
     function remove_holds($states)
@@ -820,7 +820,7 @@ EOS;
                 AND state in ($state_values)
         ";
         DPDatabase::query($sql);
-        log_project_event($this->projectid, $pguser, 'remove_holds', join($states, ' '));
+        log_project_event($this->projectid, $pguser, 'remove_holds', join(' ', $states));
     }
 
     // -------------------------------------------------------------------------

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -331,8 +331,7 @@ class OptionsColumn extends Column
         $topic_id = $project->topic_id;
         if (!empty($topic_id))
         {
-            $details = get_topic_details($topic_id);
-            $url = get_url_to_view_topic($details["topic_id"]) . "&amp;view=unread#unread";
+            $url = get_url_to_view_topic($topic_id) . "&amp;view=unread#unread";
             $actions .= "<a href='$url' target='_blank'>" . _("View Forum") . "</a><br>\n";
         }
         if($project->user_can_do_quick_check())

--- a/pinc/maybe_mail.inc
+++ b/pinc/maybe_mail.inc
@@ -29,7 +29,7 @@ function maybe_mail( $to, $subject, $message, $additional_headers = null )
         }
     }
 
-    $additional_headers = implode($additional_headers, "\r\n") . "\r\n";
+    $additional_headers = implode("\r\n", $additional_headers) . "\r\n";
 
     // Append a standard footer to all emails sent out by the system.
     if(!endswith($message, "\n"))

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -566,7 +566,7 @@ function get_rounds_with_data( $projectid )
     {
         $sums[] = "SUM({$round->user_column_name} != '') AS $round_id";
     }
-    $body = join($sums,',');
+    $body = join(',', $sums);
 
     validate_projectid($projectid);
     $sql = "

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -85,7 +85,14 @@ function get_special_color_for_project($book)
         $special_day = $specials_array[$special_code];
     }
 
-    return $bgcolor = "#".$special_day["color"];
+    if($special_day)
+    {
+        return "#".$special_day["color"];
+    }
+    else
+    {
+        return NULL;
+    }
 }
 
 

--- a/project.php
+++ b/project.php
@@ -1444,7 +1444,7 @@ function do_history()
                 $state_labels[] = get_medium_label_for_project_state($state);
             }
             echo "<td colspan='3'>";
-            echo join($state_labels, ", ");
+            echo join(", ", $state_labels);
             echo "</td>\n";
             $spare_cols = 0;
         }

--- a/project.php
+++ b/project.php
@@ -668,9 +668,16 @@ function do_project_info_table()
             else
             {
                 $details = get_topic_details($topic_id);
-                $url = get_url_to_view_topic($details["topic_id"]);
+                if($details)
+                {
+                    $replies = sprintf(_("(%d replies)"), $details['num_replies']);
+                }
+                else
+                {
+                    $replies = '';
+                }
                 $blurb = _("Discuss this project");
-                $replies = sprintf(_("(%d replies)"), $details['num_replies']);
+                $url = get_url_to_view_topic($topic_id);
                 echo_row_a(_("Forum"), "<a href='$url'>$blurb</a> $replies");
             }
         }

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -612,7 +612,7 @@ function showMbrHistory($user, $tally_name) {
             : sprintf( _('Last %d Days'), $d );
         $choices[] = "<a href='mdetail.php?id=$u_id&amp;tally_name=$tally_name&amp;range=$d'>$text</a>";
     }
-    $choices_str = join( $choices, ' | ' );
+    $choices_str = join( ' | ', $choices );
 
     $image_url = $GLOBALS['code_url']."/stats/jpgraph_files/tallyboard_deltas.php?tally_name=$tally_name&amp;holder_type=U&amp;holder_id=$u_id&amp;days_back=$range";
 

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -430,7 +430,7 @@ function showTeamHistory($curTeam, $tally_name) {
             : sprintf( _('Last %d Days'), $d );
         $choices[] = "<a href='tdetail.php?tid=".$curTeam['id']."&amp;tally_name=$tally_name&amp;range=$d'>$text</a>";
     }
-    $choices_str = join( $choices, ' | ' );
+    $choices_str = join( ' | ', $choices );
 
     $image_url = $GLOBALS['code_url']."/stats/jpgraph_files/tallyboard_deltas.php?tally_name=$tally_name&amp;holder_type=T&amp;holder_id=".$curTeam['id']."&amp;days_back=$range";
 

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -609,7 +609,7 @@ function do_stuff( $projectid_, $from_image_, $page_name_handling,
         }
     }
 
-    $items_list_template = join( $items_array, ',' );
+    $items_list_template = join( ',', $items_array );
 
     // Switch to <pre> for the 'technical' output section
     echo "<pre>\n";


### PR DESCRIPTION
After swapping TEST to PHP 7.4 these few notices popped up. There are likely to be more but these were the low hanging fruit. I did a grep for all `join()` and `implode()` calls and believe I have all of the ones using the deprecated form.

Testable, if you want, in the [php-7.4-updates](https://www.pgdp.org/~cpeel/c.branch/php-7.4-updates) sandbox.