### PR TITLE
Centralize project manage check in Project class

### DIFF
--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath.'Project.inc');
-include_once($relPath.'project_edit.inc');
 include_once($relPath.'ProjectTransition.inc');
 include_once($relPath.'forum_interface.inc');
 include_once($relPath.'wordcheck_engine.inc');

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -59,7 +59,7 @@ function abort_if_cant_edit_project($projectid)
     if (!$project->can_be_managed_by_current_user) {
         echo "
             <P>
-            "._("You are not allowed to manage this project")." ($projectid).
+            "._("You are not authorized to manage this project.")." ($projectid).
             <P>
             ", sprintf(_("If this message is an error, contact a <a href='%s'>site manager</a>"),
                 "mailto:$site_manager_email_addr"), "

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -3,35 +3,6 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'project_states.inc');
 
-define('PROJECT_DOES_NOT_EXIST', 1);
-define('USER_CANNOT_EDIT_PROJECT', 2);
-define('USER_CAN_EDIT_PROJECT', 3);
-
-function user_can_edit_project($projectid)
-// Ascertain whether the current user ($pguser)
-// is allowed to edit the specified project
-// (i.e., is either the project's manager or a site manager).
-{
-    global $pguser;
-
-    $res = mysqli_query(DPDatabase::get_connection(), "SELECT username FROM projects WHERE projectid = '$projectid' LIMIT 1");
-    $row = mysqli_fetch_assoc($res);
-    if (!$row) {
-        return PROJECT_DOES_NOT_EXIST;
-    }
-
-    if ($pguser == $row["username"]) {
-        // The current user is the project manager for the project.
-        return USER_CAN_EDIT_PROJECT;
-    }
-
-    if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
-        // The user is a site manager or project facilitator, and thus can edit any existing project.
-        return USER_CAN_EDIT_PROJECT;
-    }
-
-    return USER_CANNOT_EDIT_PROJECT;
-}
 
 function user_can_add_project_pages($projectid, $page_type = "normal")
 {
@@ -72,9 +43,9 @@ function abort_if_cant_edit_project($projectid)
 {
     global $site_manager_email_addr;
 
-    $result = user_can_edit_project($projectid);
-
-    if ($result == PROJECT_DOES_NOT_EXIST) {
+    try {
+        $project = new Project($projectid);
+    } catch (NonexistentProjectException $exception) {
         echo "
             <P>
             "._("There appears to be no such project")." ($projectid).
@@ -83,7 +54,9 @@ function abort_if_cant_edit_project($projectid)
                 "mailto:$site_manager_email_addr"), "
             <P><a href=\"projectmgr.php\">"._("Back")."</a>";
         exit;
-    } elseif ($result == USER_CANNOT_EDIT_PROJECT) {
+    }
+
+    if (!$project->can_be_managed_by_current_user) {
         echo "
             <P>
             "._("You are not allowed to manage this project")." ($projectid).
@@ -92,26 +65,7 @@ function abort_if_cant_edit_project($projectid)
                 "mailto:$site_manager_email_addr"), "
             <P><a href=\"projectmgr.php\">"._("Back")."</a>";
         exit;
-    } elseif ($result == USER_CAN_EDIT_PROJECT) {
-        return;
-    } else {
-        echo _("unexpected return value from user_can_edit_project") . ": '$result'";
-        exit;
     }
-}
-
-function user_can_delete_project_in_state($project_state)
-// Can the current user delete a project in the given state?
-// (assuming that the current user can edit/manage the project)
-{
-    // PM/PF/SA can delete a project when it's new.
-    // SA can 'delete' a project when it's in any state but already-deleted.
-    // (There's a difference to what 'deletion' means in the latter case.)
-    return (
-        $project_state == PROJ_NEW
-        ||
-        $project_state != PROJ_DELETE && user_is_a_sitemanager()
-    );
 }
 
 function check_user_can_load_projects($exit_if_not)

--- a/tools/pending_access_requests.php
+++ b/tools/pending_access_requests.php
@@ -8,7 +8,7 @@ include_once($relPath.'theme.inc');
 require_login();
 
 if (!(user_is_a_sitemanager() || user_is_an_access_request_reviewer())) {
-    die("permission denied");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $title = _('Pending Access Requests');

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -6,7 +6,6 @@ include_once($relPath.'links.inc');
 include_once('edit_common.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'project_edit.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'misc.inc');  // attr_safe(), html_safe()
 include_once($relPath.'faq.inc');
@@ -92,15 +91,8 @@ class ProjectWordListHolder
             return _("Project directory does not exist, unable to manage word lists.");
         }
 
