### PR TITLE
Minor updates to error logging

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -88,7 +88,7 @@ if($create_user_status !== TRUE) {
     echo "\n";
     echo "<!-- Forum error: $create_user_status -->";
     echo "\n";
-    error_log("Error activating $ID: $create_user_status");
+    error_log("activate.php - Error activating $ID: $create_user_status");
     $mailto_url = "mailto:$general_help_email_addr";
     echo sprintf(
         _('For assistance, please contact <a href="%1$s">%2$s</a>.'),

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -259,7 +259,7 @@ function virus_check($file_path, $verbose)
     if ($av_retval == 1)
     {
         // Log the infected upload so that we can track user/frequency
-        $reporting_string = "Infected upload: " . $av_test_result[0];
+        $reporting_string = "upload_file.inc - Infected upload: " . $av_test_result[0];
         error_log($reporting_string);
         throw new FileUploadException(sprintf(_("AntiVirus: The scan reported an infection: %s. The upload has been discarded.
             You should perform a complete virus scan on your computer as soon as possible."), $av_test_result[0]));

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -325,12 +325,6 @@ function do_upload()
         }
 
         echo "<p>" . sprintf(_('File %1$s successfully uploaded to folder %2$s.'), html_safe($target_name), $hce_curr_displaypath), "</p>\n";
-
-        // Log the file upload
-        // In part so that we can possibly clean up with some automation later
-        $reporting_string = "DPSCANS: File uploaded to " . $target_path;
-        error_log($reporting_string);
-
     }
     // in php 7.1 the  two exceptions could be caught together
     catch(FileUploadException $e)

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -119,7 +119,7 @@ else
 
 function report_error($error)
 {
-    error_log($error);
+    error_log("upload_resumable_file.php - $error");
     http_response_code(500);
     echo $error;
 }


### PR DESCRIPTION
Preface all our `error_log()` calls with the name of the script to we know where it came from.

Remove the logging from `remote_file_manager.php` since it isn't an actual error.