### PR TITLE
DPage.inc: Stop project automodify setting n_available_pages to 0

### DIFF
--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -840,7 +840,7 @@ function _project_adjust_n_available_pages( $projectid, $adjustment )
 
     $sql = sprintf("
         UPDATE projects
-        SET n_available_pages = %d
+        SET n_available_pages = %s
         WHERE projectid = '%s'
     ",
         $expr,


### PR DESCRIPTION
I introduced a bug into _project_adjust_n_available_pages.
$expr is an expression string, not a number.