### PR TITLE
set browser default font size to 'unset' in wordcheck

### DIFF
--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -55,6 +55,8 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
     [$font_style, $font_size, $font_family] = get_user_proofreading_font();
     if ($font_size != '') {
         $font_size = "font-size: $font_size";
+    } else {
+        $font_size = "font-size: unset";
     }
     // define the styles used for the interface (highlight for the punctuation, AW button, etc)
     $returnString .= "<style>" .


### PR DESCRIPTION
This makes suggestible word  font size same as rest of text if browser default font size.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/wcheck_font_size