### PR TITLE
Snapshot table display fix

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -400,15 +400,7 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects = fals
         echo "<td class='pages-completed'>{$round_stats->curr_day_actual}</td>";
         echo "<td><div class='progressbar $progress_bar_class' style='width: $progress_bar_width%;'>&nbsp;</div><p style='clear: both; margin: 0;'>$percent_complete%</p></td>";
     } else {
-        // IE6 & 7 do not display the top and left borders of a cell if
-        // border-collapse=collapse and the border=1px. The following
-        // tweak is to ensure that if we show the filter that the filter
-        // cell has a border all the way around it.
-        if ($show_filtered_projects) {
-            echo "<td colspan='4' class='nocell' style='border-bottom: 1px solid black;'></td>";
-        } else {
-            echo "<td colspan='4' class='nocell'></td>";
-        }
+        echo "<td colspan='4' class='nocell'></td>";
     }
 
     echo "</tr>\n";
@@ -421,8 +413,14 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects = fals
         } else {
             $display_filter = sprintf(_('<a href="%1$s">Add filter</a>'), $filter_link);
         }
+        // specificity of inline style is needed to override default style to
+        // force the filter links to align to the left.
         echo "<tr>";
-        echo "<td colspan='7' style='text-align: left;'>";
+        if (is_a($stage, 'Round')) {
+            echo "<td colspan='7' style='text-align: left;'>";
+        } else {
+            echo "<td colspan='3' style='text-align: left;'>";
+        }
         echo "<small>$display_filter</small>";
         echo "</td>";
         echo "</tr>";

--- a/project.php
+++ b/project.php
@@ -1870,6 +1870,7 @@ function do_smooth_reading()
             echo "</li>\n";
 
             echo "<li>";
+            // TRANSLATORS: Should be translated as past tense.
             echo_uploaded_zips('_smooth_done_', _('Smooth Read'));
             echo "</li>";
             echo "</ul>";

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -60,7 +60,7 @@ echo "<tr>";
 echo "<th>" . _("Title") . "</th>";
 echo "<th>" . _("Author") . "</th>";
 echo "<th>" . _("Project Manager") . "</th>";
-echo "<th>" . _("State") . "</th>";
+echo "<th>" . pgettext("project state", "State") . "</th>";
 echo "<th>" . _("Clearance") . "</th>";
 echo "</tr>";
 


### PR DESCRIPTION
On the Activity Hub, if filters are enabled for the  Site Progress Snapshot table, the rows in the Post-Processing part of the table displays the rows with the filter links the full width of the Round section of the table. This removes the IE hack, and re-does the logic to match row display to the table section. Sandbox here: [cleanup-2021-06](https://www.pgdp.org/~srjfoo/c.branch/cleanup-2021-06/activity_hub.php).

The other commit contains a couple of tweaks to the `gettext()` code that are designed for translators, but that will be invisible to users.