### PR TITLE
Add project validation logic to the Project class

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -2,8 +2,215 @@
 
 class ProjectTest extends PHPUnit\Framework\TestCase
 {
+    private $TEST_USERNAME_PM = "ProjectTestPM_php";
+    private $TEST_USERNAME = "ProjectTest_php";
+    private $TEST_IMAGESOURCE = "PrjTest";
     private $valid_projectID = "projectID45c225f598e32";
     private $valid_page_image = "001.png";
+    private $valid_project_data = [
+        "nameofwork" => "War and Peace",
+        "authorsname" => "Bob Smith",
+        "language" => "English",
+        "genre" => "Other",
+        "difficulty" => "average",
+        // username and image_source are set in setUp() after creation
+    ];
+
+    protected function setUp(): void
+    {
+        create_test_user($this->TEST_USERNAME_PM);
+
+        // make the user a PM
+        $settings = new Settings($this->TEST_USERNAME_PM);
+        $settings->set_boolean("manager", true);
+
+        create_test_user($this->TEST_USERNAME);
+
+        create_test_image_source($this->TEST_IMAGESOURCE);
+
+        $this->valid_project_data["username"] = $this->TEST_USERNAME_PM;
+        $this->valid_project_data["image_source"] = $this->TEST_IMAGESOURCE;
+    }
+
+    protected function tearDown(): void
+    {
+        // clean up the PM value
+        $settings = new Settings($this->TEST_USERNAME_PM);
+        $settings->set_value("manager", null);
+
+        delete_test_user($this->TEST_USERNAME_PM);
+        delete_test_user($this->TEST_USERNAME);
+        delete_test_image_source($this->TEST_IMAGESOURCE);
+    }
+
+    //------------------------------------------------------------------------
+    // Project object validation
+    public function test_validate_required_fields_positive_path()
+    {
+        $project = new Project($this->valid_project_data);
+        $errors = $project->validate();
+        $this->assertEquals([], $errors);
+    }
+
+    public function test_validate_required_fields_negative_path()
+    {
+        // defaults are not sufficient for validation; test exception raised
+        $project = new Project();
+        $this->expectException(ValueError::class);
+        $project->validate(true);
+    }
+
+    public function test_validate_nameofwork_missing()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->nameofwork = '';
+        $errors = $project->validate();
+        $this->assertStringContainsString("required", $errors[0]);
+    }
+
+    public function test_validate_authorsname_missing()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->authorsname = '';
+        $errors = $project->validate();
+        $this->assertStringContainsString("required", $errors[0]);
+    }
+
+    public function test_validate_pm_missing()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->username = '';
+        $errors = $project->validate();
+        $this->assertStringContainsString("required", $errors[0]);
+    }
+
+    public function test_validate_pm_invalid()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->username = 'ProjectTest_FakeUser';
+        $errors = $project->validate();
+        $this->assertStringContainsString("must be an existing user", $errors[0]);
+    }
+
+    public function test_validate_pm_not_a_pm()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->username = $this->TEST_USERNAME;
+        $errors = $project->validate();
+        $this->assertStringContainsString("not a PM", $errors[0]);
+    }
+
+    public function test_validate_language_missing()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->language = '';
+        $errors = $project->validate();
+        $this->assertStringContainsString("required", $errors[0]);
+    }
+
+    public function test_validate_language_invalid()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->language = 'Fake Language';
+        $errors = $project->validate();
+        $this->assertStringContainsString("not a valid language", $errors[0]);
+    }
+
+    public function test_validate_genre_missing()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->genre = '';
+        $errors = $project->validate();
+        $this->assertStringContainsString("required", $errors[0]);
+    }
+
+    public function test_validate_genre_invalid()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->genre = 'Fake Genre';
+        $errors = $project->validate();
+        $this->assertStringContainsString("not a valid genre", $errors[0]);
+    }
+
+    public function test_validate_difficulty_missing()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->difficulty = '';
+        $errors = $project->validate();
+        $this->assertStringContainsString("required", $errors[0]);
+    }
+
+    public function test_validate_difficulty_invalid()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->difficulty = 'insanely_hard';
+        $errors = $project->validate();
+        $this->assertStringContainsString("not a valid difficulty", $errors[0]);
+    }
+
+    public function test_validate_otherday_positive_path()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->special_code = "Otherday 0101";
+        $errors = $project->validate();
+        $this->assertEquals([], $errors);
+    }
+
+    public function test_validate_otherday_invalid()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->special_code = "Otherday 9901";
+        $errors = $project->validate();
+        $this->assertStringContainsString("Invalid date supplied", $errors[0]);
+    }
+
+    public function test_validate_postdnum_positive_path()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->posted_num = 123;
+        $errors = $project->validate();
+        $this->assertEquals([], $errors);
+    }
+
+    public function test_validate_postedenum_invalid()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->postednum = "invalid";
+        $errors = $project->validate();
+        $this->assertStringContainsString("not of the correct format", $errors[0]);
+    }
+
+    public function test_validate_custom_chars_positive_path()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->custom_chars = '1';
+        $errors = $project->validate();
+        $this->assertEquals([], $errors);
+    }
+
+    public function test_validate_custom_chars_duplicates()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->custom_chars = '11';
+        $errors = $project->validate();
+        $this->assertStringContainsString("must be unique", $errors[0]);
+    }
+
+    public function test_validate_custom_chars_too_many()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->custom_chars = 'abcdefghijklmnopqrstuvwxyABCDEFGHJKLMNOPQRSTUVWXYZ';
+        $errors = $project->validate();
+        $this->assertStringContainsString("maximum of 32", $errors[0]);
+    }
+
+    public function test_validate_custom_chars_invalid()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->custom_chars = '…';
+        $errors = $project->validate();
+        $this->assertStringContainsString("are not allowed", $errors[0]);
+    }
 
     //------------------------------------------------------------------------
     // projectID validation

