### PR TITLE
Speed up select WordCheck functions

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -971,12 +971,12 @@ function get_distinct_words_in_text($text)
     // So if $text is project-sized (say, 1.5Mb), the resulting array will be
     // rather large (about 30 Mb).)
     //
-    // Somewhat arbitrarily, we say that an intermediate array of about 1Mb is
-    // the maximum acceptable, which roughly works out to a $text of 50kb.
-    $break_point = 50 * 1024;
+    // Somewhat arbitrarily, we say that an intermediate array of about 2.5Mb is
+    // the maximum acceptable, which roughly works out to a $text of 128kb.
+    $break_point = 128 * 1024;
     // In practice, $text is either a page (usually under 5kb) or a project
-    // (usually at least 100kb), so any value for $break_point in the range of
-    // 5kb to 100kb would have the same effect on branching.
+    // (close to the 1Mb mark), so any value for $break_point in the range of
+    // 5kb to 1Mb would have the same effect on branching.
 
     if (is_string($text)) {
         if (strlen($text) < $break_point) {

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -785,19 +785,24 @@ function load_word_list($path)
         return [];
     }
 
-    // Note: we're unable to use the file() function's FILE_IGNORE_NEW_LINES
-    // parameter since it wasn't added until PHP 5.0.0 *and* because
-    // it only removes \n, not \r\n, so we'd still need to rtrim later
-    $words = file($path);
-    if ($words === false) {
+    // It's faster to load the entire file into memory, remove any trailing
+    // spaces, and then explode it into an array than use file() to load
+    // it into an array and then rtrim() / rtrim_walk() the entries. Word lists
+    // should certainly be small enough that we can load the contents into
+    // memory for a brief period.
+
+    // Note that this function needs to work on files that contain \r\n line
+    // endings since that's what we write out in save_word_list() -- which
+    // precludes us from using file() with the FILE_IGNORE_NEW_LINES flag.
+    $file_contents = file_get_contents($path);
+    if ($file_contents === false) {
         return sprintf(_("Error reading file %s"), $path);
     }
 
-    // trim word list to remove trailing spaces
-    // needed in case site word list has trailing spaces
-    // And if/since the file has \r\n line-ends,
-    // this will also remove the trailing \r.
-    array_walk($words, 'rtrim_walk');
+    // remove any trailing spaces, although there shouldn't be any for
+    // lists saved with save_word_list(), and \r
+    $file_contents = preg_replace("/\s*\r*\n/", "\n", $file_contents);
+    $words = explode("\n", $file_contents);
 
     // remove the last "empty" word caused by the last newline
     if (count($words) && $words[count($words) - 1] == "") {

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -999,13 +999,19 @@ function get_distinct_words_in_text($text)
         }
     } elseif (is_array($text)) {
         // We assume that the strings in $text are smaller than $break_point,
-        // so it's okay to call get_all_words_in_text() on each. (Currently,
-        // each string is a single page-text, so the assumption is valid.)
+        // so it's okay to call get_all_words_in_text() on each. To improve
+        // performance, group the strings in $text together until we reach
+        // $break_point for fewer calls to get_all_words_in_text().
 
         $input_words_w_freq = [];
-        foreach ($text as $chunk) {
-            foreach (get_all_words_in_text($chunk) as $word) {
-                @$input_words_w_freq[$word] += 1;
+        $partial_text = "";
+        foreach ($text as $index => $chunk) {
+            $partial_text .= " $chunk";
+            if (strlen($partial_text) >= $break_point || $index == count($text) - 1) {
+                foreach (array_count_values(get_all_words_in_text($partial_text)) as $word => $count) {
+                    @$input_words_w_freq[$word] += $count;
+                }
+                $partial_text = "";
             }
         }
     } else {


### PR DESCRIPTION
After some profiling using xdebug on "Manage proofreaders' Suggestions" in response to [Task 2010](https://www.pgdp.net/c/tasks.php?action=show&task_id=2010) I made some surgical fixes to two WordCheck functions that improved the processing time by 25% according to the profile. I don't know how much this will improve okrick's performance problems on PROD, as I think the overriding factors for him are the total number of projects (70!) & text therein.

Testing should focus on ensuring that the results shown on the "Manage proofreaders' Suggestions" in the sandbox match TEST for various users at the "1" cutoff. Other WordCheck PM tools use this underlying code as well, but that's probably the most robust method.

Testable in the [faster-wordcheck-funcs](https://www.pgdp.org/~cpeel/c.branch/faster-wordcheck-funcs/) sandbox.