### PR TITLE
Centralize queries against image_sources table

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -128,14 +128,8 @@ class Project
             return;
         }
 
-        $sql = sprintf("
-            SELECT full_name, credit
-            FROM image_sources
-            WHERE code_name = '%s'",
-            DPDatabase::escape($this->image_source)
-        );
-        $result = DPDatabase::query($sql);
-        $imso_res = mysqli_fetch_assoc($result);
+        $image_sources = load_image_sources();
+        $imso_res = array_get($image_sources, (string)$this->image_source, null);
         if ($imso_res) {
             $this->image_source_name = $imso_res['full_name'];
             $this->image_source_credit = $imso_res['credit'];
@@ -1316,4 +1310,48 @@ function get_page_image_param($arr, $key, $allownull = false)
         ));
     }
     return $page_name;
+}
+
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Image source functions
+
+function load_image_sources()
+{
+    static $image_sources = [];
+    if ($image_sources) {
+        return $image_sources;
+    }
+
+    $sql = "
+        SELECT *
+        FROM image_sources
+        ORDER BY display_name
+    ";
+    $result = DPDatabase::query($sql);
+    while ($row = mysqli_fetch_assoc($result)) {
+        $image_sources[(string)$row['code_name']] = $row;
+    }
+    mysqli_free_result($result);
+    return $image_sources;
+}
+
+// Can the current user see this image source based on the source's settings
+function can_user_see_image_source($image_source)
+{
+    // info page visibility
+    //  0 = Image Source Managers and SAs
+    //  1 = also any PM
+    //  2 = also any logged-in user
+    //  3 = anyone
+
+    if (user_is_image_sources_manager()) {
+        $visibility = 0;
+    } elseif (user_is_PM()) {
+        $visibility = 1;
+    } else {
+        $visibility = 2;
+    }
+
+    return $visibility <= $image_source["info_page_visibility"];
 }

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -8,6 +8,7 @@ include_once($relPath.'user_is.inc'); // user_is_a_sitemanager
 include_once($relPath.'misc.inc'); // attr_safe(), html_safe(), endswith()
 include_once($relPath.'User.inc');
 include_once($relPath.'CharSuites.inc');
+include_once($relPath.'Project.inc'); // load_image_sources()
 
 function just_echo($field_value)
 {
@@ -254,28 +255,17 @@ function special_list($special)
 function image_source_list($image_source)
 {
     global $site_abbreviation;
-    // get info on image_sources
-    $sql = "
-        SELECT code_name, display_name
-        FROM image_sources
-        WHERE is_active = 1
-        ORDER BY display_name
-    ";
-    $imso_result = DPDatabase::query($sql);
 
     $imso_array = [
         // TRANSLATORS: %s is the site abbreviation
         "_internal" => sprintf(_("%s Internal"), $site_abbreviation),
     ];
-
-    // put list into array
-    while ($i_row = mysqli_fetch_assoc($imso_result)) {
-        $code = $i_row['code_name'];
-        // unfortunately, $code can be a numeric value which confuses the php array
-        // e.g. 1.5 and 1.6 would both be cast to 1
-        // so we append a colon at the end here to force it to be a string and then
-        // strip it again later
-        $imso_array["$code:"] = $i_row['display_name'];
+    foreach (load_image_sources() as $code => $source) {
+        if (($source["is_active"] == 1 && can_user_see_image_source($source)) ||
+            $code == $image_source) {
+            // $code can be a numeric value so we cast it to a string
+            $imso_array[(string)$code] = $source['display_name'];
+        }
     }
 
     // drop down select box for which image source
@@ -283,10 +273,6 @@ function image_source_list($image_source)
     maybe_echo_placeholder_option($image_source);
     // add the pre-defined image_sources
     foreach ($imso_array as $k => $v) {
-        // strip off the string-forcing trailing colon if it exists
-        if (endswith($k, ':')) {
-            $k = substr($k, 0, strlen($k) - 1);
-        }
         echo "<option value='".attr_safe($k)."'";
         if ($image_source === $k) {
             echo " SELECTED";


### PR DESCRIPTION
This centralizes the queries against the `image_sources` table, with the exception of those in `manage_image_sources.php`. The `Project.inc` file isn't the ideal place for this, but it is at least a reasonable one until we make an `ImageSource` abstraction.

This has only one functional change: image source visibility is now enforced when creating or editing a project. Prior, any image source -- even ones that shouldn't be visible to PMs -- were selectable on the Edit Project page. This work enables progress on Task 2011.

Testable in the [centralize-image-sources-query](https://www.pgdp.org/~cpeel/c.branch/centralize-image-sources-query/) sandbox.