### PR TITLE
Pull projects_with_odd_values.php out of noncvs

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -263,7 +263,7 @@ class Project
 
     public function __get($name)
     {
-        global $pguser, $projects_url, $projects_dir;
+        global $pguser, $projects_url, $projects_dir, $code_url;
 
         static $project_page_table_exists = null;
 
@@ -272,6 +272,8 @@ class Project
                 return "$projects_url/$this->projectid";
             case "dir":
                 return "$projects_dir/$this->projectid";
+            case "page_url":
+                return "$code_url/project.php?id={$this->projectid}";
             case "is_utf8":
                 return DPDatabase::is_table_utf8($this->projectid);
             case "dir_exists":

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -34,6 +34,7 @@ $sections = [
             "../project_manager/clearance_check.php?username=" => _("Questionable Clearances"),
             "shared_postednums.php" => _("Detect duplicate postednum"),
             "show_common_words_from_project_word_lists.php" => _("Show common words from project word lists"),
+            "projects_with_odd_values.php" => _("Show projects with 'odd' values"),
         ],
     ],
     _("Site") => [

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -29,17 +29,19 @@ $sections = [
         "delete_pages.php" => _("Delete Pages"),
         "rename_pages.php" => _("Rename Pages"),
         "project_jump.php" => _("Jump Project to State"),
-        "../project_manager/clearance_check.php?username=" => _("Questionable Clearances"),
         "convert_project_table_utf8.php" => _("Convert Project Table to UTF-8"),
+        _("Data review") => [
+            "../project_manager/clearance_check.php?username=" => _("Questionable Clearances"),
+            "shared_postednums.php" => _("Detect duplicate postednum"),
+            "show_common_words_from_project_word_lists.php" => _("Show common words from project word lists"),
+        ],
     ],
     _("Site") => [
         "sitenews.php" => _("Manage Site News"),
         "manage_random_rules.php" => _("Manage Random Rules"),
         "manage_special_days.php" => _("Manage Special Days"),
-        "shared_postednums.php" => _("Detect duplicate postednum"),
         "manage_site_charsuites.php" => _("Manage Site Character Suites"),
         "manage_site_word_lists.php" => _("Manage Site Word Lists"),
-        "show_common_words_from_project_word_lists.php" => _("Show common words from project word lists"),
         "../../locale/translators/index.php" => _("Translation Center"),
     ],
 ];
@@ -52,7 +54,17 @@ foreach ($sections as $section => $pages) {
     echo "<h2>$section</h2>";
     echo "<ul>";
     foreach ($pages as $page => $label) {
-        echo "<li><a href='$page'>$label</a></li>";
+        if (is_array($label)) {
+            echo "<li><b>$page</b>";
+            echo "<ul>";
+            foreach ($label as $subpage => $sublabel) {
+                echo "<li><a href='$subpage'>$sublabel</a></li>";
+            }
+            echo "</ul>";
+            echo "</li>";
+        } else {
+            echo "<li><a href='$page'>$label</a></li>";
+        }
     }
     echo "</ul>";
 }

--- a/tools/site_admin/projects_with_odd_values.php
+++ b/tools/site_admin/projects_with_odd_values.php
@@ -1,0 +1,115 @@
+<?php
+$relPath = "./../../pinc/";
+include_once($relPath.'base.inc');
+include_once($relPath.'slim_header.inc');
+include_once($relPath.'iso_lang_list.inc');
+include_once($relPath.'genres.inc'); // load_genre_translation_array()
+include_once($relPath.'user_is.inc');
+
+require_login();
+
+if (!user_is_a_sitemanager() && !user_is_proj_facilitator()) {
+    die(_("You are not authorized to access this page."));
+}
+
+$title = _("Projects with 'odd' values");
+slim_header($title);
+echo "<h1>$title</h1>";
+
+echo "<p>" . _("This page shows projects that contain 'odd' values for fields with well-known values.") . "</p>";
+
+$lc = load_common_values();
+
+$sections = [];
+foreach (array_keys($lc) as $property) {
+    $sections[] = "<a href='#$property'>$property</a>";
+}
+echo "<p>" . join(" | ", $sections) . "</p>";
+
+foreach (load_projects_with_bad_values($lc) as $property => $projects) {
+    echo "<a id='$property'>\n";
+    echo "<h2>$property</h2>\n";
+    echo "<table class='basic striped'>\n";
+    echo "<tr>";
+    echo "<th>" . _("Value") . "</th>";
+    echo "<th>" . _("Project") . "</th>";
+    echo "</tr>";
+
+    foreach ($projects as $project) {
+        echo "<tr>\n";
+        echo "<td>{$project->$property}</td>\n";
+        $label = $project->nameofwork ? $project->nameofwork : "<i>" . _("No project title") . "</i>";
+        echo "<td><a href='$project->page_url'>$label</a></td>\n";
+        echo "</tr>\n";
+    }
+    echo "</table>\n";
+}
+
+// ---------------------------------------------------------------------------
+
+function load_common_values()
+{
+    $lc = [];
+
+    $lc['language'] = [];
+    foreach (get_iso_language_list() as $lang) {
+        $lc['language'][strtolower($lang['lang_name'])] = 1;
+    }
+
+    $lc['genre'] = [];
+    foreach (array_keys(load_genre_translation_array()) as $genre) {
+        $lc['genre'][strtolower($genre)] = 1;
+    }
+
+    $lc['difficulty'] = [];
+    foreach (get_project_difficulties() as $value => $label) {
+        $lc['difficulty'][$value] = 1;
+    }
+
+    $lc['special_code'] = [];
+    foreach (load_special_days() as $special_day) {
+        $lc['special_code'][strtolower($special_day["spec_code"])] = 1;
+    }
+
+    $lc['special_code'][''] = 1;
+    for ($m = 1; $m <= 12; $m++) {
+        for ($d = 1; $d <= 31; $d++) {
+            foreach (['birthday', 'otherday'] as $x) {
+                $v = sprintf('%s %02d%02d', $x, $m, $d);
+                $lc['special_code'][$v] = 1;
+            }
+        }
+    }
+
+    return $lc;
+}
+
+function load_projects_with_bad_values($lc)
+{
+    $projects_with_bad = [];
+
+    $sql = "
+        SELECT projectid, nameofwork, language, genre, difficulty, special_code
+        FROM projects
+        ORDER BY projectid
+    ";
+    $res = DPDatabase::query($sql);
+    while ($row = mysqli_fetch_assoc($res)) {
+        $project = new Project($row);
+
+        // language
+        foreach ($project->languages as $lang) {
+            if (! array_key_exists(strtolower($lang), $lc['language'])) {
+                $projects_with_bad['language'][] = $project;
+            }
+        }
+
+        foreach (['genre', 'difficulty', 'special_code'] as $property) {
+            if (! array_key_exists(strtolower($project->$property), $lc[$property])) {
+                $projects_with_bad[$property][] = $project;
+            }
+        }
+    }
+
+    return $projects_with_bad;
+}


### PR DESCRIPTION
Pull `noncvs/projects_with_odd_values.php` into the code so it can be maintained and make it work. This script has been broken since 2020-11-03 when langauges were pulled out of the global context into a function.

This also slightly changes the tool groupings on the Site Admin page.

Testable in the [data-check-tools](https://www.pgdp.org/~cpeel/c.branch/data-check-tools/) sandbox.