### PR TITLE
Avoid scrolling vertical toolbar in page browse

### DIFF
--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -438,7 +438,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                             stretchDiv.append(textDiv);
                             break;
                         case "imageText": {
-                            const imageDiv = $("<div>");
+                            const imageDiv = $("<div>").css({overflow: "hidden"});
                             imageWidget = makeImageWidget(imageDiv);
                             stretchDiv.append(imageDiv, textDiv);
                             const theSplitter = viewSplitter(stretchDiv, storageKey);

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -48,8 +48,8 @@ var splitControl = function(container, config) {
     let maxPos;
     container = $(container).css({display: 'flex'});
     let children = container.children();
-    let pane1 = $(children[0]).css({overflow: 'auto'});
-    let pane2 = $(children[1]).css({flex: '1 1 1px', overflow: 'auto'});
+    let pane1 = $(children[0]);
+    let pane2 = $(children[1]).css({flex: '1 1 1px'});
 
     let dragBar = $("<div>").css({"background-color": theConfig.dragBarColor, flex: `0 0 ${theConfig.dragBarSize}px`});
     pane1.after(dragBar);


### PR DESCRIPTION
set overflow hidden in pageBrowse and do not set pane overflow in splitControl.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/widget_adjust_2