### PR TITLE
Split simplify

### DIFF
--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -295,7 +295,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
     let getProjectData;
 
     let topDiv = $("#page-browser");
-    // the non-scrolling area which will contain any error message and the form with controls
+    // the non-scrolling area which will contain the page controls
     let fixHead = $("<div>", {class: 'fixed-box control-pane'});
     // replace any previous content of topDiv
     topDiv.html(fixHead);

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -47,11 +47,10 @@ var splitControl = function(container, config) {
     let range;
     let minPos;
     let maxPos;
-    container = $(container);
-
+    container = $(container).css({display: 'flex'});
     let children = container.children();
-    let pane1 = $(children[0]);
-    let pane2 = $(children[1]);
+    let pane1 = $(children[0]).css({overflow: 'auto'});
+    let pane2 = $(children[1]).css({flex: '1 1 1px', overflow: 'auto'});
 
     let dragBar = $("<div>").css({"background-color": theConfig.dragBarColor, flex: `0 0 ${theConfig.dragBarSize}px`});
     pane1.after(dragBar);
@@ -70,15 +69,7 @@ var splitControl = function(container, config) {
         if (splitPos > maxPos) {
             splitPos = maxPos;
         }
-        pane1.css({flex: `0 0 ${splitPos - base}px`, overflow: 'auto'});
-        pane2.css({flex: '1 1 1px', overflow: 'auto'});
-        if (theConfig.splitVertical) {
-            container.css({display: 'flex', flexDirection: 'row'});
-            pane1.height('');
-        } else {
-            container.css({display: 'flex', flexDirection: 'column'});
-            pane1.width('');
-        }
+        pane1.css({flex: `0 0 ${splitPos - base}px`});
         reSize.fire();
     }
 
@@ -90,14 +81,14 @@ var splitControl = function(container, config) {
         let divTop = containerOffset.top;
         let divLeft = containerOffset.left;
         if (theConfig.splitVertical) {
+            container.css({flexDirection: 'row'});
             range = width;
             base = divLeft;
-            dragBar.height('100%');
             dragBar.css("cursor", "ew-resize");
         } else {
+            container.css({flexDirection: 'column'});
             range = height;
             base = divTop;
-            dragBar.width('100%');
             dragBar.css("cursor", "ns-resize");
         }
         range -= theConfig.dragBarSize;

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -3,11 +3,10 @@
 
 /*
  * Create a splitter between two <div>s within a container.
- * splitControl returns:
  * Arguments for splitControl:
  * container - ID of a <div> which contains two <div>s (herein referred
- *     to as pane1 and pane2). The splitter will be created between these.
- * config - optional dictionary that controls the div: (defaults in brackets)
+ * to as pane1 and pane2). The splitter will be created between these.
+ * config - optional object that controls the div: (defaults in brackets)
  * {
  *   splitVertical: (true) true or false,
  *   splitPercent: (50), percentage of contaner occupied by pane1,


### PR DESCRIPTION
This is the version of image widget we want to present for evaluation.
The text both has a splitter and is editable only for a user with Mentor, PF or Squirrel access.
The drag bar markers are not implemented. 

Sandbox at https://www.pgdp.org/~rp31/c.branch/split_simplify