### PR TITLE
Prevent racing add_files processes

### DIFF
--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -122,8 +122,6 @@ function project_add_page(
     $round = get_Round_for_round_number(1);
     $page_state = $round->page_avail_state;
 
-    $errs = '';
-
     $columns_for_rounds = [];
     for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++ )
     {
@@ -146,21 +144,12 @@ function project_add_page(
             ";
 
     // echo $sql, "\n";
-    $res = DPDatabase::query($sql, FALSE);
-    if (!$res)
-    {
-        $errs .= DPDatabase::log_error();
-    }
-
-    // If the INSERT raised an error, don't do the other stuff.
-    if ($errs) return $errs;
+    DPDatabase::query($sql);
 
     _log_page_event( $projectid, $image_file_name, 'add', $user, NULL );
 
     _project_adjust_n_pages($projectid, +1);
     _project_adjust_n_available_pages($projectid, +1);
-
-    return $errs;
 }
 
 function load_page_from_file( $file_path, $projectid )

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -64,7 +64,9 @@ else
     // Prevent sneaky parent-link tricks.
     if (str_contains($rel_source, ".."))
     {
-        echo "Source directory '$rel_source' is not acceptable.";
+        echo "<p class='error'>";
+        echo sprintf(_("Source directory '%s' is not acceptable."), html_safe($rel_source));
+        echo "</p>";
         echo "<hr>\n";
         echo "Return to <a href='$code_url/project.php?id=$projectid'>Project Page</a>.\n";
         return;
@@ -135,7 +137,9 @@ else
 $r = chdir($source_project_dir);
 if ( !$r )
 {
-    echo "Directory '$source_project_dir' does not exist, or is inaccessible.\n";
+    echo "<p class='error'>";
+    echo sprintf(_("Directory '%s' does not exist, or is inaccessible."), html_safe($source_project_dir));
+    echo "</p>";
     echo "<hr>\n";
     echo "Return to <a href='$code_url/project.php?id=$projectid'>Project Page</a>.\n";
     return;
@@ -1011,8 +1015,11 @@ class Loader
             system($cmd, $exit_status);
             if ( $exit_status != 0 )
             {
-                echo "$cmd:<br>";
-                echo "exit status was $exit_status<br>";
+                error_log("add_files.php - error running \"$cmd\"; exit code: $exit_status");
+
+                echo "<p class='error'>";
+                echo "an error occurred during a filesystem operation, this has been logged for a site administrator to view";
+                echo "</p>";
             }
         }
     }

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -19,12 +19,22 @@ $extra_args = [
             font-family: ' . get_proofreading_font_family_fallback() . ';
         }
     ',
+    'js_data' => '
+        $(document).ready(function () {
+            $("#execute").submit(function (e) {
+                // disable the submit button
+                $("#submit").attr("disabled", true);
+                return true;
+            });
+        });
+    ',
 ];
 
 $title = _("Add files");
 output_header($title, NO_STATSBAR, $extra_args);
 
-$projectid    = get_projectID_param($_GET, 'project');
+$projectid    = get_projectID_param($_REQUEST, 'project');
+$rel_source   = array_get($_REQUEST, "rel_source", "");
 $loading_tpnv = (@$_GET['tpnv'] == '1');
 
 abort_if_cant_edit_project( $projectid );
@@ -54,13 +64,12 @@ if(!user_can_add_project_pages($projectid, $loading_tpnv == 1 ? "tp&v" : "normal
     exit();
 }
 
-if ( $_GET['rel_source'] == '' )
+if ( $rel_source == '' )
 {
     die('rel_source parameter is empty or unset');
 }
 else
 {
-    $rel_source = $_GET['rel_source'];
     // Prevent sneaky parent-link tricks.
     if (str_contains($rel_source, ".."))
     {
@@ -171,7 +180,7 @@ else
     $loader = new Loader( $source_project_dir, $dest_project_dir, $projectid );
     $loader->analyze();
 
-    if ( !@$_GET['confirmed'] )
+    if ( !@$_POST['confirmed'] )
     {
         $loader->display();
 
@@ -193,8 +202,13 @@ else
         }
         else
         {
-            $url = "?project=$projectid&amp;rel_source=$rel_source&amp;confirmed=1";
-            echo "<a href='$url'>" . _('Proceed with load') . "</a>";
+            echo "<form id='execute' method='POST' action='add_files.php'>";
+            echo "<input type='hidden' name='confirmed' value='1'>";
+            echo "<input type='hidden' name='project' value='" . attr_safe($projectid) . "'>";
+            echo "<input type='hidden' name='rel_source' value='" . attr_safe($rel_source) . "'>";
+            echo "<input id='submit' type='submit' value='" . attr_safe(_('Proceed with load')) . "'>";
+            echo "</form>";
+
         }
         echo "</p>";
     }

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -917,17 +917,21 @@ class Loader
                 }
                 else
                 {
-                    $errs = project_add_page(
-                        $this->projectid,
-                        $base,
-                        $src_image_file_name,
-                        $src_text_file_path,
-                        $pguser,
-                        $now );
-                    if ( $errs )
+                    try
                     {
-                        echo "for base=$base, project_add_page raised error:<br>";
-                        echo "$errs<br>\n";
+                        project_add_page(
+                            $this->projectid,
+                            $base,
+                            $src_image_file_name,
+                            $src_text_file_path,
+                            $pguser,
+                            $now );
+                    }
+                    catch(DBQueryError $error)
+                    {
+                        echo "<p class='error'>";
+                        echo "for base=$base, project_add_page raised a DB error";
+                        echo "</p>";
                     }
                 }
 


### PR DESCRIPTION
Periodically we see a slew of errors in `php_errors` like:
```
DPDatabase.inc - log_error from /data/htdocs/c/pinc/DPage.inc:149: Duplicate entry '323' for key 'fileid'
```
This is called upstream by `add_files.php` which is used to load pages into a project. The error is that there is already a row in the project table for that page, but `add_files.php` checks for that so how is this possible? I believe this happens when a user clicks on the "Proceed with load" link and then, when it doesn't look like anything is happening (because it takes a while), they click on it again causing two `add_files.php` processes to race.

To prevent this, make the "Proceed with load" a POST and disable the submit button when it has been clicked.

As part of figuring this out I styled some of the error messages and ensured we weren't leaking filesystem details in `_do_command()` but instead log the errors to `php_errors`.

The sandbox to test this is [add-pages-errors](https://www.pgdp.org/~cpeel/c.branch/add-pages-errors/) and the focus should be on ensuring that existing page loads work as-expected.