### PR TITLE
prevent scroll caret into view on selecting a picker

### DIFF
--- a/tools/proofers/character_selector.js
+++ b/tools/proofers/character_selector.js
@@ -15,7 +15,7 @@ $(function () {
         $(".selected-tab", charSelector).removeClass("selected-tab");
         $("#" + newCode, charSelector).addClass("selected-tab");
         largeChar.value = ""; // remove old character
-        top.focusText();
+        top.focusText(true);
     }
 
     // The mru (most recently used) list stores a set of characters

--- a/tools/proofers/dp_scroll.js
+++ b/tools/proofers/dp_scroll.js
@@ -259,9 +259,9 @@ function reSizeRelative(factor) {
     return true;
 }
 
-function focusText() {
+function focusText(noScroll = false) {
     if (isLded && inProof) {
-        docRef.editform.text_data.focus();
+        docRef.editform.text_data.focus({preventScroll: noScroll});
     }
 }
 


### PR DESCRIPTION
Task https://www.pgdp.net/c/tasks.php?action=show&task_id=1985
According to https://caniuse.com/?search=focus%3ApreventScroll it won't work on Safari or some older browsers.