### PR TITLE
Bar scroll

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -121,12 +121,33 @@ function makeControlDiv(container, controls, onChange) {
     controlBar.append(control1, control2, control3);
 
     const menu = $("<div>", {class: "control-bar-menu"});
-
     const menuButton = $("<button>", {title: texts.adjustPanel})
         .append($("<i>", {class: 'fas fa-cog'}))
         .click(function () {
+            if(menu.is(":hidden")) {
+                // find the position of the menu button and set position of
+                // menu relative to it
+                const menuButtonWidth = menuButton.outerWidth();
+                const menuWidth = menu.outerWidth();
+                const buttonPos = menuButton.offset();
+                switch(compassPoint) {
+                case "N":
+                    menu.css({top: buttonPos.top + 1.5 * menuButtonWidth, left: buttonPos.left});
+                    break;
+                case "W":
+                    menu.css({top: buttonPos.top, left: buttonPos.left + 1.5 * menuButtonWidth});
+                    break;
+                case "S":
+                    menu.css({top: buttonPos.top - menuWidth - 0.5 * menuButtonWidth, left: buttonPos.left});
+                    break;
+                default: // E
+                    menu.css({top: buttonPos.top, left: buttonPos.left - menuWidth - 0.5 * menuButtonWidth});
+                    break;
+                }
+            }
             menu.toggle();
         });
+
 
     // build navBox
     const navBox = $("<table>");
@@ -194,9 +215,7 @@ function makeControlDiv(container, controls, onChange) {
     const hideButton = $("<button>", {class: 'navbutton', title: texts.hideMenu}).append('×');
 
     menu.append(navBox);
-    const menuHolder = $("<div>").css({position: "relative"})
-        .append(menu);
-    control1.append($("<div>", {class: "condiv center-align"}).append(menuButton), menuHolder);
+    control1.append($("<div>", {class: "condiv center-align"}).append(menuButton), menu);
 
     function setCompassPoint() {
         $(".navbutton", navBox).detach();
@@ -205,28 +224,24 @@ function makeControlDiv(container, controls, onChange) {
             controlFirst();
             controlHoriz();
             controlBar.css({borderWidth: "0 0 1px 0"});
-            menu.css({top: "0.21em", left: "", right: "", bottom: ""});
             fillNavBox([leftButton, centerButton, rightButton, westButton, hideButton, eastButton, "", southButton, ""]);
             break;
         case "W":
             controlFirst();
             controlVert();
             controlBar.css({borderWidth: "0 1px 0 0"});
-            menu.css({top: "", left: "3em", right: "", bottom: ""});
             fillNavBox([topButton, northButton, "", midButton, hideButton, eastButton, botButton, southButton, ""]);
             break;
         case "E":
             controlLast();
             controlVert();
             controlBar.css({borderWidth: "0 0 0 1px"});
-            menu.css({top: "", left: "", right: "3em", bottom: ""});
             fillNavBox(["", northButton, topButton, westButton, hideButton, midButton, "", southButton, botButton]);
             break;
         case "S":
             controlLast();
             controlHoriz();
             controlBar.css({borderWidth: "1px 0 0 0"});
-            menu.css({top: "", left: "", right: "", bottom: "2em"});
             fillNavBox(["", northButton, "", westButton, hideButton, eastButton, leftButton, centerButton, rightButton]);
             break;
         }

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -127,21 +127,20 @@ function makeControlDiv(container, content, controls, onChange) {
             if(menu.is(":hidden")) {
                 // find the position of the menu button and set position of
                 // menu relative to it
-                const menuButtonWidth = menuButton.outerWidth();
                 const menuWidth = menu.outerWidth();
-                const buttonPos = menuButton.offset();
+                let buttonRect = menuButton[0].getBoundingClientRect();
                 switch(compassPoint) {
                 case "N":
-                    menu.css({top: buttonPos.top + 1.5 * menuButtonWidth, left: buttonPos.left});
+                    menu.css({top: buttonRect.top, left: buttonRect.right});
                     break;
                 case "W":
-                    menu.css({top: buttonPos.top, left: buttonPos.left + 1.5 * menuButtonWidth});
+                    menu.css({top: buttonRect.top, left: buttonRect.right});
                     break;
                 case "S":
-                    menu.css({top: buttonPos.top - menuWidth - 0.5 * menuButtonWidth, left: buttonPos.left});
+                    menu.css({top: buttonRect.bottom - menuWidth, left: buttonRect.right});
                     break;
                 default: // E
-                    menu.css({top: buttonPos.top, left: buttonPos.left - menuWidth - 0.5 * menuButtonWidth});
+                    menu.css({top: buttonRect.top, left: buttonRect.left - menuWidth});
                     break;
                 }
             }

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -99,7 +99,7 @@ var makeImageControl = function(imageElement) {
     };
 };
 
-function makeControlDiv(container, controls, onChange) {
+function makeControlDiv(container, content, controls, onChange) {
     let barKey;
     let compassPoint;
     let begMidEnd;
@@ -109,7 +109,7 @@ function makeControlDiv(container, controls, onChange) {
         localStorage.setItem(barKey, JSON.stringify(barData));
     }
 
-    const content = $("<div>", {class: 'overflow-auto'}).css({flex: 'auto'});
+    content.addClass('overflow-auto').css({flex: 'auto'});
     container.css({display: 'flex', height: "100%"});
     container.append(content);
 
@@ -335,8 +335,6 @@ function makeControlDiv(container, controls, onChange) {
     });
 
     return {
-        content: content,
-
         setupControls: function (storageKey) {
             barKey = storageKey + "-bar";
             let barData = JSON.parse(localStorage.getItem(barKey));
@@ -362,15 +360,15 @@ function makeImageWidget(container, align = "C") {
     };
     const imageElement = $("<img>", {class: "middle-align"}).css("cursor", "grab");
     const imageControl = makeImageControl(imageElement);
-    const controlDiv = makeControlDiv(container, imageControl.controls);
-
-    controlDiv.content.css("text-align", alignment[align]).append(imageElement);
+    const content = $("<div>").css("text-align", alignment[align])
+        .append(imageElement);
+    const controlDiv = makeControlDiv(container, content, imageControl.controls);
 
     let scrollDiffX = 0;
     let scrollDiffY = 0;
     function mousemove(event) {
-        controlDiv.content.scrollTop(scrollDiffY - event.pageY);
-        controlDiv.content.scrollLeft(scrollDiffX - event.pageX);
+        content.scrollTop(scrollDiffY - event.pageY);
+        content.scrollLeft(scrollDiffX - event.pageX);
     }
 
     function mouseup() {
@@ -381,8 +379,8 @@ function makeImageWidget(container, align = "C") {
     imageElement.mousedown( function(event) {
         event.preventDefault();
         imageElement.css("cursor", "grabbing");
-        scrollDiffX = event.pageX + controlDiv.content.scrollLeft();
-        scrollDiffY = event.pageY + controlDiv.content.scrollTop();
+        scrollDiffX = event.pageX + content.scrollLeft();
+        scrollDiffY = event.pageY + content.scrollTop();
         $(document).on("mousemove", mousemove)
             .on("mouseup", mouseup);
     });
@@ -396,7 +394,7 @@ function makeImageWidget(container, align = "C") {
 
         setImage: function (src) {
             imageElement.attr("src", src);
-            controlDiv.content
+            content
                 .scrollTop(0)
                 .scrollLeft(0);
         }

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -170,8 +170,12 @@ function makeControlDiv(container, controls, onChange) {
     }
 
     function controlFirst() {
+        // this could be done more simply using prepend
+        // but on Safari the tools disappear sometimes.
+        content.detach();
         controlBar.detach();
-        container.prepend(controlBar);
+        container.append(controlBar);
+        container.append(content);
     }
 
     function controlLast() {

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -98,22 +98,23 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
     const textArea = $("<textarea>", {class: "text-pane"});
     textArea.prop("readonly", !splitter);
     const textControl = maketextControl(textArea);
-    const controlDiv = makeControlDiv(container, textControl.controls, reLayout);
+    const content = $("<div>");
+    const controlDiv = makeControlDiv(container, content, textControl.controls, reLayout);
     let subSplitter;
     let splitterKey;
     let textSplitData;
     if(splitter) {
         const topTextDiv = $("<div>").append(textArea);
         const bottomTextDiv = $("<div>");
-        controlDiv.content.append(topTextDiv, bottomTextDiv);
+        content.append(topTextDiv, bottomTextDiv);
 
-        subSplitter = splitControl(controlDiv.content, {splitVertical: false, reDraw: reLayout});
+        subSplitter = splitControl(content, {splitVertical: false, reDraw: reLayout});
         subSplitter.dragEnd.add(function (percent) {
             textSplitData.splitPercent = percent;
             localStorage.setItem(splitterKey, JSON.stringify(textSplitData));
         });
     } else {
-        controlDiv.content.append(textArea);
+        content.append(textArea);
     }
     return {
         setup: function(storageKey) {

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -104,7 +104,7 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
     let splitterKey;
     let textSplitData;
     if(splitter) {
-        const topTextDiv = $("<div>").append(textArea);
+        const topTextDiv = $("<div>", {class: "display-flex"}).append(textArea);
         const bottomTextDiv = $("<div>");
         content.append(topTextDiv, bottomTextDiv);
 
@@ -114,7 +114,7 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
             localStorage.setItem(splitterKey, JSON.stringify(textSplitData));
         });
     } else {
-        content.append(textArea);
+        content.addClass("display-flex").append(textArea);
     }
     return {
         setup: function(storageKey) {

--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -445,7 +445,6 @@
 
     .text-pane {
         width: 100%;
-        height: 100%;
         box-sizing: border-box;
         padding-left: .25em;
         resize: none;

--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -466,6 +466,7 @@
     color: @control-pane-text;
     border-style: solid;
     border-color: gray;
+    overflow: auto;
 
     input, select, button {
         background-color: @text-pane-background;
@@ -503,11 +504,15 @@
 
 .control-bar-menu {
     position: absolute;
-    padding: 0.3em;
+    padding: 0.2em;
     box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.5);
     border-radius: 0.3em;
     background-color: @control-pane-background;
     border: 1px solid gray;
     display: none;
     z-index: 1;
+
+    td {
+        padding: 0.2em 0.2em;
+    }
 }

--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -478,6 +478,7 @@
         width: 2.2em;
         text-align: right;
         -moz-appearance: textfield;
+        -webkit-logical-width: -webkit-fit-content;
     }
 
     input::-webkit-outer-spin-button, input::-webkit-inner-spin-button {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -976,6 +976,7 @@
   width: 2.2em;
   text-align: right;
   -moz-appearance: textfield;
+  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -963,6 +963,7 @@
   color: black;
   border-style: solid;
   border-color: gray;
+  overflow: auto;
 }
 .control-bar input,
 .control-bar select,
@@ -1000,13 +1001,16 @@
 }
 .control-bar-menu {
   position: absolute;
-  padding: 0.3em;
+  padding: 0.2em;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.5);
   border-radius: 0.3em;
   background-color: #CDC0B0;
   border: 1px solid gray;
   display: none;
   z-index: 1;
+}
+.control-bar-menu td {
+  padding: 0.2em 0.2em;
 }
 /* ------------------------------------------------------------------------ */
 /* Common color definitions

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -945,7 +945,6 @@
 }
 #page-browser .text-pane {
   width: 100%;
-  height: 100%;
   box-sizing: border-box;
   padding-left: 0.25em;
   resize: none;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -976,6 +976,7 @@
   width: 2.2em;
   text-align: right;
   -moz-appearance: textfield;
+  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -963,6 +963,7 @@
   color: black;
   border-style: solid;
   border-color: gray;
+  overflow: auto;
 }
 .control-bar input,
 .control-bar select,
@@ -1000,13 +1001,16 @@
 }
 .control-bar-menu {
   position: absolute;
-  padding: 0.3em;
+  padding: 0.2em;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.5);
   border-radius: 0.3em;
   background-color: #CDC0B0;
   border: 1px solid gray;
   display: none;
   z-index: 1;
+}
+.control-bar-menu td {
+  padding: 0.2em 0.2em;
 }
 /* ------------------------------------------------------------------------ */
 /* Common color definitions

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -945,7 +945,6 @@
 }
 #page-browser .text-pane {
   width: 100%;
-  height: 100%;
   box-sizing: border-box;
   padding-left: 0.25em;
   resize: none;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -976,6 +976,7 @@
   width: 2.2em;
   text-align: right;
   -moz-appearance: textfield;
+  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -963,6 +963,7 @@
   color: black;
   border-style: solid;
   border-color: gray;
+  overflow: auto;
 }
 .control-bar input,
 .control-bar select,
@@ -1000,13 +1001,16 @@
 }
 .control-bar-menu {
   position: absolute;
-  padding: 0.3em;
+  padding: 0.2em;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.5);
   border-radius: 0.3em;
   background-color: #CDC0B0;
   border: 1px solid gray;
   display: none;
   z-index: 1;
+}
+.control-bar-menu td {
+  padding: 0.2em 0.2em;
 }
 /* ------------------------------------------------------------------------ */
 /* Common color definitions

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -945,7 +945,6 @@
 }
 #page-browser .text-pane {
   width: 100%;
-  height: 100%;
   box-sizing: border-box;
   padding-left: 0.25em;
   resize: none;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -976,6 +976,7 @@
   width: 2.2em;
   text-align: right;
   -moz-appearance: textfield;
+  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -963,6 +963,7 @@
   color: black;
   border-style: solid;
   border-color: gray;
+  overflow: auto;
 }
 .control-bar input,
 .control-bar select,
@@ -1000,13 +1001,16 @@
 }
 .control-bar-menu {
   position: absolute;
-  padding: 0.3em;
+  padding: 0.2em;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.5);
   border-radius: 0.3em;
   background-color: #CDC0B0;
   border: 1px solid gray;
   display: none;
   z-index: 1;
+}
+.control-bar-menu td {
+  padding: 0.2em 0.2em;
 }
 /* ------------------------------------------------------------------------ */
 /* Common color definitions

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -945,7 +945,6 @@
 }
 #page-browser .text-pane {
   width: 100%;
-  height: 100%;
   box-sizing: border-box;
   padding-left: 0.25em;
   resize: none;

--- a/tools/proofers/image_block_enh.inc
+++ b/tools/proofers/image_block_enh.inc
@@ -50,7 +50,7 @@ function ibe_get_styles()
                     height:{$block_height_pc}%;
                     z-index:2;
                     text-align:center;
-                    overflow:hidden;
+                    overflow:auto;
                     border: 1px solid black;
                 }
         STYLES;

--- a/tools/proofers/image_frame_std.php
+++ b/tools/proofers/image_frame_std.php
@@ -34,6 +34,6 @@ $header_args = [
 
 slim_header("Image Frame", $header_args);
 
-echo "<div style='height: 100vh; overflow: hidden;'>
+echo "<div style='height: 100vh;'>
 <div id='image-view'>
 </div></div>";


### PR DESCRIPTION
The vertical control bar now scrolls if its contents will not fit. The scroll bar covers the "%" sign. The bar can also be scrolled horizontally (by arrow keys) to reveal it but the bar is so narrow that the browser does not display the horizontal scroll bar.
The way this is implemented is that the bar overflow is now set to "auto". Unfortunately this prevents the menu from appearing. This is apparently because it is in a relatively positioned div. This div was removed and the menu position set by javascript functions instead. Thanks to "https://css-tricks.com/popping-hidden-overflow/" and other sites.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/bar_scroll