### PR TITLE
Improve language handling with encode/decode

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -44,7 +44,55 @@ class ProjectTest extends PHPUnit\Framework\TestCase
     }
 
     //------------------------------------------------------------------------
+    // Language handling functions
+
+    public function test_encode_languages_single()
+    {
+        $language = Project::encode_languages(["First"]);
+        $this->assertEquals("First", $language);
+    }
+
+    public function test_encode_languages_single_with_blank()
+    {
+        $language = Project::encode_languages(["First", ""]);
+        $this->assertEquals("First", $language);
+    }
+
+    public function test_encode_languages_double()
+    {
+        $language = Project::encode_languages(["First", "Second"]);
+        $this->assertEquals("First with Second", $language);
+    }
+
+    public function test_decode_languages_single()
+    {
+        $languages = Project::decode_language("First");
+        $this->assertEquals(["First"], $languages);
+    }
+
+    public function test_decode_languages_double()
+    {
+        $languages = Project::decode_language("First with Second");
+        $this->assertEquals(["First", "Second"], $languages);
+    }
+
+    public function test_project_languages_setter_single()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->languages = ["First"];
+        $this->assertEquals("First", $project->language);
+    }
+
+    public function test_project_languages_setter_double()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->languages = ["First", "Second"];
+        $this->assertEquals("First with Second", $project->language);
+    }
+
+    //------------------------------------------------------------------------
     // Project object validation
+
     public function test_validate_required_fields_positive_path()
     {
         $project = new Project($this->valid_project_data);

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -307,6 +307,18 @@ class Project
         return null;
     }
 
+    public function __set($name, $value)
+    {
+        switch ($name) {
+            case "languages":
+                $this->language = self::encode_languages($value);
+                break;
+            default:
+                $this->$name = $value;
+                break;
+        }
+    }
+
     private function _load_image_source()
     {
         $this->image_source_name = '';
@@ -350,6 +362,11 @@ class Project
 
     public static function encode_languages($languages)
     {
+        // handle the case where the second language is empty
+        if (count($languages) == 2 && $languages[1] == '') {
+            return $languages[0];
+        }
+
         return join(" with ", $languages);
     }
 

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath.'iso_lang_list.inc');
 include_once($relPath.'genres.inc'); // load_genre_translation_array
-include_once($relPath.'site_vars.php');
 include_once($relPath.'wordcheck_engine.inc'); // get_project_word_file
 include_once($relPath.'links.inc'); // new_window_link, new_help_window_link
 include_once($relPath.'user_is.inc'); // user_is_a_sitemanager
@@ -46,13 +45,9 @@ function DP_user_field($field_value, $field_name, $args = [])
 
 function language_list($language)
 {
-    if (strpos($language, "with") > 0) {
-        $pri_language = trim(substr($language, 0, strpos($language, "with")));
-        $sec_language = trim(substr($language, (strpos($language, "with") + 5)));
-    } else {
-        $pri_language = $language;
-        $sec_language = '';
-    }
+    $languages = Project::decode_language($language);
+    $pri_language = $languages[0];
+    $sec_language = $languages[1] ?? '';
 
     echo html_safe(_("Primary")), ": <select name='pri_language' required>\n";
     maybe_echo_placeholder_option($pri_language);

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -335,12 +335,11 @@ class ProjectInfoHolder
             $errors .= _("Primary Language is required.")."<br>";
         }
 
-        $sec_language = @$_POST['sec_language'];
-
-        $this->language = (
-            $sec_language != ''
-            ? Project::encode_languages([$pri_language, $sec_language])
-            : $pri_language);
+        $this->language = Project::encode_languages(
+            [
+                @$_POST['pri_language'], @$_POST['sec_language'],
+            ]
+        );
 
         $this->charsuites = [];
         foreach ($_POST['charsuites'] ?? [] as $charsuite) {


### PR DESCRIPTION
This adds unit tests (yay!) for the existing encode/decode language functions. It also removes one more place where we parsed the string and replaces that with the decode function.

This also introduces a new setter that allows us to set a project languages directly (via `$project->languages = [..]`). This will be used in the new project API.

The only place this PR impacts the current code is within the Edit Project page when changing a project's languages.

Available in the [language-handling](https://www.pgdp.org/~cpeel/c.branch/language-handling/) sandbox.