### PR TITLE
Centralize project difficulty definition

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -272,8 +272,7 @@ function render_project_page_json($row)
 
 function api_v1_projects_difficulties($method, $data, $query_params)
 {
-    $difficulties = ProjectSearchForm::difficulty_options();
-    unset($difficulties['']);
+    $difficulties = get_project_difficulties();
     return array_keys($difficulties);
 }
 

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1355,3 +1355,16 @@ function can_user_see_image_source($image_source)
 
     return $visibility <= $image_source["info_page_visibility"];
 }
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Project difficulty
+
+function get_project_difficulties()
+{
+    return [
+        'beginner' => _('Beginner'),
+        'easy' => _('Easy'),
+        'average' => _('Average'),
+        'hard' => _('Hard'),
+    ];
+}

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -213,13 +213,7 @@ class ProjectSearchForm
 
     public static function difficulty_options()
     {
-        return [
-            '' => _('Any'),
-            'beginner' => _('Beginner'),
-            'easy' => _('Easy'),
-            'average' => _('Average'),
-            'hard' => _('Hard'),
-        ];
+        return array_merge(['' => _('Any')], get_project_difficulties());
     }
 
     public static function state_options()

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'misc.inc'); // attr_safe()
 include_once($relPath.'iso_lang_list.inc');
+include_once($relPath.'Project.inc'); // get_project_difficulties()
 
 // This file includes functions to handle the creation, update, and display of
 // the project filters used on the Round, Project, and Smooth Reading pages.
@@ -157,9 +158,9 @@ class DifficultyElement extends ProjectFilterElement
             echo " checked";
         }
         echo ">\n";
-        $difficulty_options = ['beginner' => _("Beginners Only"), 'easy' => _("Easy"), 'average' => _("Average"), 'hard' => _("Hard")];
-        foreach ($difficulty_options as $value => $option) {
-            echo "<label for='$value'>&nbsp;$option</label><input type='checkbox' name='difficulty[]' class='diff-opt' id='$value' value='$value'";
+        foreach (get_project_difficulties() as $value => $option) {
+            $escaped_option = html_safe($option);
+            echo "&nbsp;<label for='$value'>$escaped_option</label><input type='checkbox' name='difficulty[]' class='diff-opt' id='$value' value='$value'";
             if (is_array($difficulty) && in_array($value, $difficulty)) {
                 echo " checked";
                 $this->selected_options[] = $option;

--- a/project.php
+++ b/project.php
@@ -407,26 +407,11 @@ function do_project_info_table()
     // -------------------------------------------------------------------------
     // Information about the work itself (independent of DP)
 
-    // the array below should guarantee that the strings 'beginner',
-    // 'easy', 'average' and 'hard' reach the po file, so that using
-    // later _($project->difficulty) should translate the project
-    // difficulty, if regularly formed, or display the (irregular)
-    // english project difficulty.
-    if (0) {
-        $difficulty_labels = [
-            'beginner' => _('beginner'),
-            'easy' => _('easy'),
-            'average' => _('average'),
-            'hard' => _('hard'),
-        ];
-    }
-
     echo_row_a(_("Title"), $project->nameofwork, true);
     echo_row_a(_("Author"), $project->authorsname, true);
     echo_row_a(_("Language"), $project->language, true);
     echo_row_a(_("Genre"), _($project->genre), true);
-
-    echo_row_a(_("Difficulty"), _($project->difficulty), true);
+    echo_row_a(_("Difficulty"), get_project_difficulties()[$project->difficulty], true);
 
     // -------------------------------------------------------------------------
     // Basic DP info

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -126,12 +126,7 @@ function difficulty_list($difficulty_level)
 {
     global $pguser;
 
-    $difficulty_list = [
-        'beginner' => _("Beginner"),
-        'easy' => _("Easy"),
-        'average' => _("Average"),
-        'hard' => _("Hard"),
-    ];
+    $difficulty_list = get_project_difficulties();
 
     // only show the beginner level to the BEGIN PM or SiteAdmins
     if (($pguser != "BEGIN") && (!user_is_a_sitemanager())) {


### PR DESCRIPTION
Define the project difficulty options once instead of *four* times. This is in prep work for project validation as part of Task 2011.

Testable in the [centralize-difficulty-list](https://www.pgdp.org/~cpeel/c.branch/centralize-difficulty-list/) sandbox.