### PR TITLE
Faster wordchecks

### DIFF
--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -623,8 +623,7 @@ function langname_for_langcode3($langcode3)
 // or null if not found.
 {
     foreach (get_iso_language_list() as $entry) {
-        $entry_code = $entry['lang_code'];
-        if (substr($entry_code, 0, 3) == $langcode3 || substr($entry_code, 4, 3) == $langcode3) {
+        if (in_array($langcode3, explode("/", $entry['lang_code']))) {
             return $entry['lang_name'];
         }
     }
@@ -643,8 +642,7 @@ function langcode3_for_langname($langname)
             // three-letter codes separated by a slash.
             // Not sure if it matters which we return,
             // but for simplicity, we always return the first.
-            // I.e., we return the first 3 characters of $lang_code.
-            return substr($lang_code, 0, 3);
+            return explode("/", $lang_code)[0];
         }
     }
     return null;
@@ -670,8 +668,9 @@ function langcode2_for_langname($langname)
     foreach (get_iso_language_list() as $entry) {
         $entry_name = $entry['lang_name'];
         if ($entry_name == $langname) {
-            $fallback_code = substr($entry['lang_code'], 0, 3);
-            foreach (explode("/", $entry['lang_code']) as $lang_code) {
+            $lang_codes = explode("/", $entry['lang_code']);
+            $fallback_code = $lang_codes[0];
+            foreach ($lang_codes as $lang_code) {
                 if (isset($mapping[$lang_code])) {
                     return $mapping[$lang_code];
                 }

--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -9,12 +9,13 @@
 //   $array[$langcode]=$language;
 function get_languages_with_dictionaries()
 {
-    global $relPath, $aspell_prefix;
+    global $aspell_prefix;
 
     $returnArray = [];
 
     foreach (glob("$aspell_prefix/lib/aspell/*.multi") as $filename) {
-        if (preg_match("#([^/]+)\.multi\$#", $filename, $matches)) {
+        // dictionaries need to map to a two- or three-letter language code
+        if (preg_match("#/(\w{2,3})\.multi\$#", $filename, $matches)) {
             $langname = langname_for_langcode($matches[1]);
             if ($langname) {
                 $returnArray[$matches[1]] = $langname;


### PR DESCRIPTION
Shockingly, half the time spent running WordCheck is building the list of available additional dictionaries for the drop-down. This is expensive because `langname_for_langcode3()` is called within several other language functions that get used as part of generating the list, resulting in 69k calls to `substr()`. We can reduce this by only checking the 23 possibly-valid dictionary files that have a 2- or 3-letter code rather than all 84 of them. Creating a reverse lookup cache would be even faster, but I'm not certain the memory overhead is worth the value.

Also correct the logic error where we use `substr()` to split apart combined language codes. Pulling out the first three letters isn't correct and will lead to `qaa` being a valid code when it is actually part of the `qaa-qtz` reserved range.

Testable in the [faster-wordchecks](https://www.pgdp.org/~cpeel/c.branch/faster-wordchecks/) sandbox. Success is that the same list of dictionaries are listed in the dropdown on the WordCheck page.