### PR TITLE
Add API to get list of charsuites, special days, and image sources

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -173,6 +173,36 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/imagesources:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid project image sources
+      parameters:
+      - name: enabled
+        in: query
+        description: Only return enabled image sources
+        required: false
+        schema:
+          type: boolean
+      responses:
+        200:
+          description: List of valid image sources
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/image_source'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/languages:
     get:
       tags:
@@ -678,6 +708,25 @@ components:
           type: array
           items:
             type: string
+        enabled:
+          type: boolean
+
+    image_source:
+      required:
+      - id
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        name_full:
+          type: string
+        url:
+          type: string
+          format: url
+        credit:
+          type: string
         enabled:
           type: boolean
 

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -219,6 +219,36 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/specialdays:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid special days
+      parameters:
+      - name: enabled
+        in: query
+        description: Only return enabled special days
+        required: false
+        schema:
+          type: boolean
+      responses:
+        200:
+          description: List of special days
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/special_day'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/states:
     get:
       tags:
@@ -671,6 +701,39 @@ components:
           type: integer
           readOnly: true
       description: Statistics for the site
+
+    special_day:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        comment:
+          type: string
+        url:
+          type: string
+          format: url
+        color:
+          type: string
+        symbol:
+          type: string
+        date_open_month:
+          type: integer
+          description: Month the special day opens
+        date_open_day:
+          type: integer
+          description: Day of the month the special day opens
+        date_close_month:
+          type: integer
+          description: Month the special day closes
+        date_close_day:
+          type: integer
+          description: Day of the month the special day closes
+        enabled:
+          type: boolean
 
     round_stats:
       type: object

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -97,6 +97,36 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/charsuites:
+    get:
+      tags:
+      - project
+      description: Returns a list of valid project character suites
+      parameters:
+      - name: enabled
+        in: query
+        description: Only return enabled character suites
+        required: false
+        schema:
+          type: boolean
+      responses:
+        200:
+          description: List of valid character suites
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/charsuite'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/difficulties:
     get:
       tags:
@@ -604,6 +634,22 @@ components:
           type: string
         state:
           type: string
+
+    charsuite:
+      required:
+      - id
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        characters:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
 
     site_stats:
       type: object

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -27,6 +27,7 @@ $router->add_route("GET", "v1/projects/states", "api_v1_projects_states");
 $router->add_route("GET", "v1/projects/pagerounds", "api_v1_projects_pagerounds");
 $router->add_route("GET", "v1/projects/charsuites", "api_v1_projects_charsuites");
 $router->add_route("GET", "v1/projects/specialdays", "api_v1_projects_specialdays");
+$router->add_route("GET", "v1/projects/imagesources", "api_v1_projects_imagesources");
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
 $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -25,6 +25,7 @@ $router->add_route("GET", "v1/projects/genres", "api_v1_projects_genres");
 $router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
 $router->add_route("GET", "v1/projects/states", "api_v1_projects_states");
 $router->add_route("GET", "v1/projects/pagerounds", "api_v1_projects_pagerounds");
+$router->add_route("GET", "v1/projects/charsuites", "api_v1_projects_charsuites");
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
 $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -26,6 +26,7 @@ $router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
 $router->add_route("GET", "v1/projects/states", "api_v1_projects_states");
 $router->add_route("GET", "v1/projects/pagerounds", "api_v1_projects_pagerounds");
 $router->add_route("GET", "v1/projects/charsuites", "api_v1_projects_charsuites");
+$router->add_route("GET", "v1/projects/specialdays", "api_v1_projects_specialdays");
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
 $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -316,3 +316,27 @@ function api_v1_projects_pagerounds($method, $data, $query_params)
 
     return array_merge(["OCR"], array_keys($Round_for_round_id_));
 }
+
+//---------------------------------------------------------------------------
+// projects/charsuites
+
+function api_v1_projects_charsuites($method, $data, $query_params)
+{
+    if (isset($query_params["enabled"])) {
+        $charsuites = CharSuites::get_enabled();
+    } else {
+        $charsuites = CharSuites::get_all();
+    }
+
+    $return_data = [];
+    foreach ($charsuites as $charsuite) {
+        $return_data[] = [
+            "id" => $charsuite->name,
+            "name" => $charsuite->title,
+            "characters" => convert_codepoint_ranges_to_characters($charsuite->codepoints),
+            "enabled" => $charsuite->is_enabled(),
+        ];
+    }
+
+    return $return_data;
+}

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -371,3 +371,34 @@ function api_v1_projects_specialdays($method, $data, $query_params)
 
     return $return_data;
 }
