### PR TITLE
min width for bars and 0 line for negative bars

### DIFF
--- a/SETUP/GRAPHS.md
+++ b/SETUP/GRAPHS.md
@@ -90,7 +90,7 @@ respects different configuration properties.
   // the same x values;
   groupBars?: boolean;
 
-  // An array of color values for the series to be colored.
+  // An array of class names for the bars to be colored.
   barColors?: string[];
 
   // Whether a border should be drawn on the bars in the series.

--- a/SETUP/GRAPHS.md
+++ b/SETUP/GRAPHS.md
@@ -114,6 +114,7 @@ respects different configuration properties.
     [seriesTitle: string]: {
       x: string[]; // X axis labels
       y: string[]; // Y axis values, converted to a number
+      type: "bar" | "line"; // type of series. Defaults to "bar"
     };
   };
 }

--- a/SETUP/GRAPHS.md
+++ b/SETUP/GRAPHS.md
@@ -93,9 +93,6 @@ respects different configuration properties.
   // An array of class names for the bars to be colored.
   barColors?: string[];
 
-  // Whether a border should be drawn on the bars in the series.
-  barBorder?: boolean;
-
   // Title of the graph, shown at the top center.
   title?: string;
 

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -198,6 +198,7 @@ function new_users($time_interval)
     return [
         "title" => $title,
         "xAxisHeight" => 90,
+        "yAxisWidth" => 60,
         "data" => [
             _('# users') => [
                 "x" => $datax,
@@ -223,7 +224,7 @@ function average_hour_users_logging_on()
 
     return [
         "title" => _('Average number of users newly logged in each hour'),
-        "yAxisWidth" => "60",
+        "yAxisWidth" => 60,
         "data" => [
             _('Fresh Logons') => [
                 "x" => $datax,
@@ -257,7 +258,7 @@ function users_by_language()
     return [
         "title" => $title,
         "xAxisHeight" => 100,
-        "yAxisWidth" => 75,
+        "yAxisWidth" => 60,
         "data" => [
             _('Interface Language') => [
                 "x" => $x,
@@ -287,7 +288,7 @@ function users_by_country()
     $title = _("Number of users per country");
     return [
         "title" => $title,
-        "yAxisWidth" => 75,
+        "yAxisWidth" => 60,
         "data" => [
             _('Country') => [
                 "x" => $x,
@@ -536,9 +537,10 @@ function total_pages_by_month_graph($tally_name)
             ],
         ],
         "yAxisLabel" => _("Pages"),
+        "yAxisWidth" => 65,
         "legendAdjustment" => [
-            "x" => 40,
-            "y" => 100,
+            "x" => 50,
+            "y" => 15,
         ],
     ];
 }
@@ -755,9 +757,10 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
         "data" => $data,
         "yAxisLabel" => _("Pages"),
         "xAxisHeight" => 65,
+        "yAxisWidth" => 65,
         "legendAdjustment" => [
-            "x" => 40,
-            "y" => 100,
+            "x" => 50,
+            "y" => 15,
         ],
     ];
 }

--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -239,18 +239,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 .tickFormat(i => xValues[i])
                 .tickSizeOuter(0));
 
-        svg.append("g")
-            .call(xAxis)
-            .selectAll("text")
-            .attr("transform", "rotate(-90)")
-            .attr("y", -5)
-            .attr("x", -6)
-            .style("text-anchor", "end");
-
-        svg.append("g")
-            .call(yAxis);
-
-        Object.entries(config.data).forEach(([seriesTitle, seriesData], seriesIndex) => {
+        const renderSeries = ([seriesTitle, seriesData], seriesIndex) => {
             const data = seriesData.x.reduce((acc, value, index) => {
                 acc.push({
                     [seriesTitle]: value,
@@ -292,7 +281,26 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                     .on("mousemove", mouseAction)
                     .on("mouseleave", mouseLeave);
             }
-        });
+        };
+
+        Object.entries(config.data).filter(([, {type}]) => type !== "line")
+            .forEach(renderSeries);
+
+        svg.append("g")
+            .call(xAxis)
+            .selectAll("text")
+            .attr("transform", "rotate(-90)")
+            .attr("y", -5)
+            .attr("x", -6)
+            .style("text-anchor", "end");
+
+        svg.append("g")
+            .call(yAxis);
+
+        // render lines after xaxis so they are above axis, but bars are above.
+        Object.entries(config.data).filter(([, {type}]) => type === "line")
+            .forEach(renderSeries);
+
 
         addTitle(svg, config, width);
         addLegend(svg, color, config, Object.keys(config.data), width, height);

--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -258,7 +258,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                     .join("rect")
                     .attr("class", (_, i) => config.barColors ? config.barColors[i] : `graph-series-stroke-${seriesIndex + 1} graph-series-fill-${seriesIndex + 1}`)
                     .attr("stroke-width", 1)
-                    .attr("stroke", () => config.barBorder ? "black" : "")
                     .attr("x", (d, i) => x(i) + xGroupOffset(seriesTitle))
                     .attr("y", ({value}) => value < 0 ? y(0) : y(value))
                     .attr("height", d => Math.abs(y(0) - y(d.value)))

--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -239,6 +239,17 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 .tickFormat(i => xValues[i])
                 .tickSizeOuter(0));
 
+        svg.append("g")
+            .call(xAxis)
+            .selectAll("text")
+            .attr("transform", "rotate(-90)")
+            .attr("y", -5)
+            .attr("x", -6)
+            .style("text-anchor", "end");
+
+        svg.append("g")
+            .call(yAxis);
+
         Object.entries(config.data).forEach(([seriesTitle, seriesData], seriesIndex) => {
             const data = seriesData.x.reduce((acc, value, index) => {
                 acc.push({
@@ -248,14 +259,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 return acc;
             }, []);
 
-            let barColors;
-            if (config.barColors) {
-                barColors = d3.scaleOrdinal()
-                    .domain(seriesData.x)
-                    .range(config.barColors);
-            } else {
-                barColors = () => color(seriesTitle);
-            }
+            const barColors = () => color(seriesTitle);
 
             if (seriesData.type === "line") {
                 const line = d3.line()
@@ -265,7 +269,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 svg.append("path")
                     .datum(data)
                     .attr("fill", "none")
-                    .attr("class", config.barColors ? "" : `graph-series-stroke-${seriesIndex + 1}`)
+                    .attr("class", `graph-series-stroke-${seriesIndex + 1}`)
                     .attr("stroke", barColors())
                     .attr("stroke-width", 1.5)
                     .attr("stroke-linejoin", "round")
@@ -277,7 +281,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                     .data(data)
                     .join("rect")
                     .attr("fill", ({[seriesTitle]: d}) => barColors(d))
-                    .attr("class", config.barColors ? "" : `graph-series-fill-${seriesIndex + 1}`)
+                    .attr("class", (_, i) => config.barColors ? config.barColors[i] : `graph-series-stroke-${seriesIndex + 1}`)
                     .attr("stroke-width", 1)
                     .attr("stroke", () => config.barBorder ? "black" : "")
                     .attr("x", (d, i) => x(i) + xGroupOffset(seriesTitle))
@@ -290,16 +294,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             }
         });
 
-        svg.append("g")
-            .call(xAxis)
-            .selectAll("text")
-            .attr("transform", "rotate(-90)")
-            .attr("y", -5)
-            .attr("x", -6)
-            .style("text-anchor", "end");
-
-        svg.append("g")
-            .call(yAxis);
         addTitle(svg, config, width);
         addLegend(svg, color, config, Object.keys(config.data), width, height);
     }

--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -6,7 +6,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
         top: 20,
         right: 45,
         bottom: 30,
-        left: 30
+        left: 45
     });
 
     function addTitle(svg, config, width) {
@@ -144,7 +144,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             .call(yAxis);
 
         addTitle(svg, config, width);
-        addLegend(svg, config, Object.keys(config.data), width, height);
+        addLegend(svg, config, data.columns.slice(1) /* no date column */, width, height);
     }
 
     function barLineGraph(id, config) {

--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -19,7 +19,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             .text(config.title);
     }
 
-    function addLegend(svg, color, config, series, width, height) {
+    function addLegend(svg, config, series, width, height) {
         const hasMultipleSeries = series.length > 1;
         const yAxisLabel = config.yAxisLabel || (!hasMultipleSeries ? Object.keys(config.data)[0] : null);
         if (hasMultipleSeries) {
@@ -35,7 +35,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 .attr("cx", margin.left + (config.axisLeft ? 30 : 10))
                 .attr("cy", (d,i) => (margin.left + 10) + (i * 25))
                 .attr("r", 7)
-                .style("fill", d => color(d));
+                .attr("class", (_, i) => config.barColors ? "" : `graph-series-fill-${i + 1}`);
 
             container.selectAll("series")
                 .data(series)
@@ -117,10 +117,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 .tickFormat(d => `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`)
                 .tickSizeOuter(0));
 
-        const color = d3.scaleOrdinal()
-            .domain(data.columns.slice(1))
-            .range(d3.schemeCategory10);
-
         const area = d3.area()
             .curve(d3.curveStep)
             .x(d => x(d.data.date))
@@ -134,9 +130,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             .selectAll("path")
             .data(series)
             .join("path")
-            .attr("fill", ({
-                key
-            }) => color(key))
             .attr("class", (_, i) => `graph-series-fill-${i + 1}`)
             .attr("d", area)
             .append("title")
@@ -151,16 +144,13 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             .call(yAxis);
 
         addTitle(svg, config, width);
-        addLegend(svg, color, config, Object.keys(config.data), width, height);
+        addLegend(svg, config, Object.keys(config.data), width, height);
     }
 
     function barLineGraph(id, config) {
         const barMargin = {...margin, left: config.yAxisWidth || 50, bottom: config.xAxisHeight || 50};
         const height = config.height || 400;
         const width = config.width || 640;
-        const color = d3.scaleOrdinal()
-            .domain(Object.keys(config.data))
-            .range(d3.schemeCategory10);
         const svg = d3.select("#" + id).append("svg")
             .attr("viewBox", [0, 0, width, height]);
         const tooltip = d3.select("#" + id)
@@ -248,8 +238,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 return acc;
             }, []);
 
-            const barColors = () => color(seriesTitle);
-
             if (seriesToRender === "line" && seriesData.type === "line") {
                 const line = d3.line()
                     .x((d, i) => x(i))
@@ -259,7 +247,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                     .datum(data)
                     .attr("fill", "none")
                     .attr("class", `graph-series-stroke-${seriesIndex + 1}`)
-                    .attr("stroke", barColors())
                     .attr("stroke-width", 1.5)
                     .attr("stroke-linejoin", "round")
                     .attr("stroke-linecap", "round")
@@ -269,7 +256,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                     .selectAll("rect")
                     .data(data)
                     .join("rect")
-                    .attr("fill", ({[seriesTitle]: d}) => barColors(d))
                     .attr("class", (_, i) => config.barColors ? config.barColors[i] : `graph-series-stroke-${seriesIndex + 1} graph-series-fill-${seriesIndex + 1}`)
                     .attr("stroke-width", 1)
                     .attr("stroke", () => config.barBorder ? "black" : "")
@@ -304,7 +290,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
         });
 
         addTitle(svg, config, width);
-        addLegend(svg, color, config, Object.keys(config.data), width, height);
+        addLegend(svg, config, Object.keys(config.data), width, height);
     }
 
     function pieGraph(id, config) {
@@ -336,10 +322,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 .innerRadius(0)
                 .outerRadius(radius);
 
-            const color = d3.scaleOrdinal()
-                .domain(config.labels)
-                .range(d3.schemeCategory10);
-
             const arcs = pie(data);
 
             const arcLabel = d3.arc().innerRadius(radius + 20)
@@ -350,7 +332,6 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 .selectAll("path")
                 .data(arcs)
                 .join("path")
-                .attr("fill", d => color(d.data.name))
                 .attr("class", (_, i) => `graph-series-fill-${i + 1}`)
                 .attr("d", arc)
                 .append("title")
@@ -366,7 +347,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                     .attr("y", "-0.4em")
                     .attr("font-weight", "bold")
                     .text(d => Number(d.data.value) !== 0 ? `${d3.format(",.1f")((d.data.value / total) * 100)}%` : ''));
-            addLegend(svg, color, config, config.labels, width, height);
+            addLegend(svg, config, config.labels, width, height);
         }
 
         addTitle(svg, config, width);

--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -209,6 +209,18 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             .domain(d3.range(xValues.length))
             .range([barMargin.left, width - barMargin.right])
             .padding(0.1);
+
+        if (minYValue < 0) {
+            svg.append("g")
+                .append("line")
+                .attr("x1", barMargin.left)
+                .attr("x2", width - barMargin.right)
+                .attr("y1", y(0))
+                .attr("y2", y(0))
+                .attr("style", "stroke-width: .5px")
+                .attr("stroke", "currentColor");
+        }
+
         let xGroupOffset;
         if (config.groupBars) {
             xGroupOffset = d3.scaleBand()
@@ -271,7 +283,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                     .attr("x", (d, i) => x(i) + xGroupOffset(seriesTitle))
                     .attr("y", ({value}) => value < 0 ? y(0) : y(value))
                     .attr("height", d => Math.abs(y(0) - y(d.value)))
-                    .attr("width", config.groupBars ? xGroupOffset.bandwidth() : x.bandwidth())
+                    .attr("width", config.groupBars ? xGroupOffset.bandwidth() : Math.max(x.bandwidth(), 1))
                     .on("mouseover", mouseAction)
                     .on("mousemove", mouseAction)
                     .on("mouseleave", mouseLeave);

--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -151,6 +151,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
         const barMargin = {...margin, left: config.yAxisWidth || 50, bottom: config.xAxisHeight || 50};
         const height = config.height || 400;
         const width = config.width || 640;
+        const data = Object.entries(config.data).filter(([,{x}]) => x && x.length > 0);
         const svg = d3.select("#" + id).append("svg")
             .attr("viewBox", [0, 0, width, height]);
         const tooltip = d3.select("#" + id)
@@ -169,7 +170,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             tooltip.style("display", "none");
         };
 
-        const yValues = Object.values(config.data).map(({y}) => y.map(Number))
+        const yValues = data.map(([,{y}]) => y.map(Number))
             .flatMap(x => x);
         const minYValue = d3.min(yValues, d => d);
         const y = d3.scaleLinear()
@@ -194,7 +195,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                 .attr("fill", "currentColor")
                 .attr("text-anchor", "start"));
 
-        const xValues = Object.values(config.data)[0].x;
+        const xValues = data[0][1].x;
         const x = d3.scaleBand()
             .domain(d3.range(xValues.length))
             .range([barMargin.left, width - barMargin.right])
@@ -214,7 +215,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
         let xGroupOffset;
         if (config.groupBars) {
             xGroupOffset = d3.scaleBand()
-                .domain(Object.keys(config.data))
+                .domain(data.map(([title]) => title))
                 .rangeRound([0, x.bandwidth()])
                 .padding(0.05);
         } else {
@@ -268,7 +269,7 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             }
         };
 
-        Object.entries(config.data).forEach(([seriesTitle, seriesData], seriesIndex) => {
+        data.forEach(([seriesTitle, seriesData], seriesIndex) => {
             renderSeries(seriesTitle, seriesData, seriesIndex, "bar" /* seriesToRender */);
         });
 
@@ -284,12 +285,12 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
             .call(yAxis);
 
         // render lines after xaxis so they are above axis, but bars are above.
-        Object.entries(config.data).forEach(([seriesTitle, seriesData], seriesIndex) => {
+        data.forEach(([seriesTitle, seriesData], seriesIndex) => {
             renderSeries(seriesTitle, seriesData, seriesIndex, "line" /* seriesToRender */);
         });
 
         addTitle(svg, config, width);
-        addLegend(svg, config, Object.keys(config.data), width, height);
+        addLegend(svg, config, data.map(([title]) => title), width, height);
     }
 
     function pieGraph(id, config) {

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -67,7 +67,6 @@ $graphs = [
         "barColors" => $barColors,
         "width" => $width,
         "height" => $height,
-        "barBorder" => true,
         "bottomLegend" => $x_title,
         "yAxisTickCount" => 5,
     ]],

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -46,11 +46,10 @@ $datay = [$pp_page_goal, $pp_pages_total];
 $title = _("MTD Pages");
 $x_title = "PP = " . $goal_percent . "% of $round_before_PP";
 
-// If PP is higher than round_before_PP, use greens, else reds
 if ($pp_pages_total > $pp_page_goal) {
-    $barColors = ["darkgreen"];
+    $barColors = ["graph-normal-series"];
 } else {
-    $barColors = ["darkred"];
+    $barColors = ["graph-above-goal"];
 }
 
 $width = 160;

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -47,9 +47,9 @@ $title = _("MTD Pages");
 $x_title = "PP = " . $goal_percent . "% of $round_before_PP";
 
 if ($pp_pages_total > $pp_page_goal) {
-    $barColors = ["graph-normal-series"];
+    $barColors = ["graph-normal-series", "graph-normal-series"];
 } else {
-    $barColors = ["graph-above-goal"];
+    $barColors = ["graph-above-goal", "graph-above-goal"];
 }
 
 $width = 160;

--- a/stats/round_backlog.php
+++ b/stats/round_backlog.php
@@ -72,7 +72,6 @@ $graphs = [
         ],
         "width" => $width,
         "height" => $height,
-        "barBorder" => true,
         "bottomLegend" => $x_title,
         "yAxisTickCount" => 5,
     ]],

--- a/stats/round_backlog.php
+++ b/stats/round_backlog.php
@@ -33,9 +33,8 @@ $goal_percent = ceil(100 / count($stats));
 
 // colors
 $barColors = [];
-$barColorDefault = "#EEEEEE";
-$barColorAboveGoal = "#FF484F";
-$goalColor = "#0000FF";
+$barColorDefault = "graph-normal-series";
+$barColorAboveGoal = "graph-above-goal";
 
 // calculate the percentage of work remaining in each round
 // and the color for each bar

--- a/stats/round_backlog_days.php
+++ b/stats/round_backlog_days.php
@@ -94,7 +94,6 @@ $graphs = [
         ],
         "width" => $width,
         "height" => $height,
-        "barBorder" => true,
         "bottomLegend" => $x_title,
         "yAxisTickCount" => 5,
     ]],

