### PR TITLE
Minor unicode updates

### DIFF
--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -450,7 +450,7 @@ function javascript_safe($str, $encoding=NULL)
         // convert non-7bit ascii characters to \uHHHH notation
         $str = preg_replace_callback('/([^\000-\177])/u',
             function ($matches) {
-                return sprintf("\\u%04x", UTF8::ord($matches[0]) & 0xffff);
+                return sprintf("\\u%04x", UTF8::ord($matches[0]) & 0xffffff);
             }, $str);
     }
     else

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -206,14 +206,16 @@ function build_character_regex_filter($codepoints, $lang='php')
         elseif(strpos($codepoint, '>') !== False)
         {
             # we have a combined character
-            $alternatives[] = preg_quote(
-                utf8_combined_chr($codepoint), $lang == 'php' ? '/' : NULL
-            );
+            $combined_char = [];
+            foreach(explode(">", $codepoint) as $char) {
+                $combined_char[] = get_unicode_regex_class($char, $lang);
+            }
+            $alternatives[] = implode("", $combined_char);
         }
         else
         {
             # just a regular unicode character
-            $char_class .= get_unicode_regex_class($codepoint, $lang);
+            $alternatives[] = get_unicode_regex_class($codepoint, $lang);
         }
     }
     if($char_class)

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -30,7 +30,7 @@ else
 }
 // 'quiz' will result in codepoints for quizes
 $quiz = get_project_or_quiz("quiz");
-$valid_character_pattern = javascript_safe(build_character_regex_filter($quiz->get_valid_codepoints(), "js"));
+$valid_character_pattern = build_character_regex_filter($quiz->get_valid_codepoints(), "js");
 
 $header_args = array(
     "js_files" => array(

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -83,8 +83,7 @@ if (!$resolution) {
         $header = _("Fix Page");
     }
 
-    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
-
+    $valid_character_pattern = build_character_regex_filter($project->get_valid_codepoints(), "js");
     $header_args = [
         "js_files" => [
             "$code_url/scripts/character_test.js",

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -13,9 +13,9 @@ function echo_proof_frame_enh( $ppage )
     global $code_url;
 
     $project = new Project($ppage->projectid());
-    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
-    $switch_confirm = javascript_safe(_('Are you sure you want to save the current page and change layout?'));
-    $revert_confirm = javascript_safe(_("Are you sure you want to save the current page and revert to the original text for this round?"));
+    $valid_character_pattern = build_character_regex_filter($project->get_valid_codepoints(), "js");
+    $switch_confirm = json_encode(_('Are you sure you want to save the current page and change layout?'));
+    $revert_confirm = json_encode(_("Are you sure you want to save the current page and revert to the original text for this round?"));
 
     $header_args = array(
         "css_files" => array("$code_url/styles/preview.css"),

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -16,7 +16,7 @@ $revert_text=isset($_POST['revert_text']) ? $_POST['revert_text'] : $text_data;
 $is_header_visible = array_get($_SESSION,"is_header_visible",1);
 
 $project = new Project($ppage->projectid());
-$valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
+$valid_character_pattern = build_character_regex_filter($project->get_valid_codepoints(), "js");
 
 $keep_corrections = _("Keep corrections and return to proofreading this page");
 $rerun = _("Check page against an additional language");

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -10,9 +10,9 @@ function echo_text_frame_std( $ppage )
     global $code_url;
     
     $project = new Project($ppage->projectid());
-    $valid_character_pattern = javascript_safe(build_character_regex_filter($project->get_valid_codepoints(), "js"));
-    $switch_confirm = javascript_safe(_('Are you sure you want to save the current page and change layout?'));
-    $revert_confirm = javascript_safe(_("Are you sure you want to save the current page and revert to the original text for this round?"));
+    $valid_character_pattern = build_character_regex_filter($project->get_valid_codepoints(), "js");
+    $switch_confirm = json_encode(_('Are you sure you want to save the current page and change layout?'));
+    $revert_confirm = json_encode(_("Are you sure you want to save the current page and revert to the original text for this round?"));
 
     $header_args = array(
         "css_files" => array("$code_url/styles/preview.css"),


### PR DESCRIPTION
This includes 3 separate commits:
* Correctly escape JS characters > `0xffff` in `javascript_safe()`.
* Encode combined characters in the regex as Unicode escape sequences.
* Don't escape the regex (since it can no longer contain special characters) to improve development & debugging and use `json_encode()` for simple JS strings.

Either 1 or 2 & 3 are required, but not sufficient, to correctly support Unicode codepoints above `0xffff`. Said another way: this is not all that is required to support some high Astral plane characters but it gets us closer.

Testable in [minor-unicode-updates](https://www.pgdp.org/~cpeel/c.branch/minor-unicode-updates/)