### PR TITLE
More color tweaks

### DIFF
--- a/quiz/generic/quiz_defaults.inc
+++ b/quiz/generic/quiz_defaults.inc
@@ -534,7 +534,7 @@ $messages["G_k_ch"] = array(
 );
 $messages["G_ph_ps"] = array(
     "message_title" => _("Commonly confused letters"),
-    "message_body" => _("There is a '<kbd>ps</kbd>' in your transliteration that should be '<kbd>ph</kbd>'.  The Greek letter <kbd>φ<kbd> (phi, transliterated '<kbd>ph</kbd>') has a circular shape in the center, while the Greek letter <kbd>ψ</kbd> (psi, transliterated '<kbd>ps</kbd>') has 'arms' curving out away from the center."),
+    "message_body" => _("There is a '<kbd>ps</kbd>' in your transliteration that should be '<kbd>ph</kbd>'.  The Greek letter <kbd>φ</kbd> (phi, transliterated '<kbd>ph</kbd>') has a circular shape in the center, while the Greek letter <kbd>ψ</kbd> (psi, transliterated '<kbd>ps</kbd>') has 'arms' curving out away from the center."),
 );
 $messages["G_s_c"] = array(
     "message_title" => _("Scanno"),

--- a/quiz/generic/wizard/default_messages.php
+++ b/quiz/generic/wizard/default_messages.php
@@ -4,12 +4,9 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once('../quiz_defaults.inc'); // $messages
 
-$theme_args["css_data"] = "h2 {font-size:110%; margin: 0;}
-    p.message_id {margin: 0 0 .5em 1em; background-color: #dddddd;}";
-
 require_login();
 
-output_header(_('Quiz Messages'), SHOW_STATSBAR, $theme_args);
+output_header(_('Quiz Messages'));
 
 echo "<h1>" . _("Default Quiz Messages") . "</h1>";
 
@@ -18,7 +15,7 @@ echo "<p>" . _("(By the way, you should <b>not</b> name any of your custom messa
 
 foreach ($messages as $key => $message)
 {
-    echo "<hr><p class='message_id'>" . _("Message ID:") . " $key</p>\n";
+    echo "<hr><p>" . _("Message ID:") . " $key</p>\n";
     echo "<h2>" . $message['message_title'] . "</h2>\n";
     echo "<p>" . $message["message_body"] . "</p>\n";
     if (isset($message['wiki_ref']))

--- a/styles/global.less
+++ b/styles/global.less
@@ -116,20 +116,6 @@
     visibility: hidden;
 }
 
-.button {
-    /*
-     * We can't use appearance: button here because Chrome has deprecated it:
-     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
-     * so we make a "button like object" that won't really resemble the other
-     * buttons rendered, but still looks like a button.
-     */
-    border: solid 1px lightgray;
-    border-radius: 5px;
-    font-size: 0.7rem;
-    padding: 2px 6px;
-    cursor: default;
-}
-
 .nodisp {
     display: none;
 }

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1,7 +1,6 @@
 @import "global.less";
 @import "page_interfaces.less";
 
-
 /* ------------------------------------------------------------------------ */
 /* Common color definitions
  * Where a particular color family has multiple shades available, a
@@ -67,6 +66,10 @@
     border-bottom: thin solid @color;
 }
 
+.x-thin-border(@color: @border-color-base) {
+    border: 0.5px solid @color;
+}
+
 /* standalone classes that can be used as mixins, but that should not
  * be given parameters, as they can't be used as classes in the code
  * directly if they have parameters that the lessc compiler has to
@@ -94,7 +97,21 @@
 }
 
 .button {
+    /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+    border-radius: 3px;
+    cursor: default;
     .sans-serif;
+    .solid-border;
+}
+
+span.button {
+    font-size: 0.8em;
+    padding: 1px 4px;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -441,6 +458,10 @@ hr.divider {
     }
 }
 
+@star-gold: #ffd700;
+@star-silver: silver;
+@star-bronze: #cd7f32;
+
 .star-metal(@color) {
     font-size: 3em;
     color: @color;
@@ -449,17 +470,16 @@ hr.divider {
 }
 
 .star-gold {
-    .star-metal(#FFD700);
+    .star-metal(@star-gold);
 }
 
 .star-silver {
-    .star-metal(silver);
+    .star-metal(@star-silver);
 }
 
 .star-bronze {
-    .star-metal(#cd7f32);
+    .star-metal(@star-bronze);
 }
-
 
 @media only screen and (max-width: 481px) {
     .star-text-summary {
@@ -599,8 +619,10 @@ div.calloutheader {
     color: @text-warning;
 }
 
+@highlight: @table-cell-alert;
+
 .highlight {
-    background-color: @table-cell-alert;
+    background-color: @highlight;
     color: @page-text;
 }
 
@@ -1009,6 +1031,9 @@ table.theme_striped {
     }
 }
 
+@satisfied: @table-cell-ok-lowc;
+@not-satisfied: @table-cell-not-ok-lowc;
+
 table.basic {
     border-collapse: collapse;
     .solid-border;
@@ -1023,11 +1048,11 @@ table.basic {
     }
     td.satisfied {
         .right-align;
-        background-color: @table-cell-ok-lowc;
+        background-color: @satisfied;
     }
     td.not_satisfied {
         .right-align;
-        background-color: @table-cell-not-ok-lowc;
+        background-color: @not-satisfied;
     }
     textarea {
         width: 100%;
@@ -1094,6 +1119,10 @@ table.ppv_reportcard {
 /* ------------------------------------------------------------------------ */
 /* Image Sources */
 
+@enabled: @table-cell-ok-highc;
+@disabled: @table-cell-base-mediumc;
+@pending: @table-cell-pending;
+
 table.image_source {
     border-collapse: collapse;
     width: 90%;
@@ -1123,20 +1152,24 @@ table.image_source {
     }
     td.enabled {
         .center-align;
-        background-color: @table-cell-ok-highc;
+        background-color: @enabled;
     }
     td.disabled {
         .center-align;
-        background-color: @table-cell-base-mediumc;
+        background-color: @disabled;
     }
     td.pending {
         .center-align;
-        background-color: @table-cell-pending;
+        background-color: @pending;
     }
 }
 
 /* ------------------------------------------------------------------------ */
 /* Page Detail */
+
+@inprog: @table-cell-pending;
+@done-current: @table-cell-ok-highc;
+@done-previous: @table-cell-not-ok-highc;
 
 table.pagedetail {
     width: auto;
@@ -1148,13 +1181,13 @@ table.pagedetail {
 }
 
 .in_progress {
-    background-color: @table-cell-pending;
+    background-color: @inprog;
 }
 .done_current {
-    background-color: @table-cell-ok-highc;
+    background-color: @done-current;
 }
 .done_previous {
-    background-color: @table-cell-not-ok-highc;
+    background-color: @done-previous;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -1171,6 +1204,14 @@ table.dirlist {
         margin-top: 0.5em;
         padding: 5px;
     }
+}
+
+div.remote-file-mgr-info {
+    background-color: @table-cell-ok-highc;
+    color: @page-text;
+    .default-border;
+    padding: .5em;
+    margin: 0.8em 0;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -1245,11 +1286,11 @@ table.list_special_days {
     }
     td.enabled {
         text-align: center;
-        background-color: @table-cell-ok-highc;
+        background-color: @enabled;
     }
     td.disabled {
         text-align: center;
-        background-color: @table-cell-base-mediumc;
+        background-color: @disabled;
     }
     td.center {
         text-align: center;
@@ -1335,6 +1376,7 @@ table.search-column {
     border: none;
     padding: 1px;
     background-color: inherit;
+    color: @header-text;
     cursor: pointer;
     font-family: initial;
     font-size: initial;
@@ -1431,7 +1473,6 @@ li.spaced {
 
 /* ------------------------------------------------------------------------ */
 /* Review Work */
-
 
 td.has-diff {
     background-color: @table-cell-ok-lowc;

--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -20,9 +20,23 @@
 @control-pane-text: black;
 @control-pane-menu: Bisque;
 
+/* Links */
+@page-interface-link-color: #0000ff;
+@page-interface-visited-color: #990099;
+@page-interface-active-color: #ff0000;
+
 .page-interface {
     background-color: @page-interface-background;
     color: @page-interface-text;
+    a:link {
+        color: @page-interface-link-color;
+    }
+    a:visited {
+        color: @page-interface-visited-color;
+    }
+    a:active {
+        color: @page-interface-active-color;
+    }
 
     .text-pane {
         background-color: @text-pane-background;
@@ -87,6 +101,15 @@
             border-radius: 3px;
             margin: 2px;
         }
+    }
+    a:link {
+        color: @page-interface-link-color;
+    }
+    a:visited {
+        color: @page-interface-visited-color;
+    }
+    a:active {
+        color: @page-interface-active-color;
     }
 }
 
@@ -163,6 +186,24 @@
         padding: 0.5em;
         .solid-border;
         .page-interface .text-pane;
+        .proofingfont {
+            input {
+                background-color: white;
+                color: black;
+                padding: 3px;
+                .x-thin-border(@border-color-base-lowc);
+            }
+        }
+    }
+    #wc_header {
+        input, select {
+            background-color: @page-background;
+            color: @page-text;
+            .solid-border;
+        }
+        button, input[type=submit], input[type=button] {
+            .button;
+        }
     }
 }
 
@@ -325,6 +366,16 @@
         margin-right: 0.5em;
         text-align: right;
         width: 100%;
+
+       a:link {
+           color: @page-interface-link-color;
+       }
+       a:visited {
+           color: @page-interface-visited-color;
+       }
+       a:active {
+           color: @page-interface-active-color;
+       }
     }
 }
 

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -84,19 +84,6 @@
 .invisible {
   visibility: hidden;
 }
-.button {
-  /*
-     * We can't use appearance: button here because Chrome has deprecated it:
-     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
-     * so we make a "button like object" that won't really resemble the other
-     * buttons rendered, but still looks like a button.
-     */
-  border: solid 1px lightgray;
-  border-radius: 5px;
-  font-size: 0.7rem;
-  padding: 2px 6px;
-  cursor: default;
-}
 .nodisp {
   display: none;
 }
@@ -164,9 +151,19 @@
 /* Base layer for page interface */
 /* Text pane */
 /* Control panes */
+/* Links */
 .page-interface {
   background-color: #CDCDC1;
   color: black;
+}
+.page-interface a:link {
+  color: #0000ff;
+}
+.page-interface a:visited {
+  color: #990099;
+}
+.page-interface a:active {
+  color: #ff0000;
 }
 .page-interface .text-pane {
   background-color: #FFF8DC;
@@ -207,6 +204,15 @@
   margin: 0;
   background-color: #CDCDC1;
   color: black;
+}
+#standard_interface_image a:link {
+  color: #0000ff;
+}
+#standard_interface_image a:visited {
+  color: #990099;
+}
+#standard_interface_image a:active {
+  color: #ff0000;
 }
 #standard_interface_image .text-pane {
   background-color: #FFF8DC;
