### PR TITLE
Standardize quiz nomenclature

### DIFF
--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -163,7 +163,7 @@ class Quiz
             {
                 echo "<a href='tuts/tut_$quiz_page_id.php'>" . _("Tutorial") . "</a> | ";
             }
-            echo "<a href='generic/main.php?quiz_page_id=$quiz_page_id'>" . _("Quiz") . "</a></td>";
+            echo "<a href='generic/main.php?quiz_page_id=$quiz_page_id'>" . _("Quiz Page") . "</a></td>";
             if (!empty($username))
             {
                 $passed = user_has_passed_quiz_page($username, $quiz_page_id);

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -573,7 +573,7 @@ function qp_echo_solved_html()
     global $quiz_page_id, $quiz;
     global $parting_message;
 
-    echo "<h2>" . _("You've solved this quiz.") . "</h2>\n";
+    echo "<h2>" . _("Page solved") . "</h2>\n";
     echo "<p>" . _("Congratulations, no errors found!") . "</p>\n";
 
     if (isset($parting_message))
@@ -601,12 +601,12 @@ function qp_echo_solved_html()
         {
             echo qp_exit_link(
                 "../tuts/tut_$next_quiz_page_id.php",
-                _("Next step of tutorial")
+                _("Next quiz page tutorial")
             );
         }
         echo qp_exit_link(
             "main.php?quiz_page_id=$next_quiz_page_id",
-            _("Next step of quiz")
+            _("Next quiz page")
         );
     }
     // Give a link back to quiz home (P or F as appropriate)

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -311,7 +311,7 @@ function qp_echo_error_html($message_id)
 {
     global $messages, $constant_message; // from the qd file
     global $default_challenge; // from quiz_defaults.inc
-    global $quiz, $quiz_feedbacktext; // from returnfeed.php
+    global $quiz; // from returnfeed.php
 
     //If the quiz has a message to show all the time, put that in first
     if (@$constant_message != "")
@@ -381,19 +381,43 @@ function qp_echo_error_html($message_id)
         echo $default_challenge;
     echo "</p>\n";
 
+    echo_quiz_feedback_and_links(@$message["feedbacktext"]);
+}
+
+function echo_quiz_feedback_and_links($message=NULL)
+{
+    global $code_dir;
+    global $quiz_feedbacktext;
+    global $quiz, $quiz_page_id;
+
+    echo "<h3>" . _("Need more help?") . "</h2>";
+
     // Add a disclaimer re the error-finding algorithm,
     // and invite feedback somewhere.
     echo "<p>";
-    if (isset($message["feedbacktext"]))
-    {
-        echo $message["feedbacktext"];
-        // XXX: Currently unused. Might be discontinued.
-    }
-    else
-    {
-        echo $quiz_feedbacktext;
-    }
+    echo $message ?? $quiz_feedbacktext;
     echo "</p>\n";
+
+    echo "<p>";
+    echo _("You might also want to re-read the page tutorial, if one is available, or take a break and try again later.");
+    echo "</p>";
+
+    echo "<ul>";
+    // if there is a tutorial link, show it
+    $tutfile = "$code_dir/quiz/tuts/tut_$quiz_page_id.php";
+    if (file_exists($tutfile))
+    {
+        echo qp_exit_link(
+            "../tuts/tut_$quiz_page_id.php",
+            _("Back to quiz page tutorial")
+        );
+    }
+    // Give a link back to quiz home (P or F as appropriate)
+    echo qp_exit_link(
+        "../start.php?show_only={$quiz->activity_type}",
+        _("Back to quizzes home")
+    );
+    echo "</ul>";
 }
 
 // =============================================================================
@@ -443,8 +467,6 @@ function qp_compare_texts($user_text, $soln_text)
 // If the two texts are the same, return FALSE.
 // If they differ, output HTML that describes how they differ, and return TRUE.
 {
-    global $quiz_feedbacktext;
-
     if ($user_text == $soln_text) return FALSE;
 
     echo '<h2>' . _('Difference with expected text') . "</h2>\n";
@@ -456,7 +478,7 @@ function qp_compare_texts($user_text, $soln_text)
 
     qp_describe_difference($user_text, $soln_text);
 
-    echo "<p>$quiz_feedbacktext</p>\n";
+    echo_quiz_feedback_and_links();
 
     return TRUE;
 }
@@ -547,6 +569,7 @@ function qp_describe_difference($user_text, $soln_text)
 
 function qp_echo_solved_html()
 {
+    global $code_dir;
     global $quiz_page_id, $quiz;
     global $parting_message;
 
@@ -559,7 +582,9 @@ function qp_echo_solved_html()
         echo "\n";
     }
 
