### PR TITLE
Import the MediaWiki CSS into theme files

### DIFF
--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -157,12 +157,6 @@ if(!function_exists("wfDebug")) {
     }
 }
 
-// Return URL to main CSS file
-function get_DifferenceEngine_css_files() {
-    global $code_url;
-    return array("$code_url/pinc/3rdparty/mediawiki/mediawiki.diff.styles.css");
-}
-
 // Override default css for DP customizations
 function get_DifferenceEngine_css_data() {
     list( , $font_size, $font_family) = get_user_proofreading_font();

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1584,3 +1584,11 @@ p.mentor-oldest {
     .bold;
     .center-align;
 }
+
+/* ------------------------------------------------------------------------ */
+/* Diff styling */
+/* Import diff styling from MediaWiki */
+
+@import (inline) "../pinc/3rdparty/mediawiki/mediawiki.diff.styles.css";
+
+/* ------------------------------------------------------------------------ */

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -2442,6 +2442,175 @@ p.mentor-oldest {
   font-weight: bold;
   text-align: center;
 }
+/* ------------------------------------------------------------------------ */
+/* Diff styling */
+/* Import diff styling from MediaWiki */
+/*!
+ * Diff rendering
+ */
+
+.diff {
+	border: 0;
+	border-spacing: 4px;
+	margin: 0;
+	width: 100%;
+	/* Ensure that colums are of equal width */
+	table-layout: fixed;
+}
+
+.diff td {
+	padding: 0.33em 0.5em;
+}
+
+.diff td.diff-marker {
+	/* Compensate padding for increased font-size */
+	padding: 0.25em;
+}
+
+.diff col.diff-marker {
+	width: 2%;
+}
+
+.diff .diff-content {
+	width: 48%;
+}
+
+.diff td div {
+	/* Force-wrap very long lines such as URLs or page-widening char strings */
+	word-wrap: break-word;
+}
+
+.diff-title {
+	vertical-align: top;
+}
+
+.diff-notice,
+.diff-multi,
+.diff-otitle,
+.diff-ntitle {
+	text-align: center;
+}
+
+.diff-lineno {
+	font-weight: bold;
+}
+
+td.diff-marker {
+	text-align: right;
+	font-weight: bold;
+	font-size: 1.25em;
+	line-height: 1.2;
+}
+
+.diff-addedline,
+.diff-deletedline,
+.diff-context {
+	font-size: 88%;
+	line-height: 1.6;
+	vertical-align: top;
+	white-space: -moz-pre-wrap;
+	white-space: pre-wrap;
+	border-style: solid;
+	border-width: 1px 1px 1px 4px;
+	border-radius: 0.33em;
+}
+
+.diff-addedline {
+	border-color: #a3d3ff;
+}
+
+.diff-deletedline {
+	border-color: #ffe49c;
+}
+
+.diff-context {
+	background: #f8f9fa;
+	border-color: #eaecf0;
+	color: #222;
+}
+
+.diffchange {
+	font-weight: bold;
+	text-decoration: none;
+}
+
+.diff-addedline .diffchange,
+.diff-deletedline .diffchange {
+	border-radius: 0.33em;
+	padding: 0.25em 0;
+}
+
+.diff-addedline .diffchange {
+	background: #d8ecff;
+}
+
+.diff-deletedline .diffchange {
+	background: #feeec8;
+}
+
+/* Correct user & content directionality when viewing a diff */
+.diff-currentversion-title,
+.diff {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-right td {
+	direction: rtl;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-left td {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+.diff-multi,
+.diff-otitle,
+.diff-ntitle,
+.diff-lineno {
+	direction: ltr !important; /* stylelint-disable-line declaration-no-important */
+	unicode-bidi: embed;
+}
+
+/*!
+ * Wikidiff2 rendering for moved paragraphs
+ */
+
+.mw-diff-movedpara-left,
+.mw-diff-movedpara-right,
+.mw-diff-movedpara-left:visited,
+.mw-diff-movedpara-right:visited,
+.mw-diff-movedpara-left:active,
+.mw-diff-movedpara-right:active {
+	display: block;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:hover,
+.mw-diff-movedpara-right:hover {
+	text-decoration: none;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:after,
+.mw-diff-movedpara-right:after {
+	display: block;
+	color: #222;
+	margin-top: -1.25em;
+}
+
+.mw-diff-movedpara-left:after,
+.rtl .mw-diff-movedpara-right:after {
+	content: '↪';
+}
+
+.mw-diff-movedpara-right:after,
+.rtl .mw-diff-movedpara-left:after {
+	content: '↩';
+}
+
+/* ------------------------------------------------------------------------ */
 /* Do not underline links */
 a {
   text-decoration: none;
@@ -2526,4 +2695,20 @@ table.striped tr:nth-child(odd) td {
 }
 table.striped tr:nth-child(even) td {
   background-color: #3a3a3a;
+}
+/*--------------------------------------------------------*/
+/* Diff styling */
+/* Override default MediaWiki styling */
+.diff-context {
+  color: #e2e2e2;
+  background-color: #3a3a3a;
+}
+.diff-addedline,
+.diff-deletedline {
+  color: #e2e2e2;
+}
+.diff-addedline .diffchange,
+.diff-deletedline .diffchange {
+  color: black;
+  opacity: 70%;
 }

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -216,3 +216,20 @@ table.striped {
         }
     }
 }
+
+/*--------------------------------------------------------*/
+/* Diff styling */
+/* Override default MediaWiki styling */
+
+.diff-context {
+    color: @page-text;
+    background-color: @table-cell-base-mediumc;
+}
+
+.diff-addedline, .diff-deletedline {
+    color: @page-text;
+    .diffchange {
+        color: black;
+        opacity: 70%;
+    }
+}

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2442,3 +2442,172 @@ p.mentor-oldest {
   font-weight: bold;
   text-align: center;
 }
+/* ------------------------------------------------------------------------ */
+/* Diff styling */
+/* Import diff styling from MediaWiki */
+/*!
+ * Diff rendering
+ */
+
+.diff {
+	border: 0;
+	border-spacing: 4px;
+	margin: 0;
+	width: 100%;
+	/* Ensure that colums are of equal width */
+	table-layout: fixed;
+}
+
+.diff td {
+	padding: 0.33em 0.5em;
+}
+
+.diff td.diff-marker {
+	/* Compensate padding for increased font-size */
+	padding: 0.25em;
+}
+
+.diff col.diff-marker {
+	width: 2%;
+}
+
+.diff .diff-content {
+	width: 48%;
+}
+
+.diff td div {
+	/* Force-wrap very long lines such as URLs or page-widening char strings */
+	word-wrap: break-word;
+}
+
+.diff-title {
+	vertical-align: top;
+}
+
+.diff-notice,
+.diff-multi,
+.diff-otitle,
+.diff-ntitle {
+	text-align: center;
+}
+
+.diff-lineno {
+	font-weight: bold;
+}
+
+td.diff-marker {
+	text-align: right;
+	font-weight: bold;
+	font-size: 1.25em;
+	line-height: 1.2;
+}
+
+.diff-addedline,
+.diff-deletedline,
+.diff-context {
+	font-size: 88%;
+	line-height: 1.6;
+	vertical-align: top;
+	white-space: -moz-pre-wrap;
+	white-space: pre-wrap;
+	border-style: solid;
+	border-width: 1px 1px 1px 4px;
+	border-radius: 0.33em;
+}
+
+.diff-addedline {
+	border-color: #a3d3ff;
+}
+
+.diff-deletedline {
+	border-color: #ffe49c;
+}
+
+.diff-context {
+	background: #f8f9fa;
+	border-color: #eaecf0;
+	color: #222;
+}
+
+.diffchange {
+	font-weight: bold;
+	text-decoration: none;
+}
+
+.diff-addedline .diffchange,
+.diff-deletedline .diffchange {
+	border-radius: 0.33em;
+	padding: 0.25em 0;
+}
+
+.diff-addedline .diffchange {
+	background: #d8ecff;
+}
+
+.diff-deletedline .diffchange {
+	background: #feeec8;
+}
+
+/* Correct user & content directionality when viewing a diff */
+.diff-currentversion-title,
+.diff {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-right td {
+	direction: rtl;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-left td {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+.diff-multi,
+.diff-otitle,
+.diff-ntitle,
+.diff-lineno {
+	direction: ltr !important; /* stylelint-disable-line declaration-no-important */
+	unicode-bidi: embed;
+}
+
+/*!
+ * Wikidiff2 rendering for moved paragraphs
+ */
+
+.mw-diff-movedpara-left,
+.mw-diff-movedpara-right,
+.mw-diff-movedpara-left:visited,
+.mw-diff-movedpara-right:visited,
+.mw-diff-movedpara-left:active,
+.mw-diff-movedpara-right:active {
+	display: block;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:hover,
+.mw-diff-movedpara-right:hover {
+	text-decoration: none;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:after,
+.mw-diff-movedpara-right:after {
+	display: block;
+	color: #222;
+	margin-top: -1.25em;
+}
+
+.mw-diff-movedpara-left:after,
+.rtl .mw-diff-movedpara-right:after {
+	content: '↪';
+}
+
+.mw-diff-movedpara-right:after,
+.rtl .mw-diff-movedpara-left:after {
+	content: '↩';
+}
+
+/* ------------------------------------------------------------------------ */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2442,3 +2442,172 @@ p.mentor-oldest {
   font-weight: bold;
   text-align: center;
 }
+/* ------------------------------------------------------------------------ */
+/* Diff styling */
+/* Import diff styling from MediaWiki */
+/*!
+ * Diff rendering
+ */
+
+.diff {
+	border: 0;
+	border-spacing: 4px;
+	margin: 0;
+	width: 100%;
+	/* Ensure that colums are of equal width */
+	table-layout: fixed;
+}
+
+.diff td {
+	padding: 0.33em 0.5em;
+}
+
+.diff td.diff-marker {
+	/* Compensate padding for increased font-size */
+	padding: 0.25em;
+}
+
+.diff col.diff-marker {
+	width: 2%;
+}
+
+.diff .diff-content {
+	width: 48%;
+}
+
+.diff td div {
+	/* Force-wrap very long lines such as URLs or page-widening char strings */
+	word-wrap: break-word;
+}
+
+.diff-title {
+	vertical-align: top;
+}
+
+.diff-notice,
+.diff-multi,
+.diff-otitle,
+.diff-ntitle {
+	text-align: center;
+}
+
+.diff-lineno {
+	font-weight: bold;
+}
+
+td.diff-marker {
+	text-align: right;
+	font-weight: bold;
+	font-size: 1.25em;
+	line-height: 1.2;
+}
+
+.diff-addedline,
+.diff-deletedline,
+.diff-context {
+	font-size: 88%;
+	line-height: 1.6;
+	vertical-align: top;
+	white-space: -moz-pre-wrap;
+	white-space: pre-wrap;
+	border-style: solid;
+	border-width: 1px 1px 1px 4px;
+	border-radius: 0.33em;
+}
+
+.diff-addedline {
+	border-color: #a3d3ff;
+}
+
+.diff-deletedline {
+	border-color: #ffe49c;
+}
+
+.diff-context {
+	background: #f8f9fa;
+	border-color: #eaecf0;
+	color: #222;
+}
+
+.diffchange {
+	font-weight: bold;
+	text-decoration: none;
+}
+
+.diff-addedline .diffchange,
+.diff-deletedline .diffchange {
+	border-radius: 0.33em;
+	padding: 0.25em 0;
+}
+
+.diff-addedline .diffchange {
+	background: #d8ecff;
+}
+
+.diff-deletedline .diffchange {
+	background: #feeec8;
+}
+
+/* Correct user & content directionality when viewing a diff */
+.diff-currentversion-title,
+.diff {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-right td {
+	direction: rtl;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-left td {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+.diff-multi,
+.diff-otitle,
+.diff-ntitle,
+.diff-lineno {
+	direction: ltr !important; /* stylelint-disable-line declaration-no-important */
+	unicode-bidi: embed;
+}
+
+/*!
+ * Wikidiff2 rendering for moved paragraphs
+ */
+
+.mw-diff-movedpara-left,
+.mw-diff-movedpara-right,
+.mw-diff-movedpara-left:visited,
+.mw-diff-movedpara-right:visited,
+.mw-diff-movedpara-left:active,
+.mw-diff-movedpara-right:active {
+	display: block;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:hover,
+.mw-diff-movedpara-right:hover {
+	text-decoration: none;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:after,
+.mw-diff-movedpara-right:after {
+	display: block;
+	color: #222;
+	margin-top: -1.25em;
+}
+
+.mw-diff-movedpara-left:after,
+.rtl .mw-diff-movedpara-right:after {
+	content: '↪';
+}
+
+.mw-diff-movedpara-right:after,
+.rtl .mw-diff-movedpara-left:after {
+	content: '↩';
+}
+
+/* ------------------------------------------------------------------------ */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2442,3 +2442,172 @@ p.mentor-oldest {
   font-weight: bold;
   text-align: center;
 }
+/* ------------------------------------------------------------------------ */
+/* Diff styling */
+/* Import diff styling from MediaWiki */
+/*!
+ * Diff rendering
+ */
+
+.diff {
+	border: 0;
+	border-spacing: 4px;
+	margin: 0;
+	width: 100%;
+	/* Ensure that colums are of equal width */
+	table-layout: fixed;
+}
+
+.diff td {
+	padding: 0.33em 0.5em;
+}
+
+.diff td.diff-marker {
+	/* Compensate padding for increased font-size */
+	padding: 0.25em;
+}
+
+.diff col.diff-marker {
+	width: 2%;
+}
+
+.diff .diff-content {
+	width: 48%;
+}
+
+.diff td div {
+	/* Force-wrap very long lines such as URLs or page-widening char strings */
+	word-wrap: break-word;
+}
+
+.diff-title {
+	vertical-align: top;
+}
+
+.diff-notice,
+.diff-multi,
+.diff-otitle,
+.diff-ntitle {
+	text-align: center;
+}
+
+.diff-lineno {
+	font-weight: bold;
+}
+
+td.diff-marker {
+	text-align: right;
+	font-weight: bold;
+	font-size: 1.25em;
+	line-height: 1.2;
+}
+
+.diff-addedline,
+.diff-deletedline,
+.diff-context {
+	font-size: 88%;
+	line-height: 1.6;
+	vertical-align: top;
+	white-space: -moz-pre-wrap;
+	white-space: pre-wrap;
+	border-style: solid;
+	border-width: 1px 1px 1px 4px;
+	border-radius: 0.33em;
+}
+
+.diff-addedline {
+	border-color: #a3d3ff;
+}
+
+.diff-deletedline {
+	border-color: #ffe49c;
+}
+
+.diff-context {
+	background: #f8f9fa;
+	border-color: #eaecf0;
+	color: #222;
+}
+
+.diffchange {
+	font-weight: bold;
+	text-decoration: none;
+}
+
+.diff-addedline .diffchange,
+.diff-deletedline .diffchange {
+	border-radius: 0.33em;
+	padding: 0.25em 0;
+}
+
+.diff-addedline .diffchange {
+	background: #d8ecff;
+}
+
+.diff-deletedline .diffchange {
+	background: #feeec8;
+}
+
+/* Correct user & content directionality when viewing a diff */
+.diff-currentversion-title,
+.diff {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-right td {
+	direction: rtl;
+	unicode-bidi: embed;
+}
+
+/* @noflip */ .diff-contentalign-left td {
+	direction: ltr;
+	unicode-bidi: embed;
+}
+
+.diff-multi,
+.diff-otitle,
+.diff-ntitle,
+.diff-lineno {
+	direction: ltr !important; /* stylelint-disable-line declaration-no-important */
+	unicode-bidi: embed;
+}
+
+/*!
+ * Wikidiff2 rendering for moved paragraphs
+ */
+
+.mw-diff-movedpara-left,
+.mw-diff-movedpara-right,
+.mw-diff-movedpara-left:visited,
+.mw-diff-movedpara-right:visited,
+.mw-diff-movedpara-left:active,
+.mw-diff-movedpara-right:active {
+	display: block;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:hover,
+.mw-diff-movedpara-right:hover {
+	text-decoration: none;
+	color: transparent;
+}
+
+.mw-diff-movedpara-left:after,
+.mw-diff-movedpara-right:after {
+	display: block;
+	color: #222;
+	margin-top: -1.25em;
+}
+
+.mw-diff-movedpara-left:after,
+.rtl .mw-diff-movedpara-right:after {
+	content: '↪';
+}
+
+.mw-diff-movedpara-right:after,
+.rtl .mw-diff-movedpara-left:after {
+	content: '↩';
+}
+
+/* ------------------------------------------------------------------------ */

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -110,7 +110,6 @@ $title = sprintf( _('Difference for page %s'), $image );
 $image_url = "$code_url/tools/page_browser.php?project=$projectid&amp;imagefile=$image";
 $image_link = sprintf($link_text, new_window_link($image_url, $image));
 $extra_args = array(
-    "css_files" => get_DifferenceEngine_css_files(),
     "css_data"  => get_DifferenceEngine_css_data(),
 );
 output_header("$title: $project_title", NO_STATSBAR, $extra_args);


### PR DESCRIPTION
To allow theme files to override the MediaWiki CSS for diffs, we need to import the CSS into the theme files. Also update the diff CSS for Charcoal.

Check it out in [fix-charcoal-diffs](https://www.pgdp.org/~cpeel/c.branch/fix-charcoal-diffs/).