+
+//---------------------------------------------------------------------------
+// projects/imagesources
+
+function api_v1_projects_imagesources($method, $data, $query_params)
+{
+    $return_data = [];
+
+    $image_sources = load_image_sources();
+
+    foreach ($image_sources as $id => $image_source) {
+        if (isset($query_params["enabled"]) && !($image_source["is_active"] == 1)) {
+            continue;
+        }
+
+        if (!can_user_see_image_source($image_source)) {
+            continue;
+        }
+
+        $return_data[] = [
+            "id" => $image_source["code_name"],
+            "name" => $image_source["display_name"],
+            "name_full" => $image_source["full_name"],
+            "url" => $image_source["url"],
+            "credit" => $image_source["credit"],
+            "enabled" => $image_source["is_active"] == 1,
+        ];
+    }
+
+    return $return_data;
+}

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -3,6 +3,7 @@ include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'ProjectSearchForm.inc');
 include_once($relPath.'page_table.inc');
+include_once($relPath.'special_colors.inc');
 include_once("exceptions.inc");
 
 // DP API v1 -- Projects
@@ -335,6 +336,36 @@ function api_v1_projects_charsuites($method, $data, $query_params)
             "name" => $charsuite->title,
             "characters" => convert_codepoint_ranges_to_characters($charsuite->codepoints),
             "enabled" => $charsuite->is_enabled(),
+        ];
+    }
+
+    return $return_data;
+}
+
+//---------------------------------------------------------------------------
+// projects/specialdays
+
+function api_v1_projects_specialdays($method, $data, $query_params)
+{
+    $return_data = [];
+
+    $special_days = load_special_days();
+    foreach ($special_days as $spec_code => $special_day) {
+        if (isset($query_params["enabled"]) && !($special_day["enable"] == 1)) {
+            continue;
+        }
+        $return_data[] = [
+            "id" => $special_day["spec_code"],
+            "name" => $special_day["display_name"],
+            "comment" => $special_day["comment"],
+            "url" => $special_day["info_url"],
+            "color" => $special_day["color"],
+            "symbol" => $special_day["symbol"],
+            "date_open_month" => (int)$special_day["open_month"],
+            "date_open_day" => (int)$special_day["open_day"],
+            "date_close_month" => (int)$special_day["close_month"],
+            "date_close_day" => (int)$special_day["close_day"],
+            "enabled" => $special_day["enable"] == 1,
         ];
     }
 


### PR DESCRIPTION
This PR extends the API to allow users to get a list of character suites, special days, and image sources. This will be necessary for users to create projects (eventually) as part of [Task 2011](https://www.pgdp.net/c/tasks.php?action=show&task_id=2011).

The API intentionally does not use the exact same field names as those stored in the database. Instead, we try to present a more unified view to the outside world. Like other parts of the API, these only return data that the user can already see in the UI. This is most relevant to image sources which have scoped visibility -- some can only be viewed by PMs, or Image Source Managers / SAs. The PR includes update to the Swagger schema as well.

This code is live in the sandbox at https://www.pgdp.org/~cpeel/c.branch/api-proj-gets/ but there are no UI changes. Instead, testing can be done via `curl`:

```bash
# export the user's API key
# this one is for an unprivileged proofreader on TEST:
export API_KEY=review

# charsuites
curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/api-proj-gets/api/index.php?url=v1/projects/charsuites" \
    -H "accept: application/json" \
    -H "X-API-KEY: $API_KEY"

# special days
curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/api-proj-gets/api/index.php?url=v1/projects/specialdays" \
    -H "accept: application/json" \
    -H "X-API-KEY: $API_KEY"

# image sources
curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/api-proj-gets/api/index.php?url=v1/projects/imagesources" \
    -H "accept: application/json" \
    -H "X-API-KEY: $API_KEY"
```

All of these support an `enabled` parameter that, if present, will only return the entities that are enabled.
```bash
# only enabled image sources
curl -i -g -X GET "https://www.pgdp.org/~cpeel/c.branch/api-proj-gets/api/index.php?url=v1/projects/imagesources&enabled" \
    -H "accept: application/json" \
    -H "X-API-KEY: $API_KEY"
```