--- a/stats/round_backlog_days.php
+++ b/stats/round_backlog_days.php
@@ -50,9 +50,8 @@ $goal_percent = ceil(100 / count($stats));
 
 // colors
 $barColors = [];
-$barColorDefault = "#EEEEEE";
-$barColorAboveGoal = "#FF484F";
-$goalColor = "#0000FF";
+$barColorDefault = "graph-normal-series";
+$barColorAboveGoal = "graph-above-goal";
 
 $days_total = array_sum($stats);
 if ($days_total == 0) {

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -58,7 +58,7 @@
 @border-color-base-lowc: #d3d3d3;    // lightgrey
 
 @graph-series-colors: #1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf;
-@graph-normal-series: #eeeeee;
+@graph-normal-series: #bbbbbb;
 @graph-above-goal: #ff484f;
 
 /* ------------------------------------------------------------------------ */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -58,6 +58,8 @@
 @border-color-base-lowc: #d3d3d3;    // lightgrey
 
 @graph-series-colors: #1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf;
+@graph-normal-series: #eeeeee;
+@graph-above-goal: #ff484f;
 
 /* ------------------------------------------------------------------------ */
 /* mixins with color */
@@ -402,6 +404,13 @@ footer, #footer {
   fill: @page-background;
   outline: 2px solid @border-color-base;
   border-radius: 5px;
+}
+
+.graph-normal-series {
+  fill: @graph-normal-series;
+}
+.graph-above-goal {
+  fill: @graph-above-goal;
 }
 
 .graph-series-loop (@i) when (@i > 0) {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -1392,6 +1392,12 @@ footer small,
   outline: 2px solid #565656;
   border-radius: 5px;
 }
