### PR TITLE
Correctly handle empty charsuite

### DIFF
--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -344,7 +344,7 @@ class ProjectInfoHolder
             : $pri_language);
 
         $this->charsuites = [];
-        foreach (@$_POST['charsuites'] as $charsuite) {
+        foreach ($_POST['charsuites'] ?? [] as $charsuite) {
             array_push($this->charsuites, $charsuite);
         }
         if (sizeof($this->charsuites) == 0) {


### PR DESCRIPTION
If the user selects no character suites when editing a project we need to treat the POST as an empty array (which we handle as an error case later) rather than an unset variable.

This fixes an error found in `php_errors` on PROD.