### PR TITLE
Prepare R202109 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -3,20 +3,33 @@
 Major changes to this project are documented here. For minor changes,
 see the git history.
 
-## R??????
+**If you are upgrading from a release before R202009, you must upgrade to
+[R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
+first before upgrading to R202102 or later releases.**
+
+
+## R202109
 Scripts supporting this upgrade are in `SETUP/upgrade/16`
 
-* Renamed the 'Science Fiction' genre to 'Science Fiction & Fantasy'.
-    There is no upgrade script for the `queue_defns` table; since
+**This is the last release to support jpgraph. Future releases will use
+JS-generated SVG graphs.**
+
+* Updated minimum middleware to PHP 7.4 and MySQL 5.7 (cpeel)
+* Moved to use Composer for dependency packaging (cpeel)
+* DP API is now enabled by default as it is used by JS for the UI (cpeel)
+* New standard Image Widget used in Page Browser and proofreading interfaces (70ray)
+* User-provided HTML is sanitized before output (cpeel)
+* Improved cookie security and centralized cookie management (chrismiceli)
+* Renamed the 'Science Fiction' genre to 'Science Fiction & Fantasy' (srjfoo)
+  * There is no upgrade script for the `queue_defns` table; since
     release queues do not come pre-defined, updating those entries
     should be done manually by those who have genre queues enabled.
+* Links to Project Gutenberg updated to use HTTPS (srjfoo)
+* Code style standardization via PHP-CS-Fixer and GitHub linting (cpeel)
+
 
 ## R202102
 Scripts supporting this upgrade are in `SETUP/upgrade/15`
-
-**If you are upgrading from a release before R202009, you must upgrade to
-[R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
-first before upgrading to this or later releases.**
 
 **This is the last release to support PHP versions < 7.4 and
 MySQL versions < 5.7.**

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -38,7 +38,7 @@ MySQL version 5.7 is the minimum supported version. MySQL 8.x will also work.
 MariaDB version 10.2 and later should also work but has not been tested.
 
 ### phpBB
-[phpBB](https://www.phpbb.com) 3.3 is the minimum supported verison.
+[phpBB](https://www.phpbb.com) 3.3 is the minimum supported version.
 
 For phpBB to work with the DP code, you must disable superglobal checking.
 In the phpBB code edit:
@@ -48,7 +48,7 @@ In the phpBB code edit:
 change `core.disable_super_globals` to `false`, and flush the phpbb cache.
 
 ### jpgraph
-[jpgraph](http://jpgraph.net) version 4.3 is the minimum supported verison.
+[jpgraph](http://jpgraph.net) version 4.3 is the minimum supported version.
 
 ## Distro support
 These middleware components match the following major distribution releases:

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -99,6 +99,12 @@ first.
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/15/
+* c/SETUP/upgrade/16/
+
+### Upgrading from release R202102
+Run the scripts in the following directories in order
+
+* c/SETUP/upgrade/16/
 
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.

--- a/SETUP/check_db_schema.template
+++ b/SETUP/check_db_schema.template
@@ -12,9 +12,9 @@ set -e
 # or did we sneak a db-schema change into the current installation,
 # and are perhaps now depending on it?)
 
-prev_tag=R202009
+prev_tag=R202102
 curr_tag=production
-upgrade_number=15
+upgrade_number=16
 
 setup_dir=`dirname $0`
 testing_dir=/tmp/dp_schema_check
@@ -37,7 +37,7 @@ echo ""
 echo "Creating a config file for a test install..."
 echo "
     TAG=$curr_tag
-    GROUP=users
+    GROUP=www-data
     SHIFT_TO_LIVE=yes
 
     _CODE_DIR=$testing_code_dir


### PR DESCRIPTION
This is prep work for the upcoming R202109 release, slated for the end of the month. This won't get merged in until just before the release is cut.

I welcome input on if there are other things we should include in the `CHANGELOG.md` or suggestions on the ordering (we like to focus on the most possibly-disruptive changes at the top).