### PR TITLE
Use load_special_days() in more places

### DIFF
--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -189,20 +189,12 @@ class ProjectSearchForm
 
     public static function special_day_options()
     {
-        $special_day_options = [];
-        $sql = "
-            SELECT
-                spec_code,
-                display_name,
-                DATE_FORMAT(concat('2000-',open_month,'-',open_day),'%e %b')
-            FROM special_days
-            ORDER BY open_month, open_day
-        ";
-        $special_day_res = DPDatabase::query($sql);
-        while ([$s_code, $s_display_name, $s_start] = mysqli_fetch_row($special_day_res)) {
-            $special_day_options[$s_code] = "$s_display_name ($s_start)";
-        }
-        return $special_day_options;
+        $special_days = load_special_days();
+        sort_special_days($special_days, "open_month,open_day");
+        return array_combine(
+            array_column($special_days, "spec_code"),
+            array_column($special_days, "option_label")
+        );
     }
 
     public static function language_options()

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -23,26 +23,67 @@ function load_common_special_days()
     ];
 }
 
-function load_special_days()
+function load_special_days($load_common = false)
 {
-    $specials_array = load_common_special_days();
+    if ($load_common) {
+        $specials_array = load_common_special_days();
+    } else {
+        $specials_array = [];
+    }
 
     $sql = "
-        SELECT spec_code, color, display_name, symbol
+        SELECT *
         FROM special_days
         ORDER BY display_name
     ";
     $specs_result = DPDatabase::query($sql);
 
     while ($row = mysqli_fetch_assoc($specs_result)) {
-        $specials_array[$row['spec_code']] = [
-            "color" => '#' . $row['color'],
-            "display_name" => $row['display_name'],
-            "symbol" => $row['symbol'],
-        ];
+        $specials_array[$row['spec_code']] = array_merge(
+            // start with the row from the query
+            $row,
+            [
+                // override color to make it a valid HTML value
+                "color" => '#' . $row['color'],
+
+                // provide a localized option label
+                "option_label" => sprintf("%s (%s)", $row["display_name"],
+                    date_format(
+                        date_create(
+                            sprintf("2000-%02d-%02d", $row["open_month"], $row["open_day"])
+                        ),
+                        "j M"
+                    ),
+                ),
+            ]
+        );
     }
 
     return $specials_array;
+}
+
+function sort_special_days(&$special_days, $sort_by = "display_name")
+{
+    $display_name = array_column($special_days, "display_name");
+    $display_name = array_map('strtolower', $display_name);
+
+    if ($sort_by == "display_name") {
+        array_multisort(
+            $display_name, SORT_NATURAL, SORT_ASC,
+            $special_days
+        );
+    } elseif ($sort_by == "open_month,open_day") {
+        $open_month = array_column($special_days, "open_month");
+        $open_day = array_column($special_days, "open_day");
+        array_multisort(
+            $open_month, SORT_NUMERIC, SORT_ASC,
+            $open_day, SORT_NUMERIC, SORT_ASC,
+            $display_name, SORT_NATURAL, SORT_ASC,
+            $special_days
+        );
+    } else {
+        throw Exception("Invalid value for \$sort_by");
+    }
 }
 
 // Returns the special day array associated with this
@@ -51,7 +92,7 @@ function get_special_day($special_code)
 {
     static $specials_array = [];
     if (!$specials_array) {
-        $specials_array = load_special_days();
+        $specials_array = load_special_days(true);
     }
 
     $special_day = null;
@@ -102,7 +143,7 @@ function echo_special_legend($projects_where_clause)
             WHERE $projects_where_clause
         ");
 
-    $specials_array = load_special_days();
+    $specials_array = load_special_days(true);
     $day_array = [];
 
     while ($cs_row = mysqli_fetch_assoc($currspecs_result)) {

--- a/project.php
+++ b/project.php
@@ -438,7 +438,7 @@ function do_project_info_table()
         ) {
             $spec_display = $spec_code;
         } else {
-            $special_days = load_special_days();
+            $special_days = load_special_days(true);
             $spec_display = $special_days[$spec_code]["display_name"] ?? "($spec_code)";
         }
 

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -6,6 +6,7 @@ include_once($relPath.'wordcheck_engine.inc'); // get_project_word_file
 include_once($relPath.'links.inc'); // new_window_link, new_help_window_link
 include_once($relPath.'user_is.inc'); // user_is_a_sitemanager
 include_once($relPath.'misc.inc'); // attr_safe(), html_safe(), endswith()
+include_once($relPath.'special_colors.inc'); // load_special_days()
 include_once($relPath.'User.inc');
 include_once($relPath.'CharSuites.inc');
 
@@ -149,27 +150,14 @@ function difficulty_list($difficulty_level)
 
 function special_list($special)
 {
-    // get info on special days
-    $sql = "
-        SELECT
-            spec_code,
-            display_name,
-            enable,
-            DATE_FORMAT(concat('2000-',open_month,'-',open_day),'%e %b') as 'Start Date'
-        FROM special_days
-        ORDER BY open_month, open_day
-    ";
-    $specs_result = DPDatabase::query($sql);
+    $special_days = load_special_days();
+    sort_special_days($special_days, "open_month,open_day");
 
-    // it'd be nice to make this static, or something, so it only was loaded once
+    // create an array for populating the <select> options
     $specials_array = [];
-
-    // put list into array
-    while ($s_row = mysqli_fetch_assoc($specs_result)) {
-        if ($s_row['enable'] || $s_row['spec_code'] == $special) {
-            $show = $s_row['display_name'] . " (" . $s_row['Start Date'] . ")";
-            $code = $s_row['spec_code'];
-            $specials_array["$code"] = $show;
+    foreach ($special_days as $spec_code => $special_day) {
+        if ($special_day['enable'] || $spec_code == $special) {
+            $specials_array[$spec_code] = $special_day["option_label"];
         }
     }
 

--- a/tools/project_manager/show_specials.php
+++ b/tools/project_manager/show_specials.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'dpsql.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'special_colors.inc');
 
@@ -15,18 +14,14 @@ echo "<h1>$title</h1>\n";
 
 echo "<p>" . _("If a Special Day has been disabled, <span class='small'>[Disabled]</span> will be displayed following the name of the special day in the \"Name\" column.") . "</p>\n";
 
-$sql = "
-    SELECT *
-    FROM special_days
-    ORDER BY open_month, open_day
-";
-$result = DPDatabase::query($sql);
+$special_days = load_special_days();
+sort_special_days($special_days, "open_month,open_day");
 
 echo "<table class='list_special_days show_special_days'>";
 
 $current_month = -1;
 
-while ($row = mysqli_fetch_assoc($result)) {
+foreach ($special_days as $row) {
     $month = $row['open_month'];
 
     // This handles the exceptions for the 'special' special days which aren't really


### PR DESCRIPTION
Use the `load_special_days()` code when populating the page to view them and when loading them when editing projects. This also adds a helper function for sorting them by the most commonly used methods. The only user-visible change is that special days that happen on the same month/day pair are now sub-sorted alphabetically by the special day display name. This is probably only relevant on TEST I think.

I did not change the queries used in `tools/site_admin/manage_special_days.php` since that is doing updates as well as queries. I think that's the last remaining place that queries the `special_days` table directly though.

This is some infra prep work as I putz on [Task 2011](https://www.pgdp.net/c/tasks.php?action=show&task_id=2011).

Testable in [centralize-special-day-query](https://www.pgdp.org/~cpeel/c.branch/centralize-special-day-query/) sandbox.