### PR TITLE
enable image move with arrow keys

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -32,6 +32,9 @@ var makeImageControl = function(content) {
 
     $(image).mousedown( function(event) {
         event.preventDefault();
+
+        // so image can be moved with arrow keys
+        content[0].focus();
         image.style.cursor = "grabbing";
         scrollDiffX = event.pageX + content.scrollLeft();
         scrollDiffY = event.pageY + content.scrollTop();


### PR DESCRIPTION
After clicking on the image it can be moved with the arrow keys as well as moved by dragging.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/image_drag_focus