### PR TITLE
Don't use absolute for split

### DIFF
--- a/SETUP/tests/manual_web/split_test/index.html
+++ b/SETUP/tests/manual_web/split_test/index.html
@@ -13,14 +13,5 @@
   <li><a href="switchable_split.php">Switchable between horizontal and vertical split with indicator for split percentage changes</a></li>
   <li><a href="vertical_horizontal_split_flex.php">Vertical and Horizontal Split with text in a textarea and different splitter bar colours and widths</a></li>
 </ul>
-<h2>Implementation notes</h2>
-<p>
-If window resize can cause the size of the splitter area to change then the body must have style 'overflow: hidden'. This is necessary because
-the panes are absolutely positioned with sizes calculated from the size of their container.
-When the container becomes smaller as a result of resizing the window we recalculate the size of the panes.
-But this does not happen until after the browser has redrawn the layout based on the information it already has. If overflow is not hidden it will put in scroll bars.
-These would make the client size of the container even smaller.
-The recalculated sizes will be smaller so the scroll bars will then not appear but empty areas will appear instead.
-</p>
 </body>
 </html>

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -70,7 +70,7 @@ var splitControl = function(container, config) {
         if (splitPos > maxPos) {
             splitPos = maxPos;
         }
-        pane2.css('flex',  1);
+        pane2.css('flex', 1);
         if (theConfig.splitVertical) {
             container.css({display: 'flex', flexDirection: 'row'});
             pane1.width(splitPos - base);

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -50,15 +50,13 @@ var splitControl = function(container, config) {
     container = $(container);
 
     let children = container.children();
-    let pane1 = $(children[0]).css({"position": "absolute"});
-    let pane2 = $(children[1]).css({"position": "absolute"});
+    let pane1 = $(children[0]);
+    let pane2 = $(children[1]);
 
-    let dragBar = $("<div>").css({"background-color": theConfig.dragBarColor, "position": "absolute"});
+    let dragBar = $("<div>").css({"background-color": theConfig.dragBarColor});
     pane1.after(dragBar);
 
     // coordinates of the container
-    let divTop;
-    let divLeft;
     let height;
     let width;
 
@@ -72,44 +70,38 @@ var splitControl = function(container, config) {
         if (splitPos > maxPos) {
             splitPos = maxPos;
         }
-        let splitPlusDrag = splitPos + theConfig.dragBarSize;
+        pane2.css('flex',  1);
         if (theConfig.splitVertical) {
+            container.css({display: 'flex', flexDirection: 'row'});
             pane1.width(splitPos - base);
-            dragBar.offset({top: divTop, left: splitPos});
-            pane2.offset({top: divTop, left: splitPlusDrag});
-            pane2.width(width + divLeft - splitPlusDrag);
+            pane1.height('');
         } else {
+            container.css({display: 'flex', flexDirection: 'column'});
             pane1.height(splitPos - base);
-            dragBar.offset({top: splitPos, left: divLeft});
-            pane2.height(height + divTop - splitPlusDrag);
-            pane2.offset({top: splitPlusDrag, left: divLeft});
+            pane1.width('');
         }
         reSize.fire();
     }
 
     function reLayout() {
+        container.css('overflow', 'hidden');
         height = container.height();
         width = container.width();
         let containerOffset = container.offset();
-        divTop = containerOffset.top;
-        divLeft = containerOffset.left;
-        pane1.offset(containerOffset);
+        let divTop = containerOffset.top;
+        let divLeft = containerOffset.left;
         if (theConfig.splitVertical) {
             range = width;
             base = divLeft;
-            pane1.height(height);
-            pane2.height(height);
-            dragBar.height(height);
+            dragBar.height('100%');
             dragBar.width(theConfig.dragBarSize);
             dragBar.css("cursor", "ew-resize");
         } else {
             range = height;
             base = divTop;
-            pane1.width(width);
-            pane2.width(width);
-            dragBar.width(width);
-            dragBar.css("cursor", "ns-resize");
             dragBar.height(theConfig.dragBarSize);
+            dragBar.width('100%');
+            dragBar.css("cursor", "ns-resize");
         }
         range -= theConfig.dragBarSize;
         minPos = base;


### PR DESCRIPTION
I was experimenting replacing some of the <frameset>s with splitControl, but noticed it used absolute positioning. I figured we could do this with flex.

I really want @70ray's input here and not trying to step on your toes. Just a minor tweak to your major contribution.

I deployed here and you can check it out here:
https://www.pgdp.org/~chrismiceli/c.branch/flexSplit/tools/page_browser.php?project=projectID5e23ae7ff0a81&mode=imageText&imagefile=016.png
or in the manual test pages:
https://www.pgdp.org/~chrismiceli/c.branch/flexSplit/SETUP/tests/manual_web/split_test/index.html

If we do accept this PR, we'll need to update the text here: https://github.com/DistributedProofreaders/dproofreaders/blob/master/SETUP/tests/manual_web/split_test/index.html#L19