### PR TITLE
Rem proof note

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -311,6 +311,12 @@ QUnit.module("Format preview test", function() {
         noIssueTest(assert);
     });
 
+    QUnit.test("multi-line user note", function (assert) {
+        text = "[** abcd\nefgh]";
+        issArray = analyse(text, configuration).issues;
+        noIssueTest(assert);
+    });
+
     QUnit.test("user note missing ]", function (assert) {
         text = "[** abc";
         issArray = analyse(text, configuration).issues;
@@ -318,7 +324,7 @@ QUnit.module("Format preview test", function() {
     });
 
     QUnit.test("nested user note", function (assert) {
-        text = "[** abc \n[** ABC]]";
+        text = "[** abc [** ABC]]";
         issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 0, 3, "noCloseBrack", 1);
     });

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -317,6 +317,12 @@ QUnit.module("Format preview test", function() {
         issueTest(assert, 0, 0, 3, "noCloseBrack", 1);
     });
 
+    QUnit.test("nested user note", function (assert) {
+        text = "[** abc \n[** ABC]]";
+        issArray = analyse(text, configuration).issues;
+        issueTest(assert, 0, 0, 3, "noCloseBrack", 1);
+    });
+
     QUnit.test("Footnote etc. missing ]", function (assert) {
         text = "*[Footnote: ab\ncd";
         issArray = analyse(text, configuration).issues;

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -51,348 +51,342 @@ QUnit.module("Format preview test", function() {
 
     QUnit.test("missing inline start tag", function (assert) {
         text = "df</b> ab";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 2, 4, "noStartTag", 1);
     });
 
     QUnit.test("missing out-of-line start tag", function (assert) {
         text = "abc\n#/";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 4, 2, "noStartTag", 1);
     });
 
     QUnit.test("missing inline end tag", function (assert) {
         text = "the <i>df";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 4, 3, "noEndTag", 1);
     });
 
     QUnit.test("missing out-of-line end tag", function (assert) {
         text = "abc\n\n/*\ndf";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 2, "noEndTag", 1);
     });
 
     QUnit.test("no inline end tag in the paragraph", function (assert) {
         text = "the <i>df\n\nnew paragraph</b> ab";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 1, 4, 3, "noEndTagInPara", 1);
         issueTest(assert, 0, 24, 4, "noStartTag", 1);
     });
 
     QUnit.test("mismatched tags", function (assert) {
         text = "the <i>df</b> ab";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 1, 4, 3, "misMatchTag", 1);
         issueTest(assert, 0, 9, 4, "misMatchTag", 1);
     });
 
     QUnit.test("bold inside italic, ok", function (assert) {
         text = "<i>ab <b>cd</b> ef</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("nested tag", function (assert) {
         text = "<i>ab <b>cd <i>ef</i> gh</b> ij</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 12, 3, "nestedTag", 1);
     });
 
     QUnit.test("unrecognised tag, u not enabled", function (assert) {
         text = "ab <u>cd</u>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 1, 3, 3, "unRecTag", 0);
         issueTest(assert, 0, 8, 4, "unRecTag", 0);
     });
 
     QUnit.test("u tag enabled", function (assert) {
         text = "ab <u>cd</u>";
-        issArray = analyse(text, underlineConfig);
+        issArray = analyse(text, underlineConfig).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("character before footnote", function (assert) {
         text = "xy[1]\n\nz[Footnote 1: ab]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 8, 9, "charBefore", 1);
     });
 
     QUnit.test("* before footnote without reference ok", function (assert) {
         text = "*[Footnote: ab]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("character before out-of-line tag", function (assert) {
         text = "x/#\nabc\n#/";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 1, 2, "charBefore", 1);
     });
 
     QUnit.test("non-blank line before Illustration etc.", function (assert) {
         text = "abc\n[Illustration]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 4, 13, "blankBefore", 1);
     });
 
     QUnit.test("non-blank line before Sidenote", function (assert) {
         text = "abc\n[Sidenote: abc]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 4, 9, "blankBefore", 1);
     });
 
     QUnit.test("non-blank line before Sidenote suppressed", function (assert) {
         text = "abc\n[Sidenote: abc]";
-        issArray = analyse(text, noSideNoteBlankConfig);
+        issArray = analyse(text, noSideNoteBlankConfig).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("non-blank line after Illustration <tb> etc.", function (assert) {
         text = "abc\n\n<tb>\ndef";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 4, "blankAfter", 1, "&lt;tb&gt;");
     });
 
     QUnit.test("end of no-wrap after illustration ok", function (assert) {
         text = "/*\nabc\n\n[Illustration ab]\n*/";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("no-wrap inside no-wrap", function (assert) {
         text = "/*\nabc\n\n/*\ndef\n*/\n*/";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 8, 2, "NWinNW", 1);
     });
 
     QUnit.test("block-quote inside no-wrap", function (assert) {
         text = "/*\nabc\n\n/#\ndef\n#/\n*/";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 8, 2, "BQinNW", 1);
     });
 
     QUnit.test("block-quote inside block-quote ok", function (assert) {
         text = "/#\nabc\n\n/#\ndef\n#/\n#/";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("character after out-of-line tag", function (assert) {
         text = "/*\nabc\n*/ x";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 7, 2, "charAfter", 1, "*/");
     });
 
     QUnit.test("character following Illustration Sidenote <tb> etc.", function (assert) {
         text = "[Sidenote ] x";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 10, 1, "charAfter", 0, "Sidenote");
     });
 
     QUnit.test("user note following Illustration Sidenote <tb> etc. ok", function (assert) {
         text = "[Sidenote ] [** note]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("non-blank line before out-of-line start tag", function (assert) {
         text = "x\n/*\nabc\n*/";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 2, 2, "OolPrev", 1);
     });
 
     QUnit.test("non-blank line after out-of-line start tag", function (assert) {
         text = "/*\nabc\n*/\nx";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 7, 2, "OolNext", 1);
     });
 
     QUnit.test("only 1, 2 or 4 blank lines", function (assert) {
         text = "\n\n\nabc\n\n\n\n\ndef\n\n\n\n\n\nghi";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 20, 1, "blankLines124", 1);
         issueTest(assert, 1, 3, 1, "blankLines124", 1);
     });
 
     QUnit.test(",.;:!? after start tag", function (assert) {
         text = "as<i>,df</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 1, "puncAfterStart", 0);
     });
 
     QUnit.test("space after start tag", function (assert) {
         text = "as<i> df</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 1, "spaceAfterStart", 1);
     });
 
     QUnit.test("new line after start tag", function (assert) {
         text = "as<sc>\nDf</sc>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 2, 4, "nlAfterStart", 1);
     });
 
     QUnit.test("new line before end tag", function (assert) {
         text = "as<sc>Df\n</sc>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 9, 5, "nlBeforeEnd", 1);
     });
 
     QUnit.test("space before end tag", function (assert) {
         text = "as<f>Df </f>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 7, 1, "spaceBeforeEnd", 1);
     });
 
     QUnit.test("entirely bold heading", function (assert) {
         text = "ab\n\n\n<b>cd</b>\n\nef";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 3, "noBold", 1);
     });
 
     QUnit.test("small cap text with no capitals", function (assert) {
         text = "<sc>abcd</sc>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 0, 4, "scNoCap", 1);
     });
 
     QUnit.test("small cap fragment with no capitals, possible issue", function (assert) {
         text = "<sc>*abcd</sc>";
-        issArray = analyse(text, configuration);
-        issueTest(assert, 0, 4, 1, "scNoCap", 0);
-    });
-
-    QUnit.test("small cap text with capitals only in comment, possible issue", function (assert) {
-        text = "<sc>abcd[** ABCD]</sc>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 4, 1, "scNoCap", 0);
     });
 
     QUnit.test("word character or ,.;: before start tag, possible issue", function (assert) {
         text = "a;<i>df</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 1, 1, "charBeforeStart", 0);
     });
 
     QUnit.test("number before start tag, ok", function (assert) {
         text = "It cost 9<i>l.</i> 4<i>s.</i> 1<i>d.</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("Allow character before start tag", function (assert) {
         text = "a;<i>df</i>";
-        issArray = analyse(text, allowCharBeforeStartConfig);
+        issArray = analyse(text, allowCharBeforeStartConfig).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("non-basic-latin character before start tag", function (assert) {
         text = "aÀ<i>df</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 1, 1, "charBeforeStart", 0);
     });
 
     QUnit.test("- before start tag, ok", function (assert) {
         text = "as-<i>df</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("word character after end tag, possible issue", function (assert) {
         text = "<i>df</i>éx";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 9, 1, "charAfterEnd", 0);
     });
 
     QUnit.test(",;: before end tag, possible issue", function (assert) {
         text = "<i>df;</i> abc";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 1, "puncBEnd", 0);
     });
 
     QUnit.test(",;: before end tag, ok at end of text", function (assert) {
         text = "<i>df;</i>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("user note missing ]", function (assert) {
         text = "[** abc";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 0, 3, "noCloseBrack", 1);
     });
 
     QUnit.test("Footnote etc. missing ]", function (assert) {
         text = "*[Footnote: ab\ncd";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 0, 10, "noCloseBrack", 0);
     });
 
     QUnit.test("Footnote id must be letter or number", function (assert) {
         text = "[Footnote *: ab\ncd]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 0, 9, "footnoteId", 0);
     });
 
     QUnit.test("Footnote anchor must not be *", function (assert) {
         text = "[*]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 0, 3, "starAnchor", 0);
     });
 
     QUnit.test("no Footnote corresponding to anchor", function (assert) {
         text = "[A][B]\n\n[Footnote A: abc]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 3, 3, "noFootnote", 0);
     });
 
     QUnit.test("no anchor corresponding to Footnote", function (assert) {
         text = "xyz\n\n[Footnote A: abc]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 9, "noAnchor", 0);
     });
 
     QUnit.test("a colon must be present", function (assert) {
         text = "xyz\n\n[Footnote A abc]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 9, "noColon", 0);
     });
 
     QUnit.test("colon must immediately follow continuation Footnote", function (assert) {
         text = "xyz\n\n*[Footnote : abc]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 6, 9, "colonNext", 0);
     });
 
     QUnit.test("space must immediately follow Footnote", function (assert) {
         text = "xyz\n\n[Footnote: abc]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 5, 9, "spaceNext", 0);
     });
 
     QUnit.test("duplicated footnote id", function (assert) {
         text = "xyz[A]\n\n[Footnote A: abc]\n\n[Footnote A: def]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 27, 9, "dupNote", 0);
     });
 
     QUnit.test("a continuation footnote should precede other footnotes", function (assert) {
         text = "xyz[A]\n\n[Footnote A: abc]\n\n*[Footnote: def]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 0, 28, 9, "continueFirst", 0);
     });
 
     QUnit.test("pair of inline tags with no content", function (assert) {
         text = "<g></g>";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 1, 0, 3, "emptyTag", 1);
         issueTest(assert, 0, 3, 4, "emptyTag", 1);
     });
 
     QUnit.test("multiple footnote anchors", function (assert) {
         text = "abc[A]\ndef[A]\nghi[A]\njkl[B]\n\n[Footnote A: abc]\n\n[Footnote B: mno]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         issueTest(assert, 2, 3, 3, "multipleAnchors", 0);
         issueTest(assert, 1, 10, 3, "multipleAnchors", 0);
         issueTest(assert, 0, 17, 3, "multipleAnchors", 0);
@@ -400,26 +394,26 @@ QUnit.module("Format preview test", function() {
 
     QUnit.test("missing maths start tag in non-math mode", function (assert) {
         text = "e=mc^2\\]";
-        issArray = analyse(text, configuration);
+        issArray = analyse(text, configuration).issues;
         noIssueTest(assert);
     });
 
     QUnit.test("missing maths start tag", function (assert) {
         text = "e=mc^2\\]";
-        issArray = analyse(text, mathConfig);
+        issArray = analyse(text, mathConfig).issues;
         issueTest(assert, 0, 6, 2, "noStartTag", 1);
     });
 
     QUnit.test("mismatched maths tags", function (assert) {
         text = "\\(e=mc^2\\]";
-        issArray = analyse(text, mathConfig);
+        issArray = analyse(text, mathConfig).issues;
         issueTest(assert, 1, 0, 2, "misMatchTag", 1);
         issueTest(assert, 0, 8, 2, "misMatchTag", 1);
     });
 
     QUnit.test("missing maths end tag", function (assert) {
         text = "\\[e=mc^2\\(";
-        issArray = analyse(text, mathConfig);
+        issArray = analyse(text, mathConfig).issues;
         issueTest(assert, 1, 0, 2, "noEndTag", 1);
         issueTest(assert, 0, 8, 2, "noEndTag", 1);
     });

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -749,7 +749,7 @@ $(function () {
         });
 
         return {
-            issArray: issArray,
+            issues: issArray,
             text: txt,
         };
     }; // end of analyse
@@ -1131,7 +1131,7 @@ $(function () {
         // encoded <  as &lt, so treat these lines separately.
         removeCommentLines();
         let analysis = analyse(txt, styler);
-        let issArray = analysis.issArray;
+        let issArray = analysis.issues;
         txt = analysis.text;
         addMarkUp(issArray);
         restoreCommentLines();

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -702,6 +702,9 @@ $(function () {
             }
         }
 
+        // the formatting rules are applied as if proofers' notes were
+        // invisible so remove them first. But if they are malformed mark the
+        // problem and do nothing else.
         checkProoferNotes();
         if(parseOK) {
             removeAllNotes();
@@ -712,7 +715,7 @@ $(function () {
             }
             checkBlankNumber();
             if (parseOK) {
-            // only do this is inline parse succeeded and blank lines ok
+            // only do this if inline parse succeeded and blank lines ok
                 boldHeading();
             }
             parseOol();


### PR DESCRIPTION
This first checks that proofers' notes are properly closed then removes them before format checking. This allows multi-line notes as in task 1977 and avoids various complications which can arise such as tags inside proofers' notes and notes inside markup.