### PR TITLE
Some small edit project clean-up

### DIFF
--- a/SETUP/tests/misc_UtilsTest.php
+++ b/SETUP/tests/misc_UtilsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+// Generic utilities in misc.inc
+
+class MiscUtils extends PHPUnit\Framework\TestCase
+{
+    public function test_array_get_exists()
+    {
+        $arr = ["param" => "value"];
+        $value = array_get($arr, "param", "default");
+        $this->assertEquals($arr["param"], $value);
+    }
+
+    public function test_array_get_doesnt_exists()
+    {
+        $arr = [];
+        $value = array_get($arr, "param", "default");
+        $this->assertEquals("default", $value);
+    }
+
+    public function test_get_changed_fields_for_objects()
+    {
+        $obj1 = new stdClass();
+        $obj1->param1 = "a";
+        $obj1->param2 = "b";
+
+        $obj2 = new stdClass();
+        $obj2->param1 = "a";
+        $obj2->param2 = "d";
+
+        $changed = get_changed_fields_for_objects($obj1, $obj2);
+        $this->assertEquals(["param2"], $changed);
+    }
+}

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -13,6 +13,25 @@ function array_get($arr, $key, $default)
     }
 }
 
+function get_changed_fields_for_objects($new, $old)
+// Return an array whose values are the names of the properties
+// whose values differ between the two objects $new and $old.
+{
+    $old_as_array = (array)$old;
+    $new_as_array = (array)$new;
+    // They should have the same set of keys, but just in case,
+    // merge the two sets of keys:
+    $all_keys = array_keys($old_as_array + $new_as_array);
+
+    $changed_fields = [];
+    foreach ($all_keys as $key) {
+        if (@$new_as_array[$key] != @$old_as_array[$key]) {
+            $changed_fields[] = $key;
+        }
+    }
+    return $changed_fields;
+}
+
 function get_enumerated_param($arr, $key, $default, $choices, $allownull = false)
 // If $arr[$key] is defined and is one of the strings in $choices,
 // return that string.

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -578,7 +578,7 @@ class ProjectInfoHolder
                 echo "<p class='error'>$fatal_error</p>";
                 exit;
             }
-            $changed_fields = get_changed_fields($this, $old_pih);
+            $changed_fields = get_changed_fields_for_objects($this, $old_pih);
 
             // We're particularly interested in knowing
             // when the project comments change.
@@ -958,43 +958,4 @@ class ProjectInfoHolder
         //Update the Genre
         $marc_record->literary_form = $_POST['genre'];
     }
-}
-
-function get_changed_fields($new_pih, $old_pih)
-// Return an array whose values are the names of the properties
-// whose values differ between the two objects $new_pih and $old_pih.
-// [Note that this is completely generic code, so we could consider
-// moving it to pinc/misc.inc.]
-{
-    $old_pih_as_array = (array)$old_pih;
-    $new_pih_as_array = (array)$new_pih;
-    // They should have the same set of keys, but just in case,
-    // merge the two sets of keys:
-    $all_keys = array_keys($old_pih_as_array + $new_pih_as_array);
-
-    /*
-    {
-        if (count($old_pih_as_array) != count($all_keys))
-        {
-            echo "<p>all - old:";
-            var_dump(array_diff($all_keys, array_keys($old_pih_as_array)));
-            echo "</p>\n";
-        }
-        if (count($new_pih_as_array) != count($all_keys))
-        {
-            echo "<p>all - new:";
-            var_dump(array_diff($all_keys, array_keys($new_pih_as_array)));
-            echo "</p>\n";
-        }
-    }
-    */
-
-    $changed_fields = [];
-    foreach ($all_keys as $key) {
-        if (@$new_pih_as_array[$key] != @$old_pih_as_array[$key]) {
-            // echo "<p>'$key' changed from '{$old_pih_as_array[$key]}' to '{$new_pih_as_array[$key]}'</p>\n";
-            $changed_fields[] = $key;
-        }
-    }
-    return $changed_fields;
 }

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -121,11 +121,6 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
     $pih->show_form();
 }
 
-function get_default_character_suites()
-{
-    global $default_project_char_suites;
-    return $default_project_char_suites;
-}
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -133,7 +128,7 @@ class ProjectInfoHolder
 {
     public function set_from_nothing()
     {
-        global $pguser;
+        global $pguser, $default_project_char_suites;
 
         $this->nameofwork = '';
         $this->authorsname = '';
@@ -145,7 +140,7 @@ class ProjectInfoHolder
         $this->comment_format = 'markdown';
         $this->clearance = '';
         $this->postednum = '';
-        $this->charsuites = get_default_character_suites();
+        $this->charsuites = $default_project_char_suites;
         $this->genre = '';
         $this->difficulty_level = ($pguser == "BEGIN" ? "beginner" : "average");
         $this->special_code = '';
@@ -163,7 +158,7 @@ class ProjectInfoHolder
 
     public function set_from_marc_record()
     {
-        global $pguser;
+        global $pguser, $default_project_char_suites;
 
         $encoded_marc_array = array_get($_POST, "rec", "");
         if (!$encoded_marc_array) {
@@ -182,7 +177,7 @@ class ProjectInfoHolder
         $this->authorsname = $marc_record->author;
         $this->projectmanager = $pguser;
         $this->language = $marc_record->language;
-        $this->charsuites = get_default_character_suites();
+        $this->charsuites = $default_project_char_suites;
         $this->genre = $marc_record->literary_form;
 
         $this->checkedoutby = '';


### PR DESCRIPTION
In prep for a PR with some big changes to `editproject.php` to use the new `Project->validate()` function I wanted to get these two small commits in to make reviewing that one easier.

This:
* Removes the `get_default_character_suites()` function now that they are defined in `site_vars.php`
* Moves the generic `get_changed_fields_for_objects()` function into `misc.inc`.

Testing that recording of the fields changed for a project still works can be done in the [pre-project-save](https://www.pgdp.org/~cpeel/c.branch/pre-project-save/) sandbox.