### PR TITLE
Updated quiz numbering, moderate and basicx

### DIFF
--- a/quiz/generic/data/qd_p_basicx_1.inc
+++ b/quiz/generic/data/qd_p_basicx_1.inc
@@ -1,14 +1,10 @@
 <?php
 
-
-$browser_title = _("Basic Proofreading Quiz");
+$browser_title = _("Basic Proofreading Quiz: Extra Practice");
 $initial_text = "a detective, why was he watching? There was\nindeed no reward offered whatsoever for his arrest.\nPerhaps he belonged to the wretched type of beings\nwho do pride themselves on their public spirit--\nmen who wrote letters to the newspapers and\ninterfered in other people's business. He might now\nwell have wanted to show his public spirit by hand-\ning him over to the police. The newspaper in his\nhand! Of course. He had read his description there,\nand identified him.\nCharles now found himself conjecturing how the\nman would set about carrying out his task of pub-";
 $solutions = ["a detective, why was he watching? There was\nindeed no reward offered whatsoever for his arrest.\nPerhaps he belonged to the wretched type of beings\nwho do pride themselves on their public spirit--men\nwho wrote letters to the newspapers and\ninterfered in other people's business. He might now\nwell have wanted to show his public spirit by handing\nhim over to the police. The newspaper in his\nhand! Of course. He had read his description there,\nand identified him.\n\nCharles now found himself conjecturing how the\nman would set about carrying out his task of pub-*"];
-$intro_title = _("Basic Proofreading Quiz, extra practice");
+$intro_title = sprintf(_("Basic Proofreading Quiz: Extra Practice, Page %d"), 1);
 $initial_instructions = $initial_instructions__P;
-
-
-
 
 $tests[] = ["type" => "expectedtext", "searchtext" => ["pub-*"], "case_sensitive" => true, "error" => "P_eophyphen"];
 $tests[] = ["type" => "forbiddentext", "searchtext" => [" --", "-- "], "case_sensitive" => true, "error" => "P_spacedemdash"];
