### PR TITLE
Encode Astral characters in phpBB 3.3.x subjects

### DIFF
--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -242,6 +242,12 @@ function _insert_post(
     //       $type_cast_helper->set_var() in phpBB3/phpbb/request/type_cast_helper.php
     $subject = htmlspecialchars($subject, ENT_COMPAT, 'UTF-8', false);
 
+    // phpBB 3.3.x does some munging for Astral characters in phpBB3/posting.php
+    if(function_exists('utf8_encode_ucr'))
+    {
+        $subject = utf8_encode_ucr($subject);
+    }
+
     $poll = $uid = $bitfield = $options = '';
     generate_text_for_storage($text, $uid, $bitfield, $options, true, true, true);
 


### PR DESCRIPTION
phpBB 3.3.x supports Astral characters (like emojis) in posts, but they need to be encoded correctly for topic subjects. This is most easily seen in the phpBB's [posting.php](https://github.com/phpbb/phpbb/blob/master/phpBB/posting.php#L762) file.

The `utf8_encode_ucr()` function doesn't exist in phpBB 3.2.x so this should be safe for those versions (which is also what is running on PROD right now).

Testable in the [astral-forum-subjects](https://www.pgdp.org/~cpeel/c.branch/astral-forum-subjects/) sandbox.

[Task 1886](https://www.pgdp.net/c/tasks.php?task_id=1886)