### PR TITLE
More code optimizations for page loads

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -246,7 +246,7 @@ function get_user_scores($username, $criteria)
         return [];
     }
 
-    $user_obj = new User($username);
+    $user_obj = $username == User::current_username() ? User::load_current() : new User($username);
 
     $user_scores = [];
     foreach ($criteria as $criterion_code => $criterion_descr) {

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -113,7 +113,7 @@ class Activity
             return $uao;
         }
 
-        $user_scores = get_user_scores($username);
+        $user_scores = get_user_scores($username, $this->access_minima);
 
         // -----------------------------------
         // recorded_access is the value recorded in the db for whether the user
@@ -240,16 +240,16 @@ class Activity
 
 // --------------------------------------------------------------------------
 
-function get_user_scores($username)
+function get_user_scores($username, $criteria)
 {
-    global $ACCESS_CRITERIA;
-
-    assert(!is_null($username));
+    if (!$criteria) {
+        return [];
+    }
 
     $user_obj = new User($username);
 
     $user_scores = [];
-    foreach ($ACCESS_CRITERIA as $criterion_code => $criterion_descr) {
+    foreach ($criteria as $criterion_code => $criterion_descr) {
         $user_scores[$criterion_code] = get_user_score($user_obj, $criterion_code);
     }
     return $user_scores;
@@ -448,7 +448,7 @@ function show_user_access_chart($username)
 
     // user scores line
     {
-        $user_scores = get_user_scores($username);
+        $user_scores = get_user_scores($username, $ACCESS_CRITERIA);
 
         echo "<tr>";
         echo "<th>" . _("user score:") . "</th>";


### PR DESCRIPTION
Another optimization found via xdebug profiling.
 
Determining a user's access to a round is done by computing a score based on the activity's (stage, round, etc) criteria. Only determine the score based on the necessary activity's criteria, rather than doing it based on all criteria and only using the ones for the activity. This is oddly expensive because we need to know a user's access for every activity to create the navbar links and some, but not all, activities require quiz passes. Only do the work that is actually necessary to determine a user's access.

Testable in the [more-code-optimizations](https://www.pgdp.org/~cpeel/c.branch/more-code-optimizations/) sandbox. Easiest way to test this is to confirm that the activity links in the navbar are consistent with the user's access and that the user's sat/unsat/etc page (available to SAs) matches what's live on TEST.