### PR TITLE
Use language script as part of spellcheck

### DIFF
--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -56,6 +56,43 @@ function get_languages_with_dictionaries() {
     return $returnArray;
 }
 
+// Given a langcode, return the Unicode script that language is written in.
+// Will return "Latin" if the langcode is not known.
+function get_script_for_langcode($langcode)
+{
+    // This, decidedly incomplete, mapping was created by taking the list of
+    // available aspell 0.60 dictionaries and running the "Native Name" through
+    // utf8_string_scripts().
+    $langcode_script_map = [
+        "am" => "Ethiopic",
+        "ar" => "Arabic",
+        "be" => "Cyrillic",
+        "bg" => "Cyrillic",
+        "el" => "Greek",
+        "fa" => "Arabic",
+        "grc" => "Greek",
+        "gu" => "Gujarati",
+        "he" => "Hebrew",
+        "hi" => "Devanagari",
+        "hy" => "Armenian",
+        "kn" => "Kannada",
+        "ml" => "Malayalam",
+        "mn" => "Cyrillic",
+        "mr" => "Devanagari",
+        "or" => "Oriya",
+        "pa" => "Gurmukhi",
+        "ru" => "Cyrillic",
+        "sr" => "Cyrillic",
+        "ta" => "Tamil",
+        "te" => "Telugu",
+        "uk" => "Cyrillic",
+        "uz" => "Cyrillic",
+        "yi" => "Hebrew",
+    ];
+
+    return $langcode_script_map[$langcode] ?? "Latin";
+}
+
 // The 3-letter language *CODES* in the table below are mostly those 
 // defined in the ISO-639-2 standard, with these exceptions:
 //   1. Code "qsr" which is not defined in that standard at all and

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -274,13 +274,18 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
                 // create the aspell command
                 $aspell_command="cat $tmp_file_path | {$aspell_executable} list --prefix={$aspell_prefix} -d $dict_file --encoding {$charset}";
                 //echo "<!-- aspell command: $aspell_command -->\n"; // Very useful for debugging
-                // run aspell
-                // "asr" stands for "aspell result"
-                $asr_text = trim(shell_exec($aspell_command));
-                $asr_text = str_replace(["\r","\n"], ['',"[lf]"], $asr_text);
                 // build our list of possible misspellings
-                $misspellings[$langcode] = explode("[lf]", $asr_text);
-                unset($asr_text);
+                $misspellings[$langcode] = explode("\n",
+                    str_replace("\r", "", shell_exec($aspell_command))
+                );
+
+                // Reduce the set to only words that use characters in our
+                // expected script. This is necessary for some aspell
+                // dictionaries like Ancient Greek that return all non-Greek
+                // words as misspelled.
+                $misspellings[$langcode] = filter_words_to_script(
+                    $misspellings[$langcode], get_script_for_langcode($langcode)
+                );
             }
             else
             {
@@ -303,13 +308,31 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
         return [$finalMisspellings, $messages];
     }
 
-    // now we need to find the intersection between the languages that we've checked
-    // for instance, if we've checked against an english and a french dictionary
-    // the words that are misspelled in both are the ones actually misspelled
-    $langKeys = array_keys($misspellings);
-    $finalMisspellings = $misspellings[array_shift($langKeys)];
-    foreach($langKeys as $langkey) {
-        $finalMisspellings = array_intersect($finalMisspellings, $misspellings[$langkey]);
+    // Find the intersection between the languages that we've checked grouped
+    // by language script. For instance, if we've checked against an English
+    // and a French dictionary, the words that are misspelled in both are the
+    // ones actually misspelled. We only intersect by language script, however,
+    // as a misspelled Greek word won't show up in the English list or vice versa.
+    foreach($misspellings as $lang_code => $words)
+    {
+        $lang_script = get_script_for_langcode($lang_code);
+        if(!isset($misspellings[$lang_script]))
+        {
+            $misspellings[$lang_script] = $words;
+            unset($misspellings[$lang_code]);
+            continue;
+        }
+        $misspellings[$lang_script] = array_intersect(
+            $misspellings[$lang_script], $words
+        );
+        unset($misspellings[$lang_code]);
+    }
+
+    // Now merge all misspellings by language script together
+    $finalMisspellings = [];
+    foreach($misspellings as $lang_script => $words)
+    {
+        $finalMisspellings = array_merge($finalMisspellings, $words);
     }
     unset($misspellings);
 
@@ -1108,6 +1131,19 @@ function deterministicStrnatcasecmp($a, $b)
 function rtrim_walk(&$item)
 {
     $item = rtrim($item);
+}
+
+function filter_words_to_script($words, $script)
+{
+    $script_words = [];
+    foreach($words as $word)
+    {
+        if(in_array($script, utf8_string_scripts($word)))
+        {
+            $script_words[] = $word;
+        }
+    }
+    return $script_words;
 }
 
 // vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
When presented with text containing two different scripts, aspell behaves differently based on the dictionary. Words containing non-Latin characters are ignored completely with the English dictionary, yet words containing Latin characters are flagged as spelling errors with the Ancient Greek dictionary.

To fix this, restrict misspelled words (as returned from aspell) to only words that contain the script of the language we're checking. This ensures that only words with Latin characters are returned when checking against the English or French dictionary, and only Greek words are returned when using the Ancient Greek dictionary.

This is testable in the [wordcheck-script-support](https://www.pgdp.org/~cpeel/c.branch/wordcheck-script-support/) sandbox.