### PR TITLE
Add api proofing functions and test interface

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -15,7 +15,7 @@ servers:
   description: Production
 - url: https://www.pgdp.org/api/v1
   description: Test
-- url: https://www.pgdp.org/api-dev/v1
+- url: https://www.pgdp.org/api-rp31/v1
   description: Development
 
 paths:
@@ -502,6 +502,40 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/{projectid}/projectstates/{projectstateid}/checkout:
+    post:
+      tags:
+      - project
+      description: Checkout a new page to a user
+      parameters:
+      - name: projectid
+        in: path
+        description: ID of project
+        required: true
+        schema:
+          type: string
+      - name: projectstateid
+        in: path
+        description: ID of project state
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Project page identifier and state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/project_page_state'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /stats/site:
     get:
       tags:
@@ -691,6 +725,17 @@ components:
         image_url:
           type: string
         text:
+          type: string
+        state:
+          type: string
+
+    project_page_state:
+      required:
+      - pagename
+      - state
+      type: object
+      properties:
+        pagename:
           type: string
         state:
           type: string

--- a/api/exceptions.inc
+++ b/api/exceptions.inc
@@ -42,6 +42,14 @@ class NotFoundError extends ApiException
     }
 }
 
+class LimitExceeded extends ApiException
+{
+    public function getStatusCode()
+    {
+        return 429;
+    }
+}
+
 class RateLimitExceeded extends ApiException
 {
     public function getStatusCode()

--- a/api/index.php
+++ b/api/index.php
@@ -30,7 +30,7 @@ function api()
 
     api_rate_limit($username);
 
-    $query_params = $_GET;
+    $query_params = $_REQUEST;
     $path = array_get($query_params, "url", "");
     unset($query_params["url"]);
 
@@ -167,8 +167,8 @@ function api_send_pagination_header($query_params, $total_rows, $per_page, $page
     // If the URI doesn't include the url param (because the Apache config
     // hasn't been updated) we need to include it here to make valid links.
     $link_base = $_SERVER["SCRIPT_URI"] . "?";
-    if (stripos($link_base, $_GET["url"]) === false) {
-        $link_base .= "url=" . $_GET["url"] . "&";
+    if (stripos($link_base, $_REQUEST["url"]) === false) {
+        $link_base .= "url=" . $_REQUEST["url"] . "&";
     }
     $link_base .= implode("&", $params);
 

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -4,6 +4,7 @@ include_once("ApiRouter.inc");
 // DP API v1
 include_once("v1_validators.inc");
 include_once("v1_projects.inc");
+include_once("v1_proof.inc");
 include_once("v1_stats.inc");
 
 $router = ApiRouter::get_router();
@@ -14,6 +15,9 @@ $router->add_validator(":projectid", "validate_project");
 $router->add_validator(":roundid", "validate_round");
 $router->add_validator(":pagename", "validate_page_name");
 $router->add_validator(":pageroundid", "validate_page_round");
+$router->add_validator(":projectstateid", "validate_project_state");
+$router->add_validator(":pagestateid", "validate_page_state");
+$router->add_validator(":versionname", "validate_page_version");
 
 // Add routes
 $router->add_route("GET", "v1/projects", "api_v1_projects");
@@ -31,6 +35,12 @@ $router->add_route("GET", "v1/projects/imagesources", "api_v1_projects_imagesour
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
 $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
+$router->add_route("POST", "v1/projects/:projectid/projectstates/:projectstateid/checkout", "api_v1_project_state_checkout");
+$router->add_route("GET", "v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/versions/:versionname", "api_v1_project_state_page_state_version");
+$router->add_route("PUT", "v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/return", "api_v1_project_state_page_state_return");
+$router->add_route("POST", "v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/saveinprogress", "api_v1_project_state_page_state_saveinprogress");
+$router->add_route("PUT", "v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/reopen", "api_v1_project_state_page_state_reopen");
+$router->add_route("POST", "v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/saveasdone", "api_v1_project_state_page_state_saveasdone");
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
 $router->add_route("GET", "v1/stats/site/rounds", "api_v1_stats_site_rounds");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -244,7 +244,7 @@ function api_v1_project_page_round($method, $data, $query_params)
         FROM %s
         WHERE image = '%s'
     ", $text_column, $user_column, $data[":projectid"]->projectid,
-        DPDatabase::escape($data[":pagename"])
+        DPDatabase::escape($data[":pagename"]->name)
     );
     $result = DPDatabase::query($sql);
     $row = mysqli_fetch_assoc($result);

--- a/api/v1_proof.inc
+++ b/api/v1_proof.inc
@@ -1,0 +1,388 @@
+<?php
+include_once($relPath.'Project.inc'); // can_be_proofed_by_current_user()
+include_once($relPath.'stages.inc'); // can_user_get_pages_in_project()
+include_once($relPath.'DPage.inc'); // _log_page_event(), _project_adjust_n_available_pages()
+include_once($relPath.'RoundDescriptor.inc'); // get_Round_for_project_state(), is_a_mentor_round()
+include_once("exceptions.inc");
+
+// checkout a page to a user
+// update the project table in one operation, then select the page we have
+// checked out. (This could be modified to enable checking out several pages)
+// Copying the text from previous round is different to previous action.
+// POST because not idempotent
+// POST v1/projects/:projectid/projectstates/:projectstateid/checkout
+// (similar to LPage get_available_page())
+function api_v1_project_state_checkout($method, $data, $query_params)
+{
+    global $pguser, $preceding_proofer_restriction;
+
+    $project = $data[":projectid"];
+    $project_state = $data[":projectstateid"];
+
+    [$code, $msg] = $project->can_be_proofed_by_current_user();
+    if ($code != $project->CBP_OKAY) {
+        throw new BadRequest($msg);
+    }
+
+    $round = get_Round_for_project_state($project_state);
+    $err = can_user_get_pages_in_project($pguser, $project, $round);
+    if ($err) {
+        throw new BadRequest($err);
+    }
+
+    if ($preceding_proofer_restriction == 'not_immediately_preceding') {
+        $pages = check_out_pages($project, $project_state, $pguser, 'not_previously_proofed');
+    }
+
+    // If that failed, try again with the global setting. This is also the
+    // common case if $preceding_proofer_restriction != not_immediately_preceding
+    if (0 == $pages) {
+        $pages = check_out_pages($project, $project_state, $pguser, $preceding_proofer_restriction);
+    }
+    if (0 == $pages) {
+        throw new NotFoundError(_("No more files are available for proofreading for this round of the project."));
+    }
+    $projectid = $project->projectid;
+
+    // update projects table
+    _project_adjust_n_available_pages($projectid, -$pages);
+
+    // now get the page(s) we have checked out, last first
+    $page_state = $round->page_out_state;
+    $dbQuery = "
+        SELECT image
+        FROM $projectid
+        WHERE $round->user_column_name = '$pguser' AND state = '$page_state'
+        ORDER BY image DESC
+        LIMIT 1
+    ";
+    $result = DPDatabase::query($dbQuery);
+    $row = mysqli_fetch_assoc($result);
+    $image = $row['image'];
+    _log_page_event($projectid, $image, 'checkout', $pguser, $round);
+
+    return [
+        "pagename" => $image,
+        "pageState" => $page_state,
+    ];
+}
+
+// get text and imageUrl for the given page which user has checked out, current or previous
+// GET v1/projects/:projectid/projectstate/:projectstateid/pages/:pagename/pagestates/:pagestateid/versions/:versionname
+function api_v1_project_state_page_state_version($method, $data, $query_params)
+{
+    $project_page = $data[":pagename"];
+    $project_page->validate_user();
+
+    $project = $data[":projectid"];
+    $project_state = $data[":projectstateid"];
+    $page_name = $project_page->name;
+    $version = $data[":versionname"];
+    $round = get_Round_for_project_state($project_state);
+
+    if ($version === "previous") {
+        $desired_column_name = $round->prevtext_column_name;
+    } else {
+        $desired_column_name = $round->text_column_name;
+    }
+    $sql = sprintf("
+        SELECT $desired_column_name
+        FROM $project->projectid
+        WHERE image='%s'
+    ",
+        DPDatabase::escape($page_name),
+    );
+    $res = DPDatabase::query($sql);
+    $page_text = mysqli_fetch_row($res)[0];
+    return [
+        "text" => $page_text,
+        "imageUrl" => "{$project->url}/$page_name",
+    ];
+}
+
+// return page to round
+// PUT v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/return
+function api_v1_project_state_page_state_return($method, $data, $query_params)
+{
+    global $pguser;
+    $project_page = $data[":pagename"];
+    $project_page->validate_user();
+    $project_page->check_page_out_or_temp();
+    $round = $project_page->round;
+    $projectid = $data[":projectid"]->projectid;
+    $image = $project_page->name;
+
+    $sql = sprintf("
+        UPDATE $projectid
+        SET
+            state = '$round->page_avail_state',
+            $round->time_column_name = UNIX_TIMESTAMP(),
+            $round->user_column_name = ''
+        WHERE image = '%s'
+    ",
+        DPDatabase::escape($image),
+    );
+    DPDatabase::query($sql);
+
+    _log_page_event($projectid, $image, 'returnToRound', $pguser, $round);
+
+    _project_adjust_n_available_pages($projectid, +1);
+    return [];
+}
+
+// save text for the given page which user has checked out as in progress
+// POST v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/saveinprogress
+function api_v1_project_state_page_state_saveinprogress($method, $data, $query_params)
+{
+    global $pguser;
+
+    $project_page = $data[":pagename"];
+    $project_page->validate_user();
+    $project_page->check_page_out_or_temp();
+
+    $projectid = $data[":projectid"]->projectid;
+    $page_text = $query_params["text"];
+    $page_name = $project_page->name;
+    $round = $project_page->round;
+    $page_state = $round->page_temp_state;
+    $page_text = _normalize_page_text($page_text, $projectid);
+    $timestamp = time();
+
+    $sql = sprintf("
+        UPDATE $projectid
+        SET
+            state = '$page_state',
+            $round->time_column_name = UNIX_TIMESTAMP(),
+            $round->text_column_name = '%s'
+        WHERE image = '%s'
+    ",
+        DPDatabase::escape($page_text),
+        DPDatabase::escape($page_name),
+    );
+
+    DPDatabase::query($sql);
+
+    // insert into page_events table
+    _log_page_event($projectid, $page_name, 'saveAsInProgress', $pguser, $round);
+    // insert into user_project_info
+    upi_set_t_latest_page_event($pguser, $projectid, $timestamp);
+
+    return ["pageState" => $page_state];
+}
+
+// PUT v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/reopen
+function api_v1_project_state_page_state_reopen($method, $data, $query_params)
+{
+    $projectid = $data[":projectid"]->projectid;
+    $project_page = $data[":pagename"];
+    $project_page->validate_user();
+    $page_name = $project_page->name;
+    $round = $project_page->round;
+    $page_state = $project_page->state;
+
+    if ($page_state == $round->page_save_state) {
+        global $pguser;
+
+        $page_state = $round->page_temp_state;
+
+        $sql = sprintf("
+            UPDATE $projectid
+            SET
+                state = '$page_state',
+                $round->time_column_name = UNIX_TIMESTAMP()
+            WHERE image = '%s'
+        ",
+            DPDatabase::escape($page_name),
+        );
+        DPDatabase::query($sql);
+
+        page_tallies_add($round->id, $pguser, -1);
+        _log_page_event($projectid, $page_name, 'reopen', $pguser, $round);
+    }
+    // else page must be 'out' or 'in-progress', no need to change database
+
+    return ["pageState" => $page_state];
+}
+
+// save text for the given page which user has checked out as done
+// POST v1/projects/:projectid/projectstates/:projectstateid/pages/:pagename/pagestates/:pagestateid/saveasdone
+function api_v1_project_state_page_state_saveasdone($method, $data, $query_params)
+{
+    global $pguser;
+
+    $project_page = $data[":pagename"];
+    $project_page->validate_user();
+    $project_page->check_page_out_or_temp();
+
+    $projectid = $data[":projectid"]->projectid;
+    $page_text = $query_params["text"];
+    $page_name = $project_page->name;
+    $round = $project_page->round;
+
+    if ($round->has_a_daily_page_limit()) {
+        $pre_save_dpl_count = get_dpl_count_for_user_in_round($pguser, $round);
+        if ($pre_save_dpl_count >= $round->daily_page_limit) {
+            // The user has already reached their limit of this kind of page.
+            $limit_warning = sprintf(
+                _("You have already reached the daily page limit for %s. You can save the page as 'in progress' and save more pages after server midnight."),
+                $round->id,
+            );
+            throw new LimitExceeded($limit_warning);
+        }
+    }
+
+    $page_text = _normalize_page_text($page_text, $projectid);
+    $timestamp = time();
+
+    $sql = sprintf("
+        UPDATE $projectid
+        SET
+            state = '$round->page_save_state',
+            $round->time_column_name = UNIX_TIMESTAMP(),
+            $round->text_column_name = '%s'
+        WHERE image = '%s'
+    ",
+        DPDatabase::escape($page_text),
+        DPDatabase::escape($page_name),
+    );
+    DPDatabase::query($sql);
+
+    // insert into page_events table
+    _log_page_event($projectid, $page_name, 'saveAsDone', $pguser, $round);
+    // insert into user_project_info
+    upi_set_t_latest_page_event($pguser, $projectid, $timestamp);
+    // update projects table
+    _project_set_t_last_page_done($projectid, $timestamp);
+    page_tallies_add($round->id, $pguser, +1);
+
+    $limit_warning = "";
+    if ($round->has_a_daily_page_limit()) {
+        $dpl_count = get_dpl_count_for_user_in_round($pguser, $round);
+        if (($dpl_count) >= $round->daily_page_limit) {
+            $limit_warning = sprintf(
+                _("Your page will be saved as 'Done'. However, you have now reached the daily page limit for %s. You will be able to save more pages after server midnight."),
+                $round->id
+            );
+        }
+    }
+    return ["message" => $limit_warning];
+}
+
+// this is modified from LPage.inc get_available_page_array()
+// Checks out pages for the user given the specified preceding
+// project restriction. Return the number of pages checked out
+function check_out_pages(
+    $project,
+    $proj_state,
+    $pguser,
+    $preceding_proofer_restriction
+) {
+    $round = get_Round_for_project_state($proj_state);
+
+    // Normally, pages are served in order of "page number"
+    // (i.e., by the 'image' field)
+    $order = 'image ASC';
+    // but this can be overridden below.
+
+    if ($project->difficulty == 'beginner' and $round->is_a_mentor_round()) {
+        // For beginner projects in a mentor round,
+        // we serve up pages to the mentor in a different order,
+        // to facilitate mentoring:
+        // 1) Mentors like to give prompt feedback.
+        // 2) Mentors like to deal with all of one proofreader's pages at a time.
+        //
+        // We look at the save-times recorded in the mentee round for pages
+        // in this project, and for each mentee, ascertain their earliest
+        // such save-time, and then order the mentees according to that time.
+        // (So the mentee with the "longest-waiting" page comes first.
+        // In the unlikely event that two mentees have exactly the same
+        // earliest-save-time (down to the second), we break the tie by
+        // taking the users in alphabetical order by username.)
+        //
+        // Taking the mentees in the above order, we serve each one's pages
+        // in 'book order' (i.e., ordered by 'image' field).
+        //
+        // (See http://www.pgdp.net/phpBB3/viewtopic.php?p=1027908#p1027908 and following.)
+        $order = "
+            (
+                SELECT MIN({$round->mentee_round->time_column_name})
+                FROM $project->projectid
+                WHERE {$round->mentee_round->user_column_name}
+                    = p.{$round->mentee_round->user_column_name}
+            ),
+            {$round->mentee_round->user_column_name},
+            image
+        ";
+    }
+
+    // The page to be retrieved must be an available page, of course.
+    $restrictions = "state='{$round->page_avail_state}'";
+
+    // Are there any other restrictions that the page must satisfy?
+    // (This should maybe be a property of $round.)
+    if (empty($preceding_proofer_restriction)) {
+        // Nope, no other restrictions.
+    } elseif ($preceding_proofer_restriction == 'not_immediately_preceding') {
+        // Don't give this user a page that they worked on in the preceding round.
+        // (Where "preceding" takes into account skipped rounds.)
+        if ($round->round_number > 1) {
+            // We need an SQL expression for the preceding proofreader.
+            $preceding_proofer = "CASE";
+            for ($rn = $round->round_number - 1; $rn > 0; $rn--) {
+                $earlier_round = get_Round_for_round_number($rn);
+                $ucn = $earlier_round->user_column_name;
+                $preceding_proofer .= " WHEN LENGTH($ucn) THEN $ucn";
+            }
+            // What if all of the earlier rounds were skipped?
+            // (It's pretty unlikely, but we should allow for it.)
+            // All of the WHEN LENGTH(...) clauses will fail.
+            //
+            // If the CASE expr doesn't have an ELSE clause, it will yield NULL,
+            // so we'll end up requiring that
+            //     NULL != '$pguser'
+            // which is always NULL (effectively false), so no pages will
+            // satisfy the restriction, which is not what we want.
+            //
+            // Instead, add an ELSE clause saying that the preceding proofreader's
+            // name was the empty string. So we'll end up requiring that
+            //     '' != '$pguser'
+            // which is always true, so any (available) page will satisfy the
+            // restriction, which is what we want.
+            $preceding_proofer .= " ELSE ''";
+            $preceding_proofer .= " END";
+
+            $restrictions .= " AND $preceding_proofer != '$pguser'";
+        }
+    } elseif ($preceding_proofer_restriction == 'not_previously_proofed') {
+        // Don't give this user a page that they have worked on before.
+        for ($rn = 1; $rn < $round->round_number; $rn++) {
+            $earlier_round = get_Round_for_round_number($rn);
+            $restrictions .= " AND {$earlier_round->user_column_name} != '$pguser'";
+        }
+    } else {
+        // The empty/null (i.e., no restriction) case has already been dealt with.
+        throw new UnexpectedError("Bad value for 'preceding_proofer_restriction': '$preceding_proofer_restriction'.");
+    }
+
+    // Change pages to checked out
+    $settings = sprintf("
+        state = '$round->page_out_state',
+        $round->time_column_name = UNIX_TIMESTAMP(),
+        $round->user_column_name = '%s'
+    ",
+        DPDatabase::escape($pguser),
+    );
+
+    // 'p' is referred to in the constructor for $order above
+    $sql = "
+        UPDATE $project->projectid as p
+        SET $settings
+        WHERE $restrictions
+        ORDER BY $order
+        LIMIT 1
+    ";
+    DPDatabase::query($sql);
+
+    // return the number of rows checked out
+    return DPDatabase::affected_rows();
+}

--- a/api/v1_validators.inc
+++ b/api/v1_validators.inc
@@ -1,6 +1,8 @@
 <?php
 include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
+include_once($relPath.'project_states.inc'); // project_states_text()
+include_once($relPath.'ProjectPage.inc'); // ProjectPage(),
 
 //===========================================================================
 // Validators
@@ -25,6 +27,52 @@ function validate_project($projectid, $data)
     }
 }
 
+function validate_project_state($proj_state, $data)
+{
+    global $PROJECT_STATES_IN_ORDER;
+    if (!in_array($proj_state, $PROJECT_STATES_IN_ORDER)) {
+        throw new BadRequest("Invalid project state: $proj_state");
+    }
+
+    $project = $data[":projectid"];
+    $curr_state = $project->state;
+    if ($curr_state != $proj_state) {
+        $orig_state_text = project_states_text($proj_state);
+        $curr_state_text = project_states_text($curr_state);
+        $err = sprintf(
+            _("This project is no longer '%1\$s', it is now '%2\$s', so your request cannot be fulfilled."),
+            $orig_state_text,
+            $curr_state_text
+        );
+        throw new BadRequest($err);
+    }
+    return $proj_state;
+}
+
+function validate_page_state($page_state, $data)
+{
+    $project_page = $data[":pagename"];
+    if ($project_page->state != $page_state) {
+        $err = sprintf(
+            _('Page %1$s has changed state from %2$s to %3$s, so your request cannot be fulfilled.'),
+            $project_page->name,
+            $page_state,
+            $project_page->state
+        );
+        throw new BadRequest($err);
+    }
+
+    return $page_state;
+}
+
+function validate_page_version($version_name)
+{
+    if (!in_array($version_name, ["current", "previous"])) {
+        throw new BadRequest("Bad page version");
+    }
+    return $version_name;
+}
+
 function validate_wordlist($wordlist, $data)
 {
     if (!in_array($wordlist, ["good", "bad"])) {
@@ -35,11 +83,12 @@ function validate_wordlist($wordlist, $data)
 
 function validate_page_name($pagename, $data)
 {
-    $pages = $data[":projectid"]->get_page_names_from_db();
-    if (!in_array($pagename, $pages)) {
+    $project = $data[":projectid"];
+    try {
+        return new ProjectPage($project->projectid, $pagename);
+    } catch (NonexistentPageException $exception) {
         throw new NotFoundError("No such page in project");
     }
-    return $pagename;
 }
 
 function validate_page_round($pageround, $data)

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -86,6 +86,11 @@ final class DPDatabase
         return $result;
     }
 
+    public static function affected_rows()
+    {
+        return  mysqli_affected_rows(self::$_connection);
+    }
+
     public static function log_error($backtrace_level = 0)
     {
         // Log the SQL error to the PHP error log and return a generic error

--- a/pinc/ProjectPage.inc
+++ b/pinc/ProjectPage.inc
@@ -1,0 +1,61 @@
+<?php
+include_once($relPath.'RoundDescriptor.inc');
+
+class NonexistentPageException extends Exception
+{
+}
+
+// includes only relevant details
+class ProjectPage
+{
+    public function __construct($projectid, $page_name)
+    {
+        $sql = sprintf("
+            SELECT state
+            FROM $projectid
+            WHERE image = '%s'
+        ",
+            DPDatabase::escape($page_name)
+        );
+        $res = DPDatabase::query($sql);
+        $row = mysqli_fetch_assoc($res);
+        if (!$row) {
+            throw new NonexistentPageException(sprintf(_("There is no page named '%s'"), $page_name));
+        }
+        $this->name = $page_name;
+        $this->state = $row["state"];
+        $this->projectid = $projectid;
+        $this->round = get_Round_for_page_state($this->state);
+    }
+
+    public function validate_user()
+    {
+        global $pguser;
+
+        $sql = sprintf("
+            SELECT {$this->round->user_column_name}
+            FROM $this->projectid
+            WHERE image='%s'
+        ",
+            DPDatabase::escape($this->name)
+        );
+        $res = DPDatabase::query($sql);
+        $user = mysqli_fetch_row($res)[0];
+        if ($user !== $pguser) {
+            $err = sprintf(
+                _('You (%1$s) do not have the necessary access to page %2$s'),
+                $pguser,
+                $page_name
+            );
+            throw new BadRequest($err);
+        }
+    }
+
+    public function check_page_out_or_temp()
+    {
+        $round = $this->round;
+        if (!in_array($this->state, [$round->page_out_state, $round->page_temp_state])) {
+            throw new BadRequest("Bad page state");
+        }
+    }
+}

--- a/project.js
+++ b/project.js
@@ -1,0 +1,40 @@
+/*global $ makeApiAjaxSettings codeUrl */
+
+$(function () {
+    // show error if ajax fails
+    function showError(jqxhr) {
+        alert(jqxhr.responseJSON.error);
+    }
+
+    function doProof(projectId, projState, pagename, pageState) {
+        let proofParams = new URLSearchParams({"projectid": projectId, "proj_state": projState, "imagefile": pagename, "page_state": pageState});
+        let proofUrl = new URL(`${codeUrl}/tools/proofers/proof.php`);
+        proofUrl.search = proofParams.toString();
+        window.location.href = proofUrl.href;
+    }
+
+    $(".start-proof").click(function () {
+        let projectData = JSON.parse(this.dataset.proj);
+        let projectId = projectData.projectId;
+        let projState = projectData.projState;
+        let ajaxSettings = makeApiAjaxSettings(`v1/projects/${projectId}/projectstates/${projState}/checkout`);
+        ajaxSettings.type = "POST";
+        $.ajax(ajaxSettings).done(function (pageData) {
+            doProof(projectId, projState, pageData.pagename, pageData.pageState);
+        })
+            .fail(showError);
+    });
+
+    $(".resume-proof").click(function () {
+        let projectData = JSON.parse(this.dataset.page);
+        let projectId = projectData.projectId;
+        let projState = projectData.projState;
+        let imagefile = projectData.imagefile;
+        let ajaxSettings = makeApiAjaxSettings(`v1/projects/${projectId}/projectstates/${projState}/pages/${imagefile}/pagestates/${projectData.pageState}/reopen`);
+        ajaxSettings.type = "PUT";
+        $.ajax(ajaxSettings).done(function (pageData) {
+            doProof(projectId, projState, imagefile, pageData.pageState);
+        })
+            .fail(showError);
+    });
+});

--- a/project.php
+++ b/project.php
@@ -76,6 +76,7 @@ $ld_json_object = [
 ];
 
 $extra_args = [
+    "js_files" => ["$code_url/project.js"],
     "head_data" => '<script type="application/ld+json">' .
         json_encode($ld_json_object, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) .
     '</script>',
@@ -263,12 +264,15 @@ function decide_blurbs()
 
     {
         // If there's any proofreading to be done, this is the link to use.
-        $url = url_for_pi_do_whichever_page($projectid, $state, true);
+        $proj_data = json_encode([
+            "projectId" => $projectid,
+            "projState" => $state,
+        ]);
 
         // If the "Start Proofreading" text is ever changed, be sure and grep
         // through the codebase for any other instances and change them too.
         $label = _("Start Proofreading");
-        $proofreading_link = "<b><a href='$url'>$label</a></b>";
+        $proofreading_link = "<b><a href='javascript:void(0)' class='start-proof' data-proj = '$proj_data'>$label</a></b>";
 
         // When were the project comments last modified?
         $comments_timestamp = $project->t_last_change_comments;
@@ -785,8 +789,13 @@ function recentlyproofed($wlist)
             $imagefile = $row["image"];
             $timestamp = $row[$round->time_column_name];
             $pagestate = $row["state"];
-            $eURL = url_for_pi_do_particular_page(
-                $projectid, $state, $imagefile, $pagestate, true);
+
+            $page_data = json_encode([
+                "projectId" => $projectid,
+                "projState" => $state,
+                "imagefile" => $imagefile,
+                "pageState" => $pagestate,
+            ]);
 
             if ($row["wordcheck_status"] == null) {
                 $wordcheck_status = '';
@@ -796,7 +805,7 @@ function recentlyproofed($wlist)
                 $wordcheck_status = '&nbsp;<span title="' . _('This page was not WordChecked.') . '">&#x2717;</span>';
             }
             echo "<td class='center-align'>";
-            echo "<a href=\"$eURL\">";
+            echo "<a href='javascript:void(0)' class='resume-proof' data-page = '$page_data'>";
             // TRANSLATORS: This is an strftime-formatted string
             echo strftime(_("%b %d"), $timestamp) . ": " . $imagefile;
             echo "</a>$wordcheck_status";

--- a/tools/proofers/proof.js
+++ b/tools/proofers/proof.js
@@ -1,0 +1,192 @@
+/*global $ makeApiAjaxSettings codeUrl splitControl */
+
+// show error if ajax fails
+function showError(jqxhr) {
+    alert(jqxhr.responseJSON.error);
+}
+
+$(function () {
+    let url = new URL(window.location.href);
+    let params = new URLSearchParams(url.search);
+
+    let projectId = params.get("projectid");
+    let projState = params.get("proj_state");
+    let imageUrl = params.get("imageurl");
+    let pageName = params.get("imagefile");
+    let pageState = params.get("page_state");
+
+    let topDiv = $("#page-browser");
+    // the non-scrolling area which will contain the controls
+    let fixHead = $("<div>", {class: 'fixed-box control-pane'});
+    let stretchDiv = $("<div>", {class: 'imtext stretch-box'});
+    topDiv.append(fixHead, stretchDiv);
+
+    let imageElement = $("<img>", {src: imageUrl});
+    let textArea = $("<textarea>", {class: "text-pane proof-control"});
+    let imageDiv = $("<div>", {class: 'overflow-auto'}).append(imageElement);
+    let textDiv = $("<div>", {class: 'overflow-auto display-flex'});
+
+    stretchDiv.append(imageDiv, textDiv);
+    let mainSplit = splitControl(stretchDiv, {splitVertical: true, splitPercent: 50});
+    mainSplit.reLayout();
+
+    let saveAsInProgButton = $("<input>", {type: 'button', class: 'proof-control', value: "Save as in Progress"});
+    let saveAsDoneButton = $("<input>", {type: 'button', class: 'proof-control', value: "Save as Done"});
+    let saveAsDoneAndNextButton = $("<input>", {type: 'button', class: 'proof-control', value: "Save as Done and proofread next page"});
+    let returnToRoundButton = $("<input>", {type: 'button', class: 'proof-control', value: "Return to Round"});
+    let stopProofButton = $("<input>", {type: 'button', class: 'proof-control', value: "Stop Proofreading"});
+    let revertToOrigButton = $("<input>", {type: 'button', class: 'proof-control', value: "Revert to original"});
+    let revertToSaveButton = $("<input>", {type: 'button', class: 'proof-control', value: "Revert to last Save"});
+
+    function isPageOutState() {
+        return /page_out/.test(pageState);
+    }
+
+    function enableRestoreButton() {
+        revertToSaveButton.prop("disabled", isPageOutState());
+    }
+
+    function replaceUrl() {
+        url.search = params.toString();
+        window.history.replaceState(null, '', url.href);
+        enableRestoreButton();
+    }
+
+    function doNothing() {}
+
+    function toProjectPage() {
+        let params = new URLSearchParams({"id": projectId, "expected_state": projState});
+        let url = new URL(`${codeUrl}/project.php`);
+        url.search = params.toString();
+        window.location.href = url.href;
+    }
+
+    function loadTextImage(version, loadImage) {
+        $.ajax(makeApiAjaxSettings(`v1/projects/${projectId}/projectstates/${projState}/pages/${pageName}/pagestates/${pageState}/versions/${version}`))
+            .done(function (data) {
+                textArea.val(data.text);
+                if(loadImage) {
+                    imageElement.attr("src", data.imageUrl);
+                }
+            })
+            .fail(showError);
+    }
+
+    function savedInProg(data) {
+        pageState = data.pageState;
+        params.set("page_state", pageState);
+        replaceUrl();
+        // reload data incase invalid characters removed or changed
+        loadTextImage("current", false);
+    }
+
+    function savedDone(data) {
+        let limitWarn = data.message;
+        if(limitWarn) {
+            alert(limitWarn);
+        }
+        toProjectPage();
+    }
+
+    function showNewPage(data) {
+        pageName = data.pagename;
+        pageState = data.pageState;
+        params.set("imagefile", pageName);
+        params.set("page_state", pageState);
+        replaceUrl();
+        loadTextImage("previous", true);
+    }
+
+    function andNext(data) {
+        let limitWarn = data.message;
+        if(limitWarn) {
+            alert(limitWarn);
+            toProjectPage();
+        } else {
+            // get a new page
+            let ajaxSettings = makeApiAjaxSettings(`v1/projects/${projectId}/projectstates/${projState}/checkout`);
+            ajaxSettings.type = "POST";
+            $.ajax(ajaxSettings).done(showNewPage)
+                .fail( function (jqxhr) {
+                    showError(jqxhr);
+                    toProjectPage();
+                });
+        }
+    }
+
+    function saveAsInProgress(text) {
+        let ajaxSettings = makeApiAjaxSettings(`v1/projects/${projectId}/projectstates/${projState}/pages/${pageName}/pagestates/${pageState}/saveinprogress`);
+        ajaxSettings.type = "POST";
+        ajaxSettings.data = {text: text};
+        $.ajax(ajaxSettings)
+            .done(savedInProg)
+            .fail(showError);
+    }
+
+    function saveAsDone(text) {
+        return new Promise(function(resolve, reject) {
+            let ajaxSettings = makeApiAjaxSettings(`v1/projects/${projectId}/projectstates/${projState}/pages/${pageName}/pagestates/${pageState}/saveasdone`);
+            ajaxSettings.type = "POST";
+            ajaxSettings.data = {text};
+            $.ajax(ajaxSettings)
+                .done(resolve)
+                .fail( function errorAndReject(data) {
+                    showError(data);
+                    reject();
+                });
+        });
+    }
+
+    function returnToRound() {
+        let ajaxSettings = makeApiAjaxSettings(`v1/projects/${projectId}/projectstates/${projState}/pages/${pageName}/pagestates/${pageState}/return`);
+        ajaxSettings.type = "PUT";
+        $.ajax(ajaxSettings)
+            .done(toProjectPage)
+            .fail(showError);
+    }
+
+    saveAsInProgButton.click( function() {
+        saveAsInProgress(textArea.val());
+    });
+
+    saveAsDoneButton.click( function () {
+        saveAsDone(textArea.val()).then(savedDone)
+            .catch(doNothing);
+    });
+
+    saveAsDoneAndNextButton.click(function () {
+        saveAsDone(textArea.val()).then(andNext)
+            .catch(doNothing);
+    });
+
+    returnToRoundButton.click( function() {
+        if(confirm("This will discard all changes you have made on this page. Are you sure you want to return this page to the current round?")) {
+            returnToRound();
+        }
+    });
+
+    stopProofButton.click( function() {
+        if(confirm("Are you sure you want to stop proofreading?")) {
+            toProjectPage();
+        }
+    });
+
+    revertToOrigButton.click( function() {
+        if(confirm("Are you sure you want to revert to the original text for this round?")) {
+            loadTextImage("previous", false);
+        }
+    });
+
+    revertToSaveButton.click( function() {
+        if(confirm("Are you sure you want to revert to your last save?")) {
+            loadTextImage("current", false);
+        }
+    });
+
+    fixHead.append(returnToRoundButton, saveAsInProgButton, revertToOrigButton, revertToSaveButton, saveAsDoneButton, saveAsDoneAndNextButton, stopProofButton);
+    textDiv.append(textArea);
+
+    enableRestoreButton();
+    let round = isPageOutState() ? "previous" : "current";
+    loadTextImage(round, true);
+});

--- a/tools/proofers/proof.php
+++ b/tools/proofers/proof.php
@@ -1,65 +1,24 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'Project.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'abort.inc');
+
+// This is not intended to be a new proofreading interface but only to test the api.
 
 require_login();
 
-// (User clicked on "Start Proofreading" link or
-// one of the links in "Done" or "In Progress" trays.)
+$title = _("Proof test");
 
-$projectid = get_projectID_param($_GET, 'projectid');
-$expected_state = get_enumerated_param($_GET, 'proj_state', null, $PROJECT_STATES_IN_ORDER, true);
-
-$project = new Project($projectid);
-
-// Check $expected_state.
-if (!$expected_state) {
-    abort(_("No expected state found in request."));
-} elseif ($expected_state != $project->state) {
-    slim_header($project->nameofwork);
-
-    echo "<p>";
-    echo sprintf(
-         ('Warning: Project "%1$s" is no longer in state "%2$s"; it is now in state "%3$s".'),
-        $project->nameofwork,
-        project_states_text($expected_state),
-        project_states_text($project->state)
-    );
-    echo "</p>\n";
-
-    provide_escape_links();
-    exit;
-}
-
-// Check that the project is in a proofable state
-[$code, $msg] = $project->can_be_proofed_by_current_user();
-if ($code != $project->CBP_OKAY) {
-    abort($msg);
-}
-
-//load the master frameset
-
-// Add name of round before nameofwork
-$round = get_Round_for_project_state($project->state);
-$nameofwork = "[" . $round->id . "] " . $project->nameofwork;
+$js_files = [
+    "$code_url/scripts/splitControl.js",
+    "$code_url/tools/proofers/proof.js",
+];
 
 $header_args = [
-    "js_files" => [
-        "$code_url/tools/proofers/dp_proof.js",
-        "$code_url/tools/proofers/dp_scroll.js",
-    ],
+    "js_files" => $js_files,
+    "body_attributes" => "style='margin: 0; overflow: hidden;'",
 ];
-slim_header_frameset($nameofwork." - "._("Proofreading Interface"), $header_args);
 
-$frameGet = "?" . $_SERVER['QUERY_STRING'];
-?>
-<frameset id="proof_frames" rows="*,85">
-<frame name="proofframe" src="<?php echo "$code_url/tools/proofers/proof_frame.php{$frameGet}"; ?>" marginwidth="2" marginheight="2" frameborder="0">
-<frame name="menuframe" src="ctrl_frame.php?projectid=<?php echo $projectid; ?>&amp;round_id=<?php echo $round->id; ?>" marginwidth="2" marginheight="2" frameborder="0">
-</frameset>
-<noframes>
-<?php echo _("Your browser currently does not display frames!"); ?>
-</noframes>
+slim_header($title, $header_args);
+
+echo "<div id='page-browser'></div>";


### PR DESCRIPTION
This adds some api functions for proofreading and a test interface. It does not do any character validation or wordcheck or format preview. Most of the functions haven't yet been added to the yaml file. Not intended for merging but for preliminary evaluation.
From the project page it moves to a basic proofreading page.
Sandbox at: https://www.pgdp.org/~rp31/c.branch/api_proof_22_01