### PR TITLE
Widget rotate 2

### DIFF
--- a/pinc/control_bar.inc
+++ b/pinc/control_bar.inc
@@ -18,7 +18,9 @@ function get_control_bar_texts()
         "fitWidth" => _("Fit image to width of window"),
         "zoomIn" => _("Zoom in 10%"),
         "zoomOut" => _("Zoom out 10%"),
-        "zoomPercent" => _("Zoom to percentage of 1000 pixels wide"),
+        "zoomPercent" => _("Zoom to percentage of natural width"),
+        "clockRotate" => _("Rotate image clockwise 90°"),
+        "anticlockRotate" => _("Rotate image anticlockwise 90°"),
     ]);
 
     return "var texts = $texts;";

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -132,7 +132,7 @@ var makeImageControl = function(canvas, reSize) {
     })
         .append($("<i>", {class: 'fas fa-arrows-alt-v'}));
 
-    let clockRotateInput = $("<button>")
+    let clockRotateInput = $("<button>", {title: texts.clockRotate})
         .append($("<i>", {class: 'fas fa-redo-alt'}))
         .click( function () {
             let newCos = sine;
@@ -141,7 +141,7 @@ var makeImageControl = function(canvas, reSize) {
             reDraw();
         });
 
-    let anticlockRotateInput = $("<button>")
+    let anticlockRotateInput = $("<button>", {title: texts.anticlockRotate})
         .append($("<i>", {class: 'fas fa-undo-alt'}))
         .click( function () {
             let newCos = -sine;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -223,7 +223,6 @@ var makeImageControl = function(canvas, align, reSize) {
         });
 
     const zoomIn = $("<button>", {title: texts.zoomIn}).click(function () {
-        setPercent();
         scale *= 1.1;
         setPercent();
         drawImage();

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -37,7 +37,7 @@ var makeImageControl = function(canvas, align, reSize) {
     // of view. So redraw when pane size changes.
     // This would be easy if we could use ResizeObserver(). In the meantime
     // use a resize callback which gets fired when pane size changes.
-    function reDraw() {
+    function drawImage() {
         getScrollbarWidth();
         // clearRect acts through transform
         ctx.resetTransform();
@@ -109,7 +109,7 @@ var makeImageControl = function(canvas, align, reSize) {
     }
 
     if(reSize) {
-        reSize.add(reDraw);
+        reSize.add(drawImage);
     }
 
     function clearCanvas() {
@@ -121,7 +121,7 @@ var makeImageControl = function(canvas, align, reSize) {
         clearCanvas();
         imageWidth = image.width;
         imageHeight = image.height;
-        reDraw();
+        drawImage();
     };
 
     function saveZoom(percent) {
@@ -143,7 +143,7 @@ var makeImageControl = function(canvas, align, reSize) {
         // in case above has changed it
         this.value = percent;
         scale = percent / 100;
-        reDraw();
+        drawImage();
         saveZoom(percent);
     });
 
@@ -181,7 +181,7 @@ var makeImageControl = function(canvas, align, reSize) {
             }
         }
         setPercent();
-        reDraw();
+        drawImage();
     })
         .append($("<i>", {class: 'fas fa-arrows-alt-h'}));
 
@@ -200,7 +200,7 @@ var makeImageControl = function(canvas, align, reSize) {
             }
         }
         setPercent();
-        reDraw();
+        drawImage();
     })
         .append($("<i>", {class: 'fas fa-arrows-alt-v'}));
 
@@ -210,7 +210,7 @@ var makeImageControl = function(canvas, align, reSize) {
             let newCos = sine;
             sine = -cosine;
             cosine = newCos;
-            reDraw();
+            drawImage();
         });
 
     let anticlockRotateInput = $("<button>", {title: texts.anticlockRotate})
@@ -219,21 +219,21 @@ var makeImageControl = function(canvas, align, reSize) {
             let newCos = -sine;
             sine = cosine;
             cosine = newCos;
-            reDraw();
+            drawImage();
         });
 
     const zoomIn = $("<button>", {title: texts.zoomIn}).click(function () {
         setPercent();
         scale *= 1.1;
         setPercent();
-        reDraw();
+        drawImage();
     })
         .append($("<i>", {class: 'fas fa-search-plus'}));
 
     const zoomOut = $("<button>", {title: texts.zoomOut}).click(function () {
         scale /= 1.1;
         setPercent();
-        reDraw();
+        drawImage();
     })
         .append($("<i>", {class: 'fas fa-search-minus'}));
 
