### PR TITLE
Move project field labels into Project table

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -116,6 +116,8 @@ class Project
 
     public function validate($throw_on_error = false)
     {
+        $labels = self::get_field_labels();
+
         $errors = [];
 
         if ($this->projectid) {
@@ -127,35 +129,35 @@ class Project
         }
 
         $required_fields = [
-            "nameofwork" => _("Title"),
-            "authorsname" => _("Author"),
-            "username" => _("Project Manager"),
-            "language" => _("Language"),
-            "genre" => _("Genre"),
-            "image_source" => _("Image Source"),
-            "difficulty" => _("Difficulty"),
+            "nameofwork",
+            "authorsname",
+            "username",
+            "language",
+            "genre",
+            "image_source",
+            "difficulty",
         ];
 
-        foreach ($required_fields as $field => $label) {
+        foreach ($required_fields as $field) {
             if (preg_match('/^\s*$/', $this->$field)) {
-                $errors[] = sprintf(_("%s is required."), $label);
+                $errors[] = sprintf(_("%s is required."), $labels[$field]);
             }
         }
 
         $user_fields = [
-            "username" => _("Project Manager"),
-            "checkedoutby" => _("PPer/PPVer"),
-            "image_preparer" => _("Image Preparer"),
-            "text_preparer" => _("Text Preparer"),
-            "postproofer" => _("Post Processor"),
-            "ppverifier" => _("Post Processor Verifier"),
+            "username",
+            "checkedoutby",
+            "image_preparer",
+            "text_preparer",
+            "postproofer",
+            "ppverifier",
         ];
 
-        foreach ($user_fields as $field => $label) {
+        foreach ($user_fields as $field) {
             // only check non-empty fields
             if (!preg_match('/^\s*$/', $this->$field) && !User::is_valid_user($this->$field)) {
                 $errors[] = sprintf(_("%s must be an existing user - check case and spelling and ensure there is no trailing whitespace."),
-                    $label);
+                    $labels[$field]);
             }
         }
 
@@ -340,6 +342,42 @@ class Project
             $credits_line = "$credits_line ({$this->image_source_credit})";
         }
         return $credits_line;
+    }
+
+    // -------------------------------------------------------------------------
+
+    // Return an associative array of project fields with localized labels
+    // for use in the UI.
+    public static function get_field_labels()
+    {
+        return [
+            "projectid" => _("Project ID"),
+            "nameofwork" => _("Title"),
+            "authorsname" => _("Author"),
+            "username" => _("Project Manager"),
+            "comments" => _("Project Comments"),
+            "comment_format" => _("Project Comments Format"),
+            "special_code" => _("Special Day"),
+            "checkedoutby" => _("PPer/PPVer"),
+            "scannercredit" => _("Scanner Credit"),
+            "postednum" => _("PG etext number"),
+            "clearance" => _("Clearance Line"),
+            "language" => _("Language"),
+            "genre" => _("Genre"),
+            "difficulty" => _("Difficulty"),
+            "postproofer" => _("Post Processor"),
+            "ppverifier" => _("Post Processor Verifier"),
+            "image_source" => _("Image Source"),
+            "image_preparer" => _("Image Preparer"),
+            "text_preparer" => _("Text Preparer"),
+            "extra_credits" => _("Extra Credits"),
+            "deletion_reason" => _("Reason for Deletion"),
+            "custom_chars" => _("Custom Characters"),
+            // these keys are stored in project_events details1 fields
+            // and map to fields with different names
+            "difficulty_level" => _("Difficulty"),
+            "projectmanager" => _("Project Manager"),
+        ];
     }
 
     // -------------------------------------------------------------------------

--- a/project.php
+++ b/project.php
@@ -1235,26 +1235,7 @@ function do_history()
                     // TRANSLATORS: i.e. no fields changed
                     $list_of_changed_fields = pgettext("no fields", "none");
                 } else {
-                    // Maybe move this array to Project.inc
-                    $label_for_project_field_ = [
-                        'deletion_reason' => _("Reason for Deletion"),
-                        'nameofwork' => _("Title"),
-                        'authorsname' => _("Author"),
-                        'projectmanager' => _("Project Manager"),
-                        'language' => _("Language"),
-                        'genre' => _("Genre"),
-                        'difficulty_level' => _("Difficulty"),
-                        'special_code' => _("Special Day"),
-                        'checkedoutby' => _("PPer/PPVer"),
-                        'image_source' => _("Original Image Source"),
-                        'image_preparer' => _("Image Preparer"),
-                        'text_preparer' => _("Text Preparer"),
-                        'extra_credits' => _("Extra Credits"),
-                        'scannercredit' => _("Scanner Credit"),
-                        'clearance' => _("Clearance Line"),
-                        'postednum' => _("PG etext number"),
-                        'comments' => _("Project Comments"),
-                    ];
+                    $label_for_project_field_ = Project::get_field_labels();
 
                     $labels = [];
                     foreach (explode(' ', $changed_fields) as $fieldname) {

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -858,7 +858,7 @@ class ProjectInfoHolder
             $this->row(_("PPer/PPVer"), 'just_echo', $this->checkedoutby);
             echo "<input type='hidden' name='checkedoutby' value='$this->checkedoutby'>";
         }
-        $this->row(_("Original Image Source"), 'image_source_list', $this->image_source);
+        $this->row(_("Image Source"), 'image_source_list', $this->image_source);
         $this->row(_("Image Preparer"), 'DP_user_field', $this->image_preparer, 'image_preparer', sprintf(_("%s user who scanned or harvested the images."), $site_abbreviation));
         $this->row(_("Text Preparer"), 'DP_user_field', $this->text_preparer, 'text_preparer', sprintf(_("%s user who prepared the text files."), $site_abbreviation));
         $this->row(_("Extra Credits<br>(to be included in list of names--no URLs)"),


### PR DESCRIPTION
Reduce duplicated mappings of project fields with their localized names. I introduced new ones with the new `validate()` function not realizing that we had some already mapped in `project.php` (with a helpful message that it probably belongs in `Project.inc`). In some future world we would re-use these elsewhere, but this is a starting point.

I discovered this because as part of `editproject.php` we store the names of changed fields in `project_events.details1`. But we store the names of the fields as they are in `ProjectInfoHold` -- not as they are in the `Project` object (which maps to the database). That's why we need some additional mappings.

Compare the Project History section of a project in the [main TEST sandbox](https://www.pgdp.org/c/project.php?id=projectID61e78b003e12d#holds) vs the one in [the centralize-project-labels sandbox](https://www.pgdp.org/~cpeel/c.branch/centralize-project-labels/project.php?id=projectID61e78b003e12d#holds) which includes additional labels.

This also normalizes on `Image Source` vs `Original Image Source`. The former is used in more places in the code vs the latter.