### PR TITLE
New user experience improvements

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -697,7 +697,7 @@ CREATE TABLE `user_profiles` (
   `i_layout` tinyint(1) default '0',
   `i_toolbar` tinyint(1) default '0',
   `i_statusbar` tinyint(1) default '0',
-  `i_newwin` tinyint(1) default '1',
+  `i_newwin` tinyint(1) default '0',
   `v_fnts` tinyint(2) default '0',
   `v_fntf` tinyint(1) default '2',
   `v_fntf_other` varchar(32) default '',

--- a/SETUP/upgrade/15/20201217_alter_user_profiles.php
+++ b/SETUP/upgrade/15/20201217_alter_user_profiles.php
@@ -1,0 +1,23 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Changing default on user_profiles.i_newwin..\n";
+$sql = "
+    ALTER TABLE user_profiles
+         ALTER i_newwin SET DEFAULT 0
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -51,12 +51,11 @@ if ($testing)
     echo "<li class='test_warning'>" . _("Register! (Note that this is a test site, and has a separate database from the production site, so you need to register separately.)") . "</li>\n";
 }
 echo "<li>" . _("Type your username in the exact same way as when you registered.") . "</li>\n";
-echo "<li>" . sprintf( _("<a href='%s'>Reset</a> your password."), get_reset_password_url()) . "</li>\n";
+echo "<li>" . sprintf( _("<a href='%s'>Reset your password</a>."), get_reset_password_url()) . "</li>\n";
 echo "<li>" . _("Enable Javascript.") . "</li>\n";
 echo "<li>" . sprintf(_("Accept cookies (at least from us at %s)."), $_SERVER["HTTP_HOST"]) . "</li>\n";
 echo "<li>" . sprintf(_("Allow popup windows (at least from us at %s)."), $_SERVER["HTTP_HOST"]) . "</li>\n";
-echo "<li>" . _("Caching set to off (or: refresh page every visit).") . "</li>\n";
-echo "<li>" . _("Ensure your PC clock is set to the correct date &amp; time.") . "</li>\n";
+echo "<li>" . _("Ensure your computer's clock is set to the correct date &amp; time.") . "</li>\n";
 echo "</ol>";
 echo "<p>" . sprintf( _("If all of this fails, contact a <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr") . "</p>";
 if($testing)

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -132,7 +132,7 @@ class Quiz
         foreach($Stage_for_id_ as $stage_id => $stage)
         {
             if (array_key_exists("quiz/$this->id", $stage->access_minima))
-                $stage_required_for[] = $stage_id;
+                $stage_required_for[$stage_id] = $stage;
         }
 
         if ($this->description != "" || count($stage_required_for) > 0)
@@ -141,11 +141,16 @@ class Quiz
                 <tr><td colspan='$n_columns'>";
             if (count($stage_required_for) > 0)
             {
-                echo "<p>" . _("Passing this quiz is required for:") . " ";
-                echo implode(", ", $stage_required_for);
+                echo "<p>" . _("Passing this quiz is required prior to working in:") . " ";
+                $stage_links = [];
+                foreach($stage_required_for as $stage_id => $stage)
+                {
+                    $stage_links[] = "<a href='$code_url/$stage->relative_url'>$stage_id</a>";
+                }
+                echo implode(", ", $stage_links);
                 echo "</p>"; 
             }
-            echo "$this->description";
+            echo "<p>$this->description</p>";
             echo "</td></tr>";
         }
 

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -145,7 +145,7 @@ function maybe_output_new_proofer_project_message()
         echo "</div>";
 
         echo "<p>";
-        echo _("You are a click away from proofreading a page. Take a moment to scroll down and read the Project Comments which contain instructions specific to this project. Once you're ready to start proofreading, click the \"Start Proofreading\" link.");
+        echo sprintf(_("You are a click away from proofreading a page. Take a moment to scroll down and read the Project Comments which contain instructions specific to this project. Once you're ready to start proofreading, click the '%s' link."), _("Start Proofreading"));
         echo "<p>";
 
         echo "<p>";

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -54,6 +54,11 @@ function welcome_see_beginner_forum( $pagesproofed, $page_id )
             // guidelines.
             echo _("This page is where you can find a project to start proofreading. Choose a title from the list of projects at the bottom of this page.");
             echo "</p>";
