### PR TITLE
Update revoke message

### DIFF
--- a/tools/modify_access.php
+++ b/tools/modify_access.php
@@ -100,7 +100,7 @@ foreach ( $_POST as $name => $value )
 
         if ($activity->after_satisfying_minima == 'REQ-AUTO')
         {
-            echo "Warning: you can revoke access, but it can just be auto-granted again.<br>\n";
+            echo "Warning: you are revoking (not blocking) access, but it can just be auto-granted again as long as the user meets all the access requirements.<br>\n";
         }
     }
     elseif ( $action_type == 'deny_request_for' )


### PR DESCRIPTION
This message is only seen by those who are granting or revoking accesses to rounds which are auto-granted. It emphasizes that the operation is a revoke, not a block, and that, for the stages the message applies to, if the user meets all prerequisites, access can be auto-granted again. For P1, P2 and F1, it happens automatically if the user meets the access requirements; for PP, it's auto-granted after the user clicks the link to request access.

Reviewable in the [update-revoke-message](https://www.pgdp.org/~srjfoo/c.branch/update-revoke-message) sandbox.