### PR TITLE
Better account activation experience

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -144,13 +144,23 @@ echo " ";
 printf(_("Please check the e-mail being sent to you for further information about %s."),
         $site_name);
 
-echo "<p class='large'>"._("Enter your password below to sign in and start proofreading!!") . "</p>";
+echo "<p>"._("Enter your password below to sign in and start proofreading!!") . "</p>";
+
+// We use the same field labels here that are in the navbar
 $csrf_token = get_csrf_token_form_input();
 echo "<form action='login.php' method='post'>
 $csrf_token
-<input type='hidden' name='userNM' value='".attr_safe($user->username)."'>
-<input type='password' name='userPW' required>
-<input type='submit' value='".attr_safe(_("Sign In"))."'>
+<table class='themed theme_striped' style='width: auto'>
+<tr>
+  <th><label for='loginform-userNM'>" . _("ID") . "</label></th>
+  <td><input type='text' id='loginform-userNM' name='userNM' value='".attr_safe($user->username)."' required></td>
+</tr>
+<tr>
+  <th><label for='loginform-userPW'>" . _("Password") . "</label></th>
+  <td><input type='password' id='loginform-userPW' name='userPW' required></td>
+</tr>
+</table>
+<p><input type='submit' value='".attr_safe(_("Sign In"))."'></p>
 </form>";
 
 // vim: sw=4 ts=4 expandtab

--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -145,9 +145,12 @@ printf(_("Please check the e-mail being sent to you for further information abou
         $site_name);
 
 echo "<p class='large'>"._("Enter your password below to sign in and start proofreading!!") . "</p>";
+$csrf_token = get_csrf_token_form_input();
 echo "<form action='login.php' method='post'>
+$csrf_token
 <input type='hidden' name='userNM' value='".attr_safe($user->username)."'>
 <input type='password' name='userPW' required>
-<input type='submit' value='".attr_safe(_("Sign In"))."'></form>";
+<input type='submit' value='".attr_safe(_("Sign In"))."'>
+</form>";
 
 // vim: sw=4 ts=4 expandtab

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -80,15 +80,18 @@ if(count($_POST))
             setcookie("http_referer", '', time() - 1);
 
             // Page shown when account is successfully created
-            $header = sprintf(_("User %s Registered Successfully"), $username);
-            output_header($header);
+            $title = _("Registration complete");
+            output_header($title);
+            echo "<h1>$title</h1>";
 
             // Send them an activation e-mail
             maybe_activate_mail($email, $real_name, $register->id, $username, $intlang);
 
+            echo "<p>";
             echo sprintf(
                _("User %s registered successfully. Please check the e-mail being sent to you for further information about activating your account. This extra step is taken so that no-one can register you to the site without your knowledge."),
-               $username);
+               html_safe($username));
+            echo "</p>";
             exit();
         }
         catch(Exception $exception)


### PR DESCRIPTION
The account activation experience is one of the first entrypoints for new users and yet has some of the poorest user experience because it gets so little visibility for current users / developers.

This MR seeks to improve that by:
* Fixing the post-activation login form. Adding the CSRF token in e0c3ecd4a back in late August broke this so every time a new user is asked to sign in with it they get an error message.
* Improving the layout of the post-activation login form so it's more than a single input and looks like a login form.
* Improving the text layout of the activation page, adding a heading and some paragraph tags.
* Adding a header to the post-addproofer form submission page.

The only user workflow change is always redirecting logged-in users to the Activity Hub when they access the activation page. This should be an edge case anyway as, ideally, existing users should not be creating additional accounts.

These can be tested in the [better-activation-experience](https://www.pgdp.org/~cpeel/c.branch/better-activation-experience/) sandbox.