### PR TITLE
Add a row cell for special days indicator

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -522,6 +522,7 @@ CREATE TABLE `special_days` (
   `date_changes` varchar(100) default NULL,
   `info_url` varchar(255) default NULL,
   `image_url` varchar(255) default NULL,
+  `symbol` varchar(2) default '',
   UNIQUE KEY `spec_code` (`spec_code`)
 ) COMMENT='definitions of SPECIAL days';
 # --------------------------------------------------------

--- a/SETUP/upgrade/15/20201231_alter_special_days.php
+++ b/SETUP/upgrade/15/20201231_alter_special_days.php
@@ -1,0 +1,23 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding symbol column to special_days..\n";
+$sql = "
+    ALTER TABLE special_days
+        ADD COLUMN symbol varchar(2) DEFAULT ''
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -626,6 +626,10 @@ class ProjectSearchResults
 
         echo "\n<table class='themed theme_striped'>\n";
         echo "<tr>\n";
+        if($this->show_special_colors)
+        {
+            echo "<th></th>";
+        }
         foreach($this->active_columns as $column)
         {
             $column->echo_header_cell($this->sort_column_id, $this->sql_sort_dir, $this->sec_sort);
@@ -636,20 +640,21 @@ class ProjectSearchResults
             $project = new Project($project_assoc);
             $projectid = $project->projectid;
 
-            $bgcolor = '';
-            // Special colours for special books of various types
-            if ($this->show_special_colors)
+            echo "<tr>\n";
+
+            if($this->show_special_colors)
             {
-                $special_color = get_special_color_for_project($project_assoc);
-                if (!is_null($special_color)) {
-                    $bgcolor = $special_color;
+                $style = '';
+                $cell = '';
+                $special_day = get_special_day($project_assoc['special_code']);
+                if (!is_null($special_day))
+                {
+                    list($style, $cell) = get_special_day_cell_parts($special_day);
+                    $style = "style='$style'";
                 }
+                echo "<td $style>$cell</td>";
             }
 
-            $row_style = '';
-            if($bgcolor)
-                $row_style = "style='background-color: $bgcolor;'";
-            echo "<tr $row_style>\n";
             foreach($this->active_columns as $column)
             {
                 $column->echo_data_cell($project);

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -11,7 +11,7 @@ include_once($relPath.'post_processing.inc');
 
 // -----------------------------------------------------------------------------
 
-function show_projects_for_round( $round, $show_filter_block, $allow_special_colors_legend )
+function show_projects_for_round( $round, $show_filter_block=TRUE, $allow_special_colors_legend=TRUE )
 {
     $initial_project_selector = "state = '{$round->project_available_state}'";
 
@@ -388,6 +388,14 @@ function show_project_listing(
         "days_since_visit" => "text-align: right;",
     );
 
+    // Determine whether to use special colors or not.
+    // Visitors always see special colors.
+    $userSettings =& Settings::get_Settings($pguser);
+    if(!isset($pguser) || !$userSettings->get_boolean('hide_special_colors'))
+    {
+        $columns = array_merge(["specialday" => ['SpecialDay', '']], $columns);
+    }
+
     // Load the sort column and direction
     list($curr_sql_sort_col, $curr_sql_sort_dir) =
         process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setting_name, $default_ext_sort);
@@ -503,23 +511,6 @@ function show_project_listing(
 
     echo "</tr>";
 
-    if(isset($pguser))
-    {
-        // Determine whether to use special colors or not
-        // (this does not affect the alternating between two
-        // background colors) in the project listing.
-        // Regardless of the preference, don't display
-        // special colors to newbies.
-        $userSettings =& Settings::get_Settings($pguser);
-        $show_special_colors = (get_pages_proofed_maybe_simulated() >= 10
-                                && !$userSettings->get_boolean('hide_special_colors'));
-    }
-    else
-    {
-        // Visitors see the special colours.
-        $show_special_colors = TRUE;
-    }
-
     // Show email addresses for site administrators
     $show_email = user_is_a_sitemanager();
 
@@ -527,23 +518,23 @@ function show_project_listing(
 
     while ($book=mysqli_fetch_assoc($result))
     {
-        $style_attr = "";
-
-        // Special colours for special books of various types
-        if ($show_special_colors)
-        {
-            $special_color = get_special_color_for_project($book);
-            if (!is_null($special_color))
-            {
-                $style_attr = "style='background-color: $special_color;'";
-            }
-        }
-
-        echo "<tr $style_attr>";
+        echo "<tr>";
 
         foreach($columns as $col_id => $col_info)
         {
-            if($col_id == "nameofwork")
+            if($col_id == "specialday")
+            {
+                $cell = "";
+                $column_styles[$col_id] = '';
+
+                $special_day = get_special_day($book['special_code']);
+                if (!is_null($special_day))
+                {
+                    list($column_styles[$col_id], $cell) =
+                        get_special_day_cell_parts($special_day);
+                }
+            }
+            elseif($col_id == "nameofwork")
             {
                 $eURL = "$code_url/project.php?id={$book['projectid']}&amp;expected_state={$book['state']}";
                 $onclick_attr = (

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -6,16 +6,19 @@ function load_common_special_days()
 {
     return [
         "_BIRTHDAY_RECENT" => [
-            'color' => "CCFFFF",
+            'color' => "#CCFFFF",
             'display_name' => "Authors with recent birthdays",
+            'symbol' => '🍰',
         ],
         "_BIRTHDAY_TODAY" => [
-            'color' => "33CCFF",
+            'color' => "#33CCFF",
             'display_name' => "Authors with birthdays today",
+            'symbol' => '🎂',
         ],
         "_OTHER_SPECIAL" => [
-            'color' => "FFFF66",
+            'color' => "#FFFF66",
             'display_name' => "Other Special",
+            'symbol' => '🎉',
         ],
     ];
 }
@@ -25,7 +28,7 @@ function load_special_days()
     $specials_array = load_common_special_days();
 
     $sql = "
-        SELECT spec_code, color, display_name
+        SELECT spec_code, color, display_name, symbol
         FROM special_days
         ORDER BY display_name
     ";
@@ -33,25 +36,19 @@ function load_special_days()
 
     while ($row = mysqli_fetch_assoc($specs_result)) {
         $specials_array[$row['spec_code']] = [
-            "color" => $row['color'],
+            "color" => '#' . $row['color'],
             "display_name" => $row['display_name'],
+            "symbol" => $row['symbol'],
         ];
     }
 
     return $specials_array;
 }
 
-// Returns the special color associated with this
-// project, or null if no such color is specified.
-//
-// $book is supposed to be an associative array
-// representing a  record from the
-// projects table. At the moment it is 'enough'
-// that the key 'special_code' exists.
-function get_special_color_for_project($book)
+// Returns the special day array associated with this
+// project, or null if no such special day is specified.
+function get_special_day($special_code)
 {
-    $special_code = $book['special_code'];
-
     static $specials_array = [];
     if(!$specials_array)
     {
@@ -87,7 +84,7 @@ function get_special_color_for_project($book)
 
     if($special_day)
     {
-        return "#".$special_day["color"];
+        return $special_day;
     }
     else
     {
@@ -126,27 +123,70 @@ function echo_special_legend( $projects_where_clause)
     $day_array = array_merge($day_array, array_values(load_common_special_days()));
 
     $specs_count = count($day_array);
-    echo "<h3><a href='$code_url/tools/project_manager/show_specials.php'>$legend_text</a></h3>";
-    echo "<table class='basic'>\n";
-    $day_index = 0;
-    $table_columns = min($specs_count, 4);
-    while($day_index < $specs_count)
+    echo "<h3>" . html_safe($legend_text) . "</h3>";
+    echo "<p><a href='$code_url/tools/project_manager/show_specials.php'>" . _("View all Special Days") . "</a></p>";
+
+    $num_columns = 4;
+    $items_in_columns = round(count($day_array) / $num_columns);
+    $column_index = 0;
+    $columns = [];
+    foreach($day_array as $day_entry)
     {
-        echo "<tr>\n";
-        $column_index = 0;
-        while($column_index++ < $table_columns)
+        $columns[$column_index][] = $day_entry;
+        if(count($columns[$column_index]) % $items_in_columns == 0)
         {
-            if($day_index < $specs_count)
-            {
-                $this_day = $day_array[$day_index++];
-                echo "<td style='background-color:#{$this_day['color']}'>{$this_day['display_name']}</td>\n";
-            }
-            else
-                echo "<td></td>\n";
+            $column_index += 1;
         }
-        echo "</tr>\n";
     }
-    echo "</table>\n";
+    echo "<table>\n";
+    echo "<tr>";
+    for( ; $column_index > 0; $column_index--)
+    {
+        echo "<td class='top-align'>";
+        echo "<table class='basic'>\n";
+        $column = array_shift($columns);
+        foreach($column as $day_entry)
+        {
+            list($style, $contents) = get_special_day_cell_parts($day_entry, FALSE);
+            echo "<tr>";
+            echo "<td style='$style'>$contents</td>";
+            echo "<td>{$day_entry['display_name']}</td>";
+            echo "</tr>";
+        }
+        echo "</table>";
+        echo "</td>";
+    }
+    echo "</tr>";
+    echo "</table>";
 }
 
-?>
+// Given a special day, return building blocks to construct a cell for a row
+function get_special_day_cell_parts($special_day, $include_title=TRUE)
+{
+    $background_color = str_replace("#", "", $special_day['color']);
+    $text_color = pick_text_color_given_bgcolor($background_color, "white", "black");
+    $style = "color: $text_color; background-color: #$background_color; " .
+        "text-align: center; width: 1em;";
+
+    // If the symbol is empty, return an em-space so that the browser
+    // will show a tooltip for the cell.
+    $contents = $special_day['symbol'] == '' ? '&emsp;' : $special_day['symbol'];
+    if($include_title)
+    {
+        $title = attr_safe($special_day['display_name']);
+        $contents = "<span title='$title'>$contents</span>";
+    }
+    return [$style, $contents];
+}
+
+// Select a reasonable text color given a specific background color.
+// From https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
+function pick_text_color_given_bgcolor($bg_color, $light_color, $dark_color)
+{
+    $color = str_replace("#", "", $bg_color);
+
+    $r = hexdec(substr($color, 0, 2)); // hexToR
+    $g = hexdec(substr($color, 2, 4)); // hexToG
+    $b = hexdec(substr($color, 4, 6)); // hexToB
+    return ((($r * 0.299) + ($g * 0.587) + ($b * 0.114)) > 186) ? $dark_color : $light_color;
+}

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1298,9 +1298,6 @@ table.list_special_days {
     td.right, th.right {
         text-align: right; font-weight: normal;
     }
-    h2 {
-        margin: 1em auto auto auto; text-align: left;
-    }
 }
 
 table.show_special_days {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -2198,10 +2198,6 @@ table.list_special_days th.right {
   text-align: right;
   font-weight: normal;
 }
-table.list_special_days h2 {
-  margin: 1em auto auto auto;
-  text-align: left;
-}
 table.show_special_days th {
   background-color: #4d4d4d;
 }

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2198,10 +2198,6 @@ table.list_special_days th.right {
   text-align: right;
   font-weight: normal;
 }
-table.list_special_days h2 {
-  margin: 1em auto auto auto;
-  text-align: left;
-}
 table.show_special_days th {
   background-color: #eeeeee;
 }

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2198,10 +2198,6 @@ table.list_special_days th.right {
   text-align: right;
   font-weight: normal;
 }
-table.list_special_days h2 {
-  margin: 1em auto auto auto;
-  text-align: left;
-}
 table.show_special_days th {
   background-color: #eeeeee;
 }

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2198,10 +2198,6 @@ table.list_special_days th.right {
   text-align: right;
   font-weight: normal;
 }
-table.list_special_days h2 {
-  margin: 1em auto auto auto;
-  text-align: left;
-}
 table.show_special_days th {
   background-color: #eeeeee;
 }

--- a/tools/project_manager/show_specials.php
+++ b/tools/project_manager/show_specials.php
@@ -3,19 +3,23 @@ $relPath='../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath.'special_colors.inc');
 
 require_login();
 
-$title = _("Details of Special Days/Weeks/Months");
+$title = _("Special Days");
 
 output_header($title, NO_STATSBAR);
 
 echo "<h1>$title</h1>\n";
-echo _("The Name column shows what the colour looks like with a link on top, the Comment with ordinary text.")."<br>";
 
-$result = mysqli_query(DPDatabase::get_connection(), "SELECT * FROM special_days ORDER BY open_month, open_day");
+$sql = "
+    SELECT *
+    FROM special_days
+    ORDER BY open_month, open_day
+";
+$result = DPDatabase::query($sql);
 
-echo "<br>\n";
 echo "<table class='list_special_days show_special_days'>";
 
 $current_month = -1;
@@ -29,26 +33,28 @@ while ( $row = mysqli_fetch_assoc($result) )
     if ($month == 0 && $current_month != 0)
     {
         $current_month = $month;
-        echo "<tr class='month'><td colspan='4'><h2>" . _("Undated Entries") . "</h2></td></tr>\n";
+        echo "<tr class='month'><td colspan='5'><h2>" . _("Undated Entries") . "</h2></td></tr>\n";
         output_column_headers();
     }
 
     if ($month != $current_month)
     {
         $current_month = $month;
-        echo "<tr class='month'><td colspan='4'><h2>";
+        echo "<tr class='month'><td colspan='5'><h2>";
         echo strftime("%B", mktime(0, 0, 0, $row['open_month'], 10)) . "</h2></td></tr>\n";
         output_column_headers();
     }
 
+    list($style, $symbol_cell) = get_special_day_cell_parts($row, FALSE);
     echo "<tr>";
-    echo "<td style='background-color: #" . $row['color'] . ";'>";
+    echo "<td style='$style'>$symbol_cell</td>";
+    echo "<td>";
     echo "<a href=\"$code_url/tools/search.php?show=search&amp;special_day%5B%5D=";
     echo urlencode($row['spec_code']) ."&amp;n_results_per_page=100\" title=\"";
     echo urlencode($row['display_name']) ."\">\n";
     echo html_safe($row['display_name']) . "</a>";
     echo "</td>\n";
-    echo "<td style='background-color: #" . $row['color'] . ";'>";
+    echo "<td>";
     echo "<div title=\"" . html_safe($row['comment']) ."\">";
     echo html_safe($row['comment']) . "</div></td>\n";
     echo "<td class='center'>";
@@ -70,6 +76,7 @@ echo "<br>\n";
 function output_column_headers()
 {
     echo "<tr>";
+    echo "<th>" . _("Symbol") . "</th>";
     echo "<th>" . _("Name") . "</th>";
     echo "<th>" . _("Comment") . "</th>";
     // TRANSLATORS: Start Day is the day of the month that the special day occurs, such as 1 for New Year's Day

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -126,10 +126,9 @@ if ($pagesproofed > 20)
     }
 }
 
-// Don't display the filter block or the special colours legend to newbies.
+// Don't display the filter block to newbies.
 $show_filter_block = ($pagesproofed > 20);
-$allow_special_colors_legend = ($pagesproofed >= 10);
 
-show_projects_for_round( $round, $show_filter_block, $allow_special_colors_legend );
+show_projects_for_round( $round, $show_filter_block );
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -5,6 +5,7 @@ include_once($relPath.'metarefresh.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'user_is.inc');
+include_once($relPath.'special_colors.inc');
 
 require_login();
 
@@ -76,8 +77,9 @@ if ($action == 'update_oneshot')
 
 if ($action == 'show_specials')
 {
-    output_header(_('Manage Special Days'), NO_STATSBAR);
-    echo "<h1>", html_safe(_("Special Days Listing")), "</h1>\n";
+    $title = _('Manage Special Days');
+    output_header($title, NO_STATSBAR);
+    echo "<h1>", html_safe($title), "</h1>\n";
 
     show_sd_toolbar($action);
 
@@ -170,13 +172,13 @@ class SpecialDay
         // Output a new month header when listing month differs from previous one
         if (( $current_month < 0 ) && ($current_month != $this->open_month ))
         {
-            echo "<tr class='month'><td colspan='8'><h2>";
+            echo "<tr class='month'><td colspan='9'><h2>";
             echo _("Undated Entries") ."</h2></td></tr>";
             output_table_headers();
         }
         else if ( $this->open_month != $current_month )
         {
-            echo "<tr class='month'><td colspan='8'><h2>";
+            echo "<tr class='month'><td colspan='9'><h2>";
             echo strftime("%B", mktime(0, 0, 0, $this->open_month, 10));
             echo "</h2></td></tr>";
             output_table_headers();
@@ -191,8 +193,9 @@ class SpecialDay
                 $this->show_buttons();
         echo "</form>\n";
         echo "</td>\n";
-        echo "<td style='background-color: #". $this->color . ";'>";
-        echo html_safe($this->display_name) . "</td>";
+        echo "<td>" . html_safe($this->display_name) . "</td>";
+        list($style, $cell) = get_special_day_cell_parts((array)$this);
+        echo "<td style='$style'>$cell</td>";
         echo "<td>" . $this->color . "</td>\n";
         echo $this->_get_status_cell($this->enable,' pb') . "\n";
         echo "<td class='right'>" . $this->open_month . "</td>";
@@ -202,21 +205,21 @@ class SpecialDay
         echo "</tr>\n";
 
         echo "<tr class='$row_class'>";
-        echo "<th class='right'>" . _("Info URL") . ":</th><td colspan='6'>" . make_link($this->info_url, $this->info_url) . "</td>";
+        echo "<th class='right'>" . _("Info URL") . ":</th><td colspan='7'>" . make_link($this->info_url, $this->info_url) . "</td>";
         echo "</tr>";
         echo "<tr class='$row_class'>";
-        echo "<th class='right'>" . _("Image URL") . ":</th><td colspan='6'>" . make_link($this->image_url, $this->image_url) . "</td>";
+        echo "<th class='right'>" . _("Image URL") . ":</th><td colspan='7'>" . make_link($this->image_url, $this->image_url) . "</td>";
         echo "</tr>\n";
 
         if($this->date_changes)
         {
             echo "<tr class='$row_class'>";
-            echo "<th class='right'>" . _("Date Changes") . ":</th><td colspan='6'>" . html_safe($this->date_changes) . "</td>";
+            echo "<th class='right'>" . _("Date Changes") . ":</th><td colspan='7'>" . html_safe($this->date_changes) . "</td>";
             echo "</tr>\n";
         }
 
         echo "<tr class='$row_class'>";
-        echo "<th class='right'>" . _("Comments") . ":</th><td colspan='6'>" . html_safe($this->comment) . "</td>";
+        echo "<th class='right'>" . _("Comments") . ":</th><td colspan='7'>" . html_safe($this->comment) . "</td>";
         echo "</tr>\n";
 
         return($this->open_month);
@@ -247,6 +250,7 @@ class SpecialDay
             $this->_show_summary_row(_('Special Day ID'),$this->spec_code);
         }
         $this->_show_edit_row('display_name', _('Display Name'), 'text', 80);
+        $this->_show_edit_row('symbol', _('Symbol'), 'text', 2);
         echo "  <tr><th class='label'>Enable</th><td><input type='checkbox' name='enable'";
         if ( $this->enable )
             echo " value='1' checked";
@@ -290,9 +294,15 @@ class SpecialDay
             $max_attr = is_null($max) ? '' : "max='$max'";
             $editing = "<input type='number' style='width: 4em' name='$field' size='60' value='$value' $min_attr $max_attr>";
         }
+        $addl_data = '';
+        if($field == "symbol")
+        {
+            $addl_data = "<br>" . sprintf(_("See the full list of emojis in <a href='%s'>the Unicode standard</a>."), "http://unicode.org/emoji/charts/full-emoji-list.html");
+        }
+
         echo "  <tr>" .
             "<th class='label'>$label</th>" .
-            "<td>$editing</td>" .
+            "<td>$editing$addl_data</td>" .
             "</tr>\n";
     }
 
@@ -301,7 +311,7 @@ class SpecialDay
         global $errmsgs;
         $std_fields = array('display_name','enable','comment',
                     'color','open_day','open_month','close_day',
-                    'close_month','date_changes');
+                    'close_month','date_changes','symbol');
         $std_fields_sql = [];
         foreach ($std_fields as $field)
         {
@@ -442,6 +452,7 @@ function output_table_headers()
     echo "<tr>";
     echo "<th class='headers'>" . _("Special Day Code") . "</th>";
     echo "<th class='headers'>" . _("Display Name") . "</th>";
+    echo "<th class='headers'>" . _("Symbol") . "</th>";
     echo "<th class='headers'>" . _("Color") . "</th>";
     echo "<th class='headers'>" . _("Enable") . "</th>";
     echo "<th class='headers'>" . _("Open Month") . "</th>";


### PR DESCRIPTION
Rather than coloring the whole table row for special days, just do a single column that contains a special day indicator. This improves accessibility and overall UX.

Show special day information in round tables and show the legend to all users.

This is testable in the [special-color-improvements](https://www.pgdp.org/~cpeel/c.branch/special-color-improvements/) sandbox. See also the [discussion in the forums](https://www.pgdp.net/phpBB3/viewtopic.php?f=4&t=72729).