### PR TITLE
My Projects  & Search page optimizations

### DIFF
--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -419,8 +419,23 @@ function get_valid_transitions($project, $username)
 {
     global $PROJECT_TRANSITIONS;
 
+    // Keep a cache of viable transitions for a given "from" state
+    // so we don't have to iterate over every transition for every project/user
+    // combo. We must still do the check for the specific project and user, but
+    // this reduces the search set for the next loop for subsequent callers
+    // (common on the PM page and project search results).
+    static $viable_transitions_from = [];
+    if (!isset($viable_transitions_from[$project->state])) {
+        $viable_transitions_from[$project->state] = [];
+        foreach ($PROJECT_TRANSITIONS as $transition) {
+            if ($transition->from_state == $project->state) {
+                $viable_transitions_from[$project->state][] = $transition;
+            }
+        }
+    }
+
     $valids = [];
-    foreach ($PROJECT_TRANSITIONS as $transition) {
+    foreach ($viable_transitions_from[$project->state] as $transition) {
         if ($transition->is_valid_for($project, $username)) {
             $valids[] = $transition;
         }

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -51,12 +51,12 @@ $pool_sort = get_enumerated_param(
     $pool_sort_options
 );
 
-// Update saved view and sort settings
-$userSettings->set_value("my_projects:round_view", $round_view);
-$userSettings->set_value("my_projects:pool_view", $pool_view);
-$userSettings->set_value("my_projects:round_sort", $round_sort);
-$userSettings->set_value("my_projects:pool_sort", $pool_sort);
-
+// Update saved view and sort settings if they've changed
+foreach (["round_view", "pool_view", "round_sort", "pool_sort"] as $setting) {
+    if ($$setting != $userSettings->get_value("my_projects:$setting")) {
+        $userSettings->set_value("my_projects:$setting", $$setting);
+    }
+}
 
 $page_header = [
     "text_self" => _("My Projects"),

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -3,7 +3,6 @@ $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc'); // array_get(), surround_and_join(), html_safe()
 include_once($relPath.'theme.inc');
-include_once($relPath.'dpsql.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'User.inc');
@@ -637,7 +636,7 @@ function get_round_query_result($round_view, $round_sort, $round_column_specs, $
             $avail_state_clause
         ORDER BY $sql_order
     ";
-    return [dpsql_query($sql), $round_column_specs];
+    return [DPDatabase::query($sql), $round_column_specs];
 }
 
 function get_pool_query_result($pool_view, $pool_sort, $pool_column_specs, $username)
@@ -733,5 +732,5 @@ function get_pool_query_result($pool_view, $pool_sort, $pool_column_specs, $user
         ORDER BY $sql_order
     ";
 
-    return [dpsql_query($query), $pool_column_specs, "{$order_col}{$order_dir}"];
+    return [DPDatabase::query($query), $pool_column_specs, "{$order_col}{$order_dir}"];
 }


### PR DESCRIPTION
Last one, promise.

This has a minor improvement to the My Projects page to only update the user's My Project view settings in the DB if they've changed. This reduces some thrashing on the database in the most common case.

It has a major improvement to the PM and Search pages for users who are authorized to change page states. The aggregate time to determine what states the user can transition the projects to was almost the same as the SQL search for the list of projects. Caching viable transitions for a "from" state can help subsequent calls for later projects on the PM and Search pages.

Testable in the [myproject-search-optimizations](https://www.pgdp.org/~cpeel/c.branch/myproject-search-optimizations/) sandbox. The areas to watch out for are making sure the My Projects page correctly "remembers" the table sort settings when changed and that the states available in the drop-downs on the PM and Search pages for PMs & SAs are the same as they were prior.