@@ -261,6 +267,15 @@
   border-radius: 3px;
   margin: 2px;
 }
+#standard_interface_text a:link {
+  color: #0000ff;
+}
+#standard_interface_text a:visited {
+  color: #990099;
+}
+#standard_interface_text a:active {
+  color: #ff0000;
+}
 #text_data,
 #text_data:focus {
   background-color: white;
@@ -274,6 +289,15 @@
   overflow: hidden;
   background-color: #CDCDC1;
   color: black;
+}
+#enhanced_interface a:link {
+  color: #0000ff;
+}
+#enhanced_interface a:visited {
+  color: #990099;
+}
+#enhanced_interface a:active {
+  color: #ff0000;
 }
 #enhanced_interface .text-pane {
   background-color: #FFF8DC;
@@ -355,6 +379,15 @@
   background-color: #CDCDC1;
   color: black;
 }
+#enhanced_interface #tdtext a:link {
+  color: #0000ff;
+}
+#enhanced_interface #tdtext a:visited {
+  color: #990099;
+}
+#enhanced_interface #tdtext a:active {
+  color: #ff0000;
+}
 #enhanced_interface #tdtext .text-pane {
   background-color: #FFF8DC;
   color: black;
@@ -407,6 +440,15 @@
   overflow: auto;
   background-color: #CDCDC1;
   color: black;
