### PR TITLE
Update wording on AH and snapshot legend

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -306,7 +306,7 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects = fals
     } elseif ($uao->all_minima_satisfied) {
         $access_class = "access-eligible";
         $access_icon = "ⓘ";
-        $access_text = _("You are eligible to work in this activity");
+        $access_text = _("You may be eligible to work in this activity");
         $access_link = "{$stage->relative_url}#Entrance_Requirements";
     } else {
         $access_class = "access-no";
@@ -496,7 +496,13 @@ function activity_descriptions()
 
     foreach ($Stage_for_id_ as $stage) {
         echo "<dt><b>$stage->id</b>: <a href='$code_url/{$stage->relative_url}'>{$stage->name}</a></dt>";
-        echo "<dd>{$stage->description}</dd>\n";
+        echo "<dd>{$stage->description}";
+        if (($stage->id == "PP") || ($stage->id == "SR")) {
+            echo " " .  _("The counts in the Snapshot table, above, for projects
+                available for SR are also included in the numbers of projects in
+                PP, and the PP total.");
+        }
+        echo "</dd>\n";
     }
 
     echo "</dl>";

--- a/faq/site_progress_snapshot_legend.php
+++ b/faq/site_progress_snapshot_legend.php
@@ -31,14 +31,14 @@ output_header(_('Site Progress Snapshot'), NO_STATSBAR);
 
 <p>In addition each activity has an icon that represents your current ability to work in that stage:
 <ul>
-  <li><div class='access-yes'>✓</div> - You have access to, and are able to work in, this stage.</li>
-  <li><div class='access-eligible'>ⓘ</div> - You satisfy the basic criteria and are eligible to work in this stage. Clicking on the icon will provide more information on how to obtain access.</li>
-  <li><div class='access-no'>✗</div> - You are not yet eligible to work in this stage. Clicking on the icon will show you the entrance requirements for that stage.</li>
+  <li><span class='access-yes' style='float: none;'>✓</span> - You have access to, and are able to work in, this stage.</li>
+  <li><span class='access-eligible' style='float: none;'>ⓘ</span> - You satisfy the basic criteria and may be eligible to work in this stage. Clicking on the icon in the Snapshot table will provide more information on how to obtain access.</li>
+  <li><span class='access-no' style='float: none;'>✗</span> - You are not yet eligible to work in this stage. Clicking on the icon in the Snapshot table will show you the entrance requirements for that stage.</li>
 </ul>
 </p>
 
 <h2>Project information</h2>
-<p>For each activity, information about projects in that activity is included. For projects in the proofreading rounds, this includes the Total, Waiting, and Available projects as well as a count of how many projects were Completed Today. For non-proofreading rounds, this includes the Total, Available, and In Progress projects.</p>
+<p>For each activity, information about projects in that activity is included. For projects in the proofreading rounds, this includes the Total, Waiting, and Available projects as well as a count of how many projects were Completed Today. For post-processing activities, this includes the Total, Available, and In Progress projects. For smooth reading, it displays the number of projects Available for SR.</p>
 
 <p>Project numbers can optionally be filtered using the filter criteria specified on corresponding pages. You can toggle between viewing project numbers for All projects or Filtered projects that match your filter.</p>
 


### PR DESCRIPTION
Both the tooltip for ⓘ on the Activity Hub and the description in site_progress_snapshot_legend.php say "are" eligible. This commit changes that to "may be" eligible (for example, most people are not eligible to work as PPVers, yet everyone sees that icon for the PPV activity. Add to the Activity description for SR an explanation that the SR count is included in the PP count (should this be with PP, instead, or in addition?).

[ah-cleanup](https://www.pgdp.org/~srjfoo/c.branch/ah-cleanup/activity_hub.php)