### PR TITLE
Accept longer TLDs in email addresses

### DIFF
--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -251,7 +251,7 @@ function _validate_fields($real_name, $username, $userpass, $userpass2, $email, 
 
     // In testing mode, a fake email address is constructed using
     // 'localhost' as the domain. check_email_address() incorrectly
-    // thinks the domain should end in a 2-4 character top level
+    // thinks the domain should end in a 2-63 character top level
     // domain, so disable the address check for testing.
     if (!$testing) {
         $err = check_email_address($email);

--- a/pinc/email_address.inc
+++ b/pinc/email_address.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'site_vars.php');
 
 function check_email_address($email_address)
 // Check whether $email_address is a reasonable/acceptable E-mail Address.
@@ -15,7 +14,7 @@ function check_email_address($email_address)
     }
 
     if (strlen($email_address) > $email_address_max_len) {
-        $error = _("Your E-mail Address is too long.<br>(The maximum is")." $email_address_max_len "._("characters").".)";
+        $error = sprintf(_("Your E-mail Address is too long. The maximum is %d characters."), $email_address_max_len);
         return $error;
     }
 

--- a/pinc/email_address.inc
+++ b/pinc/email_address.inc
@@ -60,7 +60,7 @@ function check_email_address($email_address)
     $let_dig_re = '[A-Za-z0-9]';
     $ldh_str_re = '[A-Za-z0-9-]+';
     $label_re = "$let_dig_re(($ldh_str_re)?$let_dig_re)?";
-    $domain_re = "($label_re\.)+[A-Za-z]{2,4}";
+    $domain_re = "($label_re\.)+[A-Za-z]{2,63}";
 
     // Formerly:
     // $domain_re = "((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)";


### PR DESCRIPTION
Increase the length of a valid TLD to 63 characters. While I was here I cleaned up a small localization error and removed an erroneous include.

Fixes https://github.com/DistributedProofreaders/dproofreaders/issues/732.

This isn't easily testable on TEST because we skip email validation when `$testing = true`, but here's validation via script:
```php
<?php
$relPath = "./";
include_once($relPath."email_address.inc");

$addresses = [
    "testing@valid.com",
    "person@something.averylongtld",
    "localhost",
    "averyeryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong@valid.com",
];

foreach ($addresses as $address) {
    echo $address . "\n";
    echo "    " . check_email_address($address) . "\n";
}
```
Output:
```
$ php test.php
testing@valid.com

person@something.averylongtld

localhost
    Your E-mail Address does not contain an '@' sign.
averyeryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong@valid.com
    Your E-mail Address is too long. The maximum is 100 characters.
```