### PR TITLE
Add PHP-CS-Fixer to GitHub linting

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -26,7 +26,7 @@ jobs:
           php install_db.php
           cd ..
       - name: Install composer dependencies
-        run: composer install
+        run: composer install --no-dev
       - name: Install aspell dependencies for WordCheck tests
         run: sudo apt install aspell aspell-en
       - name: Run phpunit tests
@@ -49,20 +49,26 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Setup PHP
+      - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: 7.4
+          extensions: mbstring, iconv, intl, mysql, zip
+          tools: composer
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - name: Lint PHP code
+        run: cd SETUP && make lint_code && cd ..
       - name: Install NPM packages (for eslint)
         run: npm install
-      - name: Lint code
-        run: cd SETUP && make lint_code && cd ..
-      - name: Run js lint
+      - name: Run JS lint
         run: npm run lint
+      - name: Install composer dependencies
+        run: composer install
+      - name: Run PHP-CS-Fixer and confirm no changes
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
   misc_checks:
     runs-on: ubuntu-20.04
     steps:
@@ -79,7 +85,7 @@ jobs:
         with:
           node-version: '14'
       - name: Install composer dependencies (for UTF8)
-        run: composer install
+        run: composer install --no-dev
       - name: Install NPM packages (for less)
         run: npm install
       - name: Run security checks


### PR DESCRIPTION
Add PHP style enforcement to our CI pipeline. Note that the pipeline will (correctly) fail right now until https://github.com/DistributedProofreaders/dproofreaders/pull/621 merges in. I intentionally wanted to get this in prior so we can see what it looks like when it fails.

This fixes https://github.com/DistributedProofreaders/dproofreaders/issues/619