### PR TITLE
Adjust percent input

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -22,7 +22,7 @@ var makeImageControl = function(imageElement) {
 
     function setAndSaveZoom() {
         setZoom();
-        localStorage.setItem(imageKey, JSON.stringify({zoom: Math.round(percent)}));
+        localStorage.setItem(imageKey, JSON.stringify({zoom: percent}));
     }
 
     percentInput.change(function() {

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -4,25 +4,25 @@
 // Construct the image sizing controls.
 var makeImageControl = function(imageElement) {
     let imageKey;
+    // percent need not be an integer but is rounded for display and save
+    // it will typically not be an integer after fit height or width or + or -
     let percent;
     const percentInput = $("<input>", {type: 'number', min: '1', max: '999', value: percent, title: texts.zoomPercent});
 
     function setZoom() {
-        percent = Math.round(percent);
         if(percent < 10) {
             percent = 10;
         } else if(percent > 999) {
             percent = 999;
         }
-        percentInput.val(percent);
-
+        percentInput.val(Math.round(percent));
         imageElement.width(10 * percent);
         imageElement.height("auto");
     }
 
     function setAndSaveZoom() {
         setZoom();
-        localStorage.setItem(imageKey, JSON.stringify({zoom: percent}));
+        localStorage.setItem(imageKey, JSON.stringify({zoom: Math.round(percent)}));
     }
 
     percentInput.change(function() {

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -7,13 +7,17 @@ var makeImageControl = function(imageElement) {
     // percent need not be an integer but is rounded for display and save
     // it will typically not be an integer after fit height or width or + or -
     let percent;
-    const percentInput = $("<input>", {type: 'number', min: '1', max: '999', value: percent, title: texts.zoomPercent});
+    const minPercent = 10;
+    const maxPercent = 999;
+    const defaultPercent = 100;
+
+    const percentInput = $("<input>", {type: 'number', value: percent, title: texts.zoomPercent});
 
     function setZoom() {
-        if(percent < 10) {
-            percent = 10;
-        } else if(percent > 999) {
-            percent = 999;
+        if(percent < minPercent) {
+            percent = minPercent;
+        } else if(percent > maxPercent) {
+            percent = maxPercent;
         }
         percentInput.val(Math.round(percent));
         imageElement.width(10 * percent);
@@ -28,7 +32,7 @@ var makeImageControl = function(imageElement) {
     percentInput.change(function() {
         percent = parseInt(this.value);
         if(isNaN(percent)) {
-            percent = 100;
+            percent = defaultPercent;
         }
         setAndSaveZoom();
     });
@@ -80,7 +84,7 @@ var makeImageControl = function(imageElement) {
             imageKey = storageKey + "-image";
             let imageData = JSON.parse(localStorage.getItem(imageKey));
             if(!$.isPlainObject(imageData)) {
-                imageData = {zoom: 100};
+                imageData = {zoom: defaultPercent};
             }
             percent = imageData.zoom;
             setZoom();

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -8,45 +8,37 @@ var makeImageControl = function(imageElement) {
     const percentInput = $("<input>", {type: 'number', min: '1', max: '999', value: percent, title: texts.zoomPercent});
 
     function setZoom() {
+        percent = Math.round(percent);
+        if(percent < 10) {
+            percent = 10;
+        } else if(percent > 999) {
+            percent = 999;
+        }
+        percentInput.val(percent);
+
         imageElement.width(10 * percent);
         imageElement.height("auto");
     }
 
-    function saveZoom() {
+    function setAndSaveZoom() {
+        setZoom();
         localStorage.setItem(imageKey, JSON.stringify({zoom: percent}));
     }
 
     percentInput.change(function() {
-        const value = parseInt(this.value);
-        if(isNaN(value)) {
+        percent = parseInt(this.value);
+        if(isNaN(percent)) {
             percent = 100;
-        } else if(value < 10) {
-            percent = 10;
-        } else if(value > 999) {
-            percent = 999;
-        } else {
-            percent = value;
         }
-        // in case above has changed it
-        this.value = percent;
-        setZoom();
-        saveZoom();
+        setAndSaveZoom();
     });
-
-    function setPercent() {
-        percent = Math.round(percent);
-        percentInput.val(percent);
-        saveZoom();
-    }
 
     function unPersist() {
         // reset width and height so that fitting does not persist
         const width = imageElement.width();
-        imageElement.width(width);
-        imageElement.height("auto");
         // assume 100% means 1000px wide
         percent = width / 10;
-        setPercent();
+        setAndSaveZoom();
     }
 
     const fitWidth = $("<button>", {title: texts.fitWidth}).click(function () {
@@ -64,15 +56,13 @@ var makeImageControl = function(imageElement) {
 
     const zoomIn = $("<button>", {title: texts.zoomIn}).click(function () {
         percent *= 1.1;
-        setPercent();
-        setZoom();
+        setAndSaveZoom();
     })
         .append($("<i>", {class: 'fas fa-search-plus'}));
 
     const zoomOut = $("<button>", {title: texts.zoomOut}).click(function () {
-        percent *= 0.909;
-        setPercent();
-        setZoom();
+        percent /= 1.1;
+        setAndSaveZoom();
     })
         .append($("<i>", {class: 'fas fa-search-minus'}));
 
@@ -93,7 +83,6 @@ var makeImageControl = function(imageElement) {
                 imageData = {zoom: 100};
             }
             percent = imageData.zoom;
-            percentInput.val(percent);
             setZoom();
         },
     };

--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -474,10 +474,9 @@
     }
 
     input[type=number] {
-        width: 2.2em;
+        width: 1.9rem;
         text-align: right;
         -moz-appearance: textfield;
-        -webkit-logical-width: -webkit-fit-content;
     }
 
     input::-webkit-outer-spin-button, input::-webkit-inner-spin-button {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -972,10 +972,9 @@
   border: thin solid #565656;
 }
 .control-bar input[type=number] {
-  width: 2.2em;
+  width: 1.9rem;
   text-align: right;
   -moz-appearance: textfield;
-  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -972,10 +972,9 @@
   border: thin solid #000000;
 }
 .control-bar input[type=number] {
-  width: 2.2em;
+  width: 1.9rem;
   text-align: right;
   -moz-appearance: textfield;
-  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -972,10 +972,9 @@
   border: thin solid #000000;
 }
 .control-bar input[type=number] {
-  width: 2.2em;
+  width: 1.9rem;
   text-align: right;
   -moz-appearance: textfield;
-  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -972,10 +972,9 @@
   border: thin solid #000000;
 }
 .control-bar input[type=number] {
-  width: 2.2em;
+  width: 1.9rem;
   text-align: right;
   -moz-appearance: textfield;
-  -webkit-logical-width: -webkit-fit-content;
 }
 .control-bar input::-webkit-outer-spin-button,
 .control-bar input::-webkit-inner-spin-button {


### PR DESCRIPTION
the -webkit... option worked with iPad but made input too wide on Edge and Chrome. 1.9rem is better on all.

This prevents percent being > 999 which would not fit in the box.
There are some anomalies due due to rounding percent to a whole number. e.g. fit height and width sometimes show a small gap or a scrollbar.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/adjust_percent_input