-        $ucep_result = user_can_edit_project($this->projectid);
-        // we only let people clone projects that they can edit, so this
-        // is valid whether they are cloning or editing
-        if ($ucep_result == USER_CANNOT_EDIT_PROJECT) {
+        if (!$this->project->can_be_managed_by_current_user) {
             return _("You are not authorized to manage this project.");
-        } elseif ($ucep_result == USER_CAN_EDIT_PROJECT) {
-            // fine
-        } else {
-            return _("unexpected return value from user_can_edit_project") . ": '$ucep_result'";
         }
 
         return null;

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -7,7 +7,6 @@ include_once($relPath.'DPage.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'project_edit.inc');
 include_once($relPath.'misc.inc'); // attr_safe(), html_safe(), get_enumerated_param()
 include_once($relPath.'codepoint_validator.inc');
 include_once($relPath.'page_table.inc');  // page_state_is_a_bad_state()
@@ -22,11 +21,11 @@ $prev_text = array_get($_POST, 'prev_text', null);
 $text_column = array_get($_REQUEST, 'text_column', null);
 $resolution = array_get($_POST, 'resolution', null);
 
-if (user_can_edit_project($projectid) != USER_CAN_EDIT_PROJECT) {
+$project = new Project($projectid);
+
+if (!$project->can_be_managed_by_current_user) {
     die("You are not authorized to manage this project.");
 }
-
-$project = new Project($projectid);
 
 // prevent changes to the project table if it isn't UTF-8
 if (!$project->is_utf8) {

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -24,7 +24,7 @@ $resolution = array_get($_POST, 'resolution', null);
 $project = new Project($projectid);
 
 if (!$project->can_be_managed_by_current_user) {
-    die("You are not authorized to manage this project.");
+    die(_("You are not authorized to manage this project."));
 }
 
 // prevent changes to the project table if it isn't UTF-8

--- a/tools/project_manager/move_projects.php
+++ b/tools/project_manager/move_projects.php
@@ -35,7 +35,7 @@ foreach ($projectids as $projectid) {
     }
 
     if (!$project->can_be_managed_by_current_user) {
-        echo "    " . _("You are not authorize to manage this project.") . "\n";
+        echo "    " . _("You are not authorized to manage this project.") . "\n";
         continue;
     }
 

--- a/tools/project_manager/move_projects.php
+++ b/tools/project_manager/move_projects.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'project_edit.inc');
 include_once($relPath.'project_trans.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
@@ -35,8 +34,7 @@ foreach ($projectids as $projectid) {
         continue;
     }
 
-    $result = user_can_edit_project($projectid);
-    if ($result == USER_CANNOT_EDIT_PROJECT) {
+    if (!$project->can_be_managed_by_current_user) {
         echo "    " . _("You are not authorize to manage this project.") . "\n";
         continue;
     }

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath.'links.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'project_edit.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'faq.inc');
@@ -412,8 +411,9 @@ function enforce_edit_authorization($projectid)
 {
     global $code_url;
 
-    $ucep_result = user_can_edit_project($projectid);
-    if ($ucep_result != USER_CAN_EDIT_PROJECT) {
+    $project = new Project($projectid);
+
+    if (!$project->can_be_managed_by_current_user) {
         $message = _("You are not authorized to manage this project.");
         $message .= " ";
         $message .= sprintf(_("Redirecting you to the project page in %d seconds."), 5);

--- a/tools/site_admin/convert_project_table_utf8.php
+++ b/tools/site_admin/convert_project_table_utf8.php
@@ -8,7 +8,7 @@ include_once($relPath.'user_is.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die("You are not allowed to run this script.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $title = _("Convert Project Table to UTF-8");

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -13,7 +13,7 @@ include_once($relPath.'wordcheck_engine.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die("You are not authorized to invoke this script.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $extra_args["css_data"] = "

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -10,7 +10,7 @@ include_once($relPath.'../tools/project_manager/page_operations.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die("You are not authorized to invoke this script.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $extra_args["css_data"] = "

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -11,7 +11,7 @@ include_once($relPath.'email_address.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die(_('You are not authorized to invoke this script.'));
+    die(_("You are not authorized to invoke this script."));
 }
 
 $title = _("Resend Account Activation Email");

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -7,7 +7,7 @@ include_once($relPath.'user_is.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die(_("You are not authorized to access this page."));
+    die(_("You are not authorized to invoke this script."));
 }
 
 $title = _("Site Administration");

--- a/tools/site_admin/manage_random_rules.php
+++ b/tools/site_admin/manage_random_rules.php
@@ -7,7 +7,7 @@ require_login();
 
 // check to see if the user is authorized to be here
 if (!(user_is_a_sitemanager())) {
-    die("You are not authorized to use this form.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $action = array_get($_POST, "action", null);

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -10,7 +10,7 @@ include_once($relPath.'access_log.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die("permission denied");
+    die(_("You are not authorized to invoke this script."));
 }
 
 // --------------------------------------

--- a/tools/site_admin/manage_site_charsuites.php
+++ b/tools/site_admin/manage_site_charsuites.php
@@ -9,7 +9,7 @@ require_login();
 
 // check to see if the user is authorized to be here
 if (!(user_is_a_sitemanager())) {
-    die("You are not authorized to use this form.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $messages = [];

--- a/tools/site_admin/manage_site_word_lists.php
+++ b/tools/site_admin/manage_site_word_lists.php
@@ -12,7 +12,7 @@ require_login();
 
 // check to see if the user is authorized to be here
 if (!(user_is_a_sitemanager())) {
-    die("You are not authorized to use this form.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 // fetch any data sent our way. word_string will only

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -10,7 +10,7 @@ include_once($relPath.'special_colors.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die("You are not allowed to run this script.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $page_url = "$code_url/tools/site_admin/manage_special_days.php";

--- a/tools/site_admin/proj_approvals.php
+++ b/tools/site_admin/proj_approvals.php
@@ -16,7 +16,7 @@ if (!$site_supports_metadata) {
 }
 
 if (!user_is_a_sitemanager()) {
-    die('You are not authorized to invoke this script.');
+    die(_("You are not authorized to invoke this script."));
 }
 
 //----------------------------------------------------------------------------------

--- a/tools/site_admin/project_jump.php
+++ b/tools/site_admin/project_jump.php
@@ -9,7 +9,7 @@ include_once($relPath.'Project.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die("You are not authorized to invoke this script.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $action = get_enumerated_param($_POST, 'action', 'showform', ['showform', 'check', 'dojump']);

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -9,7 +9,7 @@ include_once($relPath.'user_is.inc');
 require_login();
 
 if (!user_is_a_sitemanager()) {
-    die("You are not allowed to run this script.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $extra_args["css_data"] = "

--- a/tools/site_admin/show_access_log.php
+++ b/tools/site_admin/show_access_log.php
@@ -20,7 +20,7 @@ $action = get_enumerated_param($_GET, 'action', null, $action_choices, true);
 require_login();
 
 if (!user_is_a_sitemanager() && !user_is_an_access_request_reviewer()) {
-    die(_("You are not authorized to access this page."));
+    die(_("You are not authorized to invoke this script."));
 }
 
 $title = _("Access Log");

--- a/tools/site_admin/show_common_words_from_project_word_lists.php
+++ b/tools/site_admin/show_common_words_from_project_word_lists.php
@@ -11,7 +11,7 @@ require_login();
 
 // check to see if the user is authorized to be here
 if (!(user_is_a_sitemanager() || user_is_proj_facilitator())) {
-    die("You are not authorized to use this form.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -9,7 +9,7 @@ include_once($relPath.'misc.inc'); // html_safe(), get_integer_param(), get_enum
 require_login();
 
 if (!(user_is_a_sitemanager() or user_is_site_news_editor())) {
-    die("You are not authorized to use this form.");
+    die(_("You are not authorized to invoke this script."));
 }
 
 $news_page_id = get_enumerated_param($_GET, 'news_page_id', null, array_keys($NEWS_PAGES), true);


### PR DESCRIPTION
We currently have two similar checks to determine if a user is able to manage a project. Centralize on the one within the Project class. This ensures that the API (which uses the Project-based method for checking wordlist management access) and the project edit UI (which uses the `project_edit.inc`-based way) use the same code.

Testable in the [single-manage-check](https://www.pgdp.org/~cpeel/c.branch/single-manage-check/) sandbox.