### PR TITLE
Use information_schema to determine table existence

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -121,6 +121,18 @@ final class DPDatabase
         return stripos($table_encoding, 'utf8mb4') === 0;
     }
 
+    static public function does_table_exist($table_name)
+    {
+        $sql = sprintf("
+            SELECT TABLE_NAME
+            FROM information_schema.tables
+            WHERE table_schema='%s' AND table_name='%s'",
+            self::$_db_name,
+            self::escape($table_name));
+        $result = self::query($sql);
+        return mysqli_fetch_assoc($result) !== NULL;
+    }
+
     // Prevent this class from being instantiated
     protected function __construct() {}
     protected function __clone() {}

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1152,19 +1152,7 @@ function get_formatted_postcomments( $projectid )
 // Determines if the project's pages table exists
 function does_project_page_table_exist($projectid)
 {
-    // Two queries can be done to determine if a table exists:
-    //    DESCRIBE table
-    //    SELECT 1 FROM table LIMIT 0
-    // The second is a mysql-ism and performs better, so we use that one.
-    validate_projectID($projectid);
-    $result = DPDatabase::query("SELECT 1 FROM $projectid LIMIT 0", FALSE);
-
-    if($result) {
-        mysqli_free_result($result);
-        return TRUE;
-    } else {
-        return FALSE;
-    }
+    return DPDatabase::does_table_exist($projectid);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
Rather than doing an SQL query we expect might fail (and place an error in the `php_errors` log) use the information.schema to determine if a table exists.

Testable in the [check-pages-table-sql](https://www.pgdp.org/~cpeel/c.branch/check-pages-table-sql/) sandbox.

I found this after doing a deploy to PROD today and seeing the numerous "'table' doesn't exist" errors in the `php_errors` log.