### PR TITLE
Add project metadata to archive project directory

### DIFF
--- a/SETUP/upgrade/15/20210104_generate_archive_metadata.php
+++ b/SETUP/upgrade/15/20210104_generate_archive_metadata.php
@@ -1,0 +1,40 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+include_once($relPath.'archiving.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Generating missing archive project metadata..\n";
+
+if(!is_dir($archive_projects_dir))
+{
+	echo "$archive_projects_dir (\$archive_projects_dir) does not exist so there's nothing to do.\n";
+	exit;
+}
+
+foreach(glob("$archive_projects_dir/projectID*") as $project_dir)
+{
+	$metadata_filename = "$project_dir/metadata.json";
+	if(file_exists($metadata_filename))
+	{
+		// file already exists, skip it
+		continue;
+	}
+
+	preg_match("/(projectID.*)/", $project_dir, $matches);
+	$projectid = $matches[1];
+
+	echo "Genearting metadata file for $projectid\n";
+
+	$project = new Project($projectid);
+	generate_project_metadata_json($project, $metadata_filename, FALSE);
+}
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/crontab/archive_projects.php
+++ b/crontab/archive_projects.php
@@ -12,6 +12,8 @@ header('Content-type: text/plain');
 // Find projects that were posted to PG a while ago
 // (that haven't been archived yet), and archive them.
 
+$DAYS_TO_RETAIN = 100;
+
 $dry_run = array_get( $_GET, 'dry_run', '' );
 if ($dry_run)
 {
@@ -22,7 +24,7 @@ $result = mysqli_query(DPDatabase::get_connection(), "
     SELECT *
     FROM projects
     WHERE
-        modifieddate <= UNIX_TIMESTAMP() - (24 * 60 * 60) * 100
+        modifieddate <= UNIX_TIMESTAMP() - (24 * 60 * 60) * $DAYS_TO_RETAIN
         AND archived = '0'
         AND state = '".PROJ_SUBMIT_PG_POSTED."'
     ORDER BY modifieddate
@@ -30,11 +32,12 @@ $result = mysqli_query(DPDatabase::get_connection(), "
 
 echo "Archiving page-tables for ", mysqli_num_rows($result), " projects...\n";
 
-while ( $project = mysqli_fetch_object($result) )
+while ( $project_data = mysqli_fetch_assoc($result) )
 {
+    $project = new Project($project_data);
     archive_project($project, $dry_run);
 }
 
-echo "archive_projects.php executed.";
+echo "archive_projects.php executed.\n";
 
 // vim: sw=4 ts=4 expandtab

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -11,16 +11,23 @@ include($relPath.'udb_user.php'); // $archive_db_name
 
 function archive_project( $project, $dry_run )
 // -- Move the project's page-table to the archive database.
-// -- Move the project's directory out of $projects_dir
+// -- Move the project's directory out of $projects_dir &
+//    write out project's metadata to a JSON file.
 //    (for later off-site migration).
 // -- Mark the project as having been archived.
 {
+    global $archive_projects_dir, $archive_db_name;
+
+    if(!is_dir($archive_projects_dir))
+    {
+        die("Error: archive directory $archive_projects_dir does not exist.\n");
+    }
+
     $projectid = $project->projectid;
 
     $mod_time_str = strftime('%Y-%m-%d %H:%M:%S',$project->modifieddate);
     echo "$projectid ($mod_time_str) \"$project->nameofwork\"\n";
 
-    global $archive_db_name;
     if (!does_project_page_table_exist($projectid))
     {
         echo "    Table $projectid does not exist.\n";
@@ -37,12 +44,10 @@ function archive_project( $project, $dry_run )
         ") or die(DPDatabase::log_error());
     }
 
-    global $projects_dir;
-    $project_dir = "$projects_dir/$projectid";
+    $project_dir = $project->dir;
+    $new_dir = "$archive_projects_dir/$projectid";
     if (file_exists($project_dir))
     {
-        global $archive_projects_dir;
-        $new_dir = "$archive_projects_dir/$projectid";
         if ($dry_run)
         {
             echo "    Move $project_dir to $new_dir.\n";
@@ -61,6 +66,8 @@ function archive_project( $project, $dry_run )
 
     archive_ancillary_data_for_project_etc( $project, '        ', $dry_run );
 
+    generate_project_metadata_json($project, "$new_dir/metadata.json", $dry_run);
+
     if ($dry_run)
     {
         echo "    Mark project as archived.\n";
@@ -78,6 +85,32 @@ function archive_project( $project, $dry_run )
 }
 
 // -----------------------------------------------------------------------------
+
+function generate_project_metadata_json($project, $filename, $dry_run)
+// Write out project's metadata to a JSON file within the archive
+{
+    $metadata = [
+        "projectid" => $project->projectid,
+        "nameofwork" => $project->nameofwork,
+        "authorsname" => $project->authorsname,
+        "language" => $project->language,
+        "genre" => $project->genre,
+        "postednum" => $project->postednum,
+        "image_source" => $project->image_source,
+    ];
+
+    if($dry_run)
+    {
+        echo "    Write project metadata to $filename.\n";
+    }
+    else
+    {
+        file_put_contents($filename, json_encode($metadata,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE |
+            JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK))
+            or die("Error writing project metadata to $filename.");
+    }
+}
 
 function archive_ancillary_data_for_project_etc( $project, $indent, $dry_run )
 // Archive the ancillary info relating to $project
@@ -112,7 +145,7 @@ function archive_ancillary_data_for_project( $project, $indent, $dry_run )
         return;
     }
 
-    if ( does_project_page_table_exist($projectid) == FALSE )
+    if ( does_project_page_table_exist($projectid) == FALSE || $dry_run )
     {
         // project's page table doesn't exist.
         // Good, that's consistent with it having archived='1'
@@ -233,4 +266,3 @@ function archival_skip_logs_dump()
 }
 
 // vim: sw=4 ts=4 expandtab
-?>


### PR DESCRIPTION
Previously, OLS (aka [dpcatalog](https://github.com/DistributedProofreaders/dpcatalog)) required database access to look up project metadata for cataloging. It's far simpler and more secure to include the metadata in a structured format with projects when they are archived so everything needed to catalog the projects are stored on the filesystem.

Another option would be for OLS to use the new DP API to look up this information, but having everything on a filesystem is far easier.

I tested this by archiving a project on TEST through the crontab. Here's the resulting [metadata.json](https://www.pgdp.org/out/projectID44dcf826adaa1/metadata.json). I then ran the upgrade script against a project that was already in `/out` but did not have the metadata file and [one was created](https://www.pgdp.org/out/projectID44ddab5945a9e/metadata.json).