+.graph-normal-series {
+  fill: #eeeeee;
+}
+.graph-above-goal {
+  fill: #ff484f;
+}
 .graph-series-fill-10 {
   fill: #17becf;
 }

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -1435,10 +1435,10 @@ footer small,
   stroke: #b395d0;
 }
 .graph-series-fill-4 {
-  fill: #df5353;
+  fill: #d62728;
 }
 .graph-series-stroke-4 {
-  stroke: #df5353;
+  stroke: #d62728;
 }
 .graph-series-fill-3 {
   fill: #73d973;

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -1429,22 +1429,22 @@ footer small,
   stroke: #8c564b;
 }
 .graph-series-fill-5 {
-  fill: #9467bd;
+  fill: #b395d0;
 }
 .graph-series-stroke-5 {
-  stroke: #9467bd;
+  stroke: #b395d0;
 }
 .graph-series-fill-4 {
-  fill: #d62728;
+  fill: #df5353;
 }
 .graph-series-stroke-4 {
-  stroke: #d62728;
+  stroke: #df5353;
 }
 .graph-series-fill-3 {
-  fill: #2ca02c;
+  fill: #73d973;
 }
 .graph-series-stroke-3 {
-  stroke: #2ca02c;
+  stroke: #73d973;
 }
 .graph-series-fill-2 {
   fill: #ff7f0e;
@@ -1453,10 +1453,10 @@ footer small,
   stroke: #ff7f0e;
 }
 .graph-series-fill-1 {
-  fill: #1f77b4;
+  fill: #80b3ff;
 }
 .graph-series-stroke-1 {
-  stroke: #1f77b4;
+  stroke: #80b3ff;
 }
 /*
  If the screen is "narrow enough" we move the statsbar below the page

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -1393,7 +1393,7 @@ footer small,
   border-radius: 5px;
 }
 .graph-normal-series {
-  fill: #eeeeee;
+  fill: #bbbbbb;
 }
 .graph-above-goal {
   fill: #ff484f;

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -21,7 +21,7 @@
 @active-color: #ff66aa;
 @sans-serif-font: Verdana, Helvetica, sans-serif;
 
-@graph-series-colors: #1f77b4, #ff7f0e, #2ca02c, #d62728, #9467bd, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf;
+@graph-series-colors: #80b3ff, #ff7f0e, #73d973, #df5353, #b395d0, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf;
 
 /* Do not underline links */
 a {

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -21,7 +21,7 @@
 @active-color: #ff66aa;
 @sans-serif-font: Verdana, Helvetica, sans-serif;
 
-@graph-series-colors: #80b3ff, #ff7f0e, #73d973, #df5353, #b395d0, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf;
+@graph-series-colors: #80b3ff, #ff7f0e, #73d973, #d62728, #b395d0, #8c564b, #e377c2, #7f7f7f, #bcbd22, #17becf;
 
 /* Do not underline links */
 a {

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1392,6 +1392,12 @@ footer small,
   outline: 2px solid #000000;
   border-radius: 5px;
 }
+.graph-normal-series {
+  fill: #eeeeee;
+}
+.graph-above-goal {
+  fill: #ff484f;
+}
 .graph-series-fill-10 {
   fill: #17becf;
 }

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1393,7 +1393,7 @@ footer small,
   border-radius: 5px;
 }
 .graph-normal-series {
-  fill: #eeeeee;
+  fill: #bbbbbb;
 }
 .graph-above-goal {
   fill: #ff484f;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1392,6 +1392,12 @@ footer small,
   outline: 2px solid #000000;
   border-radius: 5px;
 }
