### PR TITLE
Fix various small errors found in php_errors

### DIFF
--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -388,17 +388,18 @@ function show_project_listing(
         "days_since_visit" => "text-align: right;",
     );
 
-    // Determine whether to use special colors or not.
+    // Load the sort column and direction
+    list($curr_sql_sort_col, $curr_sql_sort_dir) =
+        process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setting_name, $default_ext_sort);
+
+    // Determine whether to use special colors or not. Do this after we process
+    // sorting controls since we can't order by specialday.
     // Visitors always see special colors.
     $userSettings =& Settings::get_Settings($pguser);
     if(!isset($pguser) || !$userSettings->get_boolean('hide_special_colors'))
     {
         $columns = array_merge(["specialday" => ['SpecialDay', '']], $columns);
     }
-
-    // Load the sort column and direction
-    list($curr_sql_sort_col, $curr_sql_sort_dir) =
-        process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setting_name, $default_ext_sort);
 
     // sort on translated column if genre
     $trans_sort_col = $curr_sql_sort_col;

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -23,7 +23,7 @@ define("RESUMABLE_UPLOAD_SIZE", 1024 * 1024 * 1024);  // 1GB
 function detect_too_large()
 {
     if($_SERVER['REQUEST_METHOD'] == 'POST' && empty($_POST) &&
-        empty($_FILES) && $_SERVER['CONTENT_LENGTH'] > 0)
+        empty($_FILES) && array_get($_SERVER, 'CONTENT_LENGTH', 0) > 0)
     {
         die( sprintf(_("Uploaded file is too large. Maximum file size is %s."), humanize_bytes(get_max_upload_size())));
     }

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -54,7 +54,7 @@ function ensure_project_blurb( $project )
 {
     static $project_blurb_echoed = [];
 
-    if ( !isset($project_blurb_echoed[$project->id]) )
+    if ( !isset($project_blurb_echoed[$project->projectid]) )
     {
         echo "\n";
         echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n";
@@ -62,7 +62,7 @@ function ensure_project_blurb( $project )
         echo "nameofwork = \"" . html_safe($project->nameofwork) . "\"\n";
         echo "state      = {$project->state}\n";
         echo "\n";
-        $project_blurb_echoed[$project->id] = true;
+        $project_blurb_echoed[$project->projectid] = true;
     }
 }
 

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -337,7 +337,7 @@ function do_upload()
     {
         if(is_file($temporary_path))
         {
-            unlink($temporary_path);
+            @unlink($temporary_path);
         }
         echo "<p class='error'>", $e->getMessage(), "</p>\n";
     }

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -110,7 +110,7 @@ function list_images( $project, $image_names, $these_are_page_images )
     echo "<h4 class='center-align'>$header</h4>";
 
     $show_replace_links = $project->can_be_managed_by_current_user;
-    $show_delete_links = !$these_are_page_images && ($project->state == PROJ_NEW || $project->state == PROJ_P1_UNAVAILABLE);
+    $show_delete_links = $project->can_be_managed_by_current_user && !$these_are_page_images && ($project->state == PROJ_NEW || $project->state == PROJ_P1_UNAVAILABLE);
 
     echo "<table>\n";
 
@@ -214,7 +214,7 @@ function show_delete_all_link( $project, $image_names )
 {
     global $code_url;
 
-    if(($project->state == PROJ_NEW || $project->state == PROJ_P1_UNAVAILABLE) && !empty($image_names))
+    if($project->can_be_managed_by_current_user && ($project->state == PROJ_NEW || $project->state == PROJ_P1_UNAVAILABLE) && !empty($image_names))
     {
         $form_target="$code_url/tools/project_manager/update_illos.php";
         $submit_label=_("Delete Illustrations");

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -142,7 +142,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
                 $replaceString = "";
 
                 // if the AW button is wanted, add the initial span
-                if($badWordHash[$word] == WC_WORLD ) {
+                if(@$badWordHash[$word] == WC_WORLD ) {
                     $replaceString .= "<span id='$wordID'>";
                     $onChange = " onBlur=\"markBox('$wordID');\"";
                     $onChange.= " oninput=\"disableAW('$wordID');\"";
@@ -157,7 +157,7 @@ function spellcheck_text( $orig_text, $projectid, $imagefile, $aux_language, $ac
                     "<input type='text' id='input_$wordID' name='sp$numBadWords' size='$textBoxLen' value='$wordSafe' class='proofingfont'$onChange>";
 
                 // if the AW button is wanted, add the closing span and the button
-                if($badWordHash[$word] == WC_WORLD ) {
+                if(@$badWordHash[$word] == WC_WORLD ) {
                     $replaceString .=
                         "<a href='#' id='a_$wordID' onClick=\"return acceptWord('$jsSanitizedWord','$wordCount[$word]');\">" .
                         "<img id='button_$wordID' src='$code_url/graphics/Book-Plus-Small.gif' title='" . attr_safe(_("Unflag All &amp; Suggest Word")) . "' class='aw'></a>" .


### PR DESCRIPTION
This addresses various small warnings and notices seen in `php_errors`. It also hides the Delete button for illustrations if the user does not have permissions to manage the project (this was reported in the forums).

Available in the [fix-errors](https://www.pgdp.org/~cpeel/c.branch/fix-errors/) sandbox (not a very creative branch title, I know).