### PR TITLE
Special quizzes not required

### DIFF
--- a/pinc/quizzes.inc
+++ b/pinc/quizzes.inc
@@ -111,7 +111,7 @@ new QuizLevel(
     "proof",
     "<p>" . _("This section covers topics that are not addressed in the <a href='../faq/proofreading_guidelines.php'>proofreading guidelines</a>. The pages include items that you are likely to see when proofreading HARD (and some Average) projects.") .
         "</p>\n<p>" .
-        _("If you are not yet familiar with a topic, you can learn about it by using the tutorial mode or following the \"Information\" link for that topic.") .
+        _("The following quizzes are not required, but can be useful. If you are not yet familiar with a topic, you can learn about it by using the tutorial mode or following the \"Information\" link for that topic.") .
         "</p>",
     [
 


### PR DESCRIPTION
The quiz page does not explicitly state that the special topic quizzes are not required for advancement, which confuses some users (for the three quizzes that are required, it does say so) -- especially beginners. Add a note to the "Specialized Proofreading Quizzes and Tutorials" section that explicitly states that they are not required. 

No separate sandbox for this, but it can be seen in [this sandbox](https://www.pgdp.org/~srjfoo/c.branch/revise-greek-quiz-p3/quiz/start.php?show_only=proof).