-    echo "<p>";
+    echo "<h3>" . _("Go to...") . "</h3>";
+
+    echo "<ul>";
 
     // Figure out what the next quiz page is, if any
     $map_index_to_quiz_page_id = array_keys($quiz->pages);
@@ -571,7 +596,6 @@ function qp_echo_solved_html()
     if (count($map_index_to_quiz_page_id) > $next_index)
     {
         $next_quiz_page_id = $map_index_to_quiz_page_id[$next_index];
-        global $code_dir;
         $tutfile = "$code_dir/quiz/tuts/tut_$next_quiz_page_id.php";
         if (file_exists($tutfile))
         {
@@ -579,13 +603,11 @@ function qp_echo_solved_html()
                 "../tuts/tut_$next_quiz_page_id.php",
                 _("Next step of tutorial")
             );
-            echo "<br>\n";
         }
         echo qp_exit_link(
             "main.php?quiz_page_id=$next_quiz_page_id",
             _("Next step of quiz")
         );
-        echo "<br>\n";
     }
     // Give a link back to quiz home (P or F as appropriate)
     echo qp_exit_link(
@@ -593,12 +615,12 @@ function qp_echo_solved_html()
         _("Back to quizzes home")
     );
 
-    echo "</p>\n";
+    echo "</ul>\n";
 }
 
 function qp_exit_link($url, $text)
 {
-    return "<a href='$url' target='_top'>$text</a>";
+    return "<li><a href='$url' target='_top'>$text</a></li>";
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/quiz/start.php
+++ b/quiz/start.php
@@ -23,7 +23,7 @@ $quiz_type_intro = array(
         "title" => _("Proofreading Quizzes and Tutorials"),
         "head" => "<h1>" . _("Interactive Proofreading Quizzes and Tutorials") . "</h1>\n" .
                   "<p>" . sprintf(_("Welcome to %s's interactive proofreading quizzes and tutorials! These quizzes cover corrections you should make in the proofreading rounds."), $site_abbreviation) . "</p>\n" .
-                  "<p>" . _("You can use these pages in two different ways. If you are not yet familiar with the proofreading guidelines you should use the tutorial mode by clicking on the 'Tutorial' links.  If you already know the proofreading guidelines you can use them as quizzes only by clicking the 'Quiz' links.") . "</p>\n"
+                  "<p>" . sprintf(_("You can use these pages in two different ways. If you are not yet familiar with the proofreading guidelines you should use the tutorial mode by clicking on the '%1\$s' links.  If you already know the proofreading guidelines you can use them as quizzes only by clicking the '%2\$s' links."), _("Tutorial"), _("Quiz Page")) . "</p>\n"
     ),
     
     "format" => array(

--- a/quiz/tuts/tut_p_aeoe_1.php
+++ b/quiz/tuts/tut_p_aeoe_1.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Ligatures Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Ligatures Proofreading Tutorial, Page %d"), 1) . "</h2>\n";
+echo "<h2>" . sprintf(_("Ligatures Proofreading Tutorial, page %d"), 1) . "</h2>\n";
 
 echo "<p>" . _("The two ligatures æ and œ can be difficult to distinguish when they are printed italics.  However, the œ (oe) ligature is usually rounder at the top, while the 'a' of æ is more teardrop-shaped.  For example:") . "</p>\n";
 echo "<table class='basic'>\n<tr><th>œ</th><th>æ</th></tr>\n";
@@ -16,6 +16,6 @@ echo "<td><img src='../generic/images/aelig_ital_teardrop.png' alt='ae ligature'
 
 echo "<p>" . sprintf(_("You can insert each of these characters using the character picker in the proofreading interface or using keyboard shortcuts. Tables for <a href='%1\$s' target='_blank'>Windows</a> and <a href='%2\$s' target='_blank'>Macintosh</a> which list these shortcuts are in the Proofreading Guidelines."), "../../faq/proofreading_guidelines.php#a_chars_win", "../../faq/proofreading_guidelines.php#a_chars_mac") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_aeoe_1'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_aeoe_1'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_aeoe_2.php
+++ b/quiz/tuts/tut_p_aeoe_2.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Ligatures Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Ligatures Proofreading Tutorial, Page %d"), 2) . "</h2>\n";
+echo "<h2>" . sprintf(_("Ligatures Proofreading Tutorial, page %d"), 2) . "</h2>\n";
 
 echo "<p>" . _("In other fonts, the æ may have a little bump sticking up in the middle showing the vertical line of the a:") . "</p>\n";
 echo "<table class='basic'>\n<tr><th>œ</th><th>æ</th></tr>\n";
@@ -15,6 +15,6 @@ echo "<tr><td><img src='../generic/images/oelig_ital.png' alt='oe ligature' widt
 echo "<td><img src='../generic/images/aelig_ital_bump.png' alt='ae ligature' width='35' height='28'></td>\n</tr></table>\n";
 
 echo "<p>" . _("If the word is in Latin (or derived from Latin), then there is another way to distinguish these characters: Latin words often end in -æ, but never in -œ.") . "</p>\n";
-echo "<p><a href='../generic/main.php?quiz_page_id=p_aeoe_2'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_aeoe_2'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_basic_1.php
+++ b/quiz/tuts/tut_p_basic_1.php
@@ -12,7 +12,7 @@ echo "<h2>" . _("Intro") . "</h2>\n";
 echo "<p>" . _("In this tutorial you will be presented extracts from the Proofreading Guidelines. After each part you will be led to a quiz page, where you can try out the newly learned rules.") . "</p>\n";
 echo "<p>" . _("Don't be alarmed by the number of changes you'll have to apply in the quizzes. On normal easy texts the rate of things to correct is usually much lower than that.") . "</p>\n";
 
-echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, Step %d"), 1) . "</h2>\n";
+echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, page %d"), 1) . "</h2>\n";
 echo "<h3>" . _("Project Comments") . "</h3>\n";
 echo "<p>" . _("When you select a project for proofreading, the Project Page is loaded. On this page there is a section called \"Project Comments\" containing information specific to that project (book). <b>Read these before you start proofreading pages!</b> If the Project Manager wants you to do something in this book differently from the way specified in these Guidelines, that will be noted here. Instructions in the Project Comments <em>override</em> the rules in these Guidelines, so follow them. There may also be instructions in the project comments that apply to the formatting phase, which do not apply during proofreading.") . "</p>\n";
 
@@ -28,6 +28,6 @@ echo "<p>" . _("The page headers are normally at the top of the image and have a
 echo "<h3>" . _("End-of-line Hyphenation") . "</h3>\n";
 echo "<p>" . _("Where a hyphen appears at the end of a line, join the two halves of the hyphenated word back together. Remove the hyphen when you join it, unless it is really a hyphenated word like well-meaning. Keep the joined word on the top line, and put a line break after it to preserve the line formatting&mdash;this makes it easier for volunteers in later rounds.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_1'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_1'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_basic_2.php
+++ b/quiz/tuts/tut_p_basic_2.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Basic Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, Step %d"), 2) . "</h2>\n";
+echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, page %d"), 2) . "</h2>\n";
 echo "<h3>" . _("Paragraph Spacing/Indenting") . "</h3>\n";
 echo "<p>" . _("Put a blank line before the start of a paragraph, even if it starts at the top of a page. You should not indent the start of the paragraph, but if it is already indented don't bother removing those spaces&mdash;that can be done automatically during post-processing.") . "</p>\n";
 
@@ -32,6 +32,6 @@ echo "    </tr>\n  </tbody>\n</table>\n";
 echo "<h3>" . _("End-of-page Hyphenation and Dashes") . "</h3>\n";
 echo "<p>" . _("Proofread end-of-page hyphens or em-dashes by leaving the hyphen or em-dash at the end of the last line, and mark it with a <kbd>*</kbd> after the hyphen or dash.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_2'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_2'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_basic_3.php
+++ b/quiz/tuts/tut_p_basic_3.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Basic Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, Step %d"), 3) . "</h2>\n";
+echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, page %d"), 3) . "</h2>\n";
 echo "<h3>" . _("Chapter Headings") . "</h3>\n";
 echo "<p>" . _("Proofread chapter headings as they appear in the image.") . "</p>\n";
 echo "<p>" . _("A chapter heading may start a bit farther down the page than the page header and won't have a page number on the same line. Chapter Headings are often printed all caps; if so, keep them as all caps.") . "</p>\n";
@@ -26,6 +26,6 @@ echo "<p>" . _("You may sometimes find formatting already present in the text. <
 echo "<h3>" . _("Words in Small Capitals") . "</h3>\n";
 echo "<p>" . _("Please proofread only the characters in <span style='font-variant: small-caps'>Small Caps</span> (capital letters which are smaller than the standard capitals). Do not worry about case changes. If the OCR'd text is already ALL-CAPPED, Mixed-Cased, or lower-cased, leave it ALL-CAPPED, Mixed-Cased, or lower-cased.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_3'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_3'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_basic_4.php
+++ b/quiz/tuts/tut_p_basic_4.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Basic Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, Step %d"), 4) . "</h2>\n";
+echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, page %d"), 4) . "</h2>\n";
 echo "<h3>" . _("Punctuation spacing") . "</h3>\n";
 echo "<p>" . _("In general, a punctuation mark should have a space after it but no space before it. If the OCR'd text has no space after a punctuation mark, add one; if there is a space before punctuation, remove it. However, punctuation marks that normally appear in pairs, such as \"quotation marks\", (parentheses), [brackets], and {braces} normally have a space before the opening mark, which should be retained.") . "</p>\n";
 
@@ -22,6 +22,6 @@ echo "<p>" . _("At the bottom of the page, proofread the footnote text as it is 
 echo "<h3>" . _("Formatting") . "</h3>\n";
 echo "<p>" . _("You may sometimes find formatting already present in the text. <b>Do not add or change this formatting information</b>; the formatters will do that later in the process. Some examples of formatting tasks include &lt;i&gt;italics&lt;/i&gt; for <i>italicized</i> text.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_4'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_4'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_basic_5.php
+++ b/quiz/tuts/tut_p_basic_5.php
@@ -7,13 +7,13 @@ require_login();
 
 output_header(_('Basic Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, Step %d"), 5) . "</h2>\n";
+echo "<h2>" . sprintf(_("Basic Proofreading Tutorial, page %d"), 5) . "</h2>\n";
 echo "<h3>" . _("Poetry/Epigrams") . "</h3>\n";
 echo "<p>" . _("Insert a blank line at the start of the poetry or epigram and another blank line at the end, so that the formatters can clearly see the beginning and end. Leave each line left justified and maintain the line breaks. Insert a blank line between stanzas, when there is one in the image.") . "</p>\n";
 
 echo "<h3>" . _("Font size changes") . "</h3>\n";
 echo "<p>" . _("Do not mark changes in font or font size. The formatters will take care of this later in the process.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_5'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_basic_5'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_fraktur.php
+++ b/quiz/tuts/tut_p_fraktur.php
@@ -17,6 +17,6 @@ echo "<p>" . _("There are two different forms of the lower case letter 's'.  The
 
 echo "<p>" . sprintf(_("If you have difficulty identifying letters in fraktur, there is a <a target='_blank' href='%s'>fraktur tool</a> similar to the Greek Transliterator but using the fraktur alphabet."), "http://www.kurald-galain.com/fraktur2ascii.html") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_fraktur'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_fraktur'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_greek_1.php
+++ b/quiz/tuts/tut_p_greek_1.php
@@ -12,13 +12,13 @@ echo "<h1>" . _("Proofreading Tutorial") . "</h1>\n";
 echo "<h2>" . _("Intro") . "</h2>\n";
 echo "<p>" . sprintf(_("In this tutorial you will be presented extracts from the Proofreading Guidelines and the %1\$s Wiki article on <a href='%2\$s' target='_blank'>Transliterating Greek</a>. After each part you will be led to a quiz page, where you can try out  the newly learned rules."), $site_abbreviation, $Greek_translit_url) . "</p>\n";
 
-echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, Page %d"), 1) . "</h2>\n";
+echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, page %d"), 1) . "</h2>\n";
 echo "<h3>" . _("Non-Latin Characters") . "</h3>\n";
 echo "<p>" . _("Some projects contain text printed in non-Latin characters; that is, characters other than the Latin A-Z&mdash;for example, Greek, Cyrillic, Hebrew, or Arabic characters. How these characters are handled depends on the project. Some Project Managers will ask you to include the characters directly while others may ask you to transliterate them. This tutorial covers Greek transliteration.") . "</p>\n";
 echo "<p>" . _("Transliteration involves converting each character of the foreign text into the equivalent Latin letter(s). A Greek transliteration tool is provided in the proofreading interface to make this task much easier.") . "</p>\n";
 echo "<p>" . sprintf(_("Press the \"Greek Transliterator\" link near the bottom of the proofreading interface to open the tool. In the tool, click on the Greek characters that match those in the word or phrase you are transliterating, and the appropriate Latin-1 characters will appear in the text box. When you are done, simply copy and paste this transliterated text into the page you are proofreading. Surround the transliterated text with the Greek markers <kbd>[Greek:&nbsp;</kbd> and <kbd>]</kbd>. For example, <span style='font-size:115%%;'>Βιβλος</span> would become <kbd>[Greek: Biblos]</kbd>. (\"Book\"&mdash;so appropriate for %s!)"), $site_abbreviation) . "</p>\n";
 echo "<p>" . sprintf(_("If the transliteration tool does not appear when you click on the button, your computer may be blocking pop-ups. Make sure that your software allows pop-ups from the %s site."), $site_abbreviation) . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_1'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_1'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_greek_2.php
+++ b/quiz/tuts/tut_p_greek_2.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Greek Transliteration Tutorial'));
 
-echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, Page %d"), 2) . "</h2>\n";
+echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, page %d"), 2) . "</h2>\n";
 echo "<h3>" . _("Letters with Multiple Transliterations") . "</h3>\n";
 echo "<p>" . _("The letter υ (upsilon) can be transliterated as either u or y. Generally, if upsilon follows another vowel, use \"u\". Otherwise, use \"y\". This isn't required, though; you can use u everywhere if you want.") . "</p>\n";
 echo "<p>" . _("<b>Note:</b> For the purposes of this quiz, please use the vowel/consonant distinction described above when transliterating.  This is only due to the limitations of the quiz, and is not required when proofreading normally.") . "</p>\n";
@@ -24,6 +24,6 @@ echo "<li>" . _("If the word begins with a vowel, it should have either a rough 
 echo "<li>" . _("If it's rough breathing, add an \"<kbd>h</kbd>\" at the beginning of the word in the transliteration.  If it's smooth breathing, ignore it.") . "</li>\n";
 echo "</ul>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_2'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_2'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_greek_3.php
+++ b/quiz/tuts/tut_p_greek_3.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Greek Transliteration Tutorial'));
 
-echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, Page %d"), 3) . "</h2>\n";
+echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, page %d"), 3) . "</h2>\n";
 
 echo "<h3>" . _("Letters with Multiple Transliterations") . "</h3>\n";
 echo "<p>" . _("The letter γ (gamma) is usually transliterated as g, but n is used instead when it occurs before certain letters:") . "</p>\n";
@@ -28,6 +28,6 @@ echo "<li>" . _("If the word begins with a diphthong (two vowels together), the 
 echo "<li>" . _("Besides vowels, the rough breathing mark can also appear over one consonant: ρ (rho).  If a word begins with rho, it always has rough breathing, with the rho transliterated as \"<kbd>rh</kbd>\" (note that the \"<kbd>h</kbd>\" goes <i>after</i> the rho, rather than before as with vowels).") . "</li>\n";
 echo "</ul>";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_3'>" . _("Continue to quiz") . "</a></p>";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_3'>" . _("Continue to quiz page") . "</a></p>";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_greek_4.php
+++ b/quiz/tuts/tut_p_greek_4.php
@@ -7,12 +7,12 @@ require_login();
 
 output_header(_('Greek Transliteration Tutorial'));
 
-echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, Page %d"), 4) . "</h2>\n";
+echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, page %d"), 4) . "</h2>\n";
 
 echo "<h3>" . _("Punctuation") . "</h3>\n";
 echo "<p>" . _("The apostrophes at the ends of some words are, in fact, apostrophes, and serve the same purpose that they do in English: The author is leavin' some letters off the ends o' words. Please include apostrophes in your transliteration.") . "</p>\n";
 echo "<p>" . _("There are usually two punctuation marks that differ from English: a question mark, and a medium stop. Modern printings of Greek often use a semicolon \";\" to indicate a question. Use a question mark \"<kbd>?</kbd>\" instead. A vertically centered single dot usually represents a medium stop; replace that with an English semicolon \"<kbd>;</kbd>\".") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_4'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_4'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_greek_5.php
+++ b/quiz/tuts/tut_p_greek_5.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Greek Transliteration Tutorial'));
 
-echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, Page %d"), 5) . "</h2>\n";
+echo "<h2>" . sprintf(_("Greek Transliteration Tutorial, page %d"), 5) . "</h2>\n";
 
 echo "<h3>" . _("Two Double Letters") . "</h3>\n";
 echo "<p>" . _("This form of sigma: ς normally only occurs at the end of a word. If you meet one in the middle of a word, it's almost always a letter called \"stigma\" and the top bit of it usually extends further to the right. It gets transliterated as <kbd>st</kbd>.") . "</p>\n";
@@ -35,6 +35,6 @@ echo "    <td>" . _("rho") . "</td>\n";
 echo "    <td><kbd>r</kbd></td></tr>\n";
 echo "</table>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_5'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_greek_5'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod1_1.php
+++ b/quiz/tuts/tut_p_mod1_1.php
@@ -11,7 +11,7 @@ echo "<h1>" . _("Proofreading Tutorial") . "</h1>\n";
 echo "<h2>" . _("Intro") . "</h2>\n";
 echo "<p>" . _("In this tutorial you will be presented extracts from the Proofreading Guidelines. After each part you will be led to a quiz page, where you can try out the newly learned rules. These Moderate Proofreading Quizzes build on the topics already covered in the tutorial for the Basic Proofreading Quiz.") . "</p>\n";
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 1) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 1) . "</h2>\n";
 echo "<h3>" . _("Superscripts") . "</h3>\n";
 echo "<p>" . _("Older books often abbreviated words as contractions, and printed them as superscripts. Proofread these by inserting a single caret (<kbd>^</kbd>) followed by the superscripted text. If the superscript continues for more than one character, then surround the text with curly braces <kbd>{</kbd> and <kbd>}</kbd> as well. For example:") . "</p>\n";
 echo "<table class='basic' summary='" . _("Superscripts example") . "'>\n";
@@ -27,6 +27,6 @@ echo "    </tr>\n";
 echo "  </tbody>\n";
 echo "</table>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_1'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_1'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod1_2.php
+++ b/quiz/tuts/tut_p_mod1_2.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 2) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 2) . "</h2>\n";
 echo "<h3>" . _("End-of-line Hyphenation") . "</h3>\n";
 echo "<p>" . _("Words like to-day and to-morrow that we don't commonly hyphenate now were often hyphenated in the old books we are working on. Leave them hyphenated the way the author did. If you're not sure if the author hyphenated it or not, leave the hyphen, put an <kbd>*</kbd> after it, and join the word together like this: <kbd>to-*day</kbd>. The asterisk will bring it to the attention of the post-processor, who has access to all the pages and can determine how the author typically wrote this word.") . "</p>\n";
 
@@ -18,6 +18,6 @@ echo "<h3>" . _("Dashes") . "</h3>\n";
 echo "<p><i>" . _("Dashes in Deliberately Omitted or Censored Words or Names.") . "</i><br>\n";
 echo _("If represented by a dash in the image, proofread these as two hyphens or four hyphens as described for em-dashes &amp; long dashes. When it represents a word, we leave appropriate space around it like it's really a word. If it's only part of a word, then no spaces&mdash;join it with the rest of the word.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_2'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_2'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod1_3.php
+++ b/quiz/tuts/tut_p_mod1_3.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 3) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 3) . "</h2>\n";
 echo "<h3>" . _("Accented/Non-ASCII Characters") . "</h3>\n";
 echo "<p>" . _("Please proofread these using the proper UTF-8 characters. For characters which are not in Unicode, see the Project Manager's instructions in the Project Comments.") . "</p>\n";
 
@@ -23,6 +23,6 @@ echo "</ul>\n";
 echo "<h3>" . _("Fractions") . "</h3>\n";
 echo "<p>" . _("Proofread fractions as follows: <kbd>¼</kbd> becomes <kbd>1/4</kbd>, and <kbd>2½</kbd> becomes <kbd>2-1/2</kbd>. The hyphen prevents the whole and fractional part from becoming separated when the lines are rewrapped during post-processing.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_3'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_3'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod1_4.php
+++ b/quiz/tuts/tut_p_mod1_4.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 4) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 4) . "</h2>\n";
 echo "<h3>" . _("Common OCR Problems") . "</h3>\n";
 echo "<p>" . _("OCR commonly has trouble distinguishing between the similar characters.  Some examples are:") . "</p>\n";
 echo "<ul>";
@@ -18,6 +18,6 @@ echo "<li>" . _("Parentheses ( ) and curly braces { }.") . "</li>\n";
 echo "</ul>";
 echo "<p>" . _("Watch out for these. Normally the context of the sentence is sufficient to determine which is the correct character, but be careful&mdash;often your mind will automatically 'correct' these as you are reading.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_4'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_4'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod1_5.php
+++ b/quiz/tuts/tut_p_mod1_5.php
@@ -7,11 +7,11 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 5) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 5) . "</h2>\n";
 echo "<h3>" . _("Footnotes/Endnotes") . "</h3>\n";
 echo "<p>" . _("Place each footnote on a separate line in order of appearance, with a blank line before each one.") . "</p>\n";
 echo "<p>" . _("Do not include any horizontal lines separating the footnotes from the main text.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_5'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_5'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod2_1.php
+++ b/quiz/tuts/tut_p_mod2_1.php
@@ -7,13 +7,13 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 6) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 6) . "</h2>\n";
 echo "<h3>" . _("Paragraph Side-Descriptions (Sidenotes)") . "</h3>\n";
 echo "<p>" . _("Some books will have short descriptions of the paragraph along the side of the text. These are called sidenotes. Proofread the sidenote text as it is printed, preserving the line breaks (while handling end-of-line hyphenation and dashes normally). Leave a blank line before and after the sidenote so that it can be distinguished from the text around it. The OCR may place the sidenotes anywhere on the page, and may even intermingle the sidenote text with the rest of the text. Separate them so that the sidenote text is all together, but don't worry about the position of the sidenotes on the page.") . "</p>\n";
 
 echo "<h3>" . _("Multiple Columns") . "</h3>\n";
 echo "<p>" . _("Proofread ordinary text that has been printed in multiple columns as a single column. Place the text from the left-most column first, the text from the next column below that, and so on. Do not mark where the columns were split, just join them together.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_1'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_1'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod2_2.php
+++ b/quiz/tuts/tut_p_mod2_2.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 7) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 7) . "</h2>\n";
 echo "<h3>" . _("Subscripts") . "</h3>\n";
 echo "<p>" . _("Subscripted text is often found in scientific works, but is not common in other material. Proofread subscripted text by inserting an underline character <kbd>_</kbd> and surrounding the text with curly braces <kbd>{</kbd> and <kbd>}</kbd>. For example:") . "</p>\n";
 
@@ -24,6 +24,6 @@ echo "    </tr>\n";
 echo "  </tbody>\n";
 echo "</table>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_2'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_2'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod2_3.php
+++ b/quiz/tuts/tut_p_mod2_3.php
@@ -7,10 +7,10 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 8) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 8) . "</h2>\n";
 echo "<h3>" . _("Accented/Non-ASCII Characters") . "</h3>\n";
 echo "<p>" . _("The œ character (oe ligature) should be inserted into the proofread text, just like other special characters.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_3'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_3'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod2_4.php
+++ b/quiz/tuts/tut_p_mod2_4.php
@@ -7,11 +7,11 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 9) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 9) . "</h2>\n";
 echo "<h3>" . _("Quote marks on each line") . "</h3>\n";
 echo "<p>" . _("Proofread quotation marks at the beginning of each line of a quotation by removing all of them <b>except for</b> the one at the start of the quotation. If a quotation like this goes on for multiple paragraphs, leave the quote mark that appears on the first line of each paragraph.") . "</p>\n";
 echo "<p>" . _("Often there is no closing quotation mark until the very end of the quoted section of text, which may not be on the same page you are proofreading. Leave it that way&mdash;do not add closing quotation marks that are not in the page image.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_4'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_4'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_mod2_5.php
+++ b/quiz/tuts/tut_p_mod2_5.php
@@ -7,11 +7,11 @@ require_login();
 
 output_header(_('Moderate Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, Page %d"), 10) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 10) . "</h2>\n";
 echo "<h3>" . _("Plays: Actor Names/Stage Directions") . "</h3>\n";
 echo "<p>" . _("In dialog, treat a change in speaker as a new paragraph, with one blank line before it.") . "</p>\n";
 echo "<p>" . _("Stage directions are kept as they are in the original image, so if the stage direction is on a line by itself, proofread it that way; if it is at the end of a line of dialog, leave it there. Stage directions often begin with an opening bracket and omit the closing bracket. This convention is retained; do not close the brackets.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_5'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_mod2_5'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_old_1.php
+++ b/quiz/tuts/tut_p_old_1.php
@@ -12,7 +12,7 @@ echo "<h1>" . _("Proofreading Tutorial") . "</h1>\n";
 echo "<h2>" . _("Intro") . "</h2>\n";
 echo "<p>" . sprintf(_("In this tutorial you will be presented extracts from the Proofreading Guidelines and the %1\$s Wiki article on <a href='%2\$s' target='_blank'>Proofing old texts</a>. After each part you will be led to a quiz page, where you can try out the newly learned rules."), $site_abbreviation, $old_texts_url) . "</p>\n";
 
-echo "<h2>" . sprintf(_("Old Texts Proofreading Tutorial, Page %d"), 1) . "</h2>\n";
+echo "<h2>" . sprintf(_("Old Texts Proofreading Tutorial, page %d"), 1) . "</h2>\n";
 echo "<h3>" . _("Long s") . "</h3>\n";
 echo "<p>" . _("The fonts in older texts are generally similar to modern fonts, but one major difference is in the letter s.  In older texts there are two different forms of the lower-case letter s: long s and round s. The round s looks like the modern letter, while the long s looks more like the letter f, except that part or all of the crossbar is missing.") . "</p>\n";
 echo "<p>" . _("The long s is usually proofread simply as s, without marking it specially.") . "</p>\n";
@@ -24,6 +24,6 @@ echo "<h3>" . _("Single word at bottom of page") . "</h3>\n";
 echo "<p>" . _("Proofread this by deleting the word, even if it's the second half of a hyphenated word.") . "</p>\n";
 echo "<p>" . _("In some older books, the single word at the bottom of the page (called a \"catchword\", usually printed near the right margin) indicates the first word on the next page of the book (called an \"incipit\"). It was used to alert the printer to print the correct reverse (called \"verso\"), to make it easier for printers' helpers to make up the pages prior to binding, and to help the reader avoid turning over more than one page.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_old_1'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_old_1'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_old_2.php
+++ b/quiz/tuts/tut_p_old_2.php
@@ -7,7 +7,7 @@ require_login();
 
 output_header(_('Old Texts Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Old Texts Proofreading Tutorial, Page %d"), 2) . "</h2>\n";
+echo "<h2>" . sprintf(_("Old Texts Proofreading Tutorial, page %d"), 2) . "</h2>\n";
 echo "<h3>" . _("Usage of u/v and i/j") . "</h3>\n";
 echo "<p>" . _("In the 1600s and before, the letters <i>u</i>, <i>v</i>, <i>i</i>, and <i>j</i> were used differently than they are today.  Often <i>v</i> was used only at the beginning of a word, while <i>u</i> was used in the middle and end, as in these words: <i>vpon</i>, <i>vntil</i>, <i>haue</i>, <i>giue</i>.  In addition, usually <i>i</i> was used where we have a <i>j</i> today: <i>iudge</i>, <i>obiect</i>.  The letter j may occur in Roman numerals, though, such as <i>iij</i>.  In capital letters, there usually was no <i>U</i> or <i>J</i>; only <i>V</i> and <i>I</i> were used.") . "</p>\n";
 echo "<p>" . _("Unless the Project Manager gives special instructions to the contrary, proofread these just the way they appear in the image.  Do <i>not</i> modernize the spelling.") . "</p>\n";
@@ -20,6 +20,6 @@ echo " <img src='../generic/images/amp_blackletter.png' width='33' height='45' a
 echo " <img src='../generic/images/amp_blackletter2.png' width='31' height='41' alt='&amp;'></p>\n";
 echo "<p>" . _("As in many books through the 1800s, the phrase <i>et cetera</i> may be abbreviated as <kbd>&amp;c.</kbd> rather than the modern <kbd>etc</kbd>.  Leave it as the author wrote it.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_old_2'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_old_2'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_old_3.php
+++ b/quiz/tuts/tut_p_old_3.php
@@ -8,7 +8,7 @@ require_login();
 
 output_header(_('Old Texts Proofreading Tutorial'));
 
-echo "<h2>" . sprintf(_("Old Texts Proofreading Tutorial, Page %d"), 3) . "</h2>\n";
+echo "<h2>" . sprintf(_("Old Texts Proofreading Tutorial, page %d"), 3) . "</h2>\n";
 echo "<h3>" . _("Nasal abbreviations") . "</h3>\n";
 echo "<p>" . _("Sometimes an <i>n</i> or <i>m</i> is abbreviated by putting a mark over the preceding letter:") . "</p>\n";
 
@@ -35,6 +35,6 @@ echo "<p>" . sprintf(_("Text like this: %1\$s is in a font known as <i>blacklett
                     "<br>\n<img src='../generic/images/blackletter_sample.png' width='207' height='52' alt='Sample Text'><br>", $blackletter_url) . "</p>\n";
 echo "<p>" . _("The hyphen in blackletter usually looks like a slanted equals sign.  Treat this just like a normal hyphen, and rejoin words that are hyphenated across lines.  You may need to leave hyphens as <kbd>-*</kbd> more frequently than in other projects, because spelling and hyphenation in older texts is often unpredictable.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_old_3'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_old_3'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/quiz/tuts/tut_p_thorn.php
+++ b/quiz/tuts/tut_p_thorn.php
@@ -28,6 +28,6 @@ echo "</table>\n";
 echo "<p>" . _("The loop of the capital thorn is normally larger, and the stem may not drop down as far below the line as the lower case.");
 echo " " . _("You can insert them using the character picker at the bottom of the Proofreading Interface.") . "</p>\n";
 
-echo "<p><a href='../generic/main.php?quiz_page_id=p_thorn'>" . _("Continue to quiz") . "</a></p>\n";
+echo "<p><a href='../generic/main.php?quiz_page_id=p_thorn'>" . _("Continue to quiz page") . "</a></p>\n";
 
 // vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
Be consistent about referring to parts of a quiz as "pages" instead of "steps". This also adds some return links on page check failure to the tutorial and quizzes home in case the user gets really stuck and wants to exit the quiz.

Many thanks to @windymilla for the suggestions on tactical ways of making this clearer for users.

Testable in the [standardize-quiz-naming](https://www.pgdp.org/~cpeel/c.branch/standardize-quiz-naming/) sandbox.