### PR TITLE
Load user by email

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -815,11 +815,14 @@ CREATE TABLE `users` (
   `u_profile` int(10) unsigned NOT NULL default '0',
   `u_intlang` varchar(25) default '',
   `u_privacy` tinyint(1) default '0',
+  `api_key` varchar(32) DEFAULT NULL,
   PRIMARY KEY  (`username`),
-  UNIQUE KEY `username` (`username`),
+  UNIQUE KEY `api_key` (`api_key`),
   KEY `u_id` (`u_id`),
   KEY `last_login` (`last_login`),
-  KEY `t_last_activity` (`t_last_activity`)
+  KEY `t_last_activity` (`t_last_activity`),
+  KEY `api_key_username` (`api_key`,`username`),
+  KEY `email` (`email`)
 );
 # --------------------------------------------------------
 

--- a/SETUP/upgrade/15/20201215_alter_users.php
+++ b/SETUP/upgrade/15/20201215_alter_users.php
@@ -1,0 +1,35 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding email index to users table..\n";
+$sql = "
+    CREATE INDEX email
+         ON users (email)
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "Dropping unnecessary unique index on username..\n";
+$sql = "
+    ALTER TABLE users
+        DROP INDEX username
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -347,6 +347,16 @@ class User
         return $user;
     }
 
+    // Load a User record by email address. email address is not guaranteed to
+    // be unique and this may very likely raise a NonuniqueUserException
+    // e.g. $user = User::load_from_email($email);
+    public static function load_from_email($email)
+    {
+        $user = new User();
+        $user->load('email', $email);
+        return $user;
+    }
+
     // Static function to determine if the specified username is associated
     // with a valid user without the overhead of creating an object.
     public static function is_valid_user($username, $strict=TRUE)


### PR DESCRIPTION
While email is not guaranteed to be unique, there are times being able to load a user by email is very useful for some admin scripts. This adds the necessary function and index. It also cleans up some indexes in the dbschema that were missed when the API landed earlier.