### PR TITLE
Hide overflow from toolbar

### DIFF
--- a/tools/proofers/image_block_enh.inc
+++ b/tools/proofers/image_block_enh.inc
@@ -50,7 +50,7 @@ function ibe_get_styles()
                     height:{$block_height_pc}%;
                     z-index:2;
                     text-align:center;
-                    overflow:auto;
+                    overflow:hidden;
                     border: 1px solid black;
                 }
         STYLES;

--- a/tools/proofers/image_frame_std.php
+++ b/tools/proofers/image_frame_std.php
@@ -34,6 +34,6 @@ $header_args = [
 
 slim_header("Image Frame", $header_args);
 
-echo "<div style='height: 100vh;'>
+echo "<div style='height: 100vh; overflow: hidden;'>
 <div id='image-view'>
 </div></div>";


### PR DESCRIPTION
This avoids the effect seen when the control bar is at the side and the image view is very short so the buttons will not fit in the available space.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/widget_adjust_1