### PR TITLE
Darken announcement-medium on default themes

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -501,7 +501,7 @@ hr.divider {
 @news-border: @border-color-base-lowc;
 @news-normal: @page-text;
 @news-announce-high: maroon;
-@news-announce-medium: orange;
+@news-announce-medium: darkorange;
 @news-announce-low: darkblue;
 @news-celebrate: green;
 @news-maintain: red;

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -173,7 +173,7 @@ select {
 @news-border: #787878;
 @news-normal: #ababab;
 @news-announce-high: #df206c;
-// @news-announce-medium:
+@news-announce-medium: orange;
 @news-announce-low: #8080ff;
 @news-celebrate: #17cf17;
 @news-maintain: #f53d3d;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1503,7 +1503,7 @@ div.newsitem img {
   color: maroon;
 }
 .news-announcement2 {
-  color: orange;
+  color: darkorange;
 }
 .news-announcement3 {
   color: darkblue;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1503,7 +1503,7 @@ div.newsitem img {
   color: maroon;
 }
 .news-announcement2 {
-  color: orange;
+  color: darkorange;
 }
 .news-announcement3 {
   color: darkblue;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1503,7 +1503,7 @@ div.newsitem img {
   color: maroon;
 }
 .news-announcement2 {
-  color: orange;
+  color: darkorange;
 }
 .news-announcement3 {
   color: darkblue;


### PR DESCRIPTION
After settling in a while, the standard orange used for the medium level news announcement was determined to be too light. Switched to darkorange for defaults, and added orange for charcoal theme, as the normal orange looks fine there.

Viewable in the [update-news-color](https://www.pgdp.org/~srjfoo/c.branch/update-news-color/tools/post_proofers/smooth_reading.php) sandbox. Compare with the [main test site](https://www.pgdp.org/c/tools/post_proofers/smooth_reading.php).