### PR TITLE
Don't include URLs in credits for PG uploads

### DIFF
--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -454,12 +454,11 @@ class ProjectInfoHolder
                 $errors .= sprintf(
                     _("Posted Number \"%s\" is not of the correct format."),
                     html_safe($this->postednum)) . "<br>";
-                // You'll sometimes see PG etext numbers with a 'C' appended.
-                // The 'C' is not part of the etext number
-                // (e.g., it does not appear in PG's RDF catalog),
-                // rather it's a bit of information about the identified text,
-                // namely that it's still under (US) copyright.
-                // Anyhow, the 'C' should not be included here.
+                // Occasionally, there will be a PG ebook that is still
+                // under U.S. copyright. This is indicated in their system
+                // by appending a 'C' to the etext number. The link to
+                // the etext, however, does not include the 'C', nor should
+                // the DP link. If this changes, update the pattern here.
             }
         }
 
@@ -877,7 +876,7 @@ class ProjectInfoHolder
         $this->row(_("Original Image Source"), 'image_source_list', $this->image_source);
         $this->row(_("Image Preparer"), 'DP_user_field', $this->image_preparer, 'image_preparer', sprintf(_("%s user who scanned or harvested the images."), $site_abbreviation));
         $this->row(_("Text Preparer"), 'DP_user_field', $this->text_preparer, 'text_preparer', sprintf(_("%s user who prepared the text files."), $site_abbreviation));
-        $this->row(_("Extra Credits<br>(to be included in list of names)"),
+        $this->row(_("Extra Credits<br>(to be included in list of names--no URLs)"),
                                                'extra_credits_field', $this->extra_credits);
         if ($this->scannercredit != '') {
             $this->row(_("Scanner Credit (deprecated)"), 'text_field', $this->scannercredit, 'scannercredit');

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -221,7 +221,7 @@ class ImageSource
 
         echo "<tr class='$row_class'>";
         echo "<td colspan='6'>";
-        echo "<b>" . _("Credits Line") . ": </b>";
+        echo "<b>" . _("Credits Line (no URLs)") . ": </b>";
         echo html_safe($this->credit);
         echo "</td></tr>";
 
@@ -275,7 +275,7 @@ class ImageSource
         $this->_show_edit_row('display_name', _('Display Name'), false, 30, true);
         $this->_show_edit_row('full_name', _('Full Name'), false, 100, true);
         $this->_show_edit_row('url', _('Website'), false, 200);
-        $this->_show_edit_row('credit', _('Credits Line'), true, 200);
+        $this->_show_edit_row('credit', _('Credits Line (no URLs)'), true, 200);
         $this->_show_edit_permissions_row();
         $this->_show_edit_row('public_comment', _('Description (public comments)'), true, 255);
         $this->_show_edit_row('internal_comment', _('Notes (internal comments)'), true);


### PR DESCRIPTION
GM request; PG has asked that URLs (including email addresses) not be included in uploads to PG. Investigation showed that some of the image sources' credit lines included links. This MR updates the edit form for PMs to edit the project pages, and the Image Sources management form and display page to explicitly emphasize that the Credits line should not include URLs. Sandbox: [image-credits-no-link](https://www.pgdp.org/~srjfoo/c.branch/image-credits-no-link/).