### PR TITLE
Move linting and other static checks to GitHub Actions

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -31,6 +31,17 @@ jobs:
         run: sudo apt install aspell aspell-en
       - name: Run phpunit tests
         run: cd SETUP/tests && phpunit
+  linting:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: 7.4
+      - name: Lint code
+        run: cd SETUP && make lint_code && cd ..
   misc_checks:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -31,3 +31,24 @@ jobs:
         run: sudo apt install aspell aspell-en
       - name: Run phpunit tests
         run: cd SETUP/tests && phpunit
+  misc_checks:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: 7.4
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - name: Install NPM packages (for less)
+        run: npm install
+      - name: Run security checks
+        run: cd SETUP && make security_checks && cd ..
+      - name: Run charsuite checks
+        run: cd SETUP && make lint_charsuites && cd ..
+      - name: Run less/CSS checks
+        run: cd SETUP && make lint_css && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
-language: php
+language: node_js
 addons:
   firefox: latest
-php:
-    - 7.4
+node_js:
+  - 12
 before_script:
     # We need npm for eslint
-    - nvm install 12 --lts
     - npm install
 script:
-    - cd SETUP
     # linting is SUCH a low bar, but it is a bar!
-    - make lint_code
     - npm run lint
     # now lets get crazy and run our meager unit tests...
     - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ before_script:
     - npm install
 script:
     - cd SETUP
-    # do minimal security checks
-    - make security_checks
     # linting is SUCH a low bar, but it is a bar!
-    - make lint
+    - make lint_code
     - npm run lint
     # now lets get crazy and run our meager unit tests...
     - npm run test

--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all less security_checks lint tests
+.PHONY: all less security_checks lint_charsuites lint_css lint_code lint tests
 
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
@@ -12,11 +12,17 @@ security_checks:
 
 #----------------------------------------------------------------------------
 # File linting
-lint:
+lint_charsuites:
+	$(SELF_DIR)lint_charsuites.php $(SELF_DIR)..
+
+lint_css:
+	$(SELF_DIR)generate_css_from_less.sh --check $(SELF_DIR)../styles
+
+lint_code:
 	$(SELF_DIR)lint_php_files.sh $(SELF_DIR)..
 	$(SELF_DIR)lint_json_files.sh $(SELF_DIR)..
-	$(SELF_DIR)lint_charsuites.php $(SELF_DIR)..
-	$(SELF_DIR)generate_css_from_less.sh --check $(SELF_DIR)../styles
+
+lint: lint_charsuites lint_less lint_code
 
 #----------------------------------------------------------------------------
 # CSS compilation


### PR DESCRIPTION
This moves everything except npm unit tests to GitHub Actions (@chrismiceli is working on moving the unit tests). Until https://github.com/github/super-linter/issues/1288 is fixed we use our current linting method for PHP and JSON. When that is fixed we can move the `linting` job over to super-linter which will help us with more advanced linting in the future.

You can see an example of what this validation looks like at https://github.com/cpeel/dproofreaders/actions/runs/616025652