### PR TITLE
Standardize project field labels

### DIFF
--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -311,7 +311,7 @@ class ProjectSearchForm
             ]),
             new SpecialDayWidget([
                 'id' => 'special_day',
-                'label' => _('Special day'),
+                'label' => _('Special Day'),
                 'type' => 'select',
                 'options' => $this->all_special_day_options(),
                 'can_be_multiple' => true,

--- a/project.php
+++ b/project.php
@@ -1238,12 +1238,12 @@ function do_history()
                     // Maybe move this array to Project.inc
                     $label_for_project_field_ = [
                         'deletion_reason' => _("Reason for Deletion"),
-                        'nameofwork' => _("Name of Work"),
-                        'authorsname' => _("Author's Name"),
+                        'nameofwork' => _("Title"),
+                        'authorsname' => _("Author"),
                         'projectmanager' => _("Project Manager"),
                         'language' => _("Language"),
                         'genre' => _("Genre"),
-                        'difficulty_level' => _("Difficulty Level"),
+                        'difficulty_level' => _("Difficulty"),
                         'special_code' => _("Special Day"),
                         'checkedoutby' => _("PPer/PPVer"),
                         'image_source' => _("Original Image Source"),
@@ -1251,8 +1251,8 @@ function do_history()
                         'text_preparer' => _("Text Preparer"),
                         'extra_credits' => _("Extra Credits"),
                         'scannercredit' => _("Scanner Credit"),
-                        'clearance' => _("Clearance Information"),
-                        'postednum' => _("Posted Number"),
+                        'clearance' => _("Clearance Line"),
+                        'postednum' => _("PG etext number"),
                         'comments' => _("Project Comments"),
                     ];
 

--- a/stats/PPV_avail.php
+++ b/stats/PPV_avail.php
@@ -29,7 +29,7 @@ echo "<h1>$title</h1>\n";
 
 $colspecs = [
     'bogus' => _('#'),
-    'nameofwork' => _('Name of Work'),
+    'nameofwork' => _('Title'),
     'PM' => _('Project Manager'),
     'PPer' => _('Post-Processed By'),
     'modifieddate' => _('Date Last Modified'),

--- a/stats/checkedout.php
+++ b/stats/checkedout.php
@@ -43,7 +43,7 @@ if (isset($inPPV)) {
     $colspecs = [
         // TRANSLATORS: this is a column header meaning "number"
         'bogus' => _('#'),
-        'nameofwork' => _('Name of Work'),
+        'nameofwork' => _('Title'),
         'postproofer' => _('PPer'),
         'checkedoutby' => _('Checked Out By'),
         'modifieddate' => _('Date Last Modified'),
@@ -52,7 +52,7 @@ if (isset($inPPV)) {
 } else {
     $colspecs = [
         'bogus' => _('#'),
-        'nameofwork' => _('Name of Work'),
+        'nameofwork' => _('Title'),
         'checkedoutby' => _('Checked Out By'),
         'modifieddate' => _('Date Last Modified'),
         'holder_t_last_activity' => _('User Last on Site'),

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -154,8 +154,8 @@ if (!isset($name)) {
         SELECT
 
             concat('$comments_url1',projectID,'$comments_url2', nameofwork, '$comments_url3') as '"
-                . DPDatabase::escape(_("Name of Work")) . "',
-            authorsname as '" . DPDatabase::escape(_("Author's Name")) . "',
+                . DPDatabase::escape(_("Title")) . "',
+            authorsname as '" . DPDatabase::escape(_("Author")) . "',
             language    as '" . DPDatabase::escape(_("Language")) . "',
             genre       as '" . DPDatabase::escape(_("Genre")) . "',
             difficulty  as '" . DPDatabase::escape(_("Difficulty")) . "',

--- a/stats/to_be_released.php
+++ b/stats/to_be_released.php
@@ -32,7 +32,7 @@ echo "<table class='themed theme_striped'>\n";
 
 echo "<tr>\n";
 echo "<th>"._("Index")."</th>
-      <th>"._("Name of Work")."</th>
+      <th>"._("Title")."</th>
       <th><a href =\"to_be_released.php?order=username\">"._("Project Manager")."</a></th>
       <th><a href =\"to_be_released.php?order=modifieddate\">"._("Date Last Modified")."</a></th>
       <th>"._("Language")."</th>

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -373,11 +373,11 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
             "<input type='hidden' name='projectid' value='$projectid'>$projectid"
         )
         . tr_w_two_cells(
-            _("Name of Work"),
+            _("Title"),
             $nameofwork
         )
         . tr_w_two_cells(
-            _("Author's Name"),
+            _("Author"),
             $authorsname
         )
         . tr_w_two_cells(

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -244,8 +244,8 @@ class ProjectWordListHolder
 
         $fields = [
             "projectid" => _("Project ID"),
-            "nameofwork" => _("Name of Work"),
-            "authorsname" => _("Author's Name"),
+            "nameofwork" => _("Title"),
+            "authorsname" => _("Author"),
             "username" => _("Project Manager"),
             "checkedoutby" => _("Post-Processor"),
             "language" => _("Language"),

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -308,7 +308,7 @@ class ProjectInfoHolder
         $this->nameofwork = @$_POST['nameofwork'];
         // we're using preg_match as this field will be space-normalised later
         if (preg_match('/^\s*$/', $this->nameofwork)) {
-            $errors .= "Name of work is required.<br>";
+            $errors .= "Title is required.<br>";
         }
 
         $this->authorsname = @$_POST['authorsname'];
@@ -452,7 +452,7 @@ class ProjectInfoHolder
         if ($this->postednum != '') {
             if (! preg_match('/^[1-9][0-9]*$/', $this->postednum)) {
                 $errors .= sprintf(
-                    _("Posted Number \"%s\" is not of the correct format."),
+                    _("PG etext number \"%s\" is not of the correct format."),
                     html_safe($this->postednum)) . "<br>";
                 // Occasionally, there will be a PG ebook that is still
                 // under U.S. copyright. This is indicated in their system
@@ -466,7 +466,7 @@ class ProjectInfoHolder
         if ($this->posted) {
             // We are in the process of marking this project as posted.
             if ($this->postednum == '') {
-                $errors .= _("Posted Number is required.")."<br>";
+                $errors .= _("PG etext number is required.")."<br>";
             }
         }
 
@@ -841,8 +841,8 @@ class ProjectInfoHolder
                 $can_edit_PPer = user_is_a_sitemanager();
             }
         }
-        $this->row(_("Name of Work"), 'text_field', $this->nameofwork, 'nameofwork', '', ["maxlength" => 255, "required" => true]);
-        $this->row(_("Author's Name"), 'text_field', $this->authorsname, 'authorsname', '', ["maxlength" => 255, "required" => true]);
+        $this->row(_("Title"), 'text_field', $this->nameofwork, 'nameofwork', '', ["maxlength" => 255, "required" => true]);
+        $this->row(_("Author"), 'text_field', $this->authorsname, 'authorsname', '', ["maxlength" => 255, "required" => true]);
         if (user_is_a_sitemanager()) {
             // SAs are the only ones who can change this
             $this->row(_("Project Manager"), 'DP_user_field', $this->projectmanager, 'username', sprintf(_("%s username only."), $site_abbreviation), ["required" => true]);
@@ -861,12 +861,12 @@ class ProjectInfoHolder
 
         if ($this->difficulty_level == "beginner" && !$can_set_difficulty_tofrom_beginner) {
             // allow PF to edit a BEGIN project, but without altering the difficulty
-            $this->row(_("Difficulty Level"), 'just_echo', _("Beginner"));
+            $this->row(_("Difficulty"), 'just_echo', _("Beginner"));
             echo "<input type='hidden' name='difficulty_level' value='$this->difficulty_level'>";
         } else {
-            $this->row(_("Difficulty Level"), 'difficulty_list', $this->difficulty_level);
+            $this->row(_("Difficulty"), 'difficulty_list', $this->difficulty_level);
         }
-        $this->row(_("Special Day (optional)"), 'special_list', $this->special_code);
+        $this->row(_("Special Day"), 'special_list', $this->special_code);
         if ($can_edit_PPer) {
             $this->row(_("PPer/PPVer"), 'DP_user_field', $this->checkedoutby, 'checkedoutby', sprintf(_("Optionally reserve for a PPer. %s username only."), $site_abbreviation));
         } else {
@@ -881,8 +881,8 @@ class ProjectInfoHolder
         if ($this->scannercredit != '') {
             $this->row(_("Scanner Credit (deprecated)"), 'text_field', $this->scannercredit, 'scannercredit');
         }
-        $this->row(_("Clearance Information"), 'text_field', $this->clearance, 'clearance');
-        $this->row(_("Posted Number"), 'text_field', $this->postednum, 'postednum', '', ["type" => "number"]);
+        $this->row(_("Clearance Line"), 'text_field', $this->clearance, 'clearance');
+        $this->row(_("PG etext number"), 'text_field', $this->postednum, 'postednum', '', ["type" => "number"]);
         $this->row(_("Project Comments Format"), 'proj_comments_format', $this->comment_format);
         $this->row(_("Project Comments"), 'proj_comments_field', $this->comments);
         // don't show the word list line if we're in the process of cloning


### PR DESCRIPTION
Standardize project field labels so they are consistent throughout various pages on the site (project page, project search, project edit, etc). These are message-string-only changes.

Previewable in [standardize-project-edit-labels](https://www.pgdp.org/~cpeel/c.branch/standardize-project-edit-labels/).