### PR TITLE
Remove inline <?php tags from edit_mail_address_for_non_activated_user.php

### DIFF
--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -32,14 +32,15 @@ if ($action == 'default') {
     echo "<p>";
     printf(_("To change the address, please enter the name of the user below or
     <a href='%s'>list all user accounts awaiting activation</a>."), "?action=list_all");
-    echo "</p>"; ?>
-    <br>
-    <form method='get'><input type='hidden' name='action' value='get_user'>
-    <?php echo _("Username"); ?>: <input type='text' name='username' required>
-    <input type='submit' value='<?php echo attr_safe(_("Continue")); ?>'>
-    </form>
-    <br>
-    <?php
+    echo "</p>";
+    echo "<br>";
+
+    echo "<form method='get'>";
+    echo "<input type='hidden' name='action' value='get_user'>";
+    echo _("Username") . ": <input type='text' name='username' required>";
+    echo  " <input type='submit' value='" . attr_safe(_("Continue")) . "'>";
+    echo "</form>";
+    echo "<br>";
 } elseif ($action == 'list_all') {
     $result = mysqli_query(DPDatabase::get_connection(), "
         SELECT *
@@ -87,18 +88,18 @@ if ($action == 'default') {
 
     echo "<p>";
     echo _("Enter the correct email-address below. When you submit the form, the activation mail will be resent.");
-    echo "</p>"; ?>
-    <br>
-    <form method='get'>
-    <input type='hidden' name='action' value='set_email'>
-    <input type='hidden' name='username' value='<?php echo attr_safe($username); ?>'>
-    <?php echo _("Username"); ?>: <?php echo html_safe($username); ?>
-    <br>
-    <?php echo _("E-mail"); ?>: <input type='text' name='email' size='50' value='<?php echo attr_safe($user->email); ?>' required>
-    <br>
-    <input type='submit' value='<?php echo attr_safe(_("Update address and resend activation mail")); ?>'>
-    </form>
-    <?php
+    echo "</p>";
+    echo "<br>";
+
+    echo "<form method='get'>";
+    echo "<input type='hidden' name='action' value='set_email'>";
+    echo "<input type='hidden' name='username' value='" . attr_safe($username) . "'>";
+    echo _("Username") . ": " . html_safe($username);
+    echo "<br>";
+    echo _("E-mail") . ": <input type='text' name='email' size='50' value='" . attr_safe($user->email) . "' required>";
+    echo "<br>";
+    echo "<input type='submit' value='" . attr_safe(_("Update address and resend activation mail")) . "'>";
+    echo "</form>";
 } elseif ($action == 'set_email') {
     if (check_username($username) != '') {
         die("Invalid parameter username.");


### PR DESCRIPTION
The inline tags in this file are confusing PHP-CS-Fixer.

Testable in the [fix-inline-php-formatting](https://www.pgdp.org/~cpeel/c.branch/fix-inline-php-formatting/) sandbox (requires SA privs).

Why wasn't this caught/fixed in the initial pass? Good question, I'm glad you asked. For performance purposes, PHP-CS-Fixer creates a `.php_cs.cache` cache file to allow it to skip files that haven't changed since the last time it ran and fixed things. So the first time this ran it fixed the file, but it wasn't idempotent and changed the file _again_ the second time. I've confirmed that the codebase is now format-stable by running this multiple times and removing the cache file after each run.