### PR TITLE
Remove unused WordCheck tool settings

### DIFF
--- a/SETUP/upgrade/16/20210306_clean_usersettings.php
+++ b/SETUP/upgrade/16/20210306_clean_usersettings.php
@@ -1,0 +1,24 @@
+<?php
+$relPath='../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Delete unused settings from usersettings..\n";
+$sql = "
+    DELETE FROM usersettings
+        WHERE setting = 'show_word_context_layout' OR
+            setting = 'show_good_words_layout'
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die( mysqli_error(DPDatabase::get_connection()) );
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
WordCheck tool layout is now saved in local browser web storage rather than in the database.