### PR TITLE
darken-wc-border

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -52,6 +52,7 @@
  */
 
 @border-color-base: @page-text;
+@border-color-base-highc: #6f6f6f;
 @border-color-base-mediumc: #999999;
 @border-color-base-lowc: #d3d3d3;    // lightgrey
 
@@ -64,10 +65,6 @@
 
 .solid-border-bottom(@color: @border-color-base) {
     border-bottom: thin solid @color;
-}
-
-.x-thin-border(@color: @border-color-base) {
-    border: 0.5px solid @color;
 }
 
 /* standalone classes that can be used as mixins, but that should not

--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -191,7 +191,7 @@
                 background-color: white;
                 color: black;
                 padding: 3px;
-                .x-thin-border(@border-color-base-lowc);
+                .solid-border(@border-color-base-highc);
             }
         }
     }

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -530,7 +530,7 @@
   background-color: white;
   color: black;
   padding: 3px;
-  border: 0.5px solid #d3d3d3;
+  border: thin solid #6f6f6f;
 }
 #wordcheck_interface #wc_header input,
 #wordcheck_interface #wc_header select {

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -530,7 +530,7 @@
   background-color: white;
   color: black;
   padding: 3px;
-  border: 0.5px solid #d3d3d3;
+  border: thin solid #6f6f6f;
 }
 #wordcheck_interface #wc_header input,
 #wordcheck_interface #wc_header select {

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -530,7 +530,7 @@
   background-color: white;
   color: black;
   padding: 3px;
-  border: 0.5px solid #d3d3d3;
+  border: thin solid #6f6f6f;
 }
 #wordcheck_interface #wc_header input,
 #wordcheck_interface #wc_header select {


### PR DESCRIPTION
Changed the border around words identified by WC to a darker grey, as some proofreaders felt the need for a higher contrast border between the two background colors. Since that was the only place the .x-thin-border mixin was used, removed it.

Testable: [darken-wc-border/](https://www.pgdp.org/~srjfoo/c.branch/darken-wc-border/)