### PR TITLE
Require users to pass the basic proofreading quiz before working in P1

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -10,9 +10,9 @@ include_once($relPath.'User.inc');
 
 $ACCESS_CRITERIA = array(
     'days since reg' => _('Days since registration'),
-    'quiz/p_mod1'    => sprintf(_('<a href="%1$s">moderate proofreading quiz %2$d</a> pass'),"$code_url/quiz/start.php?show_level=P_MOD", 1),
-    'quiz/p_mod2'    => sprintf(_('<a href="%1$s">moderate proofreading quiz %2$d</a> pass'),"$code_url/quiz/start.php?show_level=P_MOD", 2),
-    'quiz/f_only'    => sprintf(_("<a href='%s'>formatting quiz</a> pass"),"$code_url/quiz/start.php?show_only=format"),
+    'quiz/p_mod1'    => sprintf(_('Successfully complete the <a href="%1$s">moderate proofreading quiz %2$d</a>'),"$code_url/quiz/start.php?show_level=P_MOD", 1),
+    'quiz/p_mod2'    => sprintf(_('Successfully complete the <a href="%1$s">moderate proofreading quiz %2$d</a>'),"$code_url/quiz/start.php?show_level=P_MOD", 2),
+    'quiz/f_only'    => sprintf(_("Successfully complete the <a href='%s'>formatting quiz</a>"),"$code_url/quiz/start.php?show_only=format"),
 );
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -117,6 +117,7 @@ class Activity
         if (is_null($username))
         {
             $uao = new StdClass; // user access object
+            $uao->username = $username;
             $uao->can_access = FALSE;
             return $uao;
         }
@@ -136,6 +137,7 @@ class Activity
 
         $uao = new StdClass; // user access object
 
+        $uao->username = $username;
         $uao->activity_id = $this->id;
         $uao->evaluation_criteria = $this->evaluation_criteria;
         // Considering the minima...
@@ -311,7 +313,7 @@ function get_user_score( $user_obj, $criterion_code )
 
 // --------------------------------------------------------------------------
 
-function show_user_access_object( $uao )
+function show_user_access_object( $uao, $will_autogrant=False )
 {
     global $code_url;
 
@@ -400,7 +402,12 @@ function show_user_access_object( $uao )
         case 'unsat-ungranted':
             global $Activity_for_id_;
             $activity = $Activity_for_id_[$uao->activity_id];
-            if ($activity->after_satisfying_minima == 'REQ-AUTO' || $activity->after_satisfying_minima == 'REQ-HUMAN')
+
+            if ($activity->after_satisfying_minima == 'REQ-AUTO' && $will_autogrant)
+            {
+                $request_status_string = _('After you have satisfied the requirements, you will be automatically granted access.');
+            }
+            elseif ($activity->after_satisfying_minima == 'REQ-AUTO' || $activity->after_satisfying_minima == 'REQ-HUMAN')
             {
                 $request_status_string=_('After you have satisfied the requirements, a link will appear here, allowing you to request access.');
             }
@@ -423,6 +430,23 @@ function show_user_access_object( $uao )
     if(!empty($request_status_string))
         echo "<p>$request_status_string</p>\n";
 }
+
+function grant_user_access_if_sat(&$uao)
+{
+    global $Activity_for_id_;
+
+    $activity = $Activity_for_id_[$uao->activity_id];
+    if ($uao->request_status == 'sat-available' &&
+        $activity->after_satisfying_minima == 'REQ-AUTO')
+    {
+        $user = new User($uao->username);
+        $user->grant_access($uao->activity_id, 'AUTO-GRANTED');
+
+        // now we need to reconstruct the $uao to reflect this change
+        $uao = $activity->user_access($uao->username);
+    }
+}
+
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -10,6 +10,7 @@ include_once($relPath.'User.inc');
 
 $ACCESS_CRITERIA = array(
     'days since reg' => _('Days since registration'),
+    'quiz/p_basic'   => sprintf(_('Successfully complete the <a href="%1$s">basic proofreading quiz</a>'),"$code_url/quiz/start.php?show_level=P_BASIC"),
     'quiz/p_mod1'    => sprintf(_('Successfully complete the <a href="%1$s">moderate proofreading quiz %2$d</a>'),"$code_url/quiz/start.php?show_level=P_MOD", 1),
     'quiz/p_mod2'    => sprintf(_('Successfully complete the <a href="%1$s">moderate proofreading quiz %2$d</a>'),"$code_url/quiz/start.php?show_level=P_MOD", 2),
     'quiz/f_only'    => sprintf(_("Successfully complete the <a href='%s'>formatting quiz</a>"),"$code_url/quiz/start.php?show_only=format"),

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -132,6 +132,8 @@ class Quiz
                 $stage_required_for[$stage_id] = $stage;
         }
 
