### PR TITLE
set samesite cookies

### DIFF
--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -22,7 +22,7 @@ lint_code:
 	$(SELF_DIR)lint_php_files.sh $(SELF_DIR)..
 	$(SELF_DIR)lint_json_files.sh $(SELF_DIR)..
 
-lint: lint_charsuites lint_code
+lint: lint_charsuites lint_css lint_code
 
 #----------------------------------------------------------------------------
 # CSS compilation

--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -22,7 +22,7 @@ lint_code:
 	$(SELF_DIR)lint_php_files.sh $(SELF_DIR)..
 	$(SELF_DIR)lint_json_files.sh $(SELF_DIR)..
 
-lint: lint_charsuites lint_less lint_code
+lint: lint_charsuites lint_code
 
 #----------------------------------------------------------------------------
 # CSS compilation

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -77,7 +77,7 @@ if(count($_POST))
             $register->save();
 
             // delete the cookie tracking the HTTP_REFERER
-            setcookie("http_referer", '', time() - 1);
+            dp_setcookie("http_referer", '', time() - 1);
 
             // Page shown when account is successfully created
             $title = _("Registration complete");

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -76,7 +76,7 @@ class User
                 // now set the profile cookie if this is for the current user
                 if($this->username == User::current_username())
                 {
-                    setcookie("profile", $this->current_profile->id);
+                    dp_setcookie("profile", $this->current_profile->id);
                 }
                 break;
             default:
@@ -119,7 +119,7 @@ class User
                         // OK if we can't.
                         if(!header_sent())
                         {
-                            setcookie("profile");
+                            dp_setcookie("profile");
                         }
 
                         // fall through to getting the profile from the user record

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -73,4 +73,18 @@ function dp_class_autoloader($class)
     }
 }
 
+function dp_setcookie($name, $value, $expires=0, $options=[]) {
+    global $use_secure_cookie;
+
+    $defaults = [
+        "expires" => $expires,
+        "path" => "/",
+        "secure" => $use_secure_cookie,
+        "samesite" => "Lax",
+    ];
+
+    $options = array_merge($defaults, $options);
+    return setcookie($name, $value, $options);    
+}
+
 // vim: sw=4 ts=4 expandtab

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -73,7 +73,7 @@ function dp_class_autoloader($class)
     }
 }
 