+}
+#wordcheck_interface a:link {
+  color: #0000ff;
+}
+#wordcheck_interface a:visited {
+  color: #990099;
+}
+#wordcheck_interface a:active {
+  color: #ff0000;
 }
 #wordcheck_interface .text-pane {
   background-color: #FFF8DC;
@@ -484,6 +526,32 @@
   background-color: #FFF8DC;
   color: black;
 }
+#wordcheck_interface #tdtext .proofingfont input {
+  background-color: white;
+  color: black;
+  padding: 3px;
+  border: 0.5px solid #d3d3d3;
+}
+#wordcheck_interface #wc_header input,
+#wordcheck_interface #wc_header select {
+  background-color: #ffffff;
+  color: #000000;
+  border: thin solid #000000;
+}
+#wordcheck_interface #wc_header button,
+#wordcheck_interface #wc_header input[type=submit],
+#wordcheck_interface #wc_header input[type=button] {
+  /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+  border-radius: 3px;
+  cursor: default;
+  font-family: Verdana, Helvetica, sans-serif;
+  border: thin solid #000000;
+}
 .preWC {
   background-color: #c2c2c2;
 }
@@ -499,6 +567,15 @@
 #format_preview {
   background-color: #CDCDC1;
   color: black;
+}
+#format_preview a:link {
+  color: #0000ff;
+}
+#format_preview a:visited {
+  color: #990099;
+}
+#format_preview a:active {
+  color: #ff0000;
 }
 #format_preview .text-pane {
   background-color: #FFF8DC;
