### PR TITLE
change to using canvas to draw image, add rotation

### DIFF
--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -420,7 +420,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                     }
 
                     const imageDiv = $("<div>");
-                    imageWidget = makeImageWidget(imageDiv);
+                    imageWidget = makeImageWidget(imageDiv, "C");
                     imageWidget.setup(storageKey);
                     stretchDiv.append(imageDiv);
                     showImageText();
@@ -440,9 +440,9 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                             break;
                         case "imageText": {
                             const imageDiv = $("<div>");
-                            imageWidget = makeImageWidget(imageDiv);
                             stretchDiv.append(imageDiv, textDiv);
                             const theSplitter = viewSplitter(stretchDiv, storageKey);
+                            imageWidget = makeImageWidget(imageDiv, "C");
                             if(mentorMode) {
                                 // make a text widget with splitter
                                 textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.reSize);


### PR DESCRIPTION
This is simpler than the previous version but there are two issues:

Using Firefox on Linux, when reducing the size of the image, if the image is entirely contained in the window (i.e. there are no scroll bars) part of the old, larger, image is left behind. Any action which causes the screen to be redrawn, such as pressing the alt key or changing the window size redraws correctly. This appears to be a bug in Firefox on Linux since I have not seen it on chromium on linux or Firefox, chrome, edge on windows.
I previously did not realize this was a localized bug so added the complexity of the previous version to work round it.
I have reported the bug to Mozilla.

Scrollbar issue: This does not apply to Safari where it appears that temporary scrollbars are drawn on top of the window contents. On other browsers the scrollbars take space from the window so when fitting the image to width, if a vertical scrollbar appears the client width is reduced so a horizontal scrollbar will also appear. Similarly for fitting to height. This is a minor problem. Although it could be addressed by measuring the scrollbar width and doing some calculations, the extra complexity may not be justified. 

Sandbox at: https://www.pgdp.org/~rp31/c.branch/image_rotate_1