### PR TITLE
Bring project_jump.php from noncvs into the code

### DIFF
--- a/tools/project_manager/update_illos.php
+++ b/tools/project_manager/update_illos.php
@@ -132,7 +132,7 @@ if ($operation == 'replace') {
         <input type='hidden' name='operation' value='$operation'>
         <input type='hidden' name='confirmed' value='yes'>
         <br>
-        <input type='submit' value='", attr_safe(_("Do It")), "'>
+        <input type='submit' value='", attr_safe(_("Do it")), "'>
         </form>
     ";
 } else {
@@ -143,7 +143,7 @@ if ($operation == 'replace') {
         <input type='hidden' name='operation' value='$operation'>
         <input type='hidden' name='confirmed' value='yes'>
         <br>
-        <input type='submit' value='", attr_safe(_("Do It")), "'>
+        <input type='submit' value='", attr_safe(_("Do it")), "'>
         </form>
     ";
 }

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -78,7 +78,7 @@ function display_form($action, $projectid, $from_image_)
         echo "<tr>";
         echo "<td></td><td>";
         echo "<input type='hidden' name='action' value='check'>\n";
-        echo "<input type='submit' name='submit_button' value='" . _("Check") . "'>";
+        echo "<input type='submit' name='submit_button' value='" . attr_safe(_("Check")) . "'>";
         echo "</td>";
         echo "</tr>";
     } elseif ($action == "check") {
@@ -88,7 +88,7 @@ function display_form($action, $projectid, $from_image_)
         echo "<input type='hidden' name='from_image_[hi]' value='" . attr_safe($from_image_['hi']) . "'>";
         echo "<input type='hidden' name='projectid' value='" . attr_safe($projectid) . "'>";
         echo "<input type='hidden' name='action' value='dodelete'>\n";
-        echo "<input type='submit' name='submit_button' value='" . _("Do it!") . "'>";
+        echo "<input type='submit' name='submit_button' value='" . attr_safe(_("Do it")) . "'>";
         echo "</td>";
         echo "</tr>";
     }

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -28,6 +28,7 @@ $sections = [
         "copy_pages.php" => _("Copy Pages"),
         "delete_pages.php" => _("Delete Pages"),
         "rename_pages.php" => _("Rename Pages"),
+        "project_jump.php" => _("Jump Project to State"),
         "../project_manager/clearance_check.php?username=" => _("Questionable Clearances"),
         "convert_project_table_utf8.php" => _("Convert Project Table to UTF-8"),
     ],

--- a/tools/site_admin/project_jump.php
+++ b/tools/site_admin/project_jump.php
@@ -1,0 +1,137 @@
+<?php
+$relPath = '../../pinc/';
+include_once($relPath.'base.inc');
+include_once($relPath.'misc.inc');
+include_once($relPath.'user_is.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath.'Project.inc');
+include_once($relPath.'project_events.inc');
+
+require_login();
+
+if (!user_is_a_sitemanager()) {
+    die("You are not authorized to invoke this script.");
+}
+
+$action = get_enumerated_param($_POST, 'action', 'showform', ['showform', 'check', 'dojump']);
+$projectid = get_projectID_param($_POST, 'projectid', true);
+$valid_new_states = [];
+foreach ($Round_for_round_id_ as $id => $round) {
+    $valid_new_states[] = $round->project_unavailable_state;
+}
+$new_state = get_enumerated_param($_POST, 'new_state', null, $valid_new_states, true);
+
+
+$title = _("Project Jump");
+output_header($title);
+echo "<h1>$title</h1>";
+
+echo "<p>" . _("Jump a project to a specific state.") . "</p>\n";
+
+switch ($action) {
+    case 'showform':
+        display_form("showform", $projectid, $new_state);
+        break;
+
+    case 'check':
+        do_stuff($projectid, $new_state, true);
+        display_form("check", $projectid, $new_state);
+        break;
+
+    case 'dojump':
+        do_stuff($projectid, $new_state, false);
+        echo "\n\n<a href='$code_url/project.php?id={$projectid}'>" . _("Project Home") . "</a>\n";
+        break;
+}
+
+
+function display_form($action, $projectid, $new_state)
+{
+    global $Round_for_round_id_;
+
+    echo "<form method='post'>\n";
+    echo "<table>\n";
+    if ($action == "showform") {
+        echo "<tr>\n";
+        echo "<th>" . _("Project") . ":</th>\n";
+        echo "<td><input type='text' name='projectid' size='28' required></td>\n";
+        echo "</tr>";
+
+        echo "<tr>";
+        echo "<th>" . _("State") . ":</th>\n";
+        echo "<td><select name='new_state'>";
+        foreach ($Round_for_round_id_ as $id => $round) {
+            echo "<option value='{$round->project_unavailable_state}'>{$round->project_unavailable_state}</option>";
+        }
+        echo "</select></td>\n";
+        echo "</tr>";
+
+        echo "<tr>";
+        echo "<td></td>";
+        echo "<td>";
+        echo "<input type='submit' name='submit_button' value='" . attr_safe(_("Check")) . "'>\n";
+        echo "<input type='hidden' name='action' value='check'>\n";
+        echo "</td>\n";
+        echo "</tr>";
+    } elseif ($action == "check") {
+        echo "<tr>";
+        echo "<td>";
+        echo "<input type='hidden' name='projectid' value='" . attr_safe($projectid) . "'>";
+        echo "<input type='hidden' name='new_state' value='" . attr_safe($new_state) . "'>";
+        echo "<input type='hidden' name='action' value='dojump'>\n";
+        echo "<input type='submit' name='submit_button' value='" . attr_safe(_("Do it")) . "'>";
+        echo "</td>";
+        echo "</tr>";
+    }
+    echo "</table>\n";
+    echo "</form>";
+}
+
+function do_stuff($projectid, $new_state, $just_checking)
+{
+    global $pguser;
+    $project = new Project($projectid);
+    echo "<pre>";
+    echo "    projectid : $projectid\n";
+    echo "    title     : $project->nameofwork\n";
+    echo "    state     : $project->state\n";
+
+    // ----------------------
+
+    if ($project->state == $new_state) {
+        error_and_die("Project is already in {$new_state}");
+    }
+
+    if (!$project->pages_table_exists) {
+        error_and_die("Project does not have a pages table and cannot be jumped to a new state");
+    }
+
+    if ($just_checking) {
+        echo "</pre>\n";
+        echo "<p class='warning''>\n";
+        echo "The project will be jumped to state <b>{$new_state}</b>.<br>\n";
+        echo "No page details will be changed.\n";
+        echo "</p>\n";
+        return;
+    }
+
+    // ----------------------------------------------------
+
+    $sql = sprintf("
+        UPDATE projects
+        SET state = '%s', modifieddate = UNIX_TIMESTAMP()
+        WHERE projectid = '%s'
+    ", DPDatabase::escape($new_state), DPDatabase::escape($projectid));
+    DPDatabase::query($sql);
+    echo "    jumped to : $new_state\n";
+    log_project_event($projectid, $pguser, 'transition', $project->state,
+                       $new_state, 'Project jumped to correct state');
+    echo "</pre>";
+}
+
+function error_and_die($message)
+{
+    echo "</pre>";
+    echo "<p class='error'>" . html_safe($message) . "</p>";
+    die();
+}


### PR DESCRIPTION
This brings the `noncvs/project_jump.php` script into the codebase. I modeled the code off of the other SA scripts -- and like those it isn't up to the same high standards as the rest of the codebase (translatable, etc). It is now generic and applies to whatever rounds are defined in the code. We'll need to augment this in `pgdp-production` to add the PP-specific stages we're interested in.

This script also now checks that the project's pages table exists before allowing the transition.

Testable in the [project-jump](https://www.pgdp.org/~cpeel/c.branch/project-jump/tools/site_admin/index.php) sandbox.