### PR TITLE
Suppress errors on team edits

### DIFF
--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -471,9 +471,9 @@ function showEdit($tname,$ttext,$twebpage,$tedit,$tsid)
     if ($tedit == 1) { echo "new_team.php"; } else { echo "tedit.php"; }
     echo "' method='post' target='_top'>";
     echo "<input type='hidden' name='tsid' value='$tsid'>";
-    if($teamimages['avatar'])
+    if(@$teamimages['avatar'])
         echo "<input type='hidden' name='tavatar' value='".$teamimages['avatar']."'>";
-    if($teamimages['icon'])
+    if(@$teamimages['icon'])
         echo "<input type='hidden' name='ticon' value='".$teamimages['icon']."'>";
 
     echo "\n<table class='themed'>";


### PR DESCRIPTION
If a team is edited without re-uploading an avatar or an image we attempt to access an index of null. This suppresses the error but doesn't fix it, because the teams code is a mess and it's not worth the effort.

I've filed https://github.com/DistributedProofreaders/dproofreaders/issues/606 in case someone wants to take on redesigning the morass that is the Teams and Members code.