### PR TITLE
Sanitize HTML with htmlpurifier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 pinc/3rdparty
+vendor

--- a/SETUP/check_require_login.php
+++ b/SETUP/check_require_login.php
@@ -109,18 +109,18 @@ $ok_files = [
 $files = get_all_php_files("../");
 foreach($files as $file)
 {
-    echo "$file\n";
-
-    # If it requires authentication, skip it
-    if(file_requires_auth("../$file"))
-        continue;
-
     # If it's in the SETUP directory, skip it
     if(startswith($file, "SETUP/"))
         continue;
 
     # If it's in the vendor directory, skip it
     if(startswith($file, "vendor/"))
+        continue;
+
+    echo "$file\n";
+
+    # If it requires authentication, skip it
+    if(file_requires_auth("../$file"))
         continue;
 
     # If it's on the OK list, skip it

--- a/SETUP/lint_json_files.sh
+++ b/SETUP/lint_json_files.sh
@@ -11,9 +11,9 @@ else
     exit 1
 fi
 
-echo "Checking all .json files under $BASE_DIR excluding node_modules for linting errors..."
+echo "Checking all .json files under $BASE_DIR excluding node_modules/ and vendor/ for linting errors..."
 
-for file in `find $BASE_DIR -name "*.json" -not -path "*/node_modules/*"`; do
+for file in $(find $BASE_DIR -name "*.json" -not -path "*/node_modules/*" -not -path "*/vendor/*"); do
     echo $file
     OUTPUT=$(php -r "exit(json_decode(file_get_contents('$file')) === NULL);" 2>&1)
     if [ $? -ne 0 -o "$OUTPUT" = '1' ]; then

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "stable",
     "require": {
+        "ezyang/htmlpurifier" : "v4.*",
         "erusev/parsedown": "1.8.0-beta-7",
         "erusev/parsedown-extra": "0.8.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90dddb39371b0ddc80bb0922ff9ebb02",
+    "content-hash": "9384df1c6aed9fe67abafceb302d5a8d",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -101,6 +101,56 @@
                 "parser"
             ],
             "time": "2019-12-29T11:14:16+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "dev-master#72de02a7b80c6bb8864ef9bf66d41d2f58f826bd"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "time": "2020-06-29T00:56:53+00:00"
         }
     ],
     "packages-dev": [],

--- a/pinc/authors.inc
+++ b/pinc/authors.inc
@@ -23,7 +23,7 @@ function get_biography($id) {
         }
         else
         {
-            $bio_text = $row["bio"];
+            $bio_text = sanitize_html($row["bio"], 'td');
         }
 
         // wrap in commentaries and return

--- a/pinc/comment_inclusions.inc
+++ b/pinc/comment_inclusions.inc
@@ -10,7 +10,7 @@ function parse_project_comments($project) {
     global $relPath;
 
     if ($project->comment_format == 'html') {
-        $comments = $project->comments;
+        $comments = sanitize_html($project->comments, 'td');
     } else {
         $Parsedown = new ParsedownExtra();
         $Parsedown->setSafeMode(true);

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -464,6 +464,22 @@ function javascript_safe($str, $encoding=NULL)
 
 // -----------------------------------------------------------------------------
 
+// Use HTMLPurifier to sanitize HTML
+function sanitize_html($html, $parent_tag='div')
+{
+    $config = HTMLPurifier_Config::createDefault();
+    $config->set('HTML.Parent', $parent_tag);
+    $config->set('Attr.EnableID', true);
+    $config->set('CSS.AllowTricky', true);
+    $config->set('CSS.MaxImgLength', null);
+    $config->set('Cache.SerializerPath', sys_get_temp_dir());
+
+    $purifier = new HTMLPurifier($config);
+    return $purifier->purify($html);
+}
+
+// -----------------------------------------------------------------------------
+
 function normalize_whitespace($str)
 // Return a string with normalized whitespace characters.
 //


### PR DESCRIPTION
Sanitize HTML-formatted content from users with htmlpurifier before presenting it to the user.

This is the same HTML sanitizer already hacked into TEST and PROD, this just pulls it into the codebase officially via composer.

Testable in the [use-htmlpurifier](https://www.pgdp.org/~cpeel/c.branch/use-htmlpurifier) sandbox.

Fixes https://github.com/DistributedProofreaders/dproofreaders/issues/563