### PR TITLE
Make task details render better on narrow screens

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1518,12 +1518,22 @@ div.task-comment {
     margin-bottom: 1em;
     .task-comment-body {
         margin-left: 1em;
+        word-break: break-word;
     }
+}
+
+div.task-detail {
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
 }
 
 table.task-detail-block {
     .solid-border;
-    width: 100%;
+    margin: 0 0.1em;
+    width: 50%;
+    flex-grow: 1;
+    flex-basis: auto;
     tr {
         th, td {
             padding: 0.1em 0.5em 0.1em 0.5em;
@@ -1537,6 +1547,17 @@ table.task-detail-block {
             background-color: @page-background;
             width: 100%;
         }
+    }
+}
+
+/* For small enough screens, make the two columns as two rows instead. */
+@media only screen and (max-width: 768px) {
+    div.task-detail {
+        flex-direction: column;
+    }
+    table.task-detail-block {
+        margin: 0.1em 0;
+        width: 100%;
     }
 }
 

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2379,10 +2379,19 @@ div.task-comment {
 }
 div.task-comment .task-comment-body {
   margin-left: 1em;
+  word-break: break-word;
+}
+div.task-detail {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
 }
 table.task-detail-block {
   border: thin solid #000000;
-  width: 100%;
+  margin: 0 0.1em;
+  width: 50%;
+  flex-grow: 1;
+  flex-basis: auto;
 }
 table.task-detail-block tr th,
 table.task-detail-block tr td {
@@ -2396,6 +2405,16 @@ table.task-detail-block tr th {
 table.task-detail-block tr td {
   background-color: #ffffff;
   width: 100%;
+}
+/* For small enough screens, make the two columns as two rows instead. */
+@media only screen and (max-width: 768px) {
+  div.task-detail {
+    flex-direction: column;
+  }
+  table.task-detail-block {
+    margin: 0.1em 0;
+    width: 100%;
+  }
 }
 /* ------------------------------------------------------------------------ */
 /* Mentoring */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2379,10 +2379,19 @@ div.task-comment {
 }
 div.task-comment .task-comment-body {
   margin-left: 1em;
+  word-break: break-word;
+}
+div.task-detail {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
 }
 table.task-detail-block {
   border: thin solid #000000;
-  width: 100%;
+  margin: 0 0.1em;
+  width: 50%;
+  flex-grow: 1;
+  flex-basis: auto;
 }
 table.task-detail-block tr th,
 table.task-detail-block tr td {
@@ -2396,6 +2405,16 @@ table.task-detail-block tr th {
 table.task-detail-block tr td {
   background-color: #ffffff;
   width: 100%;
+}
+/* For small enough screens, make the two columns as two rows instead. */
+@media only screen and (max-width: 768px) {
+  div.task-detail {
+    flex-direction: column;
+  }
+  table.task-detail-block {
+    margin: 0.1em 0;
+    width: 100%;
+  }
 }
 /* ------------------------------------------------------------------------ */
 /* Mentoring */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2379,10 +2379,19 @@ div.task-comment {
 }
 div.task-comment .task-comment-body {
   margin-left: 1em;
+  word-break: break-word;
+}
+div.task-detail {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
 }
 table.task-detail-block {
   border: thin solid #000000;
-  width: 100%;
+  margin: 0 0.1em;
+  width: 50%;
+  flex-grow: 1;
+  flex-basis: auto;
 }
 table.task-detail-block tr th,
 table.task-detail-block tr td {
@@ -2396,6 +2405,16 @@ table.task-detail-block tr th {
 table.task-detail-block tr td {
   background-color: #ffffff;
   width: 100%;
+}
+/* For small enough screens, make the two columns as two rows instead. */
+@media only screen and (max-width: 768px) {
+  div.task-detail {
+    flex-direction: column;
+  }
+  table.task-detail-block {
+    margin: 0.1em 0;
+    width: 100%;
+  }
 }
 /* ------------------------------------------------------------------------ */
 /* Mentoring */

--- a/tasks.php
+++ b/tasks.php
@@ -1211,8 +1211,7 @@ function TaskForm($task)
     echo "<input type='text' name='task_summary' value=\"$task_summary_enc\" style='width: 50%' maxlength='80' required>";
     echo "</p>";
 
-    // left column
-    echo "<div style='float: left; width: 49.9%;'>";
+    echo "<div class='task-detail'>";
     echo "<table class='task-detail-block'>\n";
     property_echo_select_tr('task_severity', $task->task_severity, $severity_array);
     property_echo_select_tr('task_priority', $task->task_priority, $priority_array);
@@ -1220,10 +1219,8 @@ function TaskForm($task)
     property_echo_select_tr('task_os', $task->task_os, $os_array);
     property_echo_select_tr('task_browser', $task->task_browser, $browser_array);
     property_echo_select_tr('task_version', $task->task_version, $versions_array);
-    echo "</table></div>";
+    echo "</table>";
 
-    // right column
-    echo "<div style='float: right; width: 49.9%;'>";
     echo "<table class='task-detail-block'>\n";
     property_echo_select_tr('task_type', $task->task_type, $tasks_array);
     property_echo_select_tr('task_status', $task->task_status, $tasks_status_array);
@@ -1231,7 +1228,8 @@ function TaskForm($task)
     if ((user_is_a_sitemanager() || user_is_taskcenter_mgr()) && !empty($task->task_id)) {
         property_echo_select_tr('percent_complete', $task->percent_complete, $percent_complete_array);
     }
-    echo "</table></div>";
+    echo "</table>";
+    echo "</div>";
 
     echo "<h2 style='clear: both; padding-top: 0.5em;'>" . _("Details") . "</h2>\n";
     echo "<textarea name='task_details' style='width: 99%; height: 8em;' required>$task_details_enc</textarea>";
@@ -1337,7 +1335,7 @@ function TaskDetails($tid)
     echo "#$tid: " . property_format_value('task_summary', $task, FALSE);
     echo "</h1>";
 
-    echo "<div style='float: left; width: 49.9%;'>";
+    echo "<div class='task-detail'>";
     echo "<table class='task-detail-block'>\n";
     property_echo_value_tr('task_severity',    $task);
     property_echo_value_tr('task_priority',    $task);
@@ -1349,8 +1347,7 @@ function TaskDetails($tid)
     property_echo_value_tr('task_version',     $task);
     property_echo_value_tr('votes'       ,     $task, False);
     echo "</table>";
-    echo "</div>";
-    echo "<div style='float: right; width: 49.9%;'>";
+
     echo "<table class='task-detail-block'>\n";
     property_echo_value_tr('task_type',        $task);
     property_echo_value_tr('opened_composite', $task);


### PR DESCRIPTION
For narrows screens, such a mobile devices, make the task details transition to rows instead of columns using a flex layout. Task 1960

Bonus: make sure that verylongstringswithoutspacesincomments break instead of forcing the window very (very) wide.

Testable in [task-center-flex-layout](https://www.pgdp.org/~cpeel/c.branch/task-center-flex-layout/) sandbox.