### PR TITLE
Update minimum supported browser list

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -12,7 +12,7 @@ Scripts supporting this upgrade are in `SETUP/upgrade/17`
 
 * Removed jpgraph and GD dependencies (chrismiceli)
 * Graphs now rendered via client-side Javascript as themed SVGs (chrismiceli)
-
+* Updated minimum browser versions, see [INSTALL.md](INSTALL.md).
 
 ## R202109
 Scripts supporting this upgrade are in `SETUP/upgrade/16`

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -55,11 +55,11 @@ These middleware components match the following major distribution releases:
 
 ## Browser support
 The following are the lowest known supported browser versions for the code:
-* Chrome 50
-* Firefox 50
+* Chrome 54
+* Firefox 52
 * Microsoft Edge
-* Opera 40
-* Safari 10
+* Opera 41
+* Safari 11
 
 Internet Explorer is not supported.
 


### PR DESCRIPTION
Update the list of minimum browser versions that are supported. The new SVG-based charts rely on Javascript  arrow methods and array spreading not available in older browsers.