### PR TITLE
Set of small API updates

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -804,7 +804,7 @@ CREATE TABLE `users` (
   `u_profile` int(10) unsigned NOT NULL default '0',
   `u_intlang` varchar(25) default '',
   `u_privacy` tinyint(1) default '0',
-  `api_key` varchar(32) DEFAULT NULL,
+  `api_key` varchar(38) DEFAULT NULL,
   PRIMARY KEY  (`username`),
   UNIQUE KEY `api_key` (`api_key`),
   KEY `u_id` (`u_id`),

--- a/SETUP/upgrade/17/20220123_alter_users_table.php
+++ b/SETUP/upgrade/17/20220123_alter_users_table.php
@@ -1,0 +1,21 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Increasing size of users.api_key column..\n";
+$sql = "
+    ALTER TABLE users
+        CHANGE COLUMN api_key api_key varchar(38) default NULL
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -106,16 +106,16 @@ available endpoints and their parameters and return values.
 Search for all projects with genre `Other`:
 
 ```bash
-curl -i -g -X GET "https://www.pgdp.org/api/v1/projects?genre=Other" \
-    -H "accept: application/json" \
+curl -i -X GET "https://www.pgdp.org/api/v1/projects?genre=Other" \
+    -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
 ```
 
 Search for all projects with the word `Monster` in their title:
 
 ```bash
-curl -i -g -X GET "https://www.pgdp.org/api/v1/projects?title=Monster" \
-    -H "accept: application/json" \
+curl -i -X GET "https://www.pgdp.org/api/v1/projects?title=Monster" \
+    -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
 ```
 
@@ -124,31 +124,31 @@ curl -i -g -X GET "https://www.pgdp.org/api/v1/projects?title=Monster" \
 Load details about a specific project:
 
 ```bash
-curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
-    -H "accept: application/json" \
+curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
+    -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
 ```
 
 See all pages in a project:
 
 ```bash
-curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages" \
-    -H "accept: application/json" \
+curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages" \
+    -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
 ```
 
 Get the P1 text for a project page:
 
 ```bash
-curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages/001.png/pagerounds/P1" \
-    -H "accept: application/json" \
+curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages/001.png/pagerounds/P1" \
+    -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
 ```
 
 Get the good wordlist for a project:
 
 ```bash
-curl -i -g -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
-    -H "accept: application/json" \
+curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
+    -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
 ```

--- a/api/exceptions.inc
+++ b/api/exceptions.inc
@@ -50,6 +50,19 @@ class RateLimitExceeded extends ApiException
     }
 }
 
+class InvalidValue extends ApiException
+{
+    public function __construct($message = "Request contained an invalid value for a parameter")
+    {
+        parent::__construct($message);
+    }
+
+    public function getStatusCode()
+    {
+        return 400;
+    }
+}
+
 //---------------------------------------------------------------------------
 // Exceptions that shouldn't happen unless someone is futzing with something
 // they shouldn't be, or there's an unexpected problem.

--- a/api/index.php
+++ b/api/index.php
@@ -129,7 +129,11 @@ function api_rate_limit($key)
 
 function api_get_request_body()
 {
-    return json_decode(file_get_contents('php://input'));
+    $json = json_decode(file_get_contents('php://input'));
+    if ($json === null) {
+        throw new InvalidValue("Content was not valid JSON");
+    }
+    return $json;
 }
 
 function api_output_response($data, $response_code = 200)

--- a/api/index.php
+++ b/api/index.php
@@ -7,6 +7,10 @@ include_once('ApiRouter.inc');
 include_once('exceptions.inc');
 include_once('v1.inc');
 
+// capture all output to ensure that any errors that are surfaced
+// don't interfere with our HTTP return code
+ob_start();
+
 // everything is a JSON response
 header("Content-Type: application/json");
 
@@ -133,6 +137,11 @@ function api_output_response($data, $response_code = 200)
     http_response_code($response_code);
     echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE |
         JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK);
+
+    // output the output buffer we've been storing to ensure we could
+    // send the right HTTP response code
+    echo ob_get_clean();
+
     exit();
 }
 

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -175,7 +175,10 @@ function api_v1_project_wordlists($method, $data, $query_params)
         }
         $list_saver = "save_project_{$wordlist_type}_words";
         $list_saver($project->projectid, $words);
-        return [];
+
+        // return updated list
+        $list_loader = "load_project_{$wordlist_type}_words";
+        return $list_loader($project->projectid);
     }
 }
 


### PR DESCRIPTION
These are a set of small API updates, mostly fixes to docs and edge-cases, that I discovered working on the Project update API.

Notably:
* Return an error if the JSON passed into a request is invalid rather than continuing as if the request input was empty.
* Always return the right HTTP response code in the edgecase where code outputs text before we send the HTTP headers.
* Increase the size of the `api_key` field slightly so that it can contain a full version 4 UUID.
* Update the `curl` docs to not include the unnecessary `-g` param.
* On wordlist PUTs, return the newly-saved set of words rather than an empty array.

Testing:
```bash
# PUTing a new word list with invalid JSON
curl -i -X PUT "https://www.pgdp.org/~cpeel/c.branch/api-updates/api/index.php?url=v1/projects/projectID44de3936807f1/wordlists/good" \
    -H "Content-Type: application/json" \
    -H "X-API-KEY: $API_KEY" \
    -d '[ blearg ]'
HTTP/1.1 400 Bad Request
Date: Sun, 23 Jan 2022 21:15:31 GMT
Server: Apache
Upgrade: h2
Connection: Upgrade, close
Vary: Accept-Language,User-Agent
Access-Control-Allow-Headers: X-Api-Key, Content-Type
Access-Control-Allow-Methods: OPTIONS, GET, POST, PUT, PATCH
X-Rate-Limit-Limit: 3600
X-Rate-Limit-Remaining: 3599
X-Rate-Limit-Reset: 3600
Content-Length: 45
Content-Type: application/json

{
    "error": "Content was not valid JSON"
}


# PUTing a new word list with valid JSON
curl -i -X PUT "https://www.pgdp.org/~cpeel/c.branch/api-updates/api/index.php?url=v1/projects/projectID44de3936807f1/wordlists/good" \
    -H "Content-Type: application/json" \
    -H "X-API-KEY: $API_KEY" \
    -d '[ "word1", "word2" ]'

HTTP/1.1 200 OK
Date: Sun, 23 Jan 2022 21:16:10 GMT
Server: Apache
Upgrade: h2
Connection: Upgrade
Vary: Accept-Language,User-Agent
Access-Control-Allow-Headers: X-Api-Key, Content-Type
Access-Control-Allow-Methods: OPTIONS, GET, POST, PUT, PATCH
X-Rate-Limit-Limit: 3600
X-Rate-Limit-Remaining: 3597
X-Rate-Limit-Reset: 3561
Content-Length: 28
Content-Type: application/json

[
    "word1",
    "word2"
]
```

This is available in the [api-updates](https://www.pgdp.org/~cpeel/c.branch/api-updates/) sandbox but I think a code review with the above is sufficient.