--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -7,46 +7,14 @@ class UserTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        // Attempt to load our test user, if it exists don't create it
-        $sql = "SELECT username FROM users WHERE username = '$this->TEST_USERNAME'";
-        $result = mysqli_query(DPDatabase::get_connection(), $sql);
-        $row = mysqli_fetch_assoc($result);
-        if (!$row) {
-            $sql = "
-                INSERT INTO users
-                SET id = '$this->TEST_USERNAME',
-                    real_name = '$this->TEST_USERNAME',
-                    username = '$this->TEST_USERNAME',
-                    email = '$this->TEST_USERNAME@localhost'
-            ";
-            $result = mysqli_query(DPDatabase::get_connection(), $sql);
-            if (!$result) {
-                throw new Exception("Unable to create test user 1");
-            }
-
-            $sql = "
-                INSERT INTO users
-                SET id = '$this->TEST_USERNAME-2',
-                    real_name = '$this->TEST_USERNAME-2',
-                    username = '$this->TEST_USERNAME-2',
-                    email = '$this->TEST_USERNAME@localhost'
-            ";
-            $result = mysqli_query(DPDatabase::get_connection(), $sql);
-            if (!$result) {
-                throw new Exception("Unable to create test user 2");
-            }
-        } else {
-            mysqli_free_result($result);
-        }
+        create_test_user($this->TEST_USERNAME);
+        create_test_user("$this->TEST_USERNAME-2");
     }
 
     protected function tearDown(): void
     {
-        $sql = "
-            DELETE FROM users
-            WHERE id = '$this->TEST_USERNAME' or id = '$this->TEST_USERNAME-2'
-        ";
-        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        delete_test_user($this->TEST_USERNAME);
+        delete_test_user("$this->TEST_USERNAME-2");
     }
 
     public function testEmptyConstructor()

--- a/SETUP/tests/phpunit_bootstrap.php
+++ b/SETUP/tests/phpunit_bootstrap.php
@@ -5,3 +5,4 @@ include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'TableDocumentation.inc');
+include_once("phpunit_test_helpers.inc");

