### PR TITLE
Check for project table before doing query

### DIFF
--- a/tools/project_manager/downloadproofed.php
+++ b/tools/project_manager/downloadproofed.php
@@ -19,24 +19,22 @@ if ($round_num == 0) {
 }
 
 validate_projectID($project);
+if (!does_project_page_table_exist($project)) {
+    die(_("Project table not found, it may have been deleted or archived."));
+}
+
 $sql = sprintf("
     SELECT $text_column_name FROM $project WHERE image = '%s'",
     DPDatabase::escape($image));
 $result = DPDatabase::query($sql);
-if ($result === FALSE)
-{
-    // Likely the project's page-table does not exist (in this database).
-    // This could happen if a user saved a URL involving this script,
-    // and the project's page-table later got archived.
-    die(DPDatabase::log_error());
-}
 $row = mysqli_fetch_assoc($result);
 if (!$row)
 {
     // The page-table exists, but the WHERE clause did not match any row.
     // This could happen if a user saved a URL involving this script,
     // and the page was later deleted or renamed.
-    die("Could not find text for $image in $project");
+    // TRANSLATORS: %1$s is the page image; %2$s is the project ID
+    die(sprintf(_("Could not find text for %1\$s in %2\$s"), $image, $project));
 }
 
 $data = $row[$text_column_name];
@@ -45,6 +43,3 @@ header("Content-type: text/plain; charset=$charset");
 // SENDING PAGE-TEXT TO USER
 // It's a text/plain document, so no encoding is necessary.
 echo $data;
-
-// vim: sw=4 ts=4 expandtab
-?> 


### PR DESCRIPTION
Check for the project table existing before doing the query to avoid throwing an error to the user and logging one to php_errors.

This is the page accessed by going to the "View Images, Pages Proofread and Differences" link on the project page and then clicking one of the page text links. The error happens when you access a URL for a project that has been deleted or archived.

There was some discussion about removing this script entirely and making those links going to the Page Browser in text-only mode. I think that's a good idea if anyone wants to either try and convince the community of it and/or fight them after.

Testable in the [fix-download-delete-project](https://www.pgdp.org/~cpeel/c.branch/fix-download-delete-project/) sandbox.