+        echo "<h3 id='$this->id'>$this->name</h3>";
+
         // if this quiz is required for a stage that the user is now eligible
         // for, output a callout
         if(count($stage_required_for) && $username == User::current_username())
@@ -156,11 +158,11 @@ class Quiz
                     echo sprintf(_("Continue to the <a href='%1\$s'>%2\$s page</a> to access this activity and get started."), "$code_url/$stage->relative_url#Entrance_Requirements", $stage_id);
                     echo "</p>";
                     echo "</div>";
+                    echo "<br>";
                 }
             }
         }
 
-        echo "<h3>$this->name</h3>";
         echo "<table class='themed theme_striped'>";
 
         if ($this->description != "" || count($stage_required_for) > 0)

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -122,9 +122,6 @@ class Quiz
         else
             $n_columns = 2;
 
-        echo "<h3>$this->name</h3>";
-        echo "<table class='themed theme_striped'>";
-
         // This assumes that the access minima quiz strings are names
         // 'quiz/X' where X is some quiz ID (eg 'f_only', 'p_mod2', 'p_greek')
         $stage_required_for = array();
@@ -134,6 +131,37 @@ class Quiz
             if (array_key_exists("quiz/$this->id", $stage->access_minima))
                 $stage_required_for[$stage_id] = $stage;
         }
