### PR TITLE
Reduce quiz overhead for non-quiz pages

### DIFF
--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -69,27 +69,17 @@ class Quiz
             SELECT *
             FROM quiz_passes
             WHERE username = '%s'
-        ", DPDatabase::escape($username));
+                AND quiz_page IN (%s)
+                AND result = 'pass'
+        ", DPDatabase::escape($username),
+            surround_and_join(array_keys($this->pages), '"', '"', ","));
         $result = DPDatabase::query($sql);
-        while ($attempt = mysqli_fetch_object($result)) {
-            if ($attempt->result != "pass") {
-                continue;
-            }
-            if (array_key_exists($attempt->quiz_page, $pages_required_results)) {
-                $pages_required_results[$attempt->quiz_page] = $attempt->date;
-            } else {
-                //This quiz page isn't relevant to this quiz.
-                continue;
-            }
-        }
 
-        if (isset($this->pass_requirements['maximum_age'])) {
-            foreach ($pages_required_results as $quiz_page_id => $value) {
-                if ($value == "no") {
-                    // The user hasn't passed the quiz anyway.
-                    continue;
-                }
-                if ((time() - $value) > $this->pass_requirements['maximum_age']) {
+        while ($attempt = mysqli_fetch_object($result)) {
+            $pages_required_results[$attempt->quiz_page] = $attempt->date;
+
+            if (isset($this->pass_requirements['maximum_age'])) {
+                if ((time() - $attempt->date) > $this->pass_requirements['maximum_age']) {
                     $pages_required_results[$quiz_page_id] = "no";
                 }
             }

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -7,6 +7,8 @@ include_once($relPath.'CharSuites.inc'); // CharSuiteSet
 // for groups of quizzes that go together
 class QuizLevel
 {
+    public static $map_quiz_level_id_to_QuizLevel = [];
+
     public function __construct($level_id, $level_name, $activity_type, $info, $quizzes)
     {
         $this->level_id = $level_id;
@@ -19,9 +21,8 @@ class QuizLevel
             $quiz->activity_type = $activity_type;
         }
 
-        global $map_quiz_level_id_to_QuizLevel;
-        assert(!isset($map_quiz_level_id_to_QuizLevel[$level_id]));
-        $map_quiz_level_id_to_QuizLevel[$level_id] = & $this;
+        assert(!isset(QuizLevel::$map_quiz_level_id_to_QuizLevel[$level_id]));
+        QuizLevel::$map_quiz_level_id_to_QuizLevel[$level_id] = & $this;
     }
 }
 
@@ -29,6 +30,7 @@ class Quiz
 {
     public static $valid_quiz_page_ids = [];
     public static $map_quiz_page_id_to_Quiz = [];
+    public static $map_quiz_id_to_Quiz = [];
 
     public function __construct($id, $name, $short_name, $description, $thread, $pages, $pass_requirements)
     {
@@ -43,9 +45,8 @@ class Quiz
         // ['maximum_age'] => time_in_seconds:
         //     Passes recorded longer than time_in_seconds ago are not valid.
 
-        global $map_quiz_id_to_Quiz;
-        assert(!isset($map_quiz_id_to_Quiz[$id]));
-        $map_quiz_id_to_Quiz[$id] = & $this;
+        assert(!isset(Quiz::$map_quiz_id_to_Quiz[$id]));
+        Quiz::$map_quiz_id_to_Quiz[$id] = & $this;
 
         foreach (array_keys($pages) as $quiz_page_id) {
             assert(!in_array($quiz_page_id, self::$valid_quiz_page_ids));
@@ -238,8 +239,7 @@ function get_quiz_id_param($arr, $key)
 // If $arr[$key] is defined and is a valid quiz id, return it.
 // Otherwise, die with an error message.
 {
-    global $map_quiz_id_to_Quiz;
-    return get_enumerated_param($arr, $key, null, array_keys($map_quiz_id_to_Quiz));
+    return get_enumerated_param($arr, $key, null, array_keys(Quiz::$map_quiz_id_to_Quiz));
 }
 
 function get_quiz_page_id_param($arr, $key)
@@ -253,8 +253,7 @@ function get_quiz_page_id_param($arr, $key)
 
 function get_Quiz_with_id($quiz_id)
 {
-    global $map_quiz_id_to_Quiz;
-    return $map_quiz_id_to_Quiz[$quiz_id];
+    return Quiz::$map_quiz_id_to_Quiz[$quiz_id];
 }
 
 function get_Quiz_containing_page($quiz_page_id)

--- a/pinc/quizzes.inc
+++ b/pinc/quizzes.inc
@@ -1,9 +1,22 @@
 <?php
 // This file creates quiz objects for each quiz with data in CVS
 include_once($relPath."Quiz.inc");
-include_once($relPath."../quiz/generic/quiz_defaults.inc"); // $old_texts_url etc
 
 define('SIX_MONTHS_IN_SECONDS', 15778463);
+
+// URLs for Quiz links
+$default_feedbackurl = "$forums_url/viewtopic.php?t=55121";
+$old_texts_url = "$wiki_url/Proofing_old_texts";
+$Greek_translit_url = "$wiki_url/Transliterating_Greek";
+$ae_oe_ligatures_url = "$wiki_url/Ae_and_oe_ligatures";
+$thorn_url = "$wiki_url/Thorn";
+$fraktur_url = "$wiki_url/Common_Fraktur_OCR_errors";
+$blackletter_url = "$wiki_url/Proofing_blackletter";
+// XXX localization bug:
+// The preceding URLs point to English-language pages in the wiki.
+// We would generally want to point to a locale-appropriate page, if one exists.
+// E.g. $wiki_url/French/Relecture_des_textes_anciens
+//      $wiki_url/Italian/Correggere_testi_antichi
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/quiz/generic/quiz_defaults.inc
+++ b/quiz/generic/quiz_defaults.inc
@@ -4,24 +4,8 @@
 
 $default_hintlink = _("Desperate? Can't find it?");
 $default_challenge = _("Try to correct that or press 'restart'.");
+// TRANSLATORS: The first link in this string will be replaced with a URL
 $default_feedbacktext = _("If you can't find the error(s) remaining on the page, please visit <a href='%s' target='_blank'>this forum topic</a>, click on the \"post reply\" button to post a feedback request. In your post, provide the link to the quiz you're having trouble with, your version of the quiz text, and the exact error message.");
-
-
-// urls for links
-
-$default_feedbackurl = "$forums_url/viewtopic.php?t=55121";
-$old_texts_url = "$wiki_url/Proofing_old_texts";
-$Greek_translit_url = "$wiki_url/Transliterating_Greek";
-$ae_oe_ligatures_url = "$wiki_url/Ae_and_oe_ligatures";
-$thorn_url = "$wiki_url/Thorn";
-$fraktur_url = "$wiki_url/Common_Fraktur_OCR_errors";
-$blackletter_url = "$wiki_url/Proofing_blackletter";
-$latex_url = "$wiki_url/LaTeX_formatting_manual";
-// XXX localization bug:
-// The preceding URLs point to English-language pages in the wiki.
-// We would generally want to point to a locale-appropriate page, if one exists.
-// E.g. $wiki_url/French/Relecture_des_textes_anciens
-//      $wiki_url/Italian/Correggere_testi_antichi
 
 
 // Common initial instructions:

--- a/quiz/start.php
+++ b/quiz/start.php
@@ -34,7 +34,7 @@ $quiz_type_intro = [
 if (
     ($quiz_level_id = @$_GET['show_level'])
     &&
-    ($quiz_level = @$map_quiz_level_id_to_QuizLevel[$quiz_level_id])
+    ($quiz_level = @QuizLevel::$map_quiz_level_id_to_QuizLevel[$quiz_level_id])
 ) {
     output_header($quiz_level->level_name, SHOW_STATSBAR);
     echo "<h1>".$quiz_level->level_name."</h1>\n";
@@ -87,7 +87,7 @@ elseif (
     }
 
     $levels_for_current_type = [];
-    foreach ($map_quiz_level_id_to_QuizLevel as $quiz_level_id => $quiz_level) {
+    foreach (QuizLevel::$map_quiz_level_id_to_QuizLevel as $quiz_level_id => $quiz_level) {
         if ($quiz_level->activity_type == $activity_type) {
             array_push($levels_for_current_type, $quiz_level);
         }


### PR DESCRIPTION
I found a few code improvements using the xdebug profiler, this is the first one and focuses on decreasing unnecessary overhead of every page load.

`pinc/Activity.inc` -- which virtually every page load uses -- includes `pinc/quizzes.inc` to determine the user's access privileges. `pinc/quizzes.inc` includes `quiz/generic/quiz_defaults.inc` which defines a very large global `$messages` array that is only used in the quizzes. This breaks apart that dependency which reduces the overhead for every page load.

This also improves the query and logic used to determine if a user has passed a quiz.

Testable in the [reduce-quiz-overhead](https://www.pgdp.org/~cpeel/c.branch/reduce-quiz-overhead/) sandbox. Primary thing to test is that the logic for determining if a user has passed a quiz (including aging out of older quizzes) still works as it did before.