-function dp_setcookie($name, $value, $expires=0, $options=[]) {
+function dp_setcookie($name, $value="", $expires=0, $options=[]) {
     global $use_secure_cookies;
 
     $defaults = [

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -74,12 +74,12 @@ function dp_class_autoloader($class)
 }
 
 function dp_setcookie($name, $value, $expires=0, $options=[]) {
-    global $use_secure_cookie;
+    global $use_secure_cookies;
 
     $defaults = [
         "expires" => $expires,
         "path" => "/",
-        "secure" => $use_secure_cookie,
+        "secure" => $use_secure_cookies,
         "samesite" => "Lax",
     ];
 

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -68,9 +68,9 @@ function dpsession_resume()
     if(!$user_is_logged_in && !isset($_COOKIE["http_referer"]))
     {
         if(isset($_SERVER["HTTP_REFERER"]))
-            setcookie('http_referer', $_SERVER["HTTP_REFERER"]);
+            dp_setcookie('http_referer', $_SERVER["HTTP_REFERER"]);
         else
-            setcookie('http_referer', '');
+            dp_setcookie('http_referer', '');
     }
 
     return $user_is_logged_in;

--- a/pinc/dpsession_via_cookies.inc
+++ b/pinc/dpsession_via_cookies.inc
@@ -114,7 +114,12 @@ function local_send_cookie( $cookie_name, $cookie_value )
     {
         $t_offset = +86400;
     }
-    setcookie( $cookie_name, $cookie_value, time() + $t_offset, "/", COOKIE_DOMAIN, $use_secure_cookies );
+    setcookie( $cookie_name, $cookie_value, [
+      "expires" => time() + $t_offset,
+      "path" => "/",
+      "domain" => COOKIE_DOMAIN,
+      "secure" => $use_secure_cookies,
+      "samesite" => "Lax"]);
 }
 
 function local_encrypt( $str )

--- a/pinc/dpsession_via_cookies.inc
+++ b/pinc/dpsession_via_cookies.inc
@@ -114,12 +114,9 @@ function local_send_cookie( $cookie_name, $cookie_value )
     {
         $t_offset = +86400;
     }
-    setcookie( $cookie_name, $cookie_value, [
-      "expires" => time() + $t_offset,
-      "path" => "/",
+    setcookie( $cookie_name, $cookie_value, time() + $t_offset, [
       "domain" => COOKIE_DOMAIN,
-      "secure" => $use_secure_cookies,
-      "samesite" => "Lax"]);
+    ]);
 }
 
 function local_encrypt( $str )

--- a/pinc/dpsession_via_cookies.inc
+++ b/pinc/dpsession_via_cookies.inc
@@ -104,7 +104,6 @@ function user_cookie_disable()
 
 function local_send_cookie( $cookie_name, $cookie_value )
 {
-    global $use_secure_cookies;
     if ( $cookie_value == "" )
     {
         // Tell the receiver to expire the cookie.
@@ -114,7 +113,7 @@ function local_send_cookie( $cookie_name, $cookie_value )
     {
         $t_offset = +86400;
     }
-    setcookie( $cookie_name, $cookie_value, time() + $t_offset, [
+    dp_setcookie( $cookie_name, $cookie_value, time() + $t_offset, [
       "domain" => COOKIE_DOMAIN,
     ]);
 }

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -29,16 +29,10 @@ function dpsession_resume_()
         // Refresh the cookie
         // (session_start() used to do this for us,
         // but they changed that in PHP 4.3.9)
-        setcookie(
+        dp_setcookie(
             ini_get('session.name'),
             session_id(),
-            [
-                "expires" => time() + ini_get('session.cookie_lifetime'),
-                "path" => '/',
-                "domain" => '',
-                "secure" => $use_secure_cookies,
-                "samesite" => "Lax"
-            ]
+            time() + ini_get('session.cookie_lifetime')
         );
 
         // set global variable $pguser

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -31,11 +31,14 @@ function dpsession_resume_()
         // but they changed that in PHP 4.3.9)
         setcookie(
             ini_get('session.name'),
-             session_id(),
-            time() + ini_get('session.cookie_lifetime'),
-            '/',
-            '',
-            $use_secure_cookies
+            session_id(),
+            [
+                "expires" => time() + ini_get('session.cookie_lifetime'),
+                "path" => '/',
+                "domain" => '',
+                "secure" => $use_secure_cookies,
+                "samesite" => "Lax"
+            ]
         );
 
         // set global variable $pguser

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -20,7 +20,7 @@ function dpsession_begin_( $userID )
 
 function dpsession_resume_()
 {
-    global $pguser, $use_secure_cookies;
+    global $pguser;
 
     session_set_handlers_and_start();
 

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -33,13 +33,7 @@ function get_desired_language()
     if (isset($_GET['lang']) && lang_code($_GET['lang'])) {
         // User requested a specific language for this page
         $locale = lang_code($_GET['lang']);
-        setcookie("language", $locale, [
-          "expires" => time()+31536000,
-          "path" => "/",
-          "domain" => "",
-          "secure" => $use_secure_cookies,
-          "samesite" => "Lax"
-        ]);
+        dp_setcookie("language", $locale, time()+31536000);
     } else if ($user && $user->u_intlang){
         // User is logged in and has set their language preference
         $locale = $user->u_intlang;

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -20,8 +20,6 @@ include_once($relPath.'languages.inc');
 // * If everything else fails, default to en_US.
 function get_desired_language()
 {
-    global $use_secure_cookies;
-
     // This function maybe called multiple times within a page load.
     // Only do the calculations to determine the locale once.
     static $locale = NULL;

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -33,7 +33,13 @@ function get_desired_language()
     if (isset($_GET['lang']) && lang_code($_GET['lang'])) {
         // User requested a specific language for this page
         $locale = lang_code($_GET['lang']);
-        setcookie("language", $locale, time()+31536000, "/", "", $use_secure_cookies);
+        setcookie("language", $locale, [
+          "expires" => time()+31536000,
+          "path" => "/",
+          "domain" => "",
+          "secure" => $use_secure_cookies,
+          "samesite" => "Lax"
+        ]);
     } else if ($user && $user->u_intlang){
         // User is logged in and has set their language preference
         $locale = $user->u_intlang;

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1183,11 +1183,7 @@ function set_csrf_token($force_set = TRUE)
         return;
 
     $token = bin2hex(random_bytes(32));
-    setcookie("CSRFtoken", $token, [
-      "expires" => time() + 60 * 60 * 24,
-      "path" => '/',
-      "domain" => '',
-      "secure" => $use_secure_cookies,
+    dp_setcookie("CSRFtoken", $token, time() + 60 * 60 * 24, [
       "httponly" => TRUE,
       "samesite" => "Strict",
     ]);
@@ -1198,7 +1194,7 @@ function destroy_csrf_token()
 {
     global $use_secure_cookies;
 
-    setcookie("CSRFtoken", "", time() - 60, '/', '', $use_secure_cookies);
+    dp_setcookie("CSRFtoken", "", time() - 60);
 }
 
 function get_csrf_token_form_input()

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1177,8 +1177,6 @@ class InvalidCSRFTokenException extends UnexpectedValueException {}
 
 function set_csrf_token($force_set = TRUE)
 {
-    global $use_secure_cookies;
-
     if(!$force_set && @$_COOKIE["CSRFtoken"])
         return;
 
@@ -1192,8 +1190,6 @@ function set_csrf_token($force_set = TRUE)
 
 function destroy_csrf_token()
 {
-    global $use_secure_cookies;
-
     dp_setcookie("CSRFtoken", "", time() - 60);
 }
 

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1183,7 +1183,14 @@ function set_csrf_token($force_set = TRUE)
         return;
 
     $token = bin2hex(random_bytes(32));
-    setcookie("CSRFtoken", $token, time() + 60 * 60 * 24, '/', '', $use_secure_cookies, TRUE);
+    setcookie("CSRFtoken", $token, [
+      "expires" => time() + 60 * 60 * 24,
+      "path" => '/',
+      "domain" => '',
+      "secure" => $use_secure_cookies,
+      "httponly" => TRUE,
+      "samesite" => "Strict",
+    ]);
     $_COOKIE["CSRFtoken"] = $token;
 }
 

--- a/tools/setlangcookie.php
+++ b/tools/setlangcookie.php
@@ -12,7 +12,12 @@ $location = array_get($_POST, 'returnto', "$code_url/default.php");
 if($language)
 {
     // set the cookie
-    setcookie("language", $language, time()+31536000, "/");
+    setcookie("language", $language, [
+      "expires" => time()+31536000,
+      "path" => "/",
+      "secure" => $use_secure_cookies,
+      "samesite" => "Lax",
+    ]);
 }
 else
 {

--- a/tools/setlangcookie.php
+++ b/tools/setlangcookie.php
@@ -12,17 +12,12 @@ $location = array_get($_POST, 'returnto', "$code_url/default.php");
 if($language)
 {
     // set the cookie
-    setcookie("language", $language, [
-      "expires" => time()+31536000,
-      "path" => "/",
-      "secure" => $use_secure_cookies,
-      "samesite" => "Lax",
-    ]);
+    dp_setcookie("language", $language, time()+31536000);
 }
 else
 {
     // delete the cookie
-    setcookie("language", '', time()-3600, "/");
+    dp_setcookie("language", '', time()-3600);
 }
 
 metarefresh(0, $location);


### PR DESCRIPTION
Set all cookies to SameSite=Lax which is the default on newer browsers when not specified to None anyways. Set CSRFtoken cookie to SameSite=Strict as it is only sent on form POST/PUT which cannot be done from 3rd party context, even top level navigation.

Testable in sandbox here:
https://www.pgdp.org/~chrismiceli/c.branch/samesite

Scenarios to verify:

1. Login
2. Logout
3. Saving user preferences
4. Navigate to page with ?lang=<lang> and verify language cookie is set and respected throughout application as usual
5. Registering a new proofer. Also verify that navigating to the activate link works from another domain, such as an email web page like gmail.
6. Forums and wiki still accessible

You can read more about samesite cookie properties here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

This should get rid of warnings you can see in the firefox console in pgdp.net like
```
Some cookies are misusing the recommended “SameSite“ attribute 2
Cookie “DP_Session” will be soon rejected because it has the “SameSite” attribute set to “None” or an invalid value, without the “secure” attribute. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
```