### PR TITLE
Work around portable-utf8 bug by using escape sequences in regex

### DIFF
--- a/SETUP/lint_charsuites.php
+++ b/SETUP/lint_charsuites.php
@@ -15,13 +15,21 @@ foreach(CharSuites::get_all() as $charsuite)
     echo "Validating charsuite $charsuite->name...\n";
 
     // Validate that codepoint specifiers don't include both a range and a
-    // combining character.
+    // combining character. And that all ranges are low to high.
     foreach($charsuite->codepoints as $codepoint)
     {
         if(stripos($codepoint, "-") !== FALSE && stripos($codepoint, ">") !== FALSE)
         {
             echo sprintf("ERROR: %s codepoint has both a range and a combining character\n", $codepoint);
             exit(1);
+        }
+
+        if (stripos($codepoint, "-") !== FALSE) {
+            list($start, $end) = explode('-', $codepoint);
+            if ($start > $end) {
+                echo sprintf("ERROR: %s codepoint range start is greater than range end\n", $codepoint);
+                exit(1);
+            }
         }
     }
 

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -132,7 +132,7 @@ function string_to_codepoints_string($string, $imploder=" ")
 # Filter to only characters in $string that are in $valid_codepoints.
 function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement="")
 {
-    $pattern_string = build_character_regex_filter($valid_codepoints, '/');
+    $pattern_string = build_character_regex_filter($valid_codepoints);
     $result = "";
     foreach(split_graphemes($string) as $grapheme)
     {
@@ -152,7 +152,7 @@ function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement="")
 # Filter out any characters in $string that are in $remove_codepoints
 function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement="")
 {
-    $pattern_string = build_character_regex_filter($remove_codepoints, '/');
+    $pattern_string = build_character_regex_filter($remove_codepoints);
     $result = "";
     foreach (split_graphemes($string) as $grapheme) {
         if(1 === preg_match("/$pattern_string/u", $grapheme))
@@ -167,12 +167,27 @@ function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement=""
     return $result;
 }
 
+# Given a codepoint (U+####), return an escaped version of the
+# codepoint for use in a regex in the given language.
+# https://www.php.net/manual/en/regexp.reference.escape.php
+# https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
+function get_unicode_regex_class($codepoint, $lang='php')
+{
+    $hex = str_replace("U+", "", $codepoint);
+    if ($lang == "php") {
+        return '\\x{' . $hex . '}';
+    } elseif ($lang == "js") {
+        return '\\u{' . $hex . '}';
+    } else {
+        throw new Exception("invalid lang provided: $lang");
+    }
+}
+
 # Take an array of Unicode codepoints (U+####), codepoint ranges
 # (U+####-U+####), or combined characters (U+####>U+####) and
 # return a regular expression character class to match a single
-# character. $delimiter should be the one used in the preg function
-# that will use this filter.
-function build_character_regex_filter($codepoints, $delimiter=NULL)
+# character. $lang is the consuming language (php or js).
+function build_character_regex_filter($codepoints, $lang='php')
 {
     $char_class = "";
     $alternatives = [];
@@ -183,22 +198,22 @@ function build_character_regex_filter($codepoints, $delimiter=NULL)
             # we have a character range
             list($start, $end) = explode('-', $codepoint);
             $char_class .= implode("", [
-                preg_quote(UTF8::hex_to_chr($start), $delimiter),
+                get_unicode_regex_class($start, $lang),
                 '-',
-                preg_quote(UTF8::hex_to_chr($end), $delimiter)
+                get_unicode_regex_class($end, $lang),
             ]);
         }
         elseif(strpos($codepoint, '>') !== False)
         {
             # we have a combined character
             $alternatives[] = preg_quote(
-                utf8_combined_chr($codepoint), $delimiter
+                utf8_combined_chr($codepoint), $lang == 'php' ? '/' : NULL
             );
         }
         else
         {
             # just a regular unicode character
-            $char_class .= preg_quote(UTF8::hex_to_chr($codepoint), $delimiter);
+            $char_class .= get_unicode_regex_class($codepoint, $lang);
         }
     }
     if($char_class)

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -97,7 +97,18 @@ function split_graphemes($string)
 
     while ($next < $maxbytes)
     {
-        yield grapheme_extract($string, 1, GRAPHEME_EXTR_COUNT, $next, $next);
+        // grapheme_extract() returns \r\n as a single grapheme but we need it
+        // as two separate characters
+        $buffer = grapheme_extract($string, 1, GRAPHEME_EXTR_COUNT, $next, $next);
+        if ($buffer == "\r\n") {
+            $buffer = ["\r", "\n"];
+            while ($buffer) {
+                yield array_shift($buffer);
+            }
+        }
+        else {
+            yield $buffer;
+        }
     }
 }
 

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -30,7 +30,7 @@ else
 }
 // 'quiz' will result in codepoints for quizes
 $quiz = get_project_or_quiz("quiz");
-$valid_character_pattern = javascript_safe(build_character_regex_filter($quiz->get_valid_codepoints()));
+$valid_character_pattern = javascript_safe(build_character_regex_filter($quiz->get_valid_codepoints(), "js"));
 
 $header_args = array(
     "js_files" => array(

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -83,7 +83,7 @@ if (!$resolution) {
         $header = _("Fix Page");
     }
 
-    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints()));
+    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
 
     $header_args = [
         "js_files" => [

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -13,7 +13,7 @@ function echo_proof_frame_enh( $ppage )
     global $code_url;
 
     $project = new Project($ppage->projectid());
-    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints()));
+    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
     $switch_confirm = javascript_safe(_('Are you sure you want to save the current page and change layout?'));
     $revert_confirm = javascript_safe(_("Are you sure you want to save the current page and revert to the original text for this round?"));
 

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -16,7 +16,7 @@ $revert_text=isset($_POST['revert_text']) ? $_POST['revert_text'] : $text_data;
 $is_header_visible = array_get($_SESSION,"is_header_visible",1);
 
 $project = new Project($ppage->projectid());
-$valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints()));
+$valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
 
 $keep_corrections = _("Keep corrections and return to proofreading this page");
 $rerun = _("Check page against an additional language");

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -10,7 +10,7 @@ function echo_text_frame_std( $ppage )
     global $code_url;
     
     $project = new Project($ppage->projectid());
-    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints()));
+    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
     $switch_confirm = javascript_safe(_('Are you sure you want to save the current page and change layout?'));
     $revert_confirm = javascript_safe(_("Are you sure you want to save the current page and revert to the original text for this round?"));
 


### PR DESCRIPTION
This addresses two different problems:
1. For some reason `grapheme_extract()` treats "\r\n" as a single grapheme but all of our code assumes they are two separate characters (which they are).
2. Work around the portable-utf8 bug which is not correctly converting some Unicode strings to characters by using escape values for regexs instead.

Testable in the [fix-grapheme-split](https://www.pgdp.org/~cpeel/c.branch/fix-grapheme-split/) sandbox.