### PR TITLE
Revert "change href to #"

### DIFF
--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -80,7 +80,7 @@ echo "<a href='show_word_context.php?projectid=$projectid&amp;word=$encWord'>" .
       _("Show full context set for this word") . "</a>";
 
 echo " | ";
-echo "<a href='#' id='h_v_switch'></a>";
+echo "<a href='javascript:void(0)' id='h_v_switch'></a>";
 echo "</p>";
 
 foreach($word_suggestions as $suggestion) {
@@ -99,7 +99,7 @@ foreach($word_suggestions as $suggestion) {
     echo "<p><b>" . _("Date") . "</b>: " . strftime($datetime_format,$time) . "<br>";
     echo "<b>" . _("Round") . "</b>: $round &nbsp; | &nbsp; ";
     echo "<b>" . _("Proofreader") . "</b>: " . private_message_link($proofer) . "<br>";
-    echo "<b>" . _("Page") . "</b>: <a href='#' class='page-select' data-value='$page'>$page</a><br>";
+    echo "<b>" . _("Page") . "</b>: <a href='javascript:void(0)' class='page-select' data-value='$page'>$page</a><br>";
     foreach($context_strings as $lineNum => $context_string) {
         $context_string=_highlight_word(html_safe($context_string, ENT_NOQUOTES), $word);
         echo "<b>" . _("Line") . "</b>: ", 

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -54,7 +54,7 @@ $project_name = get_project_name($projectid);
 echo "<h2>", sprintf(_("Context for '%1\$s' in %2\$s"), $word, $project_name), "</h2>";
 
 echo "<p>";
-echo "<a href='#' id='h_v_switch'></a>";
+echo "<a href='javascript:void(0)' id='h_v_switch'></a>";
 echo "</p>";
 
 echo "<form method='GET' id='wordInstancesForm'>";
@@ -81,7 +81,7 @@ while( list($page_text,$page,$proofer_names) = page_info_fetch($pages_res) ) {
     if(!count($context_strings)) continue;
 
     echo "<p>";
-    echo "<b>" . _("Page") . "</b>: <a href='#' class='page-select' data-value='$page'>$page</a><br>";
+    echo "<b>" . _("Page") . "</b>: <a href='javascript:void(0)' class='page-select' data-value='$page'>$page</a><br>";
     foreach($context_strings as $lineNum => $context_string) {
         $context_string=_highlight_word(html_safe($context_string, ENT_NOQUOTES),$word);
         echo "<b>", _("Line"), "</b>: ",


### PR DESCRIPTION
This reverts commit 0c1d3b32f1cfe0942915b9f26d1a8195b08013f7.
'#' allows 'open in new tab' which opens the same page instead of the intended page in the new tab.
With the javascript void version, the options for opening in a new tab or window are not shown.
Perhaps a better fix would be to use an actual button but style it to look like a link in order to avoid changing the user experience.

published to https://www.pgdp.org/~rp31/c.branch/new_tab_fix