### PR TITLE
Make account email activations unique

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -216,7 +216,8 @@ CREATE TABLE `non_activated_users` (
   `http_referrer` varchar(256) NOT NULL DEFAULT '',
   `u_intlang` varchar(25) default '',
   `user_password` varchar(128) NOT NULL default '',
-  PRIMARY KEY  (`username`)
+  PRIMARY KEY  (`username`),
+  KEY `email` (`email`)
 ) COMMENT='Each row represents a not-yet-activated user, user_password ';
 # --------------------------------------------------------
 

--- a/SETUP/upgrade/15/20201215_alter_non_activated_users.php
+++ b/SETUP/upgrade/15/20201215_alter_non_activated_users.php
@@ -1,0 +1,23 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding email index to non_activated_users table..\n";
+$sql = "
+    CREATE INDEX email
+         ON non_activated_users (email)
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -213,7 +213,7 @@ include($relPath.'/../faq/privacy.php');
 // Returns an empty string upon success and an error message upon failure
 function _validate_fields($real_name, $username, $userpass, $userpass2, $email, $email2, $email_updates, $referrer, $referrer_details)
 {
-    global $testing;
+    global $testing, $general_help_email_addr;
 
     // Make sure that password and confirmed password are equal.
     if ($userpass != $userpass2)
@@ -225,6 +225,27 @@ function _validate_fields($real_name, $username, $userpass, $userpass2, $email, 
     if ($email != $email2)
     {
         return _("The e-mail addresses you entered were not equal.");
+    }
+
+    // See if there is already an account creation request for this email
+    try
+    {
+        NonactivatedUser::load_from_email($email);
+        $email_exists = TRUE;
+    }
+    catch(NonuniqueNonactivatedUserException $e)
+    {
+        $email_exists = TRUE;
+    }
+    catch(NonexistentNonactivatedUserException $e)
+    {
+        // this is the expected case
+        $email_exists = FALSE;
+    }
+
+    if($email_exists)
+    {
+        return sprintf(_("There is already an account creation request for this email address. Please allow time for the account activation email to get to you. If you have not received it within 12 hours, please contact %s to have it resent."), $general_help_email_addr);
     }
 
     // Do some validity-checks on inputted username, password, e-mail and real name

--- a/pinc/NonactivatedUser.inc
+++ b/pinc/NonactivatedUser.inc
@@ -209,6 +209,17 @@ class NonactivatedUser
         $user->load('id', $id);
         return $user;
     }
+
+    // Load a NonactivatedUser record by email address
+    // e.g. $user = NonactivatedUser::load_from_email($email);
+    // The email address is not guaranteed to be unique and this function
+    // may raise NonuniqueNonactivatedUserException
+    public static function load_from_email($email)
+    {
+        $user = new NonactivatedUser();
+        $user->load('email', $email);
+        return $user;
+    }
 }
 
 // vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
Disallow new user registrations for the same email address. This only prevents users from having duplicate outstanding activation requests which we've seen from users who haven't given the email enough time to get to them.

Testing this on TEST requires some code hacking which I've done. This MR is to ensure that my DB schema updates are correct and to solicit input on the error message returned to the user in this scenario.