@@ -752,6 +829,15 @@
   text-align: right;
   width: 100%;
 }
+#toolbox #tools a:link {
+  color: #0000ff;
+}
+#toolbox #tools a:visited {
+  color: #990099;
+}
+#toolbox #tools a:active {
+  color: #ff0000;
+}
 /* ------------------------------------------------------------------------ */
 /* Page Browser */
 #page-browser {
@@ -767,6 +853,15 @@
 #page-browser .stretch-box {
   flex: 1 1 100vh;
   min-height: 10px;
+}
+#page-browser a:link {
+  color: #0000ff;
+}
+#page-browser a:visited {
+  color: #990099;
+}
+#page-browser a:active {
+  color: #ff0000;
 }
 #page-browser .text-pane {
   background-color: #FFF8DC;
@@ -909,7 +1004,20 @@
   font-family: Verdana, Helvetica, sans-serif;
 }
 .button {
+  /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+  border-radius: 3px;
+  cursor: default;
   font-family: Verdana, Helvetica, sans-serif;
+  border: thin solid #000000;
+}
+span.button {
+  font-size: 0.8em;
+  padding: 1px 4px;
 }
 /* ------------------------------------------------------------------------ */
 /* Global */
@@ -1324,7 +1432,7 @@ hr.divider {
 }
 .star-gold {
   font-size: 3em;
-  color: #FFD700;
+  color: #ffd700;
   text-align: center;
   text-shadow: 3px 2px 5px black;
 }
@@ -2002,6 +2110,13 @@ table.dirlist caption {
   margin-top: 0.5em;
   padding: 5px;
 }
+div.remote-file-mgr-info {
+  background-color: #88ff88;
+  color: #000000;
+  border: thin solid #000000;
+  padding: 0.5em;
+  margin: 0.8em 0;
+}
 /* ------------------------------------------------------------------------ */
 /* Project Load (add_files.php) */
 table#addfiles td.load-add {
@@ -2144,6 +2259,7 @@ table.search-column tr th {
   border: none;
   padding: 1px;
   background-color: inherit;
+  color: #000000;
   cursor: pointer;
   font-family: initial;
   font-size: initial;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -84,19 +84,6 @@
 .invisible {
   visibility: hidden;
 }
-.button {
-  /*
-     * We can't use appearance: button here because Chrome has deprecated it:
-     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
-     * so we make a "button like object" that won't really resemble the other
-     * buttons rendered, but still looks like a button.
-     */
-  border: solid 1px lightgray;
-  border-radius: 5px;
-  font-size: 0.7rem;
-  padding: 2px 6px;
-  cursor: default;
-}
 .nodisp {
   display: none;
 }
@@ -164,9 +151,19 @@
 /* Base layer for page interface */
 /* Text pane */
 /* Control panes */
+/* Links */
 .page-interface {
   background-color: #CDCDC1;
   color: black;
+}
+.page-interface a:link {
+  color: #0000ff;
+}
+.page-interface a:visited {
+  color: #990099;
+}
+.page-interface a:active {
+  color: #ff0000;
 }
 .page-interface .text-pane {
   background-color: #FFF8DC;
@@ -207,6 +204,15 @@
   margin: 0;
   background-color: #CDCDC1;
   color: black;
+}
+#standard_interface_image a:link {
+  color: #0000ff;
+}
+#standard_interface_image a:visited {
+  color: #990099;
+}
+#standard_interface_image a:active {
+  color: #ff0000;
 }
 #standard_interface_image .text-pane {
   background-color: #FFF8DC;