+.graph-normal-series {
+  fill: #eeeeee;
+}
+.graph-above-goal {
+  fill: #ff484f;
+}
 .graph-series-fill-10 {
   fill: #17becf;
 }

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1393,7 +1393,7 @@ footer small,
   border-radius: 5px;
 }
 .graph-normal-series {
-  fill: #eeeeee;
+  fill: #bbbbbb;
 }
 .graph-above-goal {
   fill: #ff484f;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1392,6 +1392,12 @@ footer small,
   outline: 2px solid #000000;
   border-radius: 5px;
 }
+.graph-normal-series {
+  fill: #eeeeee;
+}
+.graph-above-goal {
+  fill: #ff484f;
+}
 .graph-series-fill-10 {
   fill: #17becf;
 }

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1393,7 +1393,7 @@ footer small,
   border-radius: 5px;
 }
 .graph-normal-series {
-  fill: #eeeeee;
+  fill: #bbbbbb;
 }
 .graph-above-goal {
   fill: #ff484f;


### PR DESCRIPTION
This I believe is the last MR before we can merge to master in my opinion for feedback from TEST. It fixes the faint bars in https://www.pgdp.org/~chrismiceli/c.branch/adjustments/stats/pages_proofed_graphs.php?tally_name=P1
as well as adding a 0 horizontal line for bar/line charts that include negative y values. For example
https://www.pgdp.org/~chrismiceli/c.branch/adjustments/stats/pages_proofed_graphs.php?tally_name=P1
and
https://www.pgdp.org/~chrismiceli/c.branch/adjustments/stats/members/mdetail.php?id=393&tally_name=P1&range=365

Sandbox
https://www.pgdp.org/~chrismiceli/c.branch/adjustments