### PR TITLE
skip node_modules

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,6 +3,7 @@
 $finder = PhpCsFixer\Finder::create()
     ->exclude('pinc/3rdparty')
     ->exclude('vendor')
+    ->exclude('node_modules')
     ->in(__DIR__)
     ->name('*.php')
     ->name('*.inc')

--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -166,7 +166,6 @@ if (!function_exists("wfDebug")) {
     function wfDebug($text, $dest = 'all', array $context = [])
     {
         // don't log any debug messages
-
     }
 }
 

--- a/pinc/SortUtility.inc
+++ b/pinc/SortUtility.inc
@@ -92,7 +92,7 @@ class SortUtility
     // HTTP-arguments on sorting
     public $_name;
     // the SortableValues
-      public $_collection;
+    public $_collection;
 
     // optionally: one SortableValue is 'primary' meaning it is
     // always sorted by


### PR DESCRIPTION
I noticed it scanned and found 2 php files in node_modules. This is a waste of processing as we don't want to touch these files. The linter also made these other changes so I thought I'd include them here.