@@ -261,6 +267,15 @@
   border-radius: 3px;
   margin: 2px;
 }
+#standard_interface_text a:link {
+  color: #0000ff;
+}
+#standard_interface_text a:visited {
+  color: #990099;
+}
+#standard_interface_text a:active {
+  color: #ff0000;
+}
 #text_data,
 #text_data:focus {
   background-color: white;
@@ -274,6 +289,15 @@
   overflow: hidden;
   background-color: #CDCDC1;
   color: black;
+}
+#enhanced_interface a:link {
+  color: #0000ff;
+}
+#enhanced_interface a:visited {
+  color: #990099;
+}
+#enhanced_interface a:active {
+  color: #ff0000;
 }
 #enhanced_interface .text-pane {
   background-color: #FFF8DC;
@@ -355,6 +379,15 @@
   background-color: #CDCDC1;
   color: black;
 }
+#enhanced_interface #tdtext a:link {
+  color: #0000ff;
+}
+#enhanced_interface #tdtext a:visited {
+  color: #990099;
+}
+#enhanced_interface #tdtext a:active {
+  color: #ff0000;
+}
 #enhanced_interface #tdtext .text-pane {
   background-color: #FFF8DC;
   color: black;
@@ -407,6 +440,15 @@
   overflow: auto;
   background-color: #CDCDC1;
   color: black;
+}
+#wordcheck_interface a:link {
+  color: #0000ff;
+}
+#wordcheck_interface a:visited {
+  color: #990099;
+}
+#wordcheck_interface a:active {
+  color: #ff0000;
 }
 #wordcheck_interface .text-pane {
   background-color: #FFF8DC;
@@ -484,6 +526,32 @@
   background-color: #FFF8DC;
   color: black;
 }
+#wordcheck_interface #tdtext .proofingfont input {
+  background-color: white;
+  color: black;
+  padding: 3px;
+  border: 0.5px solid #d3d3d3;
+}
+#wordcheck_interface #wc_header input,
+#wordcheck_interface #wc_header select {
+  background-color: #ffffff;
+  color: #000000;
+  border: thin solid #000000;
+}
+#wordcheck_interface #wc_header button,
+#wordcheck_interface #wc_header input[type=submit],
+#wordcheck_interface #wc_header input[type=button] {
+  /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+  border-radius: 3px;
+  cursor: default;
+  font-family: Verdana, Helvetica, sans-serif;
+  border: thin solid #000000;
+}
 .preWC {
   background-color: #c2c2c2;
 }
@@ -499,6 +567,15 @@
 #format_preview {
   background-color: #CDCDC1;
   color: black;
+}
+#format_preview a:link {
+  color: #0000ff;
+}
+#format_preview a:visited {
+  color: #990099;
+}
+#format_preview a:active {
+  color: #ff0000;
 }
 #format_preview .text-pane {
   background-color: #FFF8DC;
@@ -752,6 +829,15 @@
   text-align: right;
   width: 100%;
 }
+#toolbox #tools a:link {
+  color: #0000ff;
+}
+#toolbox #tools a:visited {
+  color: #990099;
+}
+#toolbox #tools a:active {
+  color: #ff0000;
+}
 /* ------------------------------------------------------------------------ */
 /* Page Browser */
 #page-browser {
@@ -767,6 +853,15 @@
 #page-browser .stretch-box {
   flex: 1 1 100vh;
   min-height: 10px;
+}
+#page-browser a:link {
+  color: #0000ff;
+}
+#page-browser a:visited {
+  color: #990099;
+}
+#page-browser a:active {
+  color: #ff0000;
 }
 #page-browser .text-pane {
   background-color: #FFF8DC;
@@ -909,7 +1004,20 @@
   font-family: Verdana, Helvetica, sans-serif;
 }
 .button {
+  /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+  border-radius: 3px;
+  cursor: default;
   font-family: Verdana, Helvetica, sans-serif;
+  border: thin solid #000000;
+}
+span.button {
+  font-size: 0.8em;
+  padding: 1px 4px;
 }
 /* ------------------------------------------------------------------------ */
 /* Global */