+
+            echo "<p>";
+            echo _("It's best to select a \"BEGINNERS ONLY\" project if one is available in a language in which you are proficient. These projects have been specially prepared to teach you our style of proofing. You can expect to receive feedback from a mentor on pages you proofread in BEGINNERS ONLY projects. This feedback will likely come at least a few days after you have completed the pages.");
+            echo "</p>";
+
         }
         echo "<p>";
         echo sprintf(_("Please see our <a href='%s'>Beginner's Forum</a> for answers to common questions."), get_url_to_view_forum($beginners_site_forum_idx));
@@ -118,6 +123,38 @@ function maybe_output_new_proofer_message()
         echo "</div>";
 
         echo "<p>" . sprintf(_("If you're looking for projects to proofread, consider using the list on the <a href='%1\$s'>%2\$s</a> round page."), "$code_url/{$ELR_round->relative_url}#{$ELR_round->id}", $ELR_round->id) . "</p>";
+
+        echo "<p><small>";
+        echo _("After a period of time, this message will no longer appear.");
+        echo "</small></p>";
+        echo "</div>";
+    }
+}
+
+function maybe_output_new_proofer_project_message()
+{
+    global $code_url, $ELR_round;
+
+    // Help direct new proofers to projects to proof.
+    $pagesproofed = get_pages_proofed_maybe_simulated();
+    if($pagesproofed < 100)
+    {
+        echo "<div class='callout'>";
+        echo "<div class='calloutheader'>";
+        echo _("Welcome New Proofreader!");
+        echo "</div>";
+
+        echo "<p>";
+        echo _("You are a click away from proofreading a page. Take a moment to scroll down and read the Project Comments which contain instructions specific to this project. Once you're ready to start proofreading, click the \"Start Proofreading\" link.");
+        echo "<p>";
+
+        echo "<p>";
+        echo _("If you have questions, please don't hesitate to ask them in the project's discussion topic in the forums, accessible from a link in the table below.");
+        echo "</p>";
+
+        echo "<p>";
+        echo _("Happy proofreading!");
+        echo "</p>";
 
         echo "<p><small>";
         echo _("After a period of time, this message will no longer appear.");

--- a/project.php
+++ b/project.php
@@ -86,6 +86,7 @@ output_header($title_for_theme, NO_STATSBAR, $extra_args);
 
 echo "<h1>" . html_safe($title) . "</h1>\n";
 
+maybe_output_new_proofer_project_message();
 
 if ( !$user_is_logged_in )
 {

--- a/project.php
+++ b/project.php
@@ -293,6 +293,9 @@ function decide_blurbs()
     {
         // If there's any proofreading to be done, this is the link to use.
         $url = url_for_pi_do_whichever_page( $projectid, $state, TRUE );
+
+        // If the "Start Proofreading" text is ever changed, be sure and grep
+        // through the codebase for any other instances and change them too.
         $label = _("Start Proofreading");
         $proofreading_link = "<b><a href='$url'>$label</a></b>";
 
@@ -303,7 +306,7 @@ function decide_blurbs()
 
         // Other possible components of blurbs:
         $please_scroll_down = _("Please scroll down and read the Project Comments for any special instructions <b>before</b> proofreading!");
-        $the_link_appears_below = _("The 'Start Proofreading' link appears below the Project Comments");
+        $the_link_appears_below = sprintf(_("The '%s' link appears below the Project Comments"), $label);
         $comments_have_changed =
             "<p class='error'>"
             . _("Project Comments have changed!")


### PR DESCRIPTION
This is a small set of changes to improve the new user experience:
* Change the proofreading interface default for new users to *not* open in a new window. This often interacts poorly with popup blockers and we should really phase this out altogether.
* Make the reset password link on the failed login page more prominent and remove the very outdated line about page caching.
* Copy some of the wording in the new user emails into the callouts for new users. This includes adding a new callout on the project page right at the very top for proofreaders with < 100 pages.
* Small update on the quiz pages to link to the rounds that the quizzes are pre-reqs for.

Testable in the [better-new-user-info](https://www.pgdp.org/~cpeel/c.branch/better-new-user-info) sandbox. To see the new user callouts, your user must have less than 100 pages proofread on TEST.