### PR TITLE
Added PM link to character suites

### DIFF
--- a/tools/project_manager/projectmgr.inc
+++ b/tools/project_manager/projectmgr.inc
@@ -38,6 +38,7 @@ function echo_manager_links()
         }
         echo "<li><a href='$code_url/tools/project_manager/project_quick_check.php'>"._("Project Quick Check")."</a></li>\n";
         echo "<li><a href='$code_url/tools/project_manager/clearance_check.php'>"._("Clearance Check")."</a></li>\n";
+        echo "<li><a href='$code_url/tools/charsuites.php'>"._("Character Suites")."</a></li>\n";
         // SITE-SPECIFIC
         echo "<li>"._("Email").": ";
         echo "<a href='$code_url/../noncvs/send_email.php?to=db-req'>db-req</a> | ";


### PR DESCRIPTION
This implements task 1989.
Is this the best wording and position in the list?

Sandbox at: https://www.pgdp.org/~rp31/c.branch/link_char_suite

It is apparent that the file  tools/project_manager/projectmgr.inc contains some redundant logic and is itself redundant in that the functions it implements are now each used in only one (different) php file and could be moved there. This could be addressed in another branch.