### PR TITLE
Rename SF genre to SF&F

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -6,6 +6,10 @@ see the git history.
 ## R??????
 Scripts supporting this upgrade are in `SETUP/upgrade/16`
 
+* Renamed the 'Science Fiction' genre to 'Science Fiction & Fantasy'.
+    There is no upgrade script for the `queue_defns` table; since
+    release queues do not come pre-defined, updating those entries
+    should be done manually by those who have genre queues enabled.
 
 ## R202102
 Scripts supporting this upgrade are in `SETUP/upgrade/15`

--- a/SETUP/upgrade/16/20210807_update_sf_genre.php
+++ b/SETUP/upgrade/16/20210807_update_sf_genre.php
@@ -1,0 +1,22 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Updating genre to 'Science Fiction & Fantasy' where it's 'Science Fiction' ...\n";
+$sql = "
+    UPDATE projects
+        SET genre = 'Science Fiction & Fantasy'
+        WHERE genre = 'Science Fiction'
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -218,7 +218,7 @@ class GenreColumn extends Column
         if ($prefix != "") {
             $genre = $prefix." ".$genre;
         }
-        echo $genre;
+        echo html_safe($genre);
     }
 }
 

--- a/pinc/genres.inc
+++ b/pinc/genres.inc
@@ -74,7 +74,7 @@ function load_genre_translation_array()
         'Romance' => _('Romance'),
         'Satire' => _('Satire'),
         'Science' => _('Science'),
-        'Science Fiction' => _('Science Fiction'),
+        'Science Fiction & Fantasy' => _('Science Fiction & Fantasy'),
         'Short Story' => _('Short Story'),
         'Sociology' => _('Sociology'),
         'Speech' => _('Speech'),

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -355,9 +355,9 @@ function _test_project_for_correct_metadata($projectid)
     $difficulty = $project->difficulty;
 
     $status = _("Manual");
-    $summary = sprintf(_("This is a manual test: %s. Genre: <b>%s</b>. Language: <b>%s</b>, Difficulty: <b>%s</b>"), $page_details_link, $genre, $language, $difficulty);
+    $summary = sprintf(_("This is a manual test: %s. Genre: <b>%s</b>. Language: <b>%s</b>, Difficulty: <b>%s</b>"), $page_details_link, html_safe($genre), $language, $difficulty);
     $details = "";
-    $details .= "<p><b>" . _("Genre") . "</b>: $genre</p>";
+    $details .= "<p><b>" . _("Genre") . "</b>: " . html_safe($genre) . "</p>";
     $details .= "<p><b>" . _("Language") . "</b>: $language</p>";
     $details .= "<p><b>" . _("Difficulty") . "</b>: $difficulty</p>";
 

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -528,7 +528,7 @@ function show_project_listing(
                 } elseif ($book['difficulty'] == "hard") {
                     $genre = _("HARD")." ".$genre;
                 }
-                $cell = $genre;
+                $cell = html_safe($genre);
             } elseif ($col_id == "username" || $col_id == "checkedoutby" || $col_id == "postproofer" || $col_id == "correctedby") {
                 // Create email or PM links for usernames.
                 $user_name = $book[$col_id];

--- a/project.php
+++ b/project.php
@@ -424,7 +424,7 @@ function do_project_info_table()
     echo_row_a(_("Title"), $project->nameofwork, true);
     echo_row_a(_("Author"), $project->authorsname, true);
     echo_row_a(_("Language"), $project->language);
-    echo_row_a(_("Genre"), _($project->genre));
+    echo_row_a(_("Genre"), _($project->genre), true);
 
     echo_row_a(_("Difficulty"), _($project->difficulty));
 
@@ -442,7 +442,7 @@ function do_project_info_table()
             $spec_display = $special_days[$spec_code]["display_name"] ?? "($spec_code)";
         }
 
-        echo_row_a(_("Special Day"), $spec_display);
+        echo_row_a(_("Special Day"), $spec_display, true);
     }
 
     // -------

--- a/stats/to_be_released.php
+++ b/stats/to_be_released.php
@@ -60,7 +60,7 @@ while ($row = mysqli_fetch_assoc($result)) {
     echo "<td style='white-space: nowrap;'>$username</td>";
     echo "<td style='white-space: nowrap;'>$datestamp</td>";
     echo "<td>$language</td>";
-    echo "<td>$genre</td>";
+    echo "<td>" . html_safe($genre) . "</td>";
     echo "</tr>\n";
 }
 

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -83,7 +83,7 @@ function genre_list($genre)
         if ($genre == $k) {
             echo " SELECTED";
         }
-        echo ">$v</option>";
+        echo ">" . html_safe($v) . "</option>";
         echo "\n";
     }
     echo "</select>";
@@ -207,7 +207,7 @@ function special_list($special)
         if ($special == $k) {
             echo " SELECTED";
         }
-        echo ">$v</option>";
+        echo ">" . html_safe($v) . "</option>";
         echo "\n";
     }
     echo "</select>";
@@ -291,7 +291,7 @@ function image_source_list($image_source)
         if ($image_source === $k) {
             echo " SELECTED";
         }
-        echo ">$v</option>";
+        echo ">" . html_safe($v) . "</option>";
         echo "\n";
     }
 

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -346,7 +346,7 @@ if (!isset($_GET['name'])) {
             echo html_safe($row['authorsname']);
             echo "</td>";
             echo "<td class='center-align'>";
-            echo $row['genre'];
+            echo html_safe($row['genre']);
             echo "</td>";
             echo "<td class='center-align'>";
             echo $row['language'];


### PR DESCRIPTION
GM request: Rename the `Science Fiction` genre to `Science Fiction & Fantasy`. This acknowledges explicitly how the genre is actually used.

Branch sandbox at [rename-sf-genre](https://www.pgdp.org/~srjfoo/c.branch/rename-sf-genre/).