### PR TITLE
Lazy load charsuites

### DIFF
--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -102,6 +102,22 @@ class CharSuites
 {
     private static $_available_charsuites = [];
 
+    private static function load()
+    {
+        // load all available charsuites if not already loaded
+
+        global $relPath;
+
+        if (self::$_available_charsuites) {
+            return;
+        }
+
+        $charsuite_files = glob($relPath."charsuite-*.inc");
+        foreach ($charsuite_files as $charsuite_file) {
+            include($charsuite_file);
+        }
+    }
+
     public static function add($charsuite)
     {
         self::$_available_charsuites[$charsuite->name] = $charsuite;
@@ -109,6 +125,8 @@ class CharSuites
 
     public static function get($name)
     {
+        self::load();
+
         if (!isset(self::$_available_charsuites[$name])) {
             throw new UnexpectedValueException("$name is not a valid charsuite");
         }
@@ -117,6 +135,8 @@ class CharSuites
 
     public static function get_all()
     {
+        self::load();
+
         return array_values(self::$_available_charsuites);
     }
 
@@ -215,12 +235,4 @@ function get_project_or_quiz($identifier)
     } else {
         return new Project($identifier);
     }
-}
-
-//----------------------------------------------------------------------------
-
-// load all available charsuites
-$charsuite_files = glob($relPath."charsuite-*.inc");
-foreach ($charsuite_files as $charsuite_file) {
-    include_once($charsuite_file);
 }

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -148,7 +148,7 @@ class CharSuites
             WHERE enabled=1
         ";
 
-        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result = DPDatabase::query($sql);
 
         $charsuites = [];
         while ($row = mysqli_fetch_assoc($result)) {
@@ -168,9 +168,9 @@ class CharSuites
             SET name='%s', enabled=1
             ON DUPLICATE KEY UPDATE
                 enabled=1
-        ", mysqli_real_escape_string(DPDatabase::get_connection(), $name));
+        ", DPDatabase::escape($name));
 
-        mysqli_query(DPDatabase::get_connection(), $sql);
+        DPDatabase::query($sql);
     }
 
     public static function disable($name)
@@ -181,9 +181,9 @@ class CharSuites
             UPDATE charsuites
             SET enabled=0
             WHERE name='%s'
-        ", mysqli_real_escape_string(DPDatabase::get_connection(), $name));
+        ", DPDatabase::escape($name));
 
-        mysqli_query(DPDatabase::get_connection(), $sql);
+        DPDatabase::query($sql);
     }
 
     // Check to see if $charsuite is a real CharSuite object or a charsuite name


### PR DESCRIPTION
Very few pages actually care about character suites, so don't load them unless one or more of them is actually needed. This is a very small, but easy, micro-optimization that improves all pages. While here I updated the DB escape & query functions.

Testable in the [lazy-load-charsuites](https://www.pgdp.org/~cpeel/c.branch/lazy-load-charsuites/) sandbox.