### PR TITLE
Generate post files improvements

### DIFF
--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -922,7 +922,7 @@ function round_to_PP_avail_collateral( $old_project, $project, $transition, $who
 {
     global $site_abbreviation;
     $from_round = get_Round_for_project_state($transition->from_state);
-    generate_post_files( $project->projectid, $from_round->id, 'LE', False, '' );
+    generate_post_files($project, $from_round->id, 'LE', False, '');
 
     // Always notify the PM
     configure_gettext_for_user($project->username);
@@ -964,7 +964,7 @@ function round_to_PP_out_collateral( $old_project, $project, $transition, $who )
 {
     global $site_abbreviation;
     $from_round = get_Round_for_project_state($transition->from_state);
-    generate_post_files( $project->projectid, $from_round->id, 'LE', False, '' );
+    generate_post_files($project, $from_round->id, 'LE', False, '');
 
     // The project has been checked out to someone for PPing.
     // We want to notify the PPer and the PM,

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -4,6 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
+include_once($relPath.'slim_header.inc');
 include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param(), html_safe()
 include_once('./post_files.inc');
 
@@ -18,47 +19,74 @@ $which_text           = get_enumerated_param($_REQUEST, 'which_text', null, arra
 $include_proofers     = get_integer_param($_REQUEST,'include_proofers',0,0,1);
 $save_files           = get_integer_param($_REQUEST,'save_files',0,0,1);
 
+$errors = [];
+
 // only sitemanagers are allowed to save files
-if ($save_files && !user_is_a_sitemanager())
-{
-    echo _('You are not authorized to invoke this script.');
-    exit;
+if ($save_files && !user_is_a_sitemanager()) {
+    $errors[] = _('You are not authorized to invoke this script.');
 }
 
 // only people who can see names on the page details page
 // can see names here.
 $project = new Project($projectid);
 
-if ($include_proofers && ! $project->names_can_be_seen_by_current_user)
-{
-    echo _('You are not authorized to invoke this script.');
-    exit;
+if ($include_proofers && ! $project->names_can_be_seen_by_current_user) {
+    $errors[] = _('You are not authorized to invoke this script.');
 }
 
 // if we are not saving files, then we are just downloading the zip. 
 // don't send anything out other than the headers and zip file contents.
-if ($save_files) 
-{
-    echo "projectid       = '$projectid'<br>\n";
-    echo "round_id        = '$round_id'<br>\n";
-    echo "which_text      = '$which_text'<br>\n";
-    echo "include_proofers= '$include_proofers'<br>\n";
-    echo "save_files= '$save_files'<br>\n";
+if ($save_files) {
+    output_page_header($project);
 }
-
 
 set_time_limit(0); // no time limit
 
-if ($save_files)
-{
-    echo "<p>generating files for $projectid (" . html_safe($project->nameofwork) . ") ...</p>\n";
-    flush();
-    generate_post_files($project, $round_id, $which_text, $include_proofers, '');
-    flush();
-}
-else
-{
-    generate_interim_file($project, $round_id, $which_text, $include_proofers);
+if (!$errors) {
+    try {
+        if ($save_files) {
+            flush();
+            generate_post_files($project, $round_id, $which_text, $include_proofers, '');
+            echo "<p>" . _("Done.") . "</p>";
+        }
+        else {
+            generate_interim_file($project, $round_id, $which_text, $include_proofers);
+        }
+    } catch(Exception $exception) {
+        $errors[] = $exception->getMessage();
+    }
 }
 
-// vim: sw=4 ts=4 expandtab
+if ($errors) {
+    output_page_header($project);
+
+    foreach($errors as $error) {
+        echo "<p class='error'>" . html_safe($error) . "</p>";
+    }
+    exit();
+}
+
+function output_page_header($project)
+{
+    global $round_id, $which_text, $include_proofers, $save_files;
+
+    // Allow this function to be called multiple times but only output
+    // the contents once.
+    static $was_output = false;
+    if ($was_output) {
+        return;
+    }
+    $was_output = true;
+
+    $title = _("Generating Post Files");
+    slim_header($title);
+    echo "<h1>" . html_safe($title) . "</h1>";
+    echo "<p>" . sprintf(_("Generating files for '%s'."), html_safe($project->nameofwork)) . "</p>";
+    echo "<pre>";
+    echo "projectid        = $project->projectid\n";
+    echo "round_id         = $round_id\n";
+    echo "which_text       = $which_text\n";
+    echo "include_proofers = $include_proofers\n";
+    echo "save_files       = $save_files\n";
+    echo "</pre>";
+}

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -53,12 +53,12 @@ if ($save_files)
 {
     echo "<p>generating files for $projectid (" . html_safe($project->nameofwork) . ") ...</p>\n";
     flush();
-    generate_post_files( $projectid, $round_id, $which_text, $include_proofers,  '' );
+    generate_post_files($project, $round_id, $which_text, $include_proofers, '');
     flush();
 }
 else
 {
-    generate_interim_file( $projectid, $round_id, $which_text, $include_proofers);
+    generate_interim_file($project, $round_id, $which_text, $include_proofers);
 }
 
 // vim: sw=4 ts=4 expandtab

--- a/tools/project_manager/post_files.inc
+++ b/tools/project_manager/post_files.inc
@@ -11,6 +11,14 @@ function generate_post_files($project, $limit_round_id, $which_text, $include_pr
 {
     $pathbase = $project->dir . "/" . $project->projectid . $base_extra;
 
+    if (!$project->pages_table_exists) {
+        throw new Exception(_("Project table not found, it may have been deleted or archived."));
+    }
+
+    if (!$project->dir_exists) {
+        throw new Exception(_("Project directory not found, it may have been deleted or archived."));
+    }
+
     // Generate comments html file.
     $comments_path = "{$pathbase}_comments.html";
     $fp = fopen($comments_path, "w");
@@ -53,6 +61,14 @@ function generate_post_files($project, $limit_round_id, $which_text, $include_pr
 // generate a zip file on the fly and download it
 function generate_interim_file($project, $limit_round_id, $which_text, $include_proofers)
 {
+    if (!$project->pages_table_exists) {
+        throw new Exception(_("Project table not found, it may have been deleted or archived."));
+    }
+
+    if (!$project->dir_exists) {
+        throw new Exception(_("Project directory not found, it may have been deleted or archived."));
+    }
+
     $filename = $project->projectid;
     if ('[OCR]' == $limit_round_id) 
     {

--- a/tools/project_manager/post_files.inc
+++ b/tools/project_manager/post_files.inc
@@ -6,19 +6,16 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
 
-function generate_post_files( $projectid, $limit_round_id, $which_text, $include_proofers, $base_extra )
+function generate_post_files($project, $limit_round_id, $which_text, $include_proofers, $base_extra)
 // Generate the files needed for post-processing.
 {
-    global $projects_dir;
-
-    $projectpath = "$projects_dir/$projectid";
-    $pathbase = "$projectpath/$projectid$base_extra";
+    $pathbase = $project->dir . "/" . $project->projectid . $base_extra;
 
     // Generate comments html file.
     $comments_path = "{$pathbase}_comments.html";
     $fp = fopen($comments_path, "w");
     // if ( $fp === FALSE ) ???
-    write_project_comments($projectid, $fp);
+    write_project_comments($project, $fp);
     fclose ($fp);
 
     $other_files = [$comments_path];
@@ -26,21 +23,21 @@ function generate_post_files( $projectid, $limit_round_id, $which_text, $include
     // Word files
     foreach ( array('good', 'bad') as $code )
     {
-        $f = get_project_word_file($projectid, $code);
+        $f = get_project_word_file($project->projectid, $code);
         if ( $f->size > 0 )
         {
             $other_files[] = $f->abs_path;
         }
     }
 
-    $pages_res = page_info_query($projectid, $limit_round_id, $which_text);
+    $pages_res = page_info_query($project->projectid, $limit_round_id, $which_text);
     // if ($pages_res === FALSE) ???
 
     // Join all the page texts into a plain text file...
     $plain_path = "{$pathbase}.txt";
     $fp = fopen($plain_path, "w");
     // if ( $fp === FALSE ) ???
-    join_proofed_text($projectid, $pages_res, $include_proofers, true, $fp);
+    join_proofed_text($pages_res, $include_proofers, true, $fp);
     fclose ($fp);
     //
     // and make a zip of that file (plus comments).
@@ -54,9 +51,9 @@ function generate_post_files( $projectid, $limit_round_id, $which_text, $include
 
 // -----------------------------------------------------------------------------
 // generate a zip file on the fly and download it
-function generate_interim_file($projectid, $limit_round_id, $which_text, $include_proofers)
+function generate_interim_file($project, $limit_round_id, $which_text, $include_proofers)
 {
-    $filename = $projectid;
+    $filename = $project->projectid;
     if ('[OCR]' == $limit_round_id) 
     {
         $filename .= '_OCR';
@@ -73,11 +70,11 @@ function generate_interim_file($projectid, $limit_round_id, $which_text, $includ
         }
     }
 
-    $pages_res = page_info_query($projectid, $limit_round_id, $which_text);
+    $pages_res = page_info_query($project->projectid, $limit_round_id, $which_text);
     if ($pages_res === FALSE) return;
 
     // join the page texts together
-    $filedata = join_proofed_text($projectid, $pages_res, $include_proofers, false, '');
+    $filedata = join_proofed_text($pages_res, $include_proofers, false, '');
 
     // zip it all up
 
@@ -115,12 +112,11 @@ function clean_up_temp($dirname, $textfile_path, $zip_path)
 
 // -----------------------------------------------------------------------------
 
-function write_project_comments($projectid, $fp)
+function write_project_comments($project, $fp)
 {
     $header = "<HTML><BODY>";
     fputs($fp,$header);
 
-    $project = new Project($projectid);
     // insert e.g. templates and biographies
     $comments = parse_project_comments($project);
     fputs($fp,$comments);
@@ -156,7 +152,7 @@ function join_page_texts( $pages_res )
 
 // -----------------------------------------------------------------------------
 
-function join_proofed_text ($projectid, $pages_res, $include_proofers, $save_files, $fp)
+function join_proofed_text($pages_res, $include_proofers, $save_files, $fp)
 {
     // Join the round 2 page-texts of the given project,
     // and write the result to file-object $fp.


### PR DESCRIPTION
This started out as addressing errors in `php_errors` from someone trying to download post files for a deleted project (the new error checking in `post_files.inc`) and like many things while fixing that I cleaned up some other UX for generating post files along the way.

Testable in the [generate-post-files-improvements](https://www.pgdp.org/~cpeel/c.branch/generate-post-files-improvements) sandbox.