### PR TITLE
Fix scNoCap error criterion in format preview

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -257,6 +257,12 @@ QUnit.module("Format preview test", function() {
         issueTest(assert, 0, 0, 4, "scNoCap", 1);
     });
 
+    QUnit.test("small cap fragment with no capitals, possible issue", function (assert) {
+        text = "<sc>*abcd</sc>";
+        issArray = analyse(text, configuration);
+        issueTest(assert, 0, 4, 1, "scNoCap", 0);
+    });
+
     QUnit.test("small cap text with capitals only in comment, possible issue", function (assert) {
         text = "<sc>abcd[** ABCD]</sc>";
         issArray = analyse(text, configuration);

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -384,12 +384,12 @@ $(function () {
                     continue;
                 }
                 res1 = result[1];
-                if (res1 === res1.toLowerCase()) { //no upper case found - definite
+                if (res1 === res1.toLowerCase() && res1.charAt(0) !== "*") { // no upper case found - definite
                     reportIssue(result.index, 4, "scNoCap", 1);
                     continue;
                 }
                 res1 = removeComments(res1);
-                if (res1 === res1.toLowerCase()) { //upper case was in a note - poss
+                if (res1 === res1.toLowerCase()) { // either a lowercase fragment, or upper case was in a note - poss
                 // mark only a text char incase no tags shown
                     reportIssue(result.index + 4, 1, "scNoCap", 0);
                 }


### PR DESCRIPTION
This change downgrades the scNoCap error into a warning when the text within the tags begins with an asterisk. This allows for cases where a word typed in small caps is fragmented over multiple pages or footnotes. I stumbled across this while formatting the other day, and I figured it would be a relatively trivial fix.