@@ -1324,7 +1432,7 @@ hr.divider {
 }
 .star-gold {
   font-size: 3em;
-  color: #FFD700;
+  color: #ffd700;
   text-align: center;
   text-shadow: 3px 2px 5px black;
 }
@@ -2002,6 +2110,13 @@ table.dirlist caption {
   margin-top: 0.5em;
   padding: 5px;
 }
+div.remote-file-mgr-info {
+  background-color: #88ff88;
+  color: #000000;
+  border: thin solid #000000;
+  padding: 0.5em;
+  margin: 0.8em 0;
+}
 /* ------------------------------------------------------------------------ */
 /* Project Load (add_files.php) */
 table#addfiles td.load-add {
@@ -2144,6 +2259,7 @@ table.search-column tr th {
   border: none;
   padding: 1px;
   background-color: inherit;
+  color: #000000;
   cursor: pointer;
   font-family: initial;
   font-size: initial;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -84,19 +84,6 @@
 .invisible {
   visibility: hidden;
 }
-.button {
-  /*
-     * We can't use appearance: button here because Chrome has deprecated it:
-     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
-     * so we make a "button like object" that won't really resemble the other
-     * buttons rendered, but still looks like a button.
-     */
-  border: solid 1px lightgray;
-  border-radius: 5px;
-  font-size: 0.7rem;
-  padding: 2px 6px;
-  cursor: default;
-}
 .nodisp {
   display: none;
 }
@@ -164,9 +151,19 @@
 /* Base layer for page interface */
 /* Text pane */
 /* Control panes */
+/* Links */
 .page-interface {
   background-color: #CDCDC1;
   color: black;
+}
+.page-interface a:link {
+  color: #0000ff;
+}
+.page-interface a:visited {
+  color: #990099;
+}
+.page-interface a:active {
+  color: #ff0000;
 }
 .page-interface .text-pane {
   background-color: #FFF8DC;
@@ -207,6 +204,15 @@
   margin: 0;
   background-color: #CDCDC1;
   color: black;
+}
+#standard_interface_image a:link {
+  color: #0000ff;
+}
+#standard_interface_image a:visited {
+  color: #990099;
+}
+#standard_interface_image a:active {
+  color: #ff0000;
 }
 #standard_interface_image .text-pane {
   background-color: #FFF8DC;
@@ -261,6 +267,15 @@
   border-radius: 3px;
   margin: 2px;
 }
+#standard_interface_text a:link {
+  color: #0000ff;
+}
+#standard_interface_text a:visited {
+  color: #990099;
+}
+#standard_interface_text a:active {
+  color: #ff0000;
+}
 #text_data,
 #text_data:focus {
   background-color: white;
@@ -274,6 +289,15 @@
   overflow: hidden;
   background-color: #CDCDC1;
   color: black;
+}
+#enhanced_interface a:link {
+  color: #0000ff;
+}
+#enhanced_interface a:visited {
+  color: #990099;
+}
+#enhanced_interface a:active {
+  color: #ff0000;
 }
 #enhanced_interface .text-pane {
   background-color: #FFF8DC;
@@ -355,6 +379,15 @@
   background-color: #CDCDC1;
   color: black;
 }
+#enhanced_interface #tdtext a:link {
+  color: #0000ff;
+}
+#enhanced_interface #tdtext a:visited {
+  color: #990099;
+}
+#enhanced_interface #tdtext a:active {
+  color: #ff0000;
+}
 #enhanced_interface #tdtext .text-pane {
   background-color: #FFF8DC;
   color: black;
@@ -407,6 +440,15 @@
   overflow: auto;
   background-color: #CDCDC1;
   color: black;
+}
+#wordcheck_interface a:link {
+  color: #0000ff;
+}
+#wordcheck_interface a:visited {
+  color: #990099;
+}
+#wordcheck_interface a:active {
+  color: #ff0000;
 }
 #wordcheck_interface .text-pane {
   background-color: #FFF8DC;
@@ -484,6 +526,32 @@
   background-color: #FFF8DC;
   color: black;
 }
+#wordcheck_interface #tdtext .proofingfont input {
+  background-color: white;
+  color: black;
+  padding: 3px;
+  border: 0.5px solid #d3d3d3;
+}
+#wordcheck_interface #wc_header input,
+#wordcheck_interface #wc_header select {
+  background-color: #ffffff;
+  color: #000000;
+  border: thin solid #000000;
+}
+#wordcheck_interface #wc_header button,
+#wordcheck_interface #wc_header input[type=submit],
+#wordcheck_interface #wc_header input[type=button] {
+  /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+  border-radius: 3px;
+  cursor: default;
+  font-family: Verdana, Arial, sans-serif;
+  border: thin solid #000000;
+}
 .preWC {
   background-color: #c2c2c2;
 }
