### PR TITLE
Centralize project language encoding/decoding

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -130,7 +130,7 @@ function render_project_json($project)
         "state" => $project->state,
         "title" => $project->nameofwork,
         "author" => $project->authorsname,
-        "languages" => explode(" with ", $project->language),
+        "languages" => $project->languages,
         "genre" => $project->genre,
         "difficulty" => $project->difficulty,
         "special_day" => $project->special_code,

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -289,8 +289,7 @@ class LPage
     function get_language()
     {
         $project = new Project($this->projectid);
-        $lang = proj_lang_code($project->language,"primary");
-        return $lang;
+        return langcode2_for_langname($project->languages[0]);
     }
 
     function get_username_for_round( $round )

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -84,6 +84,8 @@ class Project
                 return does_project_page_table_exist($this->projectid);
             case "credits_line":
                 return $this->_get_credits_line();
+            case "languages":
+                return self::decode_language($this->language);
             case "image_source_name":
                 $this->_load_image_source();
                 return $this->image_source_name;
@@ -153,6 +155,22 @@ class Project
             $credits_line = "$credits_line ({$this->image_source_credit})";
         }
         return $credits_line;
+    }
+
+    // -------------------------------------------------------------------------
+
+    // Multiple project languages are stored in a single "language" column
+    // by joining them with the string " with ". These functions provide a
+    // common place for encoding / decoding them.
+
+    static public function encode_languages($languages)
+    {
+        return join(" with ", $languages);
+    }
+
+    static public function decode_language($language)
+    {
+        return explode(" with ", $language);
     }
 
     // -------------------------------------------------------------------------

--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -15,7 +15,7 @@
 function proj_lang_code($proj_lang, $which="all")
 {
     $lang_codes = [];
-    foreach(preg_split('/ with /', $proj_lang ) as $language)
+    foreach(Project::decode_language($proj_lang) as $language)
     {
         $lang_codes[] = langcode2_for_langname($language);
     }

--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -4,35 +4,6 @@
 // system dictionaries used with WordCheck. The functions in language.inc
 // deal with localizations/translations and system locales.
 
-// Returns ISO 639 code(s) for language(s) of a project.
-// $which could be "primary", "secondary" or "all":
-// - "primary" returns the code of primary language
-// - "secondary" returns the code of secondary language, or NULL if the
-//   secondary language doesn't exist
-// - "all" returns array with the code(s) of both language(s); if the secondary
-//   language doesn't exist, the array only has one element
-// If a language doesn't have ISO 639 code, NULL is returned; this might change
-function proj_lang_code($proj_lang, $which="all")
-{
-    $lang_codes = [];
-    foreach(Project::decode_language($proj_lang) as $language)
-    {
-        $lang_codes[] = langcode2_for_langname($language);
-    }
-
-    switch($which) {
-    case "primary":
-        return $lang_codes[0];
-        break;
-    case "secondary":
-        return $lang_codes[1];
-        break;
-    case "all":
-        return $lang_codes;
-        break;
-    }
-}
-
 // Returns an associative array of those languages with a dictionary that is
 // installed on the system
 //   $array[$langcode]=$language;

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -870,7 +870,7 @@ function get_project_languages($projectid, $aux_language=NULL)
     {
         return $returnArray;
     }
-    $languages = preg_split('/ with /', $project->language);
+    $languages = $project->languages;
     if($aux_language)
         $languages[] = $aux_language;
 

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -1,8 +1,7 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'Project.inc');
-include_once($relPath.'languages.inc'); // proj_lang_code
-include_once($relPath.'iso_lang_list.inc'); // langcode3_for_langname
+include_once($relPath.'iso_lang_list.inc'); // langcode3_for_langname, langcode2_for_langname
 include_once($relPath.'misc.inc'); // str_contains, array_get
 include_once($relPath.'unicode.inc');
 
@@ -265,7 +264,7 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 
     $misspellings = [];
     foreach($languages as $language) {
-        $langcode = proj_lang_code($language, "primary");
+        $langcode = langcode2_for_langname($language);
         if($langcode) {
             $dict_file = "$aspell_prefix/lib/aspell/$langcode.multi";
             if(is_file($dict_file)) {
@@ -875,7 +874,7 @@ function get_project_languages($projectid, $aux_language=NULL)
         $languages[] = $aux_language;
 
     foreach($languages as $language) {
-        $langcode = proj_lang_code($language, "primary");
+        $langcode = langcode2_for_langname($language);
         if($langcode) {
             $returnArray[$langcode] = $language;
         }

--- a/project.php
+++ b/project.php
@@ -72,7 +72,7 @@ $ld_json_object = [
         "@type" => "Person",
         "name" => $project->authorsname,
     ],
-    "inLanguage" => explode(" with ", $project->language)[0],
+    "inLanguage" => $project->languages,
     "genre" => $project->genre,
 ];
 

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -394,7 +394,7 @@ class ProjectInfoHolder
 
         $this->language = (
             $sec_language != ''
-            ? "$pri_language with $sec_language"
+            ? Project::encode_languages([$pri_language, $sec_language])
             : $pri_language );
 
         $this->charsuites = [];

--- a/tools/site_admin/show_common_words_from_project_word_lists.php
+++ b/tools/site_admin/show_common_words_from_project_word_lists.php
@@ -54,15 +54,9 @@ if($display_list)
     $used_languages = array();
     while( list($language,$language_count) = mysqli_fetch_row($res) )
     {
-        if(strpos($language," with "))
+        foreach(Project::decode_language($language) as $lang)
         {
-            list($language1,$language2) = explode(" with ", $language);
-            @$used_languages[$language1] += $language_count;
-            @$used_languages[$language2] += $language_count;
-        }
-        else
-        {
-            @$used_languages[$language] += $language_count;
+            @$used_languages[$lang] += $language_count;
         }
     }
     ksort($used_languages);


### PR DESCRIPTION
We encode a project's languages into a single column with the names separated by `" with "`. Centralize that logic into a single place instead of having it smeared across the codebase. This makes it easier to remove the redundant `proj_lang_code()` function entirely.

Accessible in the [project-languages](https://www.pgdp.org/~cpeel/c.branch/project-languages/) sandbox.