### PR TITLE
fix typo header_sent

### DIFF
--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -111,7 +111,7 @@ class User
                         // yet been sent. Resetting the cookie is a nicety
                         // since it will only be used if it is valid, so it's
                         // OK if we can't.
-                        if (!header_sent()) {
+                        if (!headers_sent()) {
                             dp_setcookie("profile");
                         }
 


### PR DESCRIPTION
I hit this while switching identities. It occured in commit f3748c2bcbbde7cb8f7bf17fbacc8764d8d5b4f1