### PR TITLE
New character suite: Symbols collection

### DIFF
--- a/SETUP/UNICODE.md
+++ b/SETUP/UNICODE.md
@@ -42,7 +42,7 @@ that are shown to the users in the proofreading interface character picker.
 Picker sets are optional and, if they are used, need not cover the entire set
 of codepoints in the character suite.
 
-The code currently ships with 4 character suites:
+The code currently ships with the following character suites:
 
 * Basic Latin - characters contained within ISO-8859-1 and CP-1252
 * Extended European Latin A - Esperanto, Welsh, Sami, Romanian, Hungarian
@@ -52,6 +52,7 @@ The code currently ships with 4 character suites:
 * Polytonic Greek
 * Medievalist supplement - for transcription/analysis of medieval writings
 * Semitic and Indic transcriptions - Romanized forms of Arabic, Hebrew, Sanskrit
+* Symbols collection - Astronomical, Music, Zodiac and Apothecary symbols
 
 All character suites can be viewed using the [All Character Suites](../tools/charsuites.php)
 page.

--- a/pinc/charsuite-symbols-collection.inc
+++ b/pinc/charsuite-symbols-collection.inc
@@ -1,0 +1,53 @@
+<?php
+include_once($relPath."CharSuites.inc");
+
+$charsuite = new CharSuite("symbols-collection", _("Symbols collection"));
+$charsuite->description = _("Astronomical, zodiac, and a limited number of apothecary and music symbols. The zodiac symbols are provided with the variation selector, VS15, to try to force them to display as ordinary charcters instead of as emoji. This may not work for all fonts.");
+
+$charsuite->codepoints = [
+    'U+0292',
+    'U+2108',
+    'U+2114',
+    'U+211e',
+    'U+2125',
+    'U+2609-U+260d',
+    'U+263d-U+2646',
+    'U+2648>U+fe0e',
+    'U+2649>U+fe0e',
+    'U+264a>U+fe0e',
+    'U+264b>U+fe0e',
+    'U+264c>U+fe0e',
+    'U+264d>U+fe0e',
+    'U+264e>U+fe0e',
+    'U+264f>U+fe0e',
+    'U+2650>U+fe0e',
+    'U+2651>U+fe0e',
+    'U+2652>U+fe0e',
+    'U+2653>U+fe0e',
+    'U+2669-U+266a',
+    'U+266d-U+266f',
+];
+
+$charsuite->reference_urls = [
+    "https://www.pgdp.net/wiki/Symbols_collection",
+];
+
+$pickerset = new PickerSet();
+
+$pickerset->add_subset(utf8_chr("U+263d"), [
+    [ 'U+2609', 'U+263d', 'U+263f', 'U+2641', 'U+2643', 'U+2645', 'U+260a',
+      'U+260c', 'U+266e', 'U+266d', 'U+266f' ],
+    [ NULL, 'U+263e', 'U+2640', 'U+2642', 'U+2644', 'U+2646', 'U+260b',
+      'U+260d', NULL, 'U+2669-U+266a' ],
+], _("Astronomical and music symbols"));
+
+$pickerset->add_subset(utf8_combined_chr("U+2648>U+fe0e"), [
+    [ 'U+2648>U+fe0e', 'U+2649>U+fe0e', 'U+264a>U+fe0e', 'U+264b>U+fe0e',
+      'U+264c>U+fe0e', 'U+264d>U+fe0e', 'U+211e', 'U+0292', 'U+2108' ],
+    [ 'U+264e>U+fe0e', 'U+264f>U+fe0e', 'U+2650>U+fe0e', 'U+2651>U+fe0e',
+      'U+2652>U+fe0e', 'U+2653>U+fe0e', NULL, 'U+2125', 'U+2114' ],
+], _("Zodiac and apothecary symbols"));
+
+$charsuite->pickerset = $pickerset;
+
+CharSuites::add($charsuite);


### PR DESCRIPTION
Character suite `symbols-collection`, contains astronomical, zodiac, apothecary and music symbols, grouped into two picker sets. The Zodiac symbols are combined with the VS15 variation selector to try
to force them to appear as normal type instead of as emoji, though this does not work in all cases.

Character suite can be viewed at [symbols-collection](https://www.pgdp.org/~srjfoo/c.branch/symbols-collection/tools/charsuites.php?charsuite=symbols-collection); used in a project at [Elegantní Tanecník - WordCheck Testing](https://www.pgdp.org/~srjfoo/c.branch/symbols-collection/project.php?id=projectID47127a26a1f9b&expected_state=P1.proj_avail).
