### PR TITLE
Add the ability to disable special days

### DIFF
--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -196,7 +196,6 @@ class ProjectSearchForm
                 display_name,
                 DATE_FORMAT(concat('2000-',open_month,'-',open_day),'%e %b')
             FROM special_days
-            WHERE enable = 1
             ORDER BY open_month, open_day
         ";
         $special_day_res = DPDatabase::query($sql);

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -154,9 +154,9 @@ function special_list($special)
         SELECT
             spec_code,
             display_name,
+            enable,
             DATE_FORMAT(concat('2000-',open_month,'-',open_day),'%e %b') as 'Start Date'
         FROM special_days
-        WHERE enable = 1
         ORDER BY open_month, open_day
     ";
     $specs_result = DPDatabase::query($sql);
@@ -166,9 +166,11 @@ function special_list($special)
 
     // put list into array
     while ($s_row = mysqli_fetch_assoc($specs_result)) {
-        $show = $s_row['display_name']." (".$s_row['Start Date'].")";
-        $code = $s_row['spec_code'];
-        $specials_array["$code"] = $show;
+        if ($s_row['enable'] || $s_row['spec_code'] == $special) {
+            $show = $s_row['display_name'] . " (" . $s_row['Start Date'] . ")";
+            $code = $s_row['spec_code'];
+            $specials_array["$code"] = $show;
+        }
     }
 
     $bdaymonth = 0;
@@ -198,7 +200,6 @@ function special_list($special)
     }
     echo ">", _("Otherday"), "</option>";
     echo "\n";
-
 
     // add the rest of the special days (the "ordinary" special days ;) )
     foreach ($specials_array as $k => $v) {

--- a/tools/project_manager/show_specials.php
+++ b/tools/project_manager/show_specials.php
@@ -13,6 +13,8 @@ output_header($title, NO_STATSBAR);
 
 echo "<h1>$title</h1>\n";
 
+echo "<p>" . _("If a Special Day has been disabled, <span class='small'>[Disabled]</span> will be displayed following the name of the special day in the \"Name\" column.") . "</p>\n";
+
 $sql = "
     SELECT *
     FROM special_days
@@ -50,6 +52,10 @@ while ($row = mysqli_fetch_assoc($result)) {
     echo urlencode($row['spec_code']) ."&amp;n_results_per_page=100\" title=\"";
     echo urlencode($row['display_name']) ."\">\n";
     echo html_safe($row['display_name']) . "</a>";
+    if ($row['enable'] == 0) {
+        $maybe_disabled = _("Disabled");
+        echo "<br><span class='small'>[" . $maybe_disabled . "]</span>";
+    }
     echo "</td>\n";
     echo "<td>";
     echo "<div title=\"" . html_safe($row['comment']) ."\">";


### PR DESCRIPTION
Until now once a special day was created and enabled so that Project Managers could assign the special day to a project, it was permanent.

This fixes it so that a special day can be disabled for assigning to projects, but can remain for projects that used it prior to it being disabled. It also allows disabled special days to be selected in the project search form, and adds an indicator to the `show_specials` list to indicate which special days have been disabled.

Sandbox here [add-disable-special-day](https://www.pgdp.org/~srjfoo/c.branch/add-disable-special-day/).