@@ -21,7 +17,6 @@ $tests[] = ["type" => "expectedtext", "searchtext" => ["handing"], "case_sensiti
 $tests[] = ["type" => "forbiddentext", "searchtext" => ["\nhanding"], "case_sensitive" => true, "error" => "P_hyphenlower"];
 $tests[] = ["type" => "expectedlinebreaks", "number" => 2, "starttext" => "him.", "stoptext" => "Charles now", "case_sensitive" => true, "errorhigh" => "toomanylb", "errorlow" => "P_para"];
 $tests[] = ["type" => "longline", "lengthlimit" => 60, "error" => "P_longline"];
-
 
 $messages["dashlower"] = [
     "message_title" => _("Em-dash placement"),

--- a/quiz/generic/data/qd_p_basicx_2.inc
+++ b/quiz/generic/data/qd_p_basicx_2.inc
@@ -1,12 +1,10 @@
 <?php
 
-
-$browser_title = _("Basic Proofreading Quiz");
+$browser_title = _("Basic Proofreading Quiz: Extra Practice");
 $initial_text = "repentant and remorseful agony.\n\nCHAPTER VII.\n\nAt Oakwood\n\nDEAREST mother, this is indeed\nlike some of\nOakwood's happy hours, \" exclaimed\nEmmeline , that same evening, as with\nchildish glee she had placed herself at her\nmother's feet, arid raised her laughing eyes";
 $solutions = ["repentant and remorseful agony.\n\nCHAPTER VII.\n\nAt Oakwood\n\n\"DEAREST mother, this is indeed\nlike some of\nOakwood's happy hours,\" exclaimed\nEmmeline, that same evening, as with\nchildish glee she had placed herself at her\nmother's feet, and raised her laughing eyes"];
-$intro_title = _("Basic Proofreading Quiz, extra practice");
+$intro_title = sprintf(_("Basic Proofreading Quiz: Extra Practice, Page %d"), 2);
 $initial_instructions = $initial_instructions__P;
-
 
 $tests[] = ["type" => "forbiddentext", "searchtext" => ["arid"], "case_sensitive" => false, "error" => "arid"];
 $tests[] = ["type" => "expectedtext", "searchtext" => ["\"DE"], "case_sensitive" => false, "error" => "missingquote"];

--- a/quiz/generic/data/qd_p_mod1_1.inc
+++ b/quiz/generic/data/qd_p_mod1_1.inc
@@ -1,8 +1,7 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 1);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 1);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 1, 1);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "warm bath on March 8th (who shall say hereafter\nthat science is unfeeling?), upon which the grateful\nsnail put his head cautiously out of his shell,\nwalked up to the top of the basin, and began to take\na survey of Eritish institutions with his four eyebearing\ntentacles. So strange a recovery from a\nlong torpid condition deserved an exceptional amount\nof scientific recognition. The desert snail at\n\nDesert snail.\n\nonce found himself famous. Nay, he actually sat\nfor his portrait to an eminent zoological artist, Mr.\n\nB3";
 $solutions = [
@@ -12,7 +11,6 @@ $solutions = [
 $criteria = ["e-*b"];
 $parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
                                     "<p>" . _("In many books a page footer consisting of a number and/or letter will appear on some pages but not others.  These are <i>printer's marks</i>, used to assist the printer in assembling the sections of the book in order.  They often only appear every 16 pages.  Printer's marks should be deleted like any other page footer.") . "</p>";
-
 
 // error messages
 
@@ -24,7 +22,6 @@ $messages["Eritish"] = [
     "message_title" => _("Scanno"),
     "message_body" => _("There is still a 'scanno': an '<kbd>E</kbd>' in the text where there is a '<kbd>B</kbd>' in the image."),
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod1_2.inc
+++ b/quiz/generic/data/qd_p_mod1_2.inc
@@ -1,15 +1,13 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 2);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 1);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$s, Page %2\$d"), 1, 2);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "364   ALICE ORVILLE.\n\n\"When folks can't do as they will, they must do\nas they can, I've heard say.\"\n\nThus we leave our adventurers and return north-\neast to the land from which they are receding. We\ndid n't know what else to do here, reader, for we\nwere quite as tired of the characters as you wore,\nand wanted to get them off our hands in some\nway. * * * A few people think E--e can tell\nstories tolerably well. But she can't, reader! We";
 $solutions = ["\n\"When folks can't do as they will, they must do\nas they can, I've heard say.\"\n\nThus we leave our adventurers and return north-*east\nto the land from which they are receding. We\ndidn't know what else to do here, reader, for we\nwere quite as tired of the characters as you were,\nand wanted to get them off our hands in some\nway. * * * A few people think E--e can tell\nstories tolerably well. But she can't, reader! We"];
 $parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
                                 // xgettext:no-php-format
                                 "<p>" . _("Enlarging the image in the proofreading interface can often help you to identify characters that may seem unclear at first.  You can use the +25% button repeatedly in the standard interface, or simply enter the size you want, such as 200%, in the enhanced interface.") . "</p>";
-
 
 // error messages
 
@@ -29,7 +27,6 @@ $messages["para"] = [
     "message_title" => _("Paragraph spacing"),
     "message_body" => _("Leave a single blank line between paragraphs, even if there is an extra gap in the image."),
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod1_3.inc
+++ b/quiz/generic/data/qd_p_mod1_3.inc
@@ -1,8 +1,7 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 3);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 1);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 1, 3);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "pedagogue, of Birmingham manufacture, &lt;i&gt;viz,\nDr&lt;/i&gt;. Parr, had amassed a considerable quantity of\ngold plate. But growing every day more afraid\nof being murdered, which he knew that he could\nnot stand, he transferred the whole to the black-\nsmith; conceiving, no doubt, that the murder of\na blacksmith would fall more lightly on the\nsalus reipublicae, than that of a pedagogue. But I\nhave heard this greatly disputed ; and it seems\nnow generally agreed, that one good horse-shoe\nis worth about 2% Spital sermons.";
 $criteria = ["<i>"];
