### PR TITLE
Backport ValueError from PHP 8

### DIFF
--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1126,3 +1126,10 @@ function validate_csrf_token()
 class NotImplementedException extends BadMethodCallException
 {
 }
+
+// ValueError exists in PHP 8 but not earlier
+if (!class_exists('\ValueError')) {
+    class ValueError extends \Error
+    {
+    }
+}


### PR DESCRIPTION
`ValueError` is a very useful exception that was (finally!) included in PHP 8. Backport this so we can use it now. I am using this in the project validation work for Task 2011 but want to get it in now for some current PRs.