### PR TITLE
travis.yml: CREATE mysql user and GRANT privileges separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install -y php-zip aspell aspell-en
     - mysql -e "CREATE DATABASE dp_db CHARACTER SET utf8mb4;"
-    - mysql -e "GRANT ALL ON dp_db.* TO dp_user@localhost IDENTIFIED BY 'dp_password';"
+    - mysql -e "CREATE USER dp_user@localhost IDENTIFIED BY 'dp_password';"
+    - mysql -e "GRANT ALL ON dp_db.* TO dp_user@localhost;"
     - ./SETUP/configure ./SETUP/tests/travis-ci_configuration.sh .
 install:
     # install the database schema

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -237,7 +237,8 @@ CREATE DATABASE dp_db CHARACTER SET utf8mb4;
 
 Create the user. (See MySQL Manual 5.5.4 Adding New Users to MySQL.)
 ```
-GRANT ALL  ON dp_db.* TO dp_user@localhost IDENTIFIED BY 'dp_password';
+CREATE USER dp_user@localhost IDENTIFIED BY 'dp_password';
+GRANT ALL ON dp_db.* TO dp_user@localhost;
 ```
 
 Exit from the MySQL client.


### PR DESCRIPTION
GRANT ... ON ... TO ... IDENTIFIED BY ...; is deprecated in MySQL 5.7
(and errors in MySQL 8 on Ubuntu 20.10)