@@ -46,7 +45,6 @@ $messages["italmarkup"] = [
     "message_body" => _("Italicized text may occasionally appear with <kbd>&lt;i&gt;</kbd> inserted at the start and <kbd>&lt;/i&gt;</kbd> inserted at the end of the italics. Do not change this formatting markup, even if it is incorrect, unless it is so distracting that you find it hard to proofread.  In that case, remove it completely.  The formatters will fix or add markup later in the process."),
     "guideline" => "formatting",
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod1_4.inc
+++ b/quiz/generic/data/qd_p_mod1_4.inc
@@ -1,14 +1,12 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 4);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 1);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 1, 4);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "And the meteor on the grave,\nAnd the wisp on the morass;6\nWhen the falling stars are shooting,\nAnd the answer'd owls are hooting.\n\n6[Manfred was done into Italian by a translator\n\"who was unable to find in the dictionaries . . .\nany other signification of the 'wisp' of this line\nthan 'a bundle of straw.\"' Byron offered him\n2OO francs if he would destroy the MS. He at\nfirst refused, but finally signed the agree-\nment.--Life, p. 3l6, note.]";
 $solutions = ["And the meteor on the grave,\nAnd the wisp on the morass;[6]\nWhen the falling stars are shooting,\nAnd the answer'd owls are hooting,\n\n6 [Manfred was done into Italian by a translator\n\"who was unable to find in the dictionaries ...\nany other signification of the 'wisp' of this line\nthan 'a bundle of straw.'\" Byron offered him\n200 francs if he would destroy the MS. He at\nfirst refused, but finally signed the agreement.--Life,\np. 316, note.]"];
 $parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
                                     "<p>" . _("When the text is rewrapped during post-processing, the end of a line is converted into a space.  This means that during proofreading, anything that should have a space after it (such as an ellipsis) can be left at the end of a line.") . "</p>";
-
 
 // error messages
 
@@ -51,7 +49,6 @@ $messages["aposchange"] = [
     "message_title" => _("Primary Rule"),
     "message_body" => _("The primary rule of proofreading is <i>\"Don't change what the author wrote!\"</i> Please keep the spelling and punctuation as the author wrote it, including any contractions."),
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod1_5.inc
+++ b/quiz/generic/data/qd_p_mod1_5.inc
@@ -1,12 +1,10 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 5);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 1);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 1, 5);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "when she discovered a new suitor, she had\nrecourse to a Rakshasa, who swallowed that\nunhappy suitor wholeb. So Natabhrukuti\nlooked towards the city wall, and she saw\nAja. And at the very first glance, she fell so\nviolently in love with him^c that she could\n\nb This method of disposing of objectionable suit-ors\nis unfortunately not available in Europe.\n\nc Who ever loved that loved not at first sight?\nEvery Oriental would side with Shakspeare in\nthis matter: love, in the East, is not love, unless";
 $solutions = ["when she discovered a new suitor, she had\nrecourse to a Rákshasa, who swallowed that\nunhappy suitor whole[b]. So Natabhrúkutí\nlooked towards the city wall, and she saw\nAja. And at the very first glance, she fell so\nviolently in love with him[c] that she could\n\nb This method of disposing of objectionable suitors\nis unfortunately not available in Europe.\n\nc Who ever loved that loved not at first sight?\nEvery Oriental would side with Shakspeare in\nthis matter: love, in the East, is not love, unless"];
-
 
 // error messages
 
@@ -51,7 +49,6 @@ $messages["fnmarkerspace"] = [
     "message_body" => _("Put the footnote marker right next to the word (or punctuation mark) being footnoted, like this: <br><kbd>word[c] word</kbd>."),
     "guideline" => "footnotes",
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod2_1.inc
+++ b/quiz/generic/data/qd_p_mod2_1.inc
@@ -1,8 +1,7 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 6);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 2);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 2, 1);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "faintly defined over-head.   `\n\nThe\ntraveller.\n\nP----was a traveller: anybody could\nsee that he was a traveller, and if he had\nthen been in any part of the globe, there\nwould not have been the least doubt that\nhe was a traveller travelling on his travels.\nHe looked like a traveller, and was\ndressed like a traveller. He had with him:\n\na travelling-cap    a coat\na portable-desk   a compass\na travelling-shirt    a hand organ\n\nThe hand-organ played its part very\npleasantly in the cabin of the \" Balakla-";
 $solutions = ["faintly defined over-head.\n\nThe\ntraveller.\n\nP---- was a traveller; anybody could\nsee that he was a traveller, and if he had\nthen been in any part of the globe, there\nwould not have been the least doubt that\nhe was a traveller travelling on his travels.\nHe looked like a traveller, and was\ndressed like a traveller. He had with him:\n\na travelling-cap\na portable-desk\na travelling-shirt\na coat\na compass\na hand-organ\n\nThe hand-organ played its part very\npleasantly in the cabin of the \"Balakla-*"];

