### PR TITLE
Automodify cleanup

### DIFF
--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -387,17 +387,10 @@ class LPage
         configure_gettext_for_user();
 
         // Now determine whether the project as a whole should be marked bad.
-        // We need 10 or more bad pages reported by 3 or more distinct users.
-        // (Note duplication of code with pages_indicate_bad_project() in automodify.php)
-
         $project = new Project($this->projectid);
-
-        $n_bad_pages = $project->get_num_pages_in_state($this->round->page_bad_state);
-        if ( $n_bad_pages < 10 ) return FALSE;
-
-        $n_distinct_reporters = $project->get_num_pages_in_state(
-            $this->round->page_bad_state, "DISTINCT(b_user)");
-        if ($n_distinct_reporters < 3) return FALSE;
+        if(!$project->is_bad_from_pages($this->round)) {
+            return FALSE;
+        }
 
         $error_msg = project_transition( $this->projectid, $this->round->project_bad_state, PT_AUTO );
         if ($error_msg)

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -554,6 +554,23 @@ class Project
         return $this->can_be_managed_by_current_user || $this->PPer_is_current_user;
     }
 
+    function is_bad_from_pages($round)
+    {
+        // If it has at least 10 bad pages, reported by at least 3
+        // different users, it's bad.
+        $n_bad_pages = $this->get_num_pages_in_state($round->page_bad_state);
+        $n_unique_reporters = $this->get_num_pages_in_state(
+            $round->page_bad_state,
+            "DISTINCT(b_user)"
+        );
+
+        if ($n_bad_pages >= 10 && $n_unique_reporters >= 3) {
+            return TRUE;
+        }
+
+        return FALSE;
+    }
+
     function get_num_pages_in_state($state=NULL, $counter_sql="*")
     {
         if(!$this->pages_table_exists) {

--- a/pinc/job_log.inc
+++ b/pinc/job_log.inc
@@ -1,0 +1,19 @@
+<?php
+
+function insert_job_log_entry($filename, $event, $comments, $tracetime=NULL)
+{
+    if(!$tracetime) {
+        $tracetime = time();
+    }
+
+    $sql = sprintf("
+        INSERT INTO job_logs (filename, tracetime, event, comments)
+        VALUES ('%s', %d, '%s', '%s')
+    ",
+        DPDatabase::escape($filename),
+        $tracetime,
+        DPDatabase::escape($event),
+        DPDatabase::escape($comments)
+    );
+    DPDatabase::query($sql);
+}

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -48,38 +48,6 @@ $trace = FALSE;
 
 // -----------------------------------------------------------------------------
 
-function pages_indicate_bad_project( $project, $round )
-// Do the states of the project's pages (in the given round)
-// indicate that the project is bad?
-{
-    global $trace;
-
-    // (Note duplication of code with LPage::markAsBad in LPage.inc)
-
-    // If it has no bad pages, it's good.
-    //
-    $n_bad_pages = $project->get_num_pages_in_state($round->page_bad_state);
-    if ($trace) echo "n_bad_pages = $n_bad_pages\n";
-    //
-    if ($n_bad_pages == 0) return FALSE;
-
-
-    // If it has at least 10 bad pages,
-    // reported by at least 3 different users, it's bad.
-    //
-    $n_unique_reporters = $project->get_num_pages_in_state($round->page_bad_state, "DISTINCT(b_user)");
-    if ($trace) echo "n_unique_reporters = $n_unique_reporters\n";
-    //
-    if ($n_bad_pages >= 10 && $n_unique_reporters >= 3) return TRUE;
-
-
-    // Otherwise, it's good.
-    //
-    return FALSE;
-}
-
-// -----------------------------------------------------------------------------
-
 $have_echoed_blurb_for_this_project = 0;
 
 function ensure_project_blurb( $project )
@@ -166,7 +134,7 @@ while ( list($projectid) = mysqli_fetch_row($allprojects) ) {
     {
         if ( ($state == $round->project_available_state) || ($state == $round->project_bad_state) )
         {
-            if ( pages_indicate_bad_project( $project, $round ) )
+            if ($project->is_bad_from_pages($round))
             {
                 // This project's pages indicate that it's bad.
                 // If it isn't marked as such, make it so.


### PR DESCRIPTION
Move the bad project detection into the Project class so the definition is in one place and not two. Move `job_log` table inserts into a central function instead of doing it in multiple places. And finally some small automodify cleanup. (All in separate commits.)

This should have zero visible changes to the user, database, or log files.

Available in the [automodify-cleanup](https://www.pgdp.org/~cpeel/c.branch/automodify-cleanup/) sandbox.