@@ -258,7 +258,7 @@ var makeImageControl = function(canvas, align, reSize) {
             let percent = imageData.zoom;
             percentInput.val(percent);
             scale = percent / 100;
-            reDraw();
+            drawImage();
         },
         setImage: function(src) {
             // reset to normal orientation

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -4,6 +4,7 @@
 // Construct the image sizing controls.
 var makeImageControl = function(canvas, align, reSize) {
     let imageKey;
+    let percent;
     let scale = 1;
     let imageWidth, imageHeight;
     const image = document.createElement("img");
@@ -117,10 +118,22 @@ var makeImageControl = function(canvas, align, reSize) {
         ctx.clearRect( 0, 0, canvas.width, canvas.height);
     }
 
+    let relative1000 = true;
+    function percentToScale() {
+        if(relative1000) {
+            // 100% means image scaled to be 1000px wide
+            scale = percent * 10 / imageWidth;
+        } else {
+            // 100% means natural size
+            scale = percent / 100;
+        }
+    }
+
     image.onload = function() {
         clearCanvas();
         imageWidth = image.width;
         imageHeight = image.height;
+        percentToScale();
         drawImage();
     };
 
@@ -129,7 +142,6 @@ var makeImageControl = function(canvas, align, reSize) {
     }
 
     percentInput.change(function() {
-        let percent;
         const value = parseInt(this.value);
         if(isNaN(value)) {
             percent = 100;
@@ -142,13 +154,18 @@ var makeImageControl = function(canvas, align, reSize) {
         }
         // in case above has changed it
         this.value = percent;
-        scale = percent / 100;
+        percentToScale();
         drawImage();
         saveZoom(percent);
     });
 
     function setPercent() {
-        let percent = Math.round(100 * scale);
+        if(relative1000) {
+            percent = scale * imageWidth / 10.0;
+        } else {
+            percent = 100 * scale;
+        }
+        percent = Math.round(percent);
         percentInput.val(percent);
         saveZoom(percent);
     }
@@ -164,7 +181,6 @@ var makeImageControl = function(canvas, align, reSize) {
             rotatedImageHeight = imageWidth;
         }
     }
-
 
     const fitWidth = $("<button>", {title: texts.fitWidth}).click(function () {
         let holder = canvas.parentNode;
@@ -254,10 +270,8 @@ var makeImageControl = function(canvas, align, reSize) {
             if(!$.isPlainObject(imageData)) {
                 imageData = {zoom: 100};
             }
-            let percent = imageData.zoom;
+            percent = imageData.zoom;
             percentInput.val(percent);
-            scale = percent / 100;
-            drawImage();
         },
         setImage: function(src) {
             // reset to normal orientation

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -25,6 +25,10 @@ var makeImageControl = function(canvas, align, reSize) {
     }
     getScrollbarWidth();
 
+    function maxVal(a, b) {
+        return (a > b) ? a : b;
+    }
+
     // If we always make the canvas fit image then when reducing the image size
     // rapidly with spinner the canvas does not get cleared even when
     // redrawing with setTimer(0).
@@ -52,27 +56,28 @@ var makeImageControl = function(canvas, align, reSize) {
             rotatedWidth = scaleHeight;
             rotatedHeight = scaleWidth;
         }
-        // we have to calculate what will happen if scrollbars appear
+        // we need to know if either dimension of the image is bigger than the
+        // window but we do not yet know if there will be any scrollbars
         let holder = canvas.parentNode;
+        // suppose there are no scrollbars
         let paneWidth = holder.offsetWidth;
         let paneHeight = holder.offsetHeight;
         if(rotatedHeight > paneHeight) {
+            // there will be a vertical scrollbar
             paneWidth = holder.offsetWidth - scrollbarWidth;
         }
-        let underWidth = paneWidth - rotatedWidth;
-        if(underWidth < 0) {
-            // image is wider than pane
+        if(rotatedWidth > paneWidth) {
+            // there will be a horizontal scrollbar
             paneHeight = holder.offsetHeight - scrollbarWidth;
-            canvas.width = rotatedWidth;
-        } else {
-            canvas.width = paneWidth;
+            // pane height is now less so there could now be a vertical bar
+            if(rotatedHeight > paneHeight) {
+                // there will be a vertical scrollbar
+                paneWidth = holder.offsetWidth - scrollbarWidth;
+            }
+            // already a horiz. bar so this is the final solution
         }
-        if(rotatedHeight > paneHeight) {
-            paneWidth = holder.offsetWidth - scrollbarWidth;
-            canvas.height = rotatedHeight;
-        } else {
-            canvas.height = paneHeight;
-        }
+        canvas.width = maxVal(rotatedWidth, paneWidth);
+        canvas.height = maxVal(rotatedHeight, paneHeight);
 
         // rotation is about point (0,0); offset so image is in canvas area
         let xOff = 0;
@@ -94,6 +99,7 @@ var makeImageControl = function(canvas, align, reSize) {
 
         // image origin in canvas
         let dx = 0;
+        let underWidth = paneWidth - rotatedWidth;
         if(underWidth > 0) {
             if(align == "C") {
                 dx = underWidth / 2;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -452,6 +452,7 @@ function makeImageWidget(container, align = "C", reSize = null) {
 
     const canvas = document.createElement("canvas");
     canvas.classList.add("middle-align");
+    canvas.style.cursor = "grab";
     const imageControl = makeImageControl(canvas, reSize);
 
     const controlDiv = makeControlDiv(container, imageControl.controls, reSize);
@@ -467,12 +468,12 @@ function makeImageWidget(container, align = "C", reSize = null) {
 
     function mouseup() {
         $(document).unbind("mousemove mouseup");
-        $(canvas).css("cursor", "grab");
+        canvas.style.cursor = "grab";
     }
 
     $(canvas).mousedown( function(event) {
         event.preventDefault();
-        $(canvas).css("cursor", "grabbing");
+        canvas.style.cursor = "grabbing";
         scrollDiffX = event.pageX + controlDiv.content.scrollLeft();
         scrollDiffY = event.pageY + controlDiv.content.scrollTop();
         $(document).on("mousemove", mousemove)

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -58,6 +58,7 @@ var makeImageControl = function(canvas, reSize) {
             newWidth = scaleHeight;
             newHeight = scaleWidth;
         }
+        // we have to calculate what will happen if scrollbars appear
         let holder = canvas.parentNode;
         let paneWidth = holder.offsetWidth;
         let paneHeight = holder.offsetHeight;
@@ -139,18 +140,52 @@ var makeImageControl = function(canvas, reSize) {
         saveZoom(percent);
     }
 
+    let rotatedImageWidth;
+    let rotatedImageHeight;
+    function rotationCompensate() {
+        if(sine == 0) {
+            rotatedImageWidth = imageWidth;
+            rotatedImageHeight = imageHeight;
+        } else {
+            rotatedImageWidth = imageHeight;
+            rotatedImageHeight = imageWidth;
+        }
+    }
+
+
     const fitWidth = $("<button>", {title: texts.fitWidth}).click(function () {
-        // if rotated 90deg fit fit image height to pane width
-        let imagesize = (sine == 0) ? imageWidth : imageHeight;
-        scale = canvas.parentNode.clientWidth / imagesize;
+        let holder = canvas.parentNode;
+        rotationCompensate();
+        scale = holder.offsetWidth / rotatedImageWidth;
+        // does fitting rotatedImageWidth cause a vertical scrollbar?
+        if(scale * rotatedImageHeight > holder.offsetHeight) {
+            // there would be a vertical scrollbar, fit inside
+            scale = (holder.offsetWidth - scrollbarWidth) / rotatedImageWidth;
+            // rotatedImageHeight will be less so might not need a vertical scrollbar
+            if(scale * rotatedImageHeight < holder.offsetHeight) {
+                // best option is to fit rotatedImageHeight
+                scale = holder.offsetHeight / rotatedImageHeight;
+            }
+        }
         setPercent();
         reDraw();
     })
         .append($("<i>", {class: 'fas fa-arrows-alt-h'}));
 
     const fitHeight = $("<button>", {title: texts.fitHeight}).click(function () {
-        let imagesize = (sine == 0) ? imageHeight : imageWidth;
-        scale = canvas.parentNode.clientHeight / imagesize;
+        let holder = canvas.parentNode;
+        rotationCompensate();
+        scale = holder.offsetHeight / rotatedImageHeight;
+        // does fitting rotatedImageHeight cause a horizontal scrollbar?
+        if(scale * rotatedImageWidth > holder.offsetWidth) {
+            // there would be a vertical scrollbar, fit inside
+            scale = (holder.offsetHeight - scrollbarWidth) / rotatedImageHeight;
+            // rotatedImageWidth will be less so might not need a horizontal scrollbar
+            if(scale * rotatedImageWidth < holder.offsetWidth) {
+                // best option is to fit rotatedImageWidth
+                scale = holder.offsetWidth / rotatedImageWidth;
+            }
+        }
         setPercent();
         reDraw();
     })

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -13,18 +13,37 @@ var makeImageControl = function(canvas) {
 
     let sine = 0, cosine = 1;
 
-    function drawCanvas () {
+    function maxVal(a, b) {
+        return (a > b) ? a : b;
+    }
+
+    function reDraw() {
+        // clearRect acts through transform
+        ctx.resetTransform();
+        ctx.clearRect( 0, 0, canvas.width, canvas.height);
+
         let scaleWidth = imageWidth * scale;
         let scaleHeight = imageHeight * scale;
+        let newWidth, newHeight;
         if(cosine != 0) {
             // 0 or 180
-            canvas.width = scaleWidth;
-            canvas.height = scaleHeight;
+            newWidth = scaleWidth;
+            newHeight = scaleHeight;
         } else {
             // +- 90
-            canvas.width = scaleHeight;
-            canvas.height = scaleWidth;
+            newWidth = scaleHeight;
+            newHeight = scaleWidth;
         }
+        // if either image dimension is larger than the pane then make canvas
+        // to fit it. Scroll bars will appear. Otherwise make canvas dimension
+        // fill pane. If we always make canvas fit image then when reducing
+        // size rapidly with spinner canvas does not get cleared even when
+        // redrawing with setTimer(0).
+        canvas.width = maxVal(newWidth, canvas.parentNode.clientWidth);
+        canvas.height = maxVal(newHeight, canvas.parentNode.clientHeight);
+        // calculate again in case a scrollbar has appeared
+        canvas.width = maxVal(newWidth, canvas.parentNode.clientWidth);
+
         let xOff = 0;
         let yOff = 0;
         if(cosine == -1) {
@@ -46,18 +65,8 @@ var makeImageControl = function(canvas) {
     }
 
     function clearCanvas() {
-        canvas.width = canvas.parentNode.clientHeight;
-        canvas.height = canvas.parentNode.clientWidth;
         ctx.resetTransform();
         ctx.clearRect( 0, 0, canvas.width, canvas.height);
-    }
-
-    function reDraw() {
-        // clearRect acts through transform
-        ctx.resetTransform();
-        ctx.clearRect( 0, 0, canvas.width, canvas.height);
-        // clearRect does not take effect if we do drawCanvas immediately
-        setTimeout(drawCanvas, 0);
     }
 
     image.onload = function() {
@@ -170,10 +179,10 @@ var makeImageControl = function(canvas) {
             reDraw();
         },
         setImage: function(src) {
+            // reset to normal orientation
             sine = 0;
             cosine = 1;
             image.src = src;
-            clearCanvas();
         }
     };
 };

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -14,18 +14,16 @@ var makeImageControl = function(canvas, align, reSize) {
 
     let sine = 0, cosine = 1;
 
-    let scrollbarWidth = false;
-    var getScrollbarWidth = function() {
-        if (scrollbarWidth === false) {
-            let testDiv = document.createElement('div');
-            testDiv.innerHTML = '<div style="width:50px;height:5px;position:absolute; overflow:scroll;"><div style="width:100px;height:5px;"></div></div>';
-            let innerDiv = testDiv.firstChild;
-            document.body.appendChild(testDiv);
-            scrollbarWidth = innerDiv.offsetWidth - innerDiv.clientWidth;
-            document.body.removeChild(testDiv);
-        }
-        return scrollbarWidth;
-    };
+    let scrollbarWidth;
+    function getScrollbarWidth() {
+        let testDiv = document.createElement('div');
+        testDiv.innerHTML = '<div style="overflow:scroll;"><div"></div></div>';
+        let innerDiv = testDiv.firstChild;
+        document.body.appendChild(testDiv);
+        scrollbarWidth = innerDiv.offsetWidth - innerDiv.clientWidth;
+        document.body.removeChild(testDiv);
+    }
+    getScrollbarWidth();
 
     // If we always make the canvas fit image then when reducing the image size
     // rapidly with spinner the canvas does not get cleared even when
@@ -39,10 +37,9 @@ var makeImageControl = function(canvas, align, reSize) {
     // This would be easy if we could use ResizeObserver(). In the meantime
     // use a resize callback which gets fired when pane size changes.
     function drawImage() {
-        getScrollbarWidth();
         // clearRect acts through transform
         ctx.resetTransform();
-        ctx.clearRect( 0, 0, canvas.width, canvas.height);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
         let scaleWidth = imageWidth * scale;
         let scaleHeight = imageHeight * scale;
         let rotatedWidth, rotatedHeight;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -432,7 +432,7 @@ function makeControlDiv(container, controls, onChange) {
     };
 }
 
-function makeImageWidget(container, reSize = null) {
+function makeImageWidget(container, align, reSize = null) {
     // if we are inside a splitter then reSize will fire when pane size
     // changes.Otherwise fire on window reSize. It will also fire when the
     // control bar changes position.

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -47,9 +47,8 @@ var makeImageControl = function(canvas, reSize) {
         }
         canvas.width = maxVal(newWidth, canvas.parentNode.clientWidth);
         canvas.height = maxVal(newHeight, canvas.parentNode.clientHeight);
-        // calculate again in case a scrollbar has appeared
-        canvas.width = maxVal(newWidth, canvas.parentNode.clientWidth);
 
+        // rotation is about point (0,0); offset so image is in canvas area
         let xOff = 0;
         let yOff = 0;
         if(cosine == -1) {

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -20,9 +20,9 @@ var makeImageControl = function(canvas, reSize) {
     // If we always make the canvas fit image then when reducing the image size
     // rapidly with spinner the canvas does not get cleared even when
     // redrawing with setTimer(0).
-    // So, make canvas fit image only if either image dimension is larger
-    // than the pane. Scroll bars will then appear. Otherwise make canvas
-    // dimension fill pane.
+    // So, make canvas dimension fit image dimension only if it is larger
+    // than the pane. A scroll bar will then appear. Otherwise make canvas
+    // dimension fill pane. Canvas now always clears.
     // This introduces a new problem: if the image is smaller than the pane
     // and the pane size decreases it is possible to scroll the image out
     // of view. So redraw when pane size changes.
@@ -433,13 +433,7 @@ function makeControlDiv(container, controls, onChange) {
     };
 }
 
-function makeImageWidget(container, align = "C", reSize = null) {
-    const alignment = {
-        L: "left",
-        C: "center",
-        R: "right"
-    };
-
+function makeImageWidget(container, reSize = null) {
     // if we are inside a splitter then reSize will fire when pane size
     // changes.Otherwise fire on window reSize. It will also fire when the
     // control bar changes position.
@@ -451,13 +445,14 @@ function makeImageWidget(container, align = "C", reSize = null) {
     }
 
     const canvas = document.createElement("canvas");
+    // this avoids the extra space for descender for inline element
     canvas.classList.add("middle-align");
     canvas.style.cursor = "grab";
     const imageControl = makeImageControl(canvas, reSize);
 
     const controlDiv = makeControlDiv(container, imageControl.controls, reSize);
 
-    controlDiv.content.css("text-align", alignment[align]).append(canvas);
+    controlDiv.content.append(canvas);
 
     let scrollDiffX = 0;
     let scrollDiffY = 0;
@@ -489,6 +484,7 @@ function makeImageWidget(container, align = "C", reSize = null) {
 
         setImage: function (src) {
             imageControl.setImage(src);
+            // reset scroll to top left
             controlDiv.content
                 .scrollTop(0)
                 .scrollLeft(0);

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -13,6 +13,19 @@ var makeImageControl = function(canvas, reSize) {
 
     let sine = 0, cosine = 1;
 
+    let scrollbarWidth = false;
+    var getScrollbarWidth = function() {
+        if (scrollbarWidth === false) {
+            let testDiv = document.createElement('div');
+            testDiv.innerHTML = '<div style="width:50px;height:5px;position:absolute; overflow:scroll;"><div style="width:100px;height:5px;"></div></div>';
+            let innerDiv = testDiv.firstChild;
+            document.body.appendChild(testDiv);
+            scrollbarWidth = innerDiv.offsetWidth - innerDiv.clientWidth;
+            document.body.removeChild(testDiv);
+        }
+        return scrollbarWidth;
+    };
+
     function maxVal(a, b) {
         return (a > b) ? a : b;
     }
@@ -29,10 +42,10 @@ var makeImageControl = function(canvas, reSize) {
     // This would be easy if we could use ResizeObserver(). In the meantime
     // use a resize callback which gets fired when pane size changes.
     function reDraw() {
+        getScrollbarWidth();
         // clearRect acts through transform
         ctx.resetTransform();
         ctx.clearRect( 0, 0, canvas.width, canvas.height);
-
         let scaleWidth = imageWidth * scale;
         let scaleHeight = imageHeight * scale;
         let newWidth, newHeight;
@@ -45,8 +58,20 @@ var makeImageControl = function(canvas, reSize) {
             newWidth = scaleHeight;
             newHeight = scaleWidth;
         }
-        canvas.width = maxVal(newWidth, canvas.parentNode.clientWidth);
-        canvas.height = maxVal(newHeight, canvas.parentNode.clientHeight);
+        let holder = canvas.parentNode;
+        let paneWidth = holder.offsetWidth;
+        let paneHeight = holder.offsetHeight;
+        if(newHeight > paneHeight) {
+            paneWidth = holder.offsetWidth - scrollbarWidth;
+        }
+        if(newWidth > paneWidth) {
+            paneHeight = holder.offsetHeight - scrollbarWidth;
+        }
+        if(newHeight > paneHeight) {
+            paneWidth = holder.offsetWidth - scrollbarWidth;
+        }
+        canvas.width = maxVal(newWidth, paneWidth);
+        canvas.height = maxVal(newHeight, paneHeight);
 
         // rotation is about point (0,0); offset so image is in canvas area
         let xOff = 0;

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -439,9 +439,9 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                             break;
                         case "imageText": {
                             const imageDiv = $("<div>");
-                            imageWidget = makeImageWidget(imageDiv);
                             stretchDiv.append(imageDiv, textDiv);
                             const theSplitter = viewSplitter(stretchDiv, storageKey);
+                            imageWidget = makeImageWidget(imageDiv, "C", theSplitter.mainSplit.reSize);
                             if(mentorMode) {
                                 // make a text widget with splitter
                                 textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.reSize);

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -441,7 +441,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                             const imageDiv = $("<div>");
                             stretchDiv.append(imageDiv, textDiv);
                             const theSplitter = viewSplitter(stretchDiv, storageKey);
-                            imageWidget = makeImageWidget(imageDiv, theSplitter.mainSplit.reSize);
+                            imageWidget = makeImageWidget(imageDiv, "L", theSplitter.mainSplit.reSize);
                             if(mentorMode) {
                                 // make a text widget with splitter
                                 textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.reSize);

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -441,7 +441,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                             const imageDiv = $("<div>");
                             stretchDiv.append(imageDiv, textDiv);
                             const theSplitter = viewSplitter(stretchDiv, storageKey);
-                            imageWidget = makeImageWidget(imageDiv, "C", theSplitter.mainSplit.reSize);
+                            imageWidget = makeImageWidget(imageDiv, theSplitter.mainSplit.reSize);
                             if(mentorMode) {
                                 // make a text widget with splitter
                                 textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.reSize);

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -419,7 +419,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                     }
 
                     const imageDiv = $("<div>");
-                    imageWidget = makeImageWidget(imageDiv);
+                    imageWidget = makeImageWidget(imageDiv, "C");
                     imageWidget.setup(storageKey);
                     stretchDiv.append(imageDiv);
                     showImageText();
@@ -441,7 +441,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                             const imageDiv = $("<div>");
                             stretchDiv.append(imageDiv, textDiv);
                             const theSplitter = viewSplitter(stretchDiv, storageKey);
-                            imageWidget = makeImageWidget(imageDiv, "L", theSplitter.mainSplit.reSize);
+                            imageWidget = makeImageWidget(imageDiv, "C", theSplitter.mainSplit.reSize);
                             if(mentorMode) {
                                 // make a text widget with splitter
                                 textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.reSize);


### PR DESCRIPTION
This enables the image to be rotated using a canvas rather than the previous attempt using css transforms in which it proved difficult to prevent the image from being scrolled out of view.

This new method has the unforeseen effect of avoiding the iPad fit-height issue.

If we do not want to implement the rotation controls immediately we can disable them and test the rest of it first.

It also has the following differences:
1. The image size is relative to the natural width rather than 1000pixels. This could be changed.
2. The alignment is always to the left when the image does not fill the window. This could be implemented to be left, centre or right.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/widget_rotate_2