@@ -499,6 +567,15 @@
 #format_preview {
   background-color: #CDCDC1;
   color: black;
+}
+#format_preview a:link {
+  color: #0000ff;
+}
+#format_preview a:visited {
+  color: #990099;
+}
+#format_preview a:active {
+  color: #ff0000;
 }
 #format_preview .text-pane {
   background-color: #FFF8DC;
@@ -752,6 +829,15 @@
   text-align: right;
   width: 100%;
 }
+#toolbox #tools a:link {
+  color: #0000ff;
+}
+#toolbox #tools a:visited {
+  color: #990099;
+}
+#toolbox #tools a:active {
+  color: #ff0000;
+}
 /* ------------------------------------------------------------------------ */
 /* Page Browser */
 #page-browser {
@@ -767,6 +853,15 @@
 #page-browser .stretch-box {
   flex: 1 1 100vh;
   min-height: 10px;
+}
+#page-browser a:link {
+  color: #0000ff;
+}
+#page-browser a:visited {
+  color: #990099;
+}
+#page-browser a:active {
+  color: #ff0000;
 }
 #page-browser .text-pane {
   background-color: #FFF8DC;
@@ -909,7 +1004,20 @@
   font-family: Verdana, Arial, sans-serif;
 }
 .button {
+  /*
+     * We can't use appearance: button here because Chrome has deprecated it:
+     * https://developers.google.com/web/updates/2019/12/chrome-80-deps-rems
+     * so we make a "button like object" that won't really resemble the other
+     * buttons rendered, but still looks like a button.
+     */
+  border-radius: 3px;
+  cursor: default;
   font-family: Verdana, Arial, sans-serif;
+  border: thin solid #000000;
+}
+span.button {
+  font-size: 0.8em;
+  padding: 1px 4px;
 }
 /* ------------------------------------------------------------------------ */
 /* Global */
@@ -1324,7 +1432,7 @@ hr.divider {
 }
 .star-gold {
   font-size: 3em;
-  color: #FFD700;
+  color: #ffd700;
   text-align: center;
   text-shadow: 3px 2px 5px black;
 }
@@ -2002,6 +2110,13 @@ table.dirlist caption {
   margin-top: 0.5em;
   padding: 5px;
 }
+div.remote-file-mgr-info {
+  background-color: #88ff88;
+  color: #000000;
+  border: thin solid #000000;
+  padding: 0.5em;
+  margin: 0.8em 0;
+}
 /* ------------------------------------------------------------------------ */
 /* Project Load (add_files.php) */
 table#addfiles td.load-add {
@@ -2144,6 +2259,7 @@ table.search-column tr th {
   border: none;
   padding: 1px;
   background-color: inherit;
+  color: #000000;
   cursor: pointer;
   font-family: initial;
   font-size: initial;

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -1010,13 +1010,12 @@ function get_message($type, $message)
 {
     if ($type == 'error') {
         $prefix = _("Error") . ":";
-        $style = "color: red;";
+        $class = "error";
     } else {
         $prefix = _("Info") . ":";
-        $style = "background-color: lightgreen; color: black;";
+        $class = "remote-file-mgr-info";
     }
-    $style .= " border: 1px solid black; padding: .5em; margin: 0.8em 0;";
-    return "<div style='$style'><b>$prefix</b> $message</div>\n";
+    return "<div class='$class'><b>$prefix</b> $message</div>\n";
 }
 
 function show_message($type, $message)


### PR DESCRIPTION
In doing a series of checks to see if we were ready to actually start wider viewing of a new theme, I found a few more styling problems that needed to be resolved. Hopefully this is the last of them (at least for now).

Test in [color-tweaks](https://www.pgdp.org/~srjfoo/c.branch/color-tweaks/)

The only significant visual difference should be in the list of quiz default messages. Compare: [default-quiz-messages-before](https://www.pgdp.org/c/quiz/generic/wizard/default_messages.php) with [default-quiz-messages-after](https://www.pgdp.org/~srjfoo/c.branch/color-tweaks/quiz/generic/wizard/default_messages.php)