### PR TITLE
Add volunteer cert info to new user email

### DIFF
--- a/pinc/new_user_mails.inc
+++ b/pinc/new_user_mails.inc
@@ -161,6 +161,15 @@ and browse the resources in our Information for New and
 Returning Volunteers area at
 $dp_wiki_url/DP_Official_Documentation:General#Information_For_New_and_Returning_Volunteers
 
+
+Certification of Volunteer Work
+-------------------------------
+
+$site_name tracks only the number of pages proofread. We
+does not track the amount of time our volunteers spend working on those
+pages. For further information, see "Certification of Volunteer Work":
+$dp_wiki_url/DP_Official_Documentation:General/Certification_of_Volunteer_Work
+
 -------------------------
 
 Thank you again for joining $site_name. Every page you work on


### PR DESCRIPTION
At the request of the GM: Add a paragraph that provides a pointer for new users to information on certification of volunteer work. A larger percentage than before of new volunteers seem to be students needing to do volunteer work.

If you need to, you can test it in the [update-welcome-email](https://www.pgdp.org/~srjfoo/c.branch/update-welcome-email) sandbox.