### PR TITLE
Cache data from slow graphs

### DIFF
--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -844,7 +844,7 @@ function get_round_backlog_stats($interested_phases)
 //
 // Note that the graph function might include _() so it's important that we
 // include the user's language in the key.
-function query_graph_cache($function, $args, $expire_from_now = 3600)
+function query_graph_cache($function, $args = [], $expire_from_now = 3600)
 {
     $memcache = new Memcached();
     $memcache->addServer('localhost', 11211);

--- a/stats/pages_proofed_graphs.php
+++ b/stats/pages_proofed_graphs.php
@@ -15,7 +15,7 @@ $graphs = [
     ["barLineGraph", "pages_daily_increments_curr_month", pages_daily($tally_name, "increments", "curr_month")],
     ["barLineGraph", "pages_daily_cumulative_curr_month", pages_daily($tally_name, "cumulative", "curr_month")],
     ["barLineGraph", "pages_daily_increments_prev_month", pages_daily($tally_name, "increments", "prev_month")],
-    ["barLineGraph", "pages_daily_increments_all_time", query_graph_cache("pages_daily", [$tally_name, "increments", "all_time"])],
+    ["barLineGraph", "pages_daily_increments_all_time", query_graph_cache("pages_daily", [$tally_name, "increments", "all_time"], 60 * 60 * 6)], // cache for 6 hours
     ["barLineGraph", "pages_daily_cumulative_all_time", pages_daily($tally_name, "cumulative", "all_time")],
     ["barLineGraph", "total_pages_by_month_graph", total_pages_by_month_graph($tally_name)],
 ];

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -12,7 +12,7 @@ require_login();
 
 $title = _("Statistics Central");
 
-$cumulative_total_proj_summary_graph_data = cumulative_total_proj_summary_graph();
+$cumulative_total_proj_summary_graph_data = query_graph_cache("cumulative_total_proj_summary_graph");
 $graphs = [
     ["stackedAreaGraph", "cumulative_total_proj_summary_graph", $cumulative_total_proj_summary_graph_data],
 ];


### PR DESCRIPTION
This caches the data for the graph on the main stats page and extends the timeout to 6 hours for the very costly (51+ seconds) graph on the round stats pages.

Testable in [cache-slow-graphs](https://www.pgdp.org/~cpeel/c.branch/cache-slow-graphs/) sandbox.