### PR TITLE
Remove use of `SQL_CALC_FOUND_ROWS` & `FOUND_ROWS()`

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -75,8 +75,9 @@ function api_v1_projects($method, $data, $query_params)
     $page = get_integer_param($query_params, "page", 1, 1, null);
     $offset = $per_page * ($page - 1);
 
+    // get a page worth of projects
     $sql = "
-        SELECT SQL_CALC_FOUND_ROWS *
+        SELECT *
         FROM projects
         WHERE $where
         ORDER BY $order_by
@@ -87,8 +88,17 @@ function api_v1_projects($method, $data, $query_params)
         throw new ServerError(DPDatabase::log_error());
     }
 
-    $res_found = DPDatabase::query("SELECT FOUND_ROWS()");
-    [$total_rows] = mysqli_fetch_row($res_found);
+    // and a count of all projects
+    $sql = "
+        SELECT COUNT(*)
+        FROM projects
+        WHERE $where
+    ";
+    $result_count = DPDatabase::query($sql, false);
+    if (!$result_count) {
+        throw new ServerError(DPDatabase::log_error());
+    }
+    [$total_rows] = mysqli_fetch_row($result_count);
     $total_pages = round($total_rows / $per_page);
 
     api_send_pagination_header($query_params, $total_rows, $per_page, $page);

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -547,8 +547,22 @@ class ProjectSearchResults
     private function _search($where_condition, $results_offset)
     {
         global $testing;
+
+        // load a count of the total number of projects
         $sql = "
-            SELECT SQL_CALC_FOUND_ROWS projects.*, genre_translations.trans_genre,
+            SELECT COUNT(*)
+            FROM projects
+            NATURAL JOIN genre_translations
+            LEFT JOIN project_holds
+            USING (projectid, state)
+            WHERE $where_condition
+        ";
+        $result = DPDatabase::query($sql);
+        [$num_found_rows] = mysqli_fetch_row($result);
+
+        // load the result set
+        $sql = "
+            SELECT projects.*, genre_translations.trans_genre,
             project_holds.projectid IS NOT NULL AS hold
             FROM projects
             NATURAL JOIN genre_translations
@@ -563,7 +577,8 @@ class ProjectSearchResults
             echo_html_comment($sql);
         }
         $result = DPDatabase::query($sql);
-        return $result;
+
+        return [$result, $num_found_rows];
     }
 
     public function render($where_condition)
@@ -573,12 +588,9 @@ class ProjectSearchResults
         $results_offset = intval(@$_GET['results_offset']);
 
         maybe_create_temporary_genre_translation_table();
-        $result = $this->_search($where_condition, $results_offset);
+        [$result, $num_found_rows] = $this->_search($where_condition, $results_offset);
 
         $numrows = mysqli_num_rows($result);
-
-        $res_found = DPDatabase::query("SELECT FOUND_ROWS()");
-        [$num_found_rows] = mysqli_fetch_row($res_found);
         if ($numrows == 0) {
             echo "<p><b>", _("No projects matched the search criteria."), "</b></p>";
             return;

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -40,8 +40,26 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
 {
     global $code_url;
     global $site_supports_corrections_after_posting;
+
+    // first get the number of projects
     $sql = "
-        SELECT SQL_CALC_FOUND_ROWS
+        SELECT COUNT(*)
+        FROM projects
+            LEFT OUTER JOIN pg_books
+            ON projects.postednum=pg_books.etext_number
+        WHERE $where_condition
+    ";
+    $result = DPDatabase::query($sql);
+    [$num_found_rows] = mysqli_fetch_row($result);
+
+    if ($num_found_rows == 0) {
+        echo _("There are currently no projects in this category.");
+        return;
+    }
+
+    // now load the paged results
+    $sql = "
+        SELECT
             projectid,
             authorsname,
             nameofwork,
@@ -61,14 +79,6 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
     $result = DPDatabase::query($sql);
 
     $numrows = mysqli_num_rows($result);
-
-    $res_found = DPDatabase::query("SELECT FOUND_ROWS()");
-    [$num_found_rows] = mysqli_fetch_row($res_found);
-
-    if ($num_found_rows == 0) {
-        echo _("There are currently no projects in this category.");
-        return;
-    }
 
     $first = $offset + 1;
     $last = $offset + $numrows;

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -7,13 +7,14 @@ function list_projects_tersely($where_condition, $order_clause, $limit_clause)
 // List the specified projects,
 // giving very brief information about each.
 {
-    $result = mysqli_query(DPDatabase::get_connection(), "
+    $sql = "
         SELECT nameofwork, authorsname, language, postednum
         FROM projects
         WHERE $where_condition
         $order_clause
         $limit_clause
-    ");
+    ";
+    $result = DPDatabase::query($sql);
 
     echo "<ul>\n";
 
@@ -57,7 +58,7 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
         $order_clause
         LIMIT $per_page OFFSET $offset
     ";
-    $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
+    $result = DPDatabase::query($sql);
 
     $numrows = mysqli_num_rows($result);
 


### PR DESCRIPTION
The MySQLisms `SQL_CALC_FOUND_ROWS` & `FOUND_ROWS()` are deprecated and will be removed in future versions. This replaces them with `COUNT(*)` to get the same result. Fixes https://github.com/DistributedProofreaders/dproofreaders/issues/679.

Testable in the [remove-mysql-found-rows](https://www.pgdp.org/~cpeel/c.branch/remove-mysql-found-rows/) sandbox. The pages impacted are:
* [list_etexts.php](https://www.pgdp.org/~cpeel/c.branch/remove-mysql-found-rows/list_etexts.php?x=b&sort=5)
* [search.php](https://www.pgdp.org/~cpeel/c.branch/remove-mysql-found-rows/tools/search.php)

And the project search API:
```bash
curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/remove-mysql-found-rows/api/index.php?url=v1/projects&genre=Other" \
    -H "accept: application/json" \
    -H "X-API-KEY: $API_KEY"
```