### PR TITLE
Update description for top of P2 project pages

### DIFF
--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -112,7 +112,7 @@ new Round(
     'REQ-AUTO',
     '',
     null, // access_change_callback
-    _("The page-texts have already been proofread, and now need to have the text spellchecked and carefully compared to the image."),
+    _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
     'proofreading_guidelines.php',
     $pi_tools_for_P,
     null, // daily_page_limit


### PR DESCRIPTION
Some users find the term "spellchecked" in the description at the top of the project table on project pages (parenthesized following the project state) in P2 misleading, and consider that any spellchecker should be okay. Changed "spellchecked" to "WordChecked" to emphasize that WC should be used. This is a GM request.

See [update-p2-description](https://www.pgdp.org/~srjfoo/c.branch/update-p2-description/project.php?id=projectID4a6f6dc95e1ae) for an example.