### PR TITLE
Update bar graphs to use crisp edges

### DIFF
--- a/scripts/svgGraphs.js
+++ b/scripts/svgGraphs.js
@@ -250,11 +250,11 @@ const {barLineGraph, stackedAreaGraph, pieGraph} = (function () {
                         .attr("d", line);
                 } else if (seriesToRender === "bar" && (seriesData.type === undefined || seriesData.type === "bar")) {
                     svg.append("g")
-                        .attr("shape-rendering", "crispEdges")
                         .selectAll("rect")
                         .data(data)
                         .join("rect")
                         .attr("class", (_, i) => config.barColors ? config.barColors[i] : `graph-series-stroke-${seriesIndex + 1} graph-series-fill-${seriesIndex + 1}`)
+                        .style("shape-rendering", "crispEdges")
                         .attr("stroke-width", 1)
                         .attr("x", (d, i) => x(i) + xGroupOffset(seriesTitle))
                         .attr("y", ({value}) => value < 0 ? y(0) : y(value))


### PR DESCRIPTION
I've noticed that the bars in the new SVG bar graphs are blurry due to being specified in non-pixel increments. To prevent the blurriness, I've added `shape-rendering="crispEdges"` to the containing group, which makes the browser round the measurements to the nearest pixel. This can cause some uneven gaps between bars (e.g., 1 vs. 2 pixels), but unevenness was already present with the old bar graphs.

A more robust solution would probably just be to use `rangeRound` instead of `range` for the `x` and `y` scales, but I don't have a proper dev environment set up to test that out.