+
+        // if this quiz is required for a stage that the user is now eligible
+        // for, output a callout
+        if(count($stage_required_for) && $username == User::current_username())
+        {
+            foreach($stage_required_for as $stage_id => $stage)
+            {
+                $uao = $stage->user_access($username);
+                // if the user can't currently access it but they have satisfied
+                // all of the requirements to do so, point them in the right direction
+                if(!$uao->can_access && $uao->all_minima_satisfied)
+                {
+                    echo "<div class='callout'>";
+                    echo "<div class='calloutheader'>";
+                    echo _("You can now work in $stage_id!");
+                    echo "</div>";
+
+                    echo "<p>";
+                    echo sprintf(_("You've satisfied all requirements to work in %s!"), $stage_id);
+
+                    echo " ";
+
+                    echo sprintf(_("Continue to the <a href='%1\$s'>%2\$s page</a> to access this activity and get started."), "$code_url/$stage->relative_url#Entrance_Requirements", $stage_id);
+                    echo "</p>";
+                    echo "</div>";
+                }
+            }
+        }
+
+        echo "<h3>$this->name</h3>";
+        echo "<table class='themed theme_striped'>";
 
         if ($this->description != "" || count($stage_required_for) > 0)
         {

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -29,7 +29,33 @@ function welcome_see_beginner_forum( $pagesproofed, $page_id )
 {
     global $code_url, $ELR_round, $beginners_site_forum_idx;
 
-    if ($pagesproofed <= 100)
+    // If the ELR_round requires access and the user doesn't currently
+    // have it, show them what they need to do.
+    $accessable_stages = get_stages_user_can_work_in(User::current_username());
+    if(!isset($accessable_stages[$ELR_round->id]))
+    {
+        echo "<div class='callout'>";
+        echo "<div class='calloutheader'>";
+        echo _("Welcome New Proofreader!");
+        echo "</div>";
+
+        echo "<p>";
+        echo sprintf(_('Before you can begin proofreading, you must:'));
+        echo "<ul>";
+        $uao = $ELR_round->user_access(User::current_username());
+        foreach ($uao->minima_table as $row)
+        {
+            list($criterion_str, $minimum, $user_score, $satisfied) = $row;
+            echo "<li>$criterion_str</li>";
+        }
+        echo "</ul>\n";
+        echo "</p>";
+
+        echo "<p>";
+        echo sprintf(_('After that you will be able to work in <a href="%1$s">%2$s</a>, the first proofreading round.'), "$code_url/{$ELR_round->relative_url}", $ELR_round->id);
+        echo "</div>";
+    }
+    elseif ($pagesproofed <= 100)
     {
         echo "<div class='callout'>";
         echo "<div class='calloutheader'>";

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -59,7 +59,7 @@ function welcome_see_beginner_forum( $pagesproofed, $page_id )
     {
         echo "<div class='callout'>";
         echo "<div class='calloutheader'>";
-        echo _("Welcome!");
+        echo _("Welcome New Proofreader!");
         echo "</div>";
 
         // If the user is not on the entry level round page, direct

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -157,13 +157,42 @@ function maybe_output_new_proofer_message()
     }
 }
 
-function maybe_output_new_proofer_project_message()
+// Help direct new proofers to projects to proof.
+function maybe_output_new_proofer_project_message($project)
 {
     global $code_url, $ELR_round;
 
-    // Help direct new proofers to projects to proof.
+    // If the user isn't logged in, bail
+    if(User::current_username() === NULL)
+    {
+        return;
+    }
+
+    list($code, $msg) = $project->can_be_proofed_by_current_user();
+    $round = get_Round_for_project_state($project->state);
     $pagesproofed = get_pages_proofed_maybe_simulated();
-    if($pagesproofed < 100)
+
+    if($code != $project->CBP_OKAY && $round == $ELR_round)
+    {
+        echo "<div class='callout'>";
+        echo "<div class='calloutheader'>";
+        echo _("Welcome New Proofreader!");
+        echo "</div>";
+
+        echo "<p>";
+        echo sprintf(_('Before you can begin proofreading, you must:'));
+        echo "<ul>";
+        $uao = $ELR_round->user_access(User::current_username());
+        foreach ($uao->minima_table as $row)
+        {
+            list($criterion_str, $minimum, $user_score, $satisfied) = $row;
+            echo "<li>$criterion_str</li>";
+        }
+        echo "</ul>\n";
+        echo "</p>";
+        echo "</div>";
+    }
+    elseif($code == $project->CBP_OKAY && $pagesproofed < 100)
     {
         echo "<div class='callout'>";
         echo "<div class='calloutheader'>";

--- a/pinc/new_user_mails.inc
+++ b/pinc/new_user_mails.inc
@@ -102,25 +102,6 @@ $dp_wiki_url/DP_Official_Documentation:General/Code_of_Conduct
 and our Mission Statement at
 $dp_wiki_url/DP_Official_Documentation:General/Distributed_Proofreaders_Mission_Statement
 
-
-Log in to the $site_name Site
-----------------------------
-
-1. Go to $site_url .
-
-2. Enter your user name (ID) and password in the two boxes in the upper
-   right-hand portion of the window and click on the "Sign In" button. If
-   you don't see the log-in boxes, but do see your username on the far right
-   of the navigation bar, you are already logged in.
-
-3. Once you've logged in, please look at the navigation bar at the top of
-   the screen. This bar has links to the major areas of the site, including
-   {$ELR_round->id} (the first proofreading round), SR (the Smooth Reading pool where you
-   can access pre-released books), Forums, Wiki (documentation), and Prefs
-   (your personal preferences). Near the top of the right-hand side of
-   the screen is a list of Key Help Documents.
-
-
 Computer Requirements
 ---------------------
 
@@ -133,81 +114,20 @@ for $site_name are as follows:
 - popup windows allowed
 
 
-Problems Logging In
--------------------
-
-If your password doesn't work, please try resetting it by visiting:
-$reset_password_url
-
-If you cannot log in to the site or access the forums, please send an
-email describing the issue to $general_help_email_addr and include
-your user name in the message.
-
-
 Start Proofreading
 ------------------
 
-Note: If you use iOS 11 or later to proofread and haven't already disabled
-"Smart" punctuation, your device may insert characters such as curly quotes
-that are not valid at $site_name for proofreading. This will cause an error
-when you try to save the page. To correct this problem, please go to
-Preferences -> General -> Keyboard and turn off Smart Punctuation.
+1. Log in at $site_url
 
-1. Before proofreading, please review the Proofreading Guidelines Summary:
-   $code_url/faq/proofing_summary.pdf
+2. The site will walk you through getting started. Look for boxes labeled
+   'Welcome New Proofreader!'.
 
-2. Log in to the site and select the {$ELR_round->id} link at the top of the page.
+To understand the basics of proofreading at $site_name,
+you should review the Proofreading Guidelines Summary:
+$code_url/faq/proofing_summary.pdf
 
-3. Scroll down the page to the list of Projects Currently Available.
-
-4. Select a project by clicking on the project's title link. It's
-   best to select a "BEGINNERS ONLY" project if one is available in
-   a language in which you are proficient. BEGINNERS ONLY projects
-   have been specially prepared to teach you our style of proofing. You
-   can expect to receive feedback from a mentor on pages you proofread
-   in BEGINNERS ONLY projects. This feedback will likely come at least
-   a few days after you have completed the pages.
-
-5. Once you click on the project's title, a Project Page will appear.
-   Scroll down the page and read the Project Comments which contain
-   instructions specific to the book you have chosen.
-
-6. Once you're ready to start proofreading, locate the "Start Proofreading"
-   link at the bottom of the Project Comments section. Click on the link,
-   and the next available page will open in a proofreading interface window
-   ready for proofreading.
-
-7. Compare the text in the text box with what is in the associated image.
-   Change the text to match the image if it doesn't already do so, taking
-   into account the instructions in the Proofreading Guidelines and the
-   Project Comments. As you proofread, please keep in mind that you should
-   not change what the author wrote. If the author spelled words oddly, we
-   leave them spelled that way. If the author wrote outrageous racist or
-   biased statements, we leave them that way. If the author used commas
-   after every third word, we keep the commas. We are proofreaders, not
-   editors or modernizers.
-
-8. When you've finished proofreading the page, click on either the
-   "Save as 'Done'" or "Save as 'Done' & Proofread Next Page" button.
-   Congratulations--you've just proofread your first page!
-
-9. If you have questions, please don't hesitate to ask them in the
-   project's associated discussion topic in the forums (the link to the
-   project's topic is on the Project Page above the Project Comments).
-
-10. Once you've proofread several pages, it's a good idea to:
-    * Watch for new messages in your Distributed Proofreaders Inbox
-      ( $forums_url/ucp.php?i=pm&folder=inbox ) since
-      that is how our mentors generally contact volunteers with
-      proofreading feedback.
-    * Read the full Proofreading Guidelines at
-        $code_url/faq/proofreading_guidelines.php
-    * Work through the automated interactive Basic Proofreading Quizzes
-      and Tutorials at
-        $code_url/quiz/start.php?show_only=PQ
-      to get instant feedback and gain confidence in your understanding of
-      the $site_name proofreading process.
-
+Later you should also read the full Proofreading Guidelines:
+$dp_wiki_url/DP_Official_Documentation:Proofreading/Proofreading_Guidelines
 
 $feedback_paragraph
 
@@ -218,54 +138,16 @@ Smooth Reading involves reading a book that is almost ready for posting
 to Project Gutenberg and reporting anything that disrupts the sense or
 flow of the book.
 
-1. Log into the site and select the SR link on the navigation bar.
-
-2. Read the information on the Smooth Reading pool page. For more detailed
-   information read the Smooth Reading section of the wiki
-   ( $dp_wiki_url/DP_Official_Documentation:Smooth_Reading ).
-
-3. When you're ready to choose a book to smooth read, scroll down to the
-   list of Projects Currently Available.
-
-4. Choose a project by selecting its title. This will take you to the
-   book's Project Page.
-
-5. Scroll to the "Smooth Reading" section of the page. It is a good idea
-   to let the Post-Processor know that you have volunteered to Smooth Read
-   this book. To do this, click on the "Volunteer to SR" button.
-
-6. Choose which file type you want to Smooth Read under the "Download a
-   Smooth Reading file" heading on the Project Page, or you may wish to
-   simply select "Download all formats". Formats available may be text,
-   epub, mobi and HTML. Text, epub and mobi can be used directly by the
-   appropriate application, but the HTML version will need to be unzipped
-   (For information about zip files, please read $dp_wiki_url/ZIP_file ).
-   You may also view Smooth Reading text and HTML in your browser (however,
-   there is currently no way for you to annotate these files with any
-   possible errors that you notice if you try to Smooth Read them from
-   the browser).
-
-7. As you read the book, please mark any issues you find according to the
-   instructions given here:
-   $dp_wiki_url/DP_Official_Documentation:Smooth_Reading/Smooth_Reading_FAQ#What_are_the_basic_steps_for_Smooth_Reading.3F .
-   Because of the difficulties with annotating epub, mobi and HTML files,
-   recording questionable areas in the text file is often easiest way to go.
-
-8. Once you have finished reading the book, you should zip the text file
-   (For information about zip files, please read $dp_wiki_url/ZIP_file )
-   and upload it back to the project page from which you downloaded it.
-
-9. Please keep an eye on the Smooth Reading deadline -- if you are running
-   out of time, don't hesitate to send the Post-Processor a Private Message
-   and request additional time. Post-Processors are generally very happy to
-   give you more time to finish.
+For detailed information on how to Smooth Read, please visit the
+Smooth Readers FAQ:
+$dp_wiki_url/DP_Official_Documentation:Smooth_Reading/Smooth_Reading_FAQ
 
 
 Questions
 ---------
 
 For general questions about $site_name, please send an email to
-$general_help_email_addr or ask in our forums at $forums_url .
+$general_help_email_addr or ask in our forums at $forums_url
 
 
 General Overview
@@ -277,7 +159,7 @@ please check out our New Volunteer Frequently Asked Questions at
 $dp_wiki_url/DP_Official_Documentation:General/New_Volunteer_Frequently_Asked_Questions
 and browse the resources in our Information for New and
 Returning Volunteers area at
-$dp_wiki_url/DP_Official_Documentation:General#Information_For_New_and_Returning_Volunteers .
+$dp_wiki_url/DP_Official_Documentation:General#Information_For_New_and_Returning_Volunteers
 
 -------------------------
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -543,7 +543,7 @@ function get_activity_links()
 // return a list of round/stage links for the user
 // the returned links are in a format usable by headerbar_text_array
 {
-    global $Stage_for_id_;
+    global $Stage_for_id_, $ELR_round;
 
     $user = User::load_current();
 
@@ -559,13 +559,16 @@ function get_activity_links()
     }
 
     // Get all stages the user has access to
-    $stages_can_access_and_access_prereqs = get_stages_user_can_work_in($user->username);
+    $stages_user_can_see = get_stages_user_can_work_in($user->username);
+
+    // Always allow users to see the ELR
+    $stages_user_can_see[$ELR_round->id] = $ELR_round;
 
     // we still need to loop through $Stage_for_id_ to output the stages
     // in order
     foreach( $Stage_for_id_ as $stage)
     {
-        if(isset($stages_can_access_and_access_prereqs[$stage->id]))
+        if(isset($stages_user_can_see[$stage->id]))
         {
             $text = $stage->id;
 

--- a/project.php
+++ b/project.php
@@ -86,7 +86,7 @@ output_header($title_for_theme, NO_STATSBAR, $extra_args);
 
 echo "<h1>" . html_safe($title) . "</h1>\n";
 
-maybe_output_new_proofer_project_message();
+maybe_output_new_proofer_project_message($project);
 
 if ( !$user_is_logged_in )
 {

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -414,7 +414,7 @@ function echo_quiz_feedback_and_links($message=NULL)
     }
     // Give a link back to quiz home (P or F as appropriate)
     echo qp_exit_link(
-        "../start.php?show_only={$quiz->activity_type}",
+        "../start.php?show_only={$quiz->activity_type}#$quiz->id",
         _("Back to quizzes home")
     );
     echo "</ul>";
@@ -611,7 +611,7 @@ function qp_echo_solved_html()
     }
     // Give a link back to quiz home (P or F as appropriate)
     echo qp_exit_link(
-        "../start.php?show_only={$quiz->activity_type}",
+        "../start.php?show_only={$quiz->activity_type}#$quiz->id",
         _("Back to quizzes home")
     );
 

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -25,6 +25,8 @@ output_header("$round->id: $round->name", SHOW_STATSBAR, $header_args);
 
 $uao = $round->user_access( $pguser );
 
+grant_user_access_if_sat( $uao );
+
 $round->page_top( $uao );
 
 $pagesproofed = get_pages_proofed_maybe_simulated();
@@ -36,7 +38,7 @@ welcome_see_beginner_forum( $pagesproofed, $round->id );
 // show user how to access this round
 if ( !$uao->can_access )
 {
-    show_user_access_object( $uao );
+    show_user_access_object( $uao, TRUE /* will_autogrant */ );
 }
 
 show_news_for_page($round_id);

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -27,20 +27,17 @@ $uao = $round->user_access( $pguser );
 
 $round->page_top( $uao );
 
-// show user how to access this round
-if ( !$uao->can_access )
-{
-    show_user_access_object( $uao );
-}
-
-// ---------------------------------------
-
 $pagesproofed = get_pages_proofed_maybe_simulated();
 
 alert_re_unread_messages( $pagesproofed );
 
 welcome_see_beginner_forum( $pagesproofed, $round->id );
 
+// show user how to access this round
+if ( !$uao->can_access )
+{
+    show_user_access_object( $uao );
+}
 
 show_news_for_page($round_id);
 


### PR DESCRIPTION
By GM request, this code update requires users to pass the basic proofreading quiz before working in P1. The change itself is a two-line change in `pinc/stages.inc` but ensuring that new users can figure out that they need to do this and how to do it is what everything else is for.

Broadly, this MR attempts to guide new users to the basic proofreading quiz using a new callout and then, once they successfully pass the quiz, a pointer to P1 from the quizzes. The code has been changed such that if we decide to remove the quiz requirement the site will go back to the way it is now with only removing the requirement from `pinc/stages.inc`.

Like many changes, this is a balancing act between making things work for pgdp.net without limiting how other sites use the code. It also needs to balance how activity pre-reqs are handled for P1 vs for other rounds since they use the same underlying enforcement mechanism.

Some notable changes:
* P1 (i.e. the Entry Level Round (ELR)) is always shown on the navbar regardless if the user has access to it or not.
* The Activity Hub and Round pages will show the updated callout pointing users to the basic proofreading quiz.
* If a quiz is required for a given round/stage and the user has successfully completed it, a callout will be shown on the quiz page to point the user to the round page (this is how we get users back to the P1 page from the quizzes).
* Before, to get access to rounds that were `REQ-AUTO`, the user needed to click the link in the Entrance Requirements section on the round page to gain access to the round. Now, if the user has satisfied all requirements, `REQ-AUTO` rounds will automatically grant user's access the first time they hit the round page. This removes the "find the link" problem from new proofreaders for P1. Importantly, `P2` and `F1` are also `REQ-AUTO` meaning that as soon as the user passes all of the requirements they will also be auto-granted into that round simply by accessing the round page.
* Finally, this rips out large parts of the New User Email that are redundant, changing it from a novel to a novella. Specifically:
  * Don't tell users how to log in -- users are not idiots and can figure that out.
  * The failed login page already provides troubleshooting steps, including how to reset the password and how to contact help. Don't include this in the email too.
  * Rely on the callouts to move users through how to start proofreading. We should solve UX issues with UX fixes, not with a 200+ line new user email.

This is testable in the [require-p1-quiz](https://www.pgdp.org/~cpeel/c.branch/require-p1-quiz/) sandbox. For best results, ensure the user you are testing with has not proofread more than 100 pages on the TEST server. I strongly encourage testing with a brand new user you create so you can see the entire new user workflow.

To help testing, these two scripts can be used to reset your P1 access for your user or delete your quiz results (they don't show output, just do the necessary DB updates for your username):
* https://www.pgdp.org/~cpeel/c.branch/require-p1-quiz/tools/reset-quizzes.php
* https://www.pgdp.org/~cpeel/c.branch/require-p1-quiz/tools/reset-p1-access.php