### PR TITLE
Fix the PP alert threshold

### DIFF
--- a/pinc/post_processing.inc
+++ b/pinc/post_processing.inc
@@ -72,6 +72,10 @@ function _run_pp_threshold_query_result($state, $columns, $user, $ordering_crite
     $cutoff_timestamp = strtotime("midnight first day of this month") -
         ($pp_alert_threshold_days * 60 * 60 * 24);
 
+    // Because PPers may have projects checked out to them automatically,
+    // user_project_info.t_latest_home_visit may not always be a good
+    // timestamp to use to determine the cutoff. Use the more recent value
+    // of t_latest_home_visit and modifieddate.
     $sql = "
         SELECT
             $column_selector
@@ -79,7 +83,7 @@ function _run_pp_threshold_query_result($state, $columns, $user, $ordering_crite
             projects.projectid = user_project_info.projectid AND
             projects.checkedoutby = user_project_info.username
         WHERE state = '$state' AND
-            user_project_info.t_latest_home_visit <= $cutoff_timestamp
+            GREATEST(user_project_info.t_latest_home_visit, modifieddate) <= $cutoff_timestamp
             $user_selector
         $order_by_clause
     ";


### PR DESCRIPTION
When we switched from using projects.modifieddate to using user_project_info.t_latest_home_visit to determine when a PPer was notified of projects needing to be renewed, we left out the case where a project was reserved in the rounds and checked out automatically -- t_latest_home_visit is not updated when a project moves into a post-processing stage. This changes the query to use the more recent date for determining when it's time to renew.

I've verified on the command line that the query works, but can't think of a good way to verify it otherwise, so I haven't set up a sandbox for it.