--- a/quiz/generic/data/qd_p_mod2_2.inc
+++ b/quiz/generic/data/qd_p_mod2_2.inc
@@ -1,14 +1,12 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 7);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 2);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 2, 2);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "its terrestrial excursions. Just above\nthe gills, lie climbing perch has\ninvented a wholly original water chamber\ncontaining within it a\nfrilled bony organ, which\nenables it to extract oxygen\n--or O2 to scientists--from\nthe stored-up water\nduring the course of its aerial peregrinations\n. While on shore it picks up\nsmall insects, worms, and grubs; but it\nalso has vegetarian tastes of us own,\nand does not despise fruits and berries";
 $solutions = ["its terrestrial excursions. Just above\nthe gills, the climbing perch has\ninvented a wholly original water chamber,\ncontaining within it a\nfrilled bony organ, which\nenables it to extract oxygen--or\nO_{2} to scientists--from\nthe stored-up water\nduring the course of its aërial peregrinations.\nWhile on shore it picks up\nsmall insects, worms, and grubs; but it\nalso has vegetarian tastes of its own,\nand does not despise fruits and berries."];
 $parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
                                     "<p>" . _("The texts that we proofread sometimes have different spellings than what we use today, including accents in words like <kbd>coöperate</kbd> and <kbd>preëminent</kbd>. OCR programs often miss the accents, so be sure to check the image carefully when proofreading.") . "</p>";
-
 
 // error messages
 
@@ -40,7 +38,6 @@ $messages["accente"] = [
     "message_title" => _("Scanno"),
     "message_body" => _("There is still a scanno in the text: an accent over an '<kbd>e</kbd>' was omitted by the OCR software."),
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod2_3.inc
+++ b/quiz/generic/data/qd_p_mod2_3.inc
@@ -1,8 +1,7 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 8);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 2);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 2, 3);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "tween the quercus* and the olivet there exists a\nhatred so inveterate, that transplanted, either of\nthem, to a site previously occupied by the other,\nthey will die.I The quercus too, if planted near\nthe stoechas, will perish. There is a mortal feud\nexisting also between the cabbage and the vine;\n\n* See B. xi. c. 40. t See B. vii. cc. 5, 8, &c.\n\nI As Fee justly remarks, the greater part of these\nso-called sympathies and antipathies must be looked\nupon as so many fables.";
 $solutions = ["*tween the quercus[*] and the olive[*] there exists a\nhatred so inveterate, that transplanted, either of\nthem, to a site previously occupied by the other,\nthey will die.[*] The quercus too, if planted near\nthe stœchas, will perish. There is a mortal feud\nexisting also between the cabbage and the vine;\n\n* See B. xi. c. 40.\n\n* See B. vii. cc. 5, 8, &c.\n\n* As Fée justly remarks, the greater part of these\nso-called sympathies and antipathies must be looked\nupon as so many fables."];
