### PR TITLE
Update descriptive text for Bronze list

### DIFF
--- a/list_etexts.php
+++ b/list_etexts.php
@@ -9,7 +9,7 @@ include_once($relPath.'misc.inc'); // get_enumerated_param(), get_integer_param(
 
 $x        = get_enumerated_param($_GET, 'x', 'g', array('g', 's', 'b'));
 $sort     = get_integer_param($_GET, 'sort',      0, 0, 5);
-$per_page = get_integer_param($_GET, 'per_page', 20, 1, NULL);
+$per_page = get_integer_param($_GET, 'per_page', 20, 1, 100);
 $offset   = get_integer_param($_GET, 'offset',    0, 0, NULL);
 
 if($x == "g") {

--- a/list_etexts.php
+++ b/list_etexts.php
@@ -4,32 +4,41 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'list_projects.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param(), get_integer_param()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), get_integer_param(),
+                                   // surround_and_join()
 
 $x        = get_enumerated_param($_GET, 'x', 'g', array('g', 's', 'b'));
 $sort     = get_integer_param($_GET, 'sort',      0, 0, 5);
 $per_page = get_integer_param($_GET, 'per_page', 20, 1, NULL);
 $offset   = get_integer_param($_GET, 'offset',    0, 0, NULL);
 
-$boilerplate = _("These e-texts are the product of hundreds of hours of labor donated by all of our volunteers. The list is sorted with the most recently submitted e-texts at the top. You can sort them based upon your own preferences by clicking below. Enjoy!!");
-
 if($x == "g") {
     $type = "gold";
     $title = _("Completed Gold E-Texts");
     $state = SQL_CONDITION_GOLD;
-    $info = _("Below is the list of Gold e-texts that have been produced on this site. Gold e-texts are books that have passed through all phases of proofreading, formatting, and post-processing. They have been submitted to Project Gutenberg and are now available for your enjoyment and download.");
+    $info = [
+        _("Below is the list of Gold e-texts that have been produced on this site. Gold e-texts are books that have passed through all phases of proofreading, formatting, and post-processing. They have been submitted to Project Gutenberg and are now available for your enjoyment and download."),
+        _("These e-texts are the product of hundreds of hours of labor donated by all of our volunteers. The list is sorted with the most recently submitted e-texts at the top. You can sort them based upon your own preferences by clicking below. Enjoy!!")
+    ];
     $rss_content = "posted";
 } elseif ($x == "s") {
     $type = "silver";
     $title = _("In Progress Silver E-Texts");
     $state = SQL_CONDITION_SILVER;
-    $info = _("Below is the list of Silver e-texts that have almost completed processing on our site. Silver e-texts are books that have passed through all phases of proofreading and formatting and are now in the post-processing phase. Post-processing is the final assembly stage in which one volunteer performs a series of checks for consistency and correctness before the e-book is submitted to Project Gutenberg for your enjoyment and download.");
+    $info = [
+        _("Below is the list of Silver e-texts that have almost completed processing on our site. Silver e-texts are books that have passed through all phases of proofreading and formatting and are now in the post-processing phase. Post-processing is the final assembly stage in which one volunteer performs a series of checks for consistency and correctness before the e-book is submitted to Project Gutenberg for your enjoyment and download."),
+        _("These e-texts are the product of hundreds of hours of labor donated by our volunteers, and are in one of our post-processing states. The list is sorted by date, with the most recent to have changed state sorted to the top. You can re-sort them based on your own preferences. Enjoy!!")
+    ];
     $rss_content = "postprocessing";
 } elseif ($x == "b") {
     $type = "bronze";
     $title = _("Now Proofreading Bronze E-Texts");
     $state = SQL_CONDITION_BRONZE;
-    $info = _("Below is the list of Bronze e-texts that are currently available for proofreading on this site. Bronze e-texts are what our newest volunteers see and what you can work on now by logging in. These e-texts are in the initial stages of proofreading where everyone has a chance to correct any OCR errors which may be found. After going through a number of other phases, the e-text then goes to an experienced volunteer for final assembly (post-processing), after which the e-text is submitted to Project Gutenberg for your enjoyment and download.");
+    $info = [
+        _("Below is the list of Bronze e-texts that are currently available for proofreading on this site. Bronze e-texts are those that our volunteers are now proofreading or formatting. After going through three proofreading and two formatting rounds, the e-text then goes to an experienced volunteer for final assembly (post-processing), after which the e-text is submitted to Project Gutenberg for your enjoyment and download."),
+        _("Some of these e-texts are just beginning their journeys, others are almost done, and many variations in between. If you would like to help, log in and choose an activity from the navigation bar to see the lists of projects you are eligible to work in."),
+        _("The list is sorted by date, with the most recent to have changed state sorted to the top, and all rounds mixed together. You can re-sort them based on your own preferences.")
+    ];
     $rss_content = "proofing";
 } else {
     die("x parameter must be 'g', 's', or 'b'. ('$x')");
@@ -56,13 +65,12 @@ foreach(array("g" => _("Gold"), "s" => _("Silver"), "b"=> _("Bronze")) as $key =
 }
 echo "<p>" .  implode(" | ", $menu) . "</p>";
 echo "<div class='star-$type' style='float: left; width: 1.5em;'>★</div>";
-echo "<p>$info</p>";
-echo "<p>$boilerplate</p>";
+echo surround_and_join($info, "<p>", "</p>", "");
 
 $listurl = "list_etexts.php?x=$x&amp;per_page=$per_page&amp;offset=$offset";
 echo sprintf( _("<i>Title:</i> <a href='%1\$s'>asc</a> or <a href='%2\$s'>desc</a> | "), "$listurl&amp;sort=0", "$listurl&amp;sort=1");
 echo sprintf( _("<i>Author:</i> <a href='%1\$s'>asc</a> or <a href='%2\$s'>desc</a> | "), "$listurl&amp;sort=2", "$listurl&amp;sort=3");
-echo sprintf( _("<i>Submitted Date:</i> <a href='%1\$s'>asc</a> or <a href='%2\$s'>desc</a>"), "$listurl&amp;sort=4", "$listurl&amp;sort=5");
+echo sprintf( _("<i>Date:</i> <a href='%1\$s'>asc</a> or <a href='%2\$s'>desc</a>"), "$listurl&amp;sort=4", "$listurl&amp;sort=5");
 
 echo "<hr class='divider'>";
 
@@ -76,5 +84,3 @@ $sortlist = array(
 );
 
 list_projects($state, $sortlist[$sort], "list_etexts.php?x=$x&amp;sort=$sort&amp;", $per_page, $offset);
-
-// vim: sw=4 ts=4 expandtab


### PR DESCRIPTION
The primary goal of this MR was to update the descriptive text for the Bronze list so that it matches what's actually displayed. See [Task 1163](https://www.pgdp.net/c/tasks.php?action=show&task_id=1163). To more correctly describe each star metal, the common boilerplate paragraph was removed, and similar text was customized for each one.

The original task and comments suggested changing the text as a possible option. Possibly in the future, the other suggestion will be implemented, but meanwhile, the text will at least correctly describe what's displayed.

Also added a maximum number of items to display per page.
Testable: [~srjfoo/c.branch/update-bronze-blurb](https://www.pgdp.org/~srjfoo/c.branch/update-bronze-blurb/list_etexts.php?x=b&sort=5).