### PR TITLE
Rev Google Font URLs

### DIFF
--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v15/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v19/~ChoKC0VCIEdhcmFtb25kOgsI9NCduwcVAAAvRCAA.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v15/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v19/~ChoKC0VCIEdhcmFtb25kOgsI9NCduwcVAAAvRCAA.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v15/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v19/~ChoKC0VCIEdhcmFtb25kOgsI9NCduwcVAAAvRCAA.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v15/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v19/~ChoKC0VCIEdhcmFtb25kOgsI9NCduwcVAAAvRCAA.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */


### PR DESCRIPTION
Rev the Google Font URLs. This resolves GitHub linting errors when validating the CSS matches the LESS files.

The reason this happens is because the `global.less` file points to a static URL that resolves to a versioned URL in the generated `.css` files. This isn't a problem until the version changes and the linter sees that the new version differs from the one checked into the `.css` files.

Testable in the [update-google-fonts](https://www.pgdp.org/~cpeel/c.branch/update-google-fonts/) sandbox.