### PR TITLE
Notify PMs about holds preventing projects from transitioning

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -3,6 +3,10 @@
 Major changes to this project are documented here. For minor changes,
 see the git history.
 
+## R??????
+Scripts supporting this upgrade are in `SETUP/upgrade/16`
+
+
 ## R202102
 Scripts supporting this upgrade are in `SETUP/upgrade/15`
 

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -324,6 +324,7 @@ CREATE TABLE `project_charsuites` (
 CREATE TABLE `project_holds` (
   `projectid` varchar(22) NOT NULL,
   `state` varchar(50) NOT NULL,
+  `notify_time` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`projectid`,`state`)
 );
 # --------------------------------------------------------

--- a/SETUP/upgrade/16/20210214_alter_project_holds
+++ b/SETUP/upgrade/16/20210214_alter_project_holds
@@ -1,0 +1,23 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding column to project holds..\n";
+$sql = "
+    ALTER TABLE project_holds
+        ADD COLUMN notify_time int not null default 0
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1002,6 +1002,20 @@ XML;
         }
         return FALSE;
     }
+
+    // get time for last page proofread in round
+    public function get_last_proofread_time($round)
+    {
+        validate_projectID($this->projectid);
+        $sql = sprintf("
+            SELECT max({$round->time_column_name})
+            FROM $this->projectid
+            WHERE state = '%s'
+        ", DPDatabase::escape($round->page_save_state));
+        $res = DPDatabase::query($sql);
+        list($last_proofread) = mysqli_fetch_row($res);
+        return $last_proofread;
+    }
     
     public function check_pages_table_exists(&$message)
     {

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -834,7 +834,7 @@ EOS;
         $values = [];
         foreach ($states as $state)
         {
-            $values[] = sprintf("('%s', '%s')",
+            $values[] = sprintf("('%s', '%s', 0)",
                 DPDatabase::escape($this->projectid),
                 DPDatabase::escape($state)
             );
@@ -852,10 +852,14 @@ EOS;
     {
         global $pguser;
 
+        // We need to pre-escape the projectID because states can have
+        // %'s in them which mess up sprintf() if used with our pre-built
+        // $state_values
         $projectid_clause = sprintf(
             "projectid='%s'",
             DPDatabase::escape($this->projectid)
         );
+
         $state_values = [];
         foreach ($states as $state) {
             $state_values[] = sprintf("'%s'", DPDatabase::escape($state));
@@ -869,6 +873,69 @@ EOS;
         ";
         DPDatabase::query($sql);
         log_project_event($this->projectid, $pguser, 'remove_holds', join(' ', $states));
+    }
+
+    public function get_hold_state_notify_time($state)
+    {
+        $sql = sprintf("
+            SELECT notify_time
+            FROM project_holds
+            WHERE projectid = '%s'
+                AND state = '%s'
+        ", DPDatabase::escape($this->projectid), DPDatabase::escape($state));
+        $res = DPDatabase::query($sql);
+        list($notify_time) = mysqli_fetch_row($res);
+        return $notify_time;
+    }
+
+    public function update_hold_state_notify_time($state, $timestamp=NULL)
+    {
+        $notify_time = $timestamp === NULL ? time() : sprintf("%d", $timestamp);
+
+        $sql = sprintf("
+            UPDATE project_holds
+            SET notify_time = $notify_time
+            WHERE
+                projectid = '%s'
+                AND state = '%s'
+        ", DPDatabase::escape($this->projectid), DPDatabase::escape($state));
+        DPDatabase::query($sql);
+    }
+
+    public function send_hold_state_notification($state)
+    {
+        configure_gettext_for_user($this->username);
+        maybe_mail_project_manager(
+            $this,
+            sprintf(_("This project is unable to transition out of %s because it is held. Please review the project and remove the hold. You will receive this notification only once unless you remove and re-add the hold or another page is proofread."), $state),
+            _("Project Held"));
+        configure_gettext_for_user();
+
+        $this->update_hold_state_notify_time($state);
+    }
+
+    public function is_hold_notification_required($state)
+    {
+        // if there is no project hold on this state, no notification is required
+        if (!in_array($state, $this->get_hold_states())) {
+            return FALSE;
+        }
+
+        // if the PM has not been notified, notification is required
+        $notify_time = $this->get_hold_state_notify_time($state);
+        if (!$notify_time) {
+            return TRUE;
+        }
+
+        // if the PM has been notified, but that was before the last page
+        // was saved, reset the notification and send them another one
+        $round = get_Round_for_project_state($state);
+        if ($notify_time < $this->get_last_proofread_time($round)) {
+            $this->update_hold_state_notify_time($state, 0);
+            return TRUE;
+        }
+
+        return FALSE;
     }
 
     // -------------------------------------------------------------------------

--- a/pinc/maybe_mail.inc
+++ b/pinc/maybe_mail.inc
@@ -83,6 +83,7 @@ function maybe_mail_project_manager( $project, $info, $prefix)
         sprintf(_("Hello %s,"), $username),
         $project->email_introduction(),
         $info,
+        "",  // spacer for a blank line
         sprintf(_("Thank you for volunteering with %s!"), $site_name),
     ]);
 

--- a/project.php
+++ b/project.php
@@ -553,18 +553,10 @@ function do_project_info_table()
 
     if ($round)
     {
-        $sql = "
-            SELECT {$round->time_column_name}
-            FROM $projectid
-            WHERE state='{$round->page_save_state}'
-            ORDER BY {$round->time_column_name} DESC
-            LIMIT 1
-        ";
-        $proofdate = DPDatabase::query($sql);
-        $row = mysqli_fetch_assoc($proofdate);
-        if ($row)
+        $last_proofread_time = $project->get_last_proofread_time($round);
+        if ($last_proofread_time)
         {
-            $lastproofed = strftime($datetime_format, $row[$round->time_column_name]);
+            $lastproofed = strftime($datetime_format, $last_proofread_time);
         }
         else
         {

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -271,6 +271,14 @@ while ( list($projectid) = mysqli_fetch_row($allprojects) ) {
                     echo "    Normally, this project would now advance to {$round->project_complete_state},\n";
                     echo "    but it has a hold in $state, so it stays where it is.\n";
                 }
+                if ($project->is_hold_notification_required($state)) {
+                    // Note that notifications are only sent for Available
+                    // states, as this if() block is only reached for those.
+                    if ($verbose) {
+                        echo "    Sending notification about held project.\n";
+                    }
+                    $project->send_hold_state_notification($state);
+                }
                 continue;
             }
 


### PR DESCRIPTION
Per GM / Squirrel request: This adds a notification to the PM when automodify attempts to transition a project but is unable to do so because there is a hold on the project. This is for all project holds, not just holds in Available.

A PM will only get one email unless the hold is removed and re-added, or if a proofreader later proofreads a new page. The latter is to address the scenario where:
1. The project has a hold for Available
2. The project is prevented from transitioning and the PM is notified
3. The PM clears some pages but does not remove the hold
4. Proofreaders proofread more pages
5. The project is (again) prevented from transitioning.

This is testable in the [notify-held-projects](https://www.pgdp.org/~cpeel/c.branch/notify-held-projects/) sandbox. We might need to add some special logging since emails aren't sent out from TEST.

This doesn't address the request for the projects to be moved to Unavailable after a certain period of time. That work will build on top of this.