--- a/SETUP/tests/phpunit_test_helpers.inc
+++ b/SETUP/tests/phpunit_test_helpers.inc
@@ -1,0 +1,82 @@
+<?php
+
+function create_test_user($username)
+{
+    // Attempt to load our test user, if it exists don't create it
+    $sql = sprintf("
+        SELECT username
+        FROM users
+        WHERE username = '%s'
+    ", DPDatabase::escape($username));
+    $result = DPDatabase::query($sql);
+    $row = mysqli_fetch_assoc($result);
+    if (!$row) {
+        $sql = sprintf("
+            INSERT INTO users
+            SET id = '%1\$s',
+                real_name = '%1\$s',
+                username = '%1\$s',
+                email = '%1\$s@localhost'
+        ", DPDatabase::escape($username));
+        $result = DPDatabase::query($sql);
+        if (!$result) {
+            throw new Exception(sprintf("Unable to create test user %s", $username));
+        }
+    } else {
+        mysqli_free_result($result);
+    }
+}
+
+function delete_test_user($username)
+{
+    // remove the test user
+    $sql = sprintf("
+        DELETE FROM users
+        WHERE id = '%s'
+    ", DPDatabase::escape($username));
+    $result = DPDatabase::query($sql);
+    if (!$result) {
+        throw new Exception(sprintf("Unable to delete test user %s", $username));
+    }
+}
+
+function create_test_image_source($image_source)
+{
+    // Attempt to create the image source
+    $sql = sprintf("
+        SELECT code_name
+        FROM image_sources
+        WHERE code_name = '%s'
+    ", DPDatabase::escape($image_source));
+    $result = DPDatabase::query($sql);
+    $row = mysqli_fetch_assoc($result);
+    if (!$row) {
+        $sql = sprintf("
+            INSERT INTO image_sources
+            SET code_name = '%1\$s',
+                display_name = '%1\$s',
+                full_name = '%1\$s',
+                info_page_visibility = 1,
+                is_active = 1
+        ", DPDatabase::escape($image_source));
+        $result = DPDatabase::query($sql);
+        if (!$result) {
+            throw new Exception(sprintf("Unable to create test image source %s", $image_source));
+        }
+    } else {
+        mysqli_free_result($result);
+    }
+}
+
+function delete_test_image_source($image_source)
+{
+    // remove the test image source
+    $sql = sprintf("
+        DELETE FROM image_sources
+        WHERE code_name = '%s'
+    ", DPDatabase::escape($image_source));
+    $result = DPDatabase::query($sql);
+    if (!$result) {
+        throw new Exception(sprintf("Unable to delete test image source %s", $image_source));
+    }
+}

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -8,6 +8,7 @@ include_once($relPath.'User.inc');
 include_once($relPath.'MARCRecord.inc');
 include_once($relPath.'stages.inc'); // is_formatting_round()
 include_once($relPath.'CharSuites.inc');
+include_once($relPath.'special_colors.inc');
 
 class UTF8ConversionException extends Exception
 {
@@ -57,7 +58,7 @@ class Project
     }
 
     // -------------------------------------------------------------------------
-    // Loading & initialization
+    // Load & Validate
 
     private function _init_fields_to_defaults()
     {
@@ -111,6 +112,145 @@ class Project
         foreach ($row as $key => $value) {
             $this->$key = $value;
         }
+    }
+
+    public function validate($throw_on_error = false)
+    {
+        $errors = [];
+
+        if ($this->projectid) {
+            try {
+                validate_projectID($this->projectid);
+            } catch (InvalidProjectIDException $exception) {
+                $errors[] = $exception->getMessage();
+            }
+        }
+
+        $required_fields = [
+            "nameofwork" => _("Title"),
+            "authorsname" => _("Author"),
+            "username" => _("Project Manager"),
+            "language" => _("Language"),
+            "genre" => _("Genre"),
+            "image_source" => _("Image Source"),
+            "difficulty" => _("Difficulty"),
+        ];
+
+        foreach ($required_fields as $field => $label) {
+            if (preg_match('/^\s*$/', $this->$field)) {
+                $errors[] = sprintf(_("%s is required."), $label);
+            }
+        }
+
+        $user_fields = [
+            "username" => _("Project Manager"),
+            "checkedoutby" => _("PPer/PPVer"),
+            "image_preparer" => _("Image Preparer"),
+            "text_preparer" => _("Text Preparer"),
+            "postproofer" => _("Post Processor"),
+            "ppverifier" => _("Post Processor Verifier"),
+        ];
+
+        foreach ($user_fields as $field => $label) {
+            // only check non-empty fields
+            if (!preg_match('/^\s*$/', $this->$field) && !User::is_valid_user($this->$field)) {
+                $errors[] = sprintf(_("%s must be an existing user - check case and spelling and ensure there is no trailing whitespace."),
+                    $label);
+            }
+        }
+
+        if ($this->username && !that_user_is_PM($this->username)) {
+            // TRANSLATORS: PM = project manager
+            $errors[] = sprintf(_("%s is not a PM."), $this->username);
+        }
+
+        if ($this->languages[0]) {
+            foreach ($this->languages as $language) {
+                if (langcode2_for_langname($language) === null) {
+                    $errors[] = sprintf(_("%s is not a valid language."), $language);
+                }
+            }
+        }
+
+        if ($this->genre && !in_array($this->genre, array_keys(load_genre_translation_array()))) {
+            $errors[] = sprintf(_("%s is not a valid genre."), $this->genre);
+        }
+
+        if ($this->image_source && !in_array($this->image_source, array_keys(load_image_sources()))) {
+            $errors[] = sprintf(_("%s is not a valid image source."), $this->image_source);
+        }
+
+        if ($this->difficulty && !in_array($this->difficulty, array_keys(get_project_difficulties()))) {
+            $errors[] = sprintf(_("%s is not a valid difficulty."), $this->difficulty);
+        }
+
+        if ($this->special_code) {
+            if (startswith($this->special_code, 'Birthday') ||
+                 startswith($this->special_code, 'Otherday')
+            ) {
+                if (preg_match("/\w+ (\d{2})(\d{2})/", $this->special_code, $matches)) {
+                    if (!checkdate($matches[1], $matches[2], 2000)) {
+                        $errors[] = _("Invalid date supplied for Birthday or Otherday Special.");
+                    }
+                } else {
+                    $errors[] = _("Month and Day are required for Birthday or Otherday Specials.");
+                }
+            } else {
+                if (!in_array($this->special_code, array_keys(load_special_days()))) {
+                    $errors[] = sprintf(_("%s is not a valid special day."), $this->special_code);
+                }
+            }
+        }
+
+        // don't allow an empty PPer/PPVer if the project is checked out
+        if (($this->state == PROJ_POST_FIRST_CHECKED_OUT ||
+             $this->state == PROJ_POST_SECOND_CHECKED_OUT) &&
+             $this->checkedoutby == '') {
+            $errors[] = _("This project is checked out and must specify a PPer/PPVer");
+        }
+
+        if ($this->postednum) {
+            if (! preg_match('/^[1-9][0-9]*$/', $this->postednum)) {
+                $errors[] = sprintf(
+                    _("Posted Number \"%s\" is not of the correct format."),
+                    $this->postednum);
+                // Occasionally, there will be a PG ebook that is still
+                // under U.S. copyright. This is indicated in their system
+                // by appending a 'C' to the etext number. The link to
+                // the etext, however, does not include the 'C', nor should
+                // the DP link. If this changes, update the pattern here.
+            }
+        }
+
+        $custom_chars = utf8_normalize($this->custom_chars);
+        if ($custom_chars) {
+            $codepoints = utf8_codepoints_combining($custom_chars);
+
+            // all characters must be unique
+            if ($codepoints != array_unique($codepoints)) {
+                $errors[] = _("The set of custom characters must be unique.");
+            }
+
+            // only allow 32 characters
+            if (count($codepoints) > 32) {
+                $errors[] = _("A maximum of 32 custom characters are allowed.");
+            }
+
+            // prevent disallowed characters from being added
+            $disallowed_codepoints = array_intersect(get_disallowed_codepoints(), $codepoints);
+            if ($disallowed_codepoints != []) {
+                $errors[] = sprintf(
+                    _("The following custom characters are not allowed: %s"),
+                    implode(", ", array_map('voku\helper\UTF8::hex_to_chr', $disallowed_codepoints))
+                );
+            }
+        }
+
+        if ($errors and $throw_on_error) {
+            throw new ValueError(join("\n", $errors));
+        }
+
+        return $errors;
     }
 
     // -------------------------------------------------------------------------

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -36,31 +36,78 @@ class Project
 {
     use CharSuiteSet;
 
-    public function __construct($arg)
+    public function __construct($arg = null)
     {
         if (is_string($arg)) {
             // $arg is the projectid.
-            $sql = sprintf("
-                SELECT *
-                FROM projects
-                WHERE projectid = '%s'",
-                DPDatabase::escape($arg)
-            );
-            $res = DPDatabase::query($sql);
-            $row = mysqli_fetch_assoc($res);
-            if (!$row) {
-                throw new NonexistentProjectException(sprintf(_("There is no project with projectid '%s'"), $arg));
-            }
-            $row['t_retrieved'] = time();
+            $this->_load_from_db($arg);
         } elseif (is_array($arg)) {
             // $arg is assumed to be an associative array, such
             // as would be returned by mysqli_fetch_assoc().
-            $row = $arg;
+            $this->_init_fields_to_defaults();
+            foreach ($arg as $key => $value) {
+                $this->$key = $value;
+            }
+        } elseif ($arg === null) {
+            $this->_init_fields_to_defaults();
         } else {
             $arg_type = gettype($arg);
             die("Project::Project(): 'arg' has unexpected type $arg_type");
         }
+    }
 
+    // -------------------------------------------------------------------------
+    // Loading & initialization
+
+    private function _init_fields_to_defaults()
+    {
+        // Initialize Project with core fields and default values.
+        // These alone aren't sufficient to validate() and persist the project.
+        $fields = [
+            "projectid" => null,
+            "nameofwork" => "",
+            "authorsname" => "",
+            "username" => "",
+            "checkedoutby" => "",
+            "language" => "",
+            "scannercredit" => "",
+            "comments" => "",
+            "comment_format" => "markdown",
+            "postproofer" => "",
+            "ppverifier" => "",
+            "postcomments" => "",
+            "clearance" => "",
+            "postednum" => "",
+            "genre" => "",
+            "difficulty" => "",
+            "special_code" => "",
+            "image_source" => "",
+            "image_preparer" => "",
+            "text_preparer" => "",
+            "extra_credits" => "",
+            "deletion_reason" => "",
+            "custom_chars" => "",
+            "state" => "",
+        ];
+        foreach ($fields as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
+    private function _load_from_db($projectid)
+    {
+        $sql = sprintf("
+            SELECT *
+            FROM projects
+            WHERE projectid = '%s'",
+            DPDatabase::escape($projectid)
+        );
+        $res = DPDatabase::query($sql);
+        $row = mysqli_fetch_assoc($res);
+        if (!$row) {
+            throw new NonexistentProjectException(sprintf(_("There is no project with projectid '%s'"), $projectid));
+        }
+        $row['t_retrieved'] = time();
         foreach ($row as $key => $value) {
             $this->$key = $value;
         }

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -64,13 +64,6 @@ class Project
         foreach ($row as $key => $value) {
             $this->$key = $value;
         }
-
-        // -------------------------------------------------
-
-        global $projects_url, $projects_dir;
-
-        $this->url = "$projects_url/$this->projectid";
-        $this->dir = "$projects_dir/$this->projectid";
     }
 
     // -------------------------------------------------------------------------
@@ -78,11 +71,15 @@ class Project
 
     public function __get($name)
     {
-        global $pguser;
+        global $pguser, $projects_url, $projects_dir;
 
         static $project_page_table_exists = null;
 
         switch ($name) {
+            case "url":
+                return "$projects_url/$this->projectid";
+            case "dir":
+                return "$projects_dir/$this->projectid";
             case "is_utf8":
                 return DPDatabase::is_table_utf8($this->projectid);
             case "dir_exists":
@@ -972,9 +969,9 @@ class Project
     // Given a MARCRecord, write a dc XML document for this project
     public function create_dc_xml_oai($marc_record)
     {
-        global $charset, $site_name, $code_url, $projects_dir;
+        global $charset, $site_name, $code_url;
 
-        $dirname = "$projects_dir/$this->projectid";
+        $dirname = $this->dir;
         $filename = "$dirname/dc.xml";
 
         if (!is_dir($dirname)) {


### PR DESCRIPTION
This copies (but does not move) the project validation logic from `tools/project_manager/editproject.php` into the Project class. This will allow it to be used both for the UI and the API.

The validation logic in `editproject.php` is intertwined with the ProjectHoldInfo class in that file and I decided it was clearer if I did the move in two steps (this PR to create it, and a separate one to use it). I have a second branch prepared that uses this validation and is ready for review once this one goes in.

For validation I added several new unit tests. I also ran the validation code against all of the existing projects on TEST with this code:
```php
<?php
$relPath = "./";
include_once($relPath."base.inc");
include_once($relPath."Project.inc");

$sql = "
    SELECT projectid
    FROM projects
    ORDER BY projectid
";
$res = DPDatabase::query($sql);

$valid_project_count = 0;
$invalid_project_count = 0;
while ($row = mysqli_fetch_assoc($res)) {
    $projectid = $row["projectid"];
    $project = new Project($projectid);
    try {
        $project->validate(true);
        $valid_project_count += 1;
    } catch (Error $exception) {
        echo "$projectid\n";
        echo "    " . $exception->getMessage() . "\n";
        $invalid_project_count += 1;
    }
}
echo "\n";
echo "Valid projects: $valid_project_count\n";
echo "Invalid projects: $invalid_project_count\n";
```

Which produced this output:
```
$ php test_project_validate.php
projectID455833134db51
    Project Manager is required.
projectID45c2c47770793
    birdbird is not a PM.
projectID5d6ab3d7076b1
    r2d2 is not a valid language.
projectID61db3e758a256
    Difficulty is required.

Valid projects: 421
Invalid projects: 4
```