### PR TITLE
Prevent editing word lists for archived projects

### DIFF
--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -315,23 +315,24 @@ class OptionsColumn extends Column
 {
     public function print_cell_data($project)
     {
-        global $pguser, $projects_url, $code_url;
+        global $pguser, $code_url;
         $projectid = $project->projectid;
-        $actions = '';
+        $actions = [];
 
         $topic_id = $project->topic_id;
         if (!empty($topic_id)) {
             $url = get_url_to_view_topic($topic_id) . "&amp;view=unread#unread";
-            $actions .= "<a href='$url' target='_blank'>" . _("View Forum") . "</a><br>\n";
+            $actions[] = "<a href='$url' target='_blank'>" . _("View Forum") . "</a>";
         }
         if ($project->user_can_do_quick_check()) {
-            $actions .= "<a href='$code_url/tools/project_manager/project_quick_check.php?projectid=$projectid' target='_blank'>"._("Project Quick Check")."</a><br>";
+            $actions[] = "<a href='$code_url/tools/project_manager/project_quick_check.php?projectid=$projectid' target='_blank'>" . _("Project Quick Check") . "</a>";
         }
         if ($project->can_be_managed_by_user($pguser)) {
-            $actions .= "<a href='$code_url/tools/project_manager/editproject.php?action=edit&amp;project=$projectid' target='_blank'>" . _("Edit Info") . "</a><br>
-            <a href='$code_url/tools/project_manager/edit_project_word_lists.php?projectid=$projectid' target='_blank'>" . _("Edit Word Lists") . "</a><br>
-            <a href='$code_url/../noncvs/send_email.php?to=db-req&amp;subject=$projectid' target='_blank'>"._("Email db-req")."</a><br>
-            <a href='$code_url/../noncvs/send_email.php?to=dp-format&amp;subject=$projectid' target='_blank'>"._("Email dp-format")."</a><br>\n";
+            $actions[] = "<a href='$code_url/tools/project_manager/editproject.php?action=edit&amp;project=$projectid' target='_blank'>" . _("Edit Info") . "</a>";
+
+            if ($project->dir_exists) {
+                $actions[] = "<a href='$code_url/tools/project_manager/edit_project_word_lists.php?projectid=$projectid' target='_blank'>" . _("Edit Word Lists") . "</a>";
+            }
 
             // Should we show an "attention" icon?
             // Currently, we only do this if suggestions have been added since
@@ -350,14 +351,15 @@ class OptionsColumn extends Column
             if ($project->state == PROJ_POST_FIRST_UNAVAILABLE ||
                 $project->state == PROJ_POST_FIRST_AVAILABLE ||
                 $project->state == PROJ_POST_FIRST_CHECKED_OUT) {
-                $actions .= "<a href=\"$projects_url/$projectid/$projectid.zip\">" . _("Download") . "</a><br>\n";
+                $actions[] = "<a href=\"$project->url/$projectid.zip\">" . _("Download") . "</a>";
             }
             if ($project->state == PROJ_POST_SECOND_CHECKED_OUT ||
                 $project->state == PROJ_POST_COMPLETE) {
-                $actions .= "<a href=\"$projects_url/$projectid/".$projectid."_second.zip\">" . _("Download") . "</a><br>\n";
+                $actions[] = "<a href=\"$project->url/${projectid}_second.zip\">" . _("Download") . "</a>";
             }
         }
-        if (!empty($actions)) {
+        if ($actions) {
+            $actions = join("<br>", $actions);
             // identify the buttons by projectid
             echo "<div class='dropdown'>
                 <button class='dropdown-button' onclick='toggleList(\"$projectid\")'>", _("Links"), "</button>

--- a/project.php
+++ b/project.php
@@ -838,9 +838,11 @@ function do_edit_above()
         $links[] = "<a href='$code_url/tools/project_manager/editproject.php?action=edit&amp;project=$project->projectid&amp;return=" .
             // TRANSLATORS: "Edit" as in modify as opposed to correct
             urlencode($_SERVER["REQUEST_URI"]) . "'>" . _("Edit the above information") . "</a>";
-        $links[] = "<a href='$code_url/tools/project_manager/edit_project_word_lists.php?projectid=$project->projectid&amp;return=" .
-            // TRANSLATORS: "Edit" as in modify as opposed to correct
-            urlencode($_SERVER["REQUEST_URI"]) . "'>" . _("Edit project word lists") ."</a>";
+        if ($project->dir_exists) {
+            $links[] = "<a href='$code_url/tools/project_manager/edit_project_word_lists.php?projectid=$project->projectid&amp;return=" .
+                // TRANSLATORS: "Edit" as in modify as opposed to correct
+                urlencode($_SERVER["REQUEST_URI"]) . "'>" . _("Edit project word lists") ."</a>";
+        }
     }
 
     if ($project->user_can_do_quick_check()) {


### PR DESCRIPTION
Word lists are stored in the project directory and thus if the directory has been deleted (because the project was archived or deleted) the project's word lists cannot be managed. Prevent the link from showing up on the project page and do a more robust job of checking for these edgecases in the edit word lists page and failing early. This fixes an error seen in `php_errors` from PROD.

This consolidates some of the validation logic in `edit_project_word_lists.php`. It's still a hot mess (which I can say with both authority and shame since I wrote it all 14 years ago).

Testable in the [fix-archived-wordlist-edits](https://www.pgdp.org/~cpeel/c.branch/fix-archived-wordlist-edits/) sandbox.

Please help validate that this behaves like we would expect during project create. It should but that's the only real problematic edgecase that comes to mind.