@@ -49,7 +48,6 @@ $messages["fnmarkerspace"] = [
     "message_body" => _("Put the footnote marker right next to the word (or punctuation mark) being footnoted and leave a space on the other side of it, like this: <br><kbd>word[*] word</kbd>."),
     "guideline" => "footnotes",
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod2_4.inc
+++ b/quiz/generic/data/qd_p_mod2_4.inc
@@ -1,14 +1,12 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 9);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 2);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 2, 4);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "\"It has been said,\" he began, withdrawing\nhis eyes reluctantly from an unusually large\ninsect upon the ceiling, \"that there are few\n\"situations in life that cannot be honourably\n\"settled--and without loss of time\n\"--either by suicide, a bag of gold,\n\"or by thrusting a despised anta-\n\"gonist over the edge of a precipice upon a\n\"dark night. This inoffensive person, however,\n\nA suitor\nis chosen";
 $solutions = ["\n\"It has been said,\" he began, withdrawing\nhis eyes reluctantly from an unusually large\ninsect upon the ceiling, \"that there are few\nsituations in life that cannot be honourably\nsettled--and without loss of time--either\nby suicide, a bag of gold,\nor by thrusting a despised antagonist\nover the edge of a precipice upon a\ndark night. This inoffensive person, however,\n\nA suitor\nis chosen."];
 $parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
                                     "<p>" . _("We remove extra quote marks when they appear on every line because the text will be rewrapped in post-processing, changing the line breaks.  If we left the extra quote marks in the text they would end up in the middle of the paragraph.") . "</p>";
-
 
 // error messages
 
@@ -21,7 +19,6 @@ $messages["extraquote"] = [
     "message_body" => _("Proofread these by removing all of the quote marks except for the one at the start of the quotation."),
     "guideline" => "quote_ea",
 ];
-
 
 // error checks
 

--- a/quiz/generic/data/qd_p_mod2_5.inc
+++ b/quiz/generic/data/qd_p_mod2_5.inc
@@ -1,14 +1,12 @@
 <?php
 
-
-$browser_title = _("Moderate Proofreading Quiz");
-$intro_title = sprintf(_("Moderate Proofreading Quiz, page %d"), 10);
+$browser_title = sprintf(_("Moderate Proofreading Quiz: Part %d"), 2);
+$intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 2, 5);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "don't spare him in the slightest!    ,\n\nChrys. (virtuously indignant) Is it enough, if he\nhears mere hard words from me this day than\never Clinia2 heard from Demetrius?2\n\n[EXIT.\n\nNIC. (ruefully) That servant of mine is very\nmuch like a sore eye : if you haven't got one,\nyou don't want one and don't miss it; if you\nhave, you can't keep your hands off it. Why, if\nhe hadn 't happened by good luck to be here to-\n\n^2 Characters in some familiar play.";
 $solutions = ["don't spare him in the slightest!\n\nChrys. (virtuously indignant) Is it enough, if he\nhears more hard words from me this day than\never Clinia[2] heard from Demetrius?[2]\n\n[EXIT.\n\nNIC. (ruefully) That servant of mine is very\nmuch like a sore eye: if you haven't got one,\nyou don't want one and don't miss it; if you\nhave, you can't keep your hands off it. Why, if\nhe hadn't happened by good luck to be here to-*\n\n2 Characters in some familiar play."];
 $parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
                                     "<p>" . _("Be sure to read the Project Comments and project discussion before starting to work on a project.  There may be exceptions to the regular Proofreading Guidelines, or helpful information that will make proofreading the text easier for you.") . "</p>";
-
 
 // error messages
 
@@ -45,7 +43,6 @@ $messages["fnmarkerspace"] = [
     "message_body" => _("Put the footnote marker right next to the word (or punctuation mark) being footnoted and leave a space on the other side of it, like this: <br><kbd>word[2] word</kbd>."),
     "guideline" => "footnotes",
 ];
-
 
 // error checks
 

--- a/quiz/tuts/tut_p_mod1_1.php
+++ b/quiz/tuts/tut_p_mod1_1.php
@@ -5,13 +5,13 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 1));
 
 echo "<h1>" . _("Proofreading Tutorial") . "</h1>\n";
 echo "<h2>" . _("Intro") . "</h2>\n";
 echo "<p>" . _("In this tutorial you will be presented extracts from the Proofreading Guidelines. After each part you will be led to a quiz page, where you can try out the newly learned rules. These Moderate Proofreading Quizzes build on the topics already covered in the tutorial for the Basic Proofreading Quiz.") . "</p>\n";
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 1) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 1, 1) . "</h2>\n";
 echo "<h3>" . _("Superscripts") . "</h3>\n";
 echo "<p>" . _("Older books often abbreviated words as contractions, and printed them as superscripts. Proofread these by inserting a single caret (<kbd>^</kbd>) followed by the superscripted text. If the superscript continues for more than one character, then surround the text with curly braces <kbd>{</kbd> and <kbd>}</kbd> as well. For example:") . "</p>\n";
 echo "<table class='basic' summary='" . _("Superscripts example") . "'>\n";

--- a/quiz/tuts/tut_p_mod1_2.php
+++ b/quiz/tuts/tut_p_mod1_2.php
@@ -5,9 +5,9 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 1));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 2) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 1, 2) . "</h2>\n";
 echo "<h3>" . _("End-of-line Hyphenation") . "</h3>\n";
 echo "<p>" . _("Words like to-day and to-morrow that we don't commonly hyphenate now were often hyphenated in the old books we are working on. Leave them hyphenated the way the author did. If you're not sure if the author hyphenated it or not, leave the hyphen, put an <kbd>*</kbd> after it, and join the word together like this: <kbd>to-*day</kbd>. The asterisk will bring it to the attention of the post-processor, who has access to all the pages and can determine how the author typically wrote this word.") . "</p>\n";
 

--- a/quiz/tuts/tut_p_mod1_3.php
+++ b/quiz/tuts/tut_p_mod1_3.php
@@ -5,9 +5,9 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 1));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 3) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 1, 3) . "</h2>\n";
 echo "<h3>" . _("Accented/Non-ASCII Characters") . "</h3>\n";
 echo "<p>" . _("Please proofread these using the proper UTF-8 characters. For characters which are not in Unicode, see the Project Manager's instructions in the Project Comments.") . "</p>\n";
 

--- a/quiz/tuts/tut_p_mod1_4.php
+++ b/quiz/tuts/tut_p_mod1_4.php
@@ -5,9 +5,9 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 1));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 4) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 1, 4) . "</h2>\n";
 echo "<h3>" . _("Common OCR Problems") . "</h3>\n";
 echo "<p>" . _("OCR commonly has trouble distinguishing between the similar characters.  Some examples are:") . "</p>\n";
 echo "<ul>";

--- a/quiz/tuts/tut_p_mod1_5.php
+++ b/quiz/tuts/tut_p_mod1_5.php
@@ -5,11 +5,15 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 1));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 5) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 1, 5) . "</h2>\n";
 echo "<h3>" . _("Footnotes/Endnotes") . "</h3>\n";
-echo "<p>" . _("Place each footnote on a separate line in order of appearance, with a blank line before each one.") . "</p>\n";
+echo "<p>" . _("In the main text of the page, the character that marks a footnote
+    location should be surrounded with square brackets (<kbd>[</kbd> and <kbd>]</kbd>)
+    and placed next to the word<kbd>[*]</kbd> being footnoted or its punctuation mark.<kbd>[*]</kbd>") . "</p>\n";
+echo "<p>" . _("At the bottom of the page, place each footnote on a separate line in
+    order of appearance, with a blank line before each one.") . "</p>\n";
 echo "<p>" . _("Do not include any horizontal lines separating the footnotes from the main text.") . "</p>\n";
 
 echo "<p><a href='../generic/main.php?quiz_page_id=p_mod1_5'>" . _("Continue to quiz page") . "</a></p>\n";

--- a/quiz/tuts/tut_p_mod2_1.php
+++ b/quiz/tuts/tut_p_mod2_1.php
@@ -5,11 +5,12 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 2));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 6) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 2, 1) . "</h2>\n";
 echo "<h3>" . _("Paragraph Side-Descriptions (Sidenotes)") . "</h3>\n";
-echo "<p>" . _("Some books will have short descriptions of the paragraph along the side of the text. These are called sidenotes. Proofread the sidenote text as it is printed, preserving the line breaks (while handling end-of-line hyphenation and dashes normally). Leave a blank line before and after the sidenote so that it can be distinguished from the text around it. The OCR may place the sidenotes anywhere on the page, and may even intermingle the sidenote text with the rest of the text. Separate them so that the sidenote text is all together, but don't worry about the position of the sidenotes on the page.") . "</p>\n";
+echo "<p>" . _("Some books have short descriptions of the paragraph along the side of the text. These are called sidenotes. Proofread the sidenote text as it is printed, preserving the line breaks (while handling end-of-line hyphenation and dashes normally).") . "</p>\n";
+echo "<p>" . _("Leave a blank line before and after the sidenote so that it can be distinguished from the text around it. The OCR may place the sidenotes anywhere on the page, and may even intermingle the sidenote text with the rest of the text. Separate them so that the sidenote text is all together, but don't worry about the position of the sidenotes on the page.") . "</p>\n";
 
 echo "<h3>" . _("Multiple Columns") . "</h3>\n";
 echo "<p>" . _("Proofread ordinary text that has been printed in multiple columns as a single column. Place the text from the left-most column first, the text from the next column below that, and so on. Do not mark where the columns were split, just join them together.") . "</p>\n";

--- a/quiz/tuts/tut_p_mod2_2.php
+++ b/quiz/tuts/tut_p_mod2_2.php
@@ -5,9 +5,9 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 2));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 7) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 2, 2) . "</h2>\n";
 echo "<h3>" . _("Subscripts") . "</h3>\n";
 echo "<p>" . _("Subscripted text is often found in scientific works, but is not common in other material. Proofread subscripted text by inserting an underline character <kbd>_</kbd> and surrounding the text with curly braces <kbd>{</kbd> and <kbd>}</kbd>. For example:") . "</p>\n";
 

--- a/quiz/tuts/tut_p_mod2_3.php
+++ b/quiz/tuts/tut_p_mod2_3.php
@@ -5,9 +5,9 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 2));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 8) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 2, 3) . "</h2>\n";
 echo "<h3>" . _("Accented/Non-ASCII Characters") . "</h3>\n";
 echo "<p>" . _("The œ character (oe ligature) should be inserted into the proofread text, just like other special characters.") . "</p>\n";
 

--- a/quiz/tuts/tut_p_mod2_4.php
+++ b/quiz/tuts/tut_p_mod2_4.php
@@ -5,9 +5,9 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 2));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 9) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 2, 4) . "</h2>\n";
 echo "<h3>" . _("Quote marks on each line") . "</h3>\n";
 echo "<p>" . _("Proofread quotation marks at the beginning of each line of a quotation by removing all of them <b>except for</b> the one at the start of the quotation. If a quotation like this goes on for multiple paragraphs, leave the quote mark that appears on the first line of each paragraph.") . "</p>\n";
 echo "<p>" . _("Often there is no closing quotation mark until the very end of the quoted section of text, which may not be on the same page you are proofreading. Leave it that way&mdash;do not add closing quotation marks that are not in the page image.") . "</p>\n";

--- a/quiz/tuts/tut_p_mod2_5.php
+++ b/quiz/tuts/tut_p_mod2_5.php
@@ -5,9 +5,9 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
-output_header(_('Moderate Proofreading Tutorial'));
+output_header(sprintf(_("Moderate Proofreading Tutorial: Part %d"), 2));
 
-echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial, page %d"), 10) . "</h2>\n";
+echo "<h2>" . sprintf(_("Moderate Proofreading Tutorial: Part %1\$d, Page %2\$d"), 2, 5) . "</h2>\n";
 echo "<h3>" . _("Plays: Actor Names/Stage Directions") . "</h3>\n";
 echo "<p>" . _("In dialog, treat a change in speaker as a new paragraph, with one blank line before it.") . "</p>\n";
 echo "<p>" . _("Stage directions are kept as they are in the original image, so if the stage direction is on a line by itself, proofread it that way; if it is at the end of a line of dialog, leave it there. Stage directions often begin with an opening bracket and omit the closing bracket. This convention is retained; do not close the brackets.") . "</p>\n";


### PR DESCRIPTION
GM request: the quiz page numbering system for the actual quiz and tutorial pages for the moderate quiz and tutorial pages differs from that used on the quiz start page, and the file names. This has been known to cause confusion when one person uses one numbering system, and another uses the other. This updates the numbering used by those tutorial and quiz pages to match those on the quiz start page.

Sandbox available [here](https://www.pgdp.org/~srjfoo/c.branch/quiz-numbering-tweaks). Tutorials 1-5 and 2-1 have some wording/format changes.