### PR TITLE
Italic foot

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -401,6 +401,18 @@ QUnit.module("Format preview test", function() {
         noIssueTest(assert);
     });
 
+    QUnit.test("small cap footnote ok only with capital", function (assert) {
+        text = "xyz[<sc>A</sc>]\n\n[Footnote <sc>A</sc>: abc]";
+        issArray = analyse(text, configuration).issues;
+        noIssueTest(assert);
+    });
+
+    QUnit.test("bold number footnote ok", function (assert) {
+        text = "xyz[<b>12</b>]\n\n[Footnote <b>12</b>: abc]";
+        issArray = analyse(text, configuration).issues;
+        noIssueTest(assert);
+    });
+
     QUnit.test("multiple footnotes", function (assert) {
         text = "xyz[1] pqr[i]\n\n[Footnote i: abc]\n\n[Footnote 1: abc]";
         issArray = analyse(text, configuration).issues;

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -395,6 +395,18 @@ QUnit.module("Format preview test", function() {
         issueTest(assert, 0, 28, 9, "continueFirst", 0);
     });
 
+    QUnit.test("italic footnote ok", function (assert) {
+        text = "xyz[<i>a</i>]\n\n[Footnote <i>a</i>: abc]";
+        issArray = analyse(text, configuration).issues;
+        noIssueTest(assert);
+    });
+
+    QUnit.test("multiple footnotes", function (assert) {
+        text = "xyz[1] pqr[i]\n\n[Footnote i: abc]\n\n[Footnote 1: abc]";
+        issArray = analyse(text, configuration).issues;
+        noIssueTest(assert);
+    });
+
     QUnit.test("pair of inline tags with no content", function (assert) {
         text = "<g></g>";
         issArray = analyse(text, configuration).issues;

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -534,7 +534,7 @@ $(function () {
             var footnoteArray = [];
             // let footnote marker be an optionaly tagged letter, or a number
             // Bad tag caught elsewhere
-            let marker = `(?:<(?:${ILTags})>)?[A-Za-z](?:<.+>)?|\\d+`;
+            let marker = `(?:<(?:${ILTags})>)?(?:[A-Za-z]|\\d+)(?:<.+>)?`;
             let footnoteIDRegex = new RegExp(`^(?:${marker})$`);
             // also check for *
             let anchorRegex = new RegExp(`\\[(\\*|${marker})\\]`, "g");

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -569,9 +569,9 @@ $(function () {
 
             // search for footnote anchors and put in an array
             // match an upper case letter or digits or *
-            var result;
-            var re = /\[(\*|[A-Za-z]|\d+)\]/g;
-            while ((result = re.exec(txt)) !== null) {
+            let result;
+            let anchorRegex = /\[(\*|[A-Za-z]|\d+)\]/g;
+            while ((result = anchorRegex.exec(txt)) !== null) {
                 if (result[1] === "*") {    // found [*]
                     reportIssue(result.index, 3, "starAnchor");
                     continue;
@@ -579,42 +579,42 @@ $(function () {
                 anchorArray.push({index: result.index, id: result[1]});
             }
             // search for footnotes, get text to end of line
-            re = /\[Footnote(.*)/g;
-            var noteLine, i, rix;
+            let footnoteRegex = /\[Footnote(.*)/g;
+            let noteLine, colonIndex, footnoteStartIndex;
             function match(fNote) {
                 return fNote.id === noteLine;
             }
-            while ((result = re.exec(txt)) !== null) {
+            while ((result = footnoteRegex.exec(txt)) !== null) {
                 noteLine = result[1];
                 // find text up to :
-                i = noteLine.indexOf(":");
-                rix = result.index;
-                if (-1 === i) {
-                    reportIssue(rix, 9, "noColon");
+                colonIndex = noteLine.indexOf(":");
+                footnoteStartIndex = result.index;
+                if (-1 === colonIndex) {
+                    reportIssue(footnoteStartIndex, 9, "noColon");
                     continue;
                 }
-                if (txt.charAt(rix - 1) === "*") { // continuation
-                    if (i !== 0) {
-                        reportIssue(rix, 9, "colonNext");
+                if (txt.charAt(footnoteStartIndex - 1) === "*") { // continuation
+                    if (colonIndex !== 0) {
+                        reportIssue(footnoteStartIndex, 9, "colonNext");
                     } else if (footnoteArray.length > 0) {
-                        reportIssue(rix, 9, "continueFirst");
+                        reportIssue(footnoteStartIndex, 9, "continueFirst");
                     }
                     continue;
                 }
                 if (!(/^ [^ ]/).test(noteLine)) {
-                    reportIssue(rix, 9, "spaceNext");
+                    reportIssue(footnoteStartIndex, 9, "spaceNext");
                     continue;
                 }
-                noteLine = noteLine.slice(1, i);    // the id
+                noteLine = noteLine.slice(1, colonIndex);    // the id
                 if (!(/^[A-Za-z]$|^\d+$/).test(noteLine)) {
-                    reportIssue(rix, 9, "footnoteId");
+                    reportIssue(footnoteStartIndex, 9, "footnoteId");
                     continue;
                 }
                 if (footnoteArray.some(match)) {
-                    reportIssue(rix, 9, "dupNote");
+                    reportIssue(footnoteStartIndex, 9, "dupNote");
                     continue;
                 }
-                footnoteArray.push({index: rix, id: noteLine});
+                footnoteArray.push({index: footnoteStartIndex, id: noteLine});
             }
             anchorArray.forEach(checkAnchor);
             footnoteArray.forEach(checkNote);

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -532,6 +532,12 @@ $(function () {
         function checkFootnotes() {
             var anchorArray = [];
             var footnoteArray = [];
+            // let footnote marker be an optionaly tagged letter, or a number
+            // Bad tag caught elsewhere
+            let marker = `(?:<(?:${ILTags})>)?[A-Za-z](?:<.+>)?|\\d+`;
+            let footnoteIDRegex = new RegExp(`^(?:${marker})$`);
+            // also check for *
+            let anchorRegex = new RegExp(`\\[(\\*|${marker})\\]`, "g");
 
             function checkAnchor(anch) {
                 function match(fNote) {
@@ -568,9 +574,7 @@ $(function () {
             }
 
             // search for footnote anchors and put in an array
-            // match an upper case letter or digits or *
             let result;
-            let anchorRegex = /\[(\*|[A-Za-z]|\d+)\]/g;
             while ((result = anchorRegex.exec(txt)) !== null) {
                 if (result[1] === "*") {    // found [*]
                     reportIssue(result.index, 3, "starAnchor");
@@ -606,7 +610,7 @@ $(function () {
                     continue;
                 }
                 noteLine = noteLine.slice(1, colonIndex);    // the id
-                if (!(/^[A-Za-z]$|^\d+$/).test(noteLine)) {
+                if (!footnoteIDRegex.test(noteLine)) {
                     reportIssue(footnoteStartIndex, 9, "footnoteId");
                     continue;
                 }


### PR DESCRIPTION
This enables footnote markers to be italic or other tagged letters. Also improve some variable names and add tests.

Addresses https://www.pgdp.net/c/tasks.php?task_id=2013

Sandbox at: https://www.pgdp.org/~rp31/c.branch/italic_foot