### PR TITLE
Check headers before resetting profile cookie

### DIFF
--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -112,7 +112,15 @@ class User
                     catch(NonexistentUserProfileException $exception)
                     {
                         // reset the cookie since the value was invalid
-                        setcookie("profile");
+
+                        // We can only reset the cookie if the headers haven't
+                        // yet been sent. Resetting the cookie is a nicety
+                        // since it will only be used if it is valid, so it's
+                        // OK if we can't.
+                        if(!header_sent())
+                        {
+                            setcookie("profile");
+                        }
 
                         // fall through to getting the profile from the user record
                     }


### PR DESCRIPTION
Cookies can only be set before headers have been sent to the browser, otherwise PHP generates a warning. Check that headers haven't been sent before resetting invalid profile cookies. Failing to reset it is fine since only valid profile cookies are ever used.

Seen in the `php_errors` log on PROD.

While I don't know for certain why we're seeing this, it could happen by a user deleting a profile in one browser that a second web browser had been using.