### PR TITLE
Move project create and update logic to Project class

### DIFF
--- a/SETUP/tests/phpunit_test_helpers.inc
+++ b/SETUP/tests/phpunit_test_helpers.inc
@@ -80,3 +80,54 @@ function delete_test_image_source($image_source)
         throw new Exception(sprintf("Unable to delete test image source %s", $image_source));
     }
 }
+
+function load_project_events($project)
+{
+    $sql = sprintf("
+        SELECT *
+        FROM project_events
+        WHERE projectid = '%s'
+        ORDER BY event_id
+    ", DPDatabase::escape($project->projectid));
+    $res = DPDatabase::query($sql);
+    $events = [];
+    while ($event = mysqli_fetch_assoc($res)) {
+        $events[] = $event;
+    }
+
+    return $events;
+}
+
+// Delete remains of test projects that end up in other tables
+function delete_test_project_remains($project)
+{
+    $projectid = $project->projectid;
+
+    // character suites
+    $project->set_charsuites([]);
+
+    // project_holds
+    $hold_states = $project->get_hold_states();
+    if ($hold_states) {
+        $project->remove_holds($hold_states);
+    }
+
+    // project pages table and directory
+    if (does_project_page_table_exist($project->projectid)) {
+        $project->delete();
+    }
+
+    // project_events
+    $sql = sprintf("
+        DELETE FROM project_events
+        WHERE projectid  = '%s'
+    ", DPDatabase::escape($projectid));
+    DPDatabase::query($sql);
+
+    // projects table
+    $sql = sprintf("
+        DELETE FROM projects
+        WHERE projectid  = '%s'
+    ", DPDatabase::escape($projectid));
+    DPDatabase::query($sql);
+}

--- a/pinc/MARCRecord.inc
+++ b/pinc/MARCRecord.inc
@@ -3,6 +3,10 @@ include_once($relPath.'iso_lang_list.inc');
 include_once($relPath.'genres.inc'); // load_genre_translation_array
 include_once($relPath.'unicode.inc'); // guess_string_encoding()
 
+class InvalidMARCRecord extends Exception
+{
+}
+
 class MARCRecord
 {
     // MARC record in the yaz_search 'array' format

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -10,6 +10,7 @@ include_once($relPath.'stages.inc'); // is_formatting_round()
 include_once($relPath.'CharSuites.inc');
 include_once($relPath.'special_colors.inc');
 include_once($relPath.'wordcheck_engine.inc'); // delete_project_wordcheck_events()
+include_once($relPath.'DPage.inc'); // project_allow_pages()
 
 class UTF8ConversionException extends Exception
 {
@@ -41,11 +42,14 @@ class Project
 {
     use CharSuiteSet;
 
+    private $_create_source = null;
+
     public function __construct($arg = null)
     {
         if (is_string($arg)) {
             // $arg is the projectid.
             $this->_load_from_db($arg);
+            $this->_create_source = "db";
         } elseif (is_array($arg)) {
             // $arg is assumed to be an associative array, such
             // as would be returned by mysqli_fetch_assoc().
@@ -53,8 +57,10 @@ class Project
             foreach ($arg as $key => $value) {
                 $this->$key = $value;
             }
+            $this->_create_source = "array";
         } elseif ($arg === null) {
             $this->_init_fields_to_defaults();
+            $this->_create_source = "empty";
         } else {
             $arg_type = gettype($arg);
             die("Project::Project(): 'arg' has unexpected type $arg_type");
@@ -116,6 +122,22 @@ class Project
         foreach ($row as $key => $value) {
             $this->$key = $value;
         }
+    }
+
+    public function populate_from_marc_record($encoded_marc_array)
+    {
+        $yaz_array = unserialize(base64_decode($encoded_marc_array));
+        if (!$yaz_array) {
+            throw new InvalidMARCRecord();
+        }
+
+        $marc_record = new MARCRecord();
+        $marc_record->load_yaz_array($yaz_array);
+
+        $this->nameofwork = $marc_record->title;
+        $this->authorsname = $marc_record->author;
+        $this->language = $marc_record->language;
+        $this->genre = $marc_record->literary_form;
     }
 
     public function validate($throw_on_error = false)
@@ -257,6 +279,143 @@ class Project
         }
 
         return $errors;
+    }
+
+    public function save()
+    {
+        // Disallow save if the object was created from an array. There's too
+        // great a chance that there might be missing fields.
+        if ($this->_create_source == "array") {
+            throw new ProjectException("Saving a Project object from an array source is disallowed.");
+        }
+
+        $postednum_str = ($this->postednum == "") ? "NULL" : sprintf("%d", $this->postednum);
+        $project_settings = "
+            username       = '".DPDatabase::escape($this->username)."',
+            nameofwork     = '".DPDatabase::escape(utf8_normalize($this->nameofwork))."',
+            authorsname    = '".DPDatabase::escape(utf8_normalize($this->authorsname))."',
+            language       = '".DPDatabase::escape($this->language)."',
+            genre          = '".DPDatabase::escape($this->genre)."',
+            difficulty     = '".DPDatabase::escape($this->difficulty)."',
+            special_code   = '".DPDatabase::escape($this->special_code)."',
+            clearance      = '".DPDatabase::escape($this->clearance)."',
+            comments       = '".DPDatabase::escape(utf8_normalize($this->comments))."',
+            comment_format = '".DPDatabase::escape($this->comment_format)."',
+            postcomments   = '".DPDatabase::escape(utf8_normalize($this->postcomments))."',
+            postproofer    = '".DPDatabase::escape($this->postproofer)."',
+            ppverifier     = '".DPDatabase::escape($this->ppverifier)."',
+            image_source   = '".DPDatabase::escape($this->image_source)."',
+            scannercredit  = '".DPDatabase::escape($this->scannercredit)."',
+            checkedoutby   = '".DPDatabase::escape($this->checkedoutby)."',
+            postednum      = $postednum_str,
+            image_preparer = '".DPDatabase::escape($this->image_preparer)."',
+            text_preparer  = '".DPDatabase::escape($this->text_preparer)."',
+            extra_credits  = '".DPDatabase::escape(utf8_normalize($this->extra_credits))."',
+            deletion_reason= '".DPDatabase::escape($this->deletion_reason)."',
+            custom_chars   = '".DPDatabase::escape(utf8_normalize($this->custom_chars))."',
+        ";
+
+        // are we creating a new project or updating an existing one?
+        if ($this->projectid) {
+            // Updating an existing project
+
+            // find out what is changing so we can log it
+            $current_values = new Project($this->projectid);
+            $changed_fields = get_changed_fields_for_objects($this, $current_values);
+
+            // If the comments have changed, update t_last_change_comments
+            if (in_array('comments', $changed_fields)) {
+                $project_settings .= "t_last_change_comments = UNIX_TIMESTAMP(),";
+            }
+
+            // We also want to know if the edit is resulting in the project
+            // effectively being checked out to a new PPer. Store the value
+            // for logging after we do the update.
+            if (in_array('checkedoutby', $changed_fields) &&
+                $current_values->state == PROJ_POST_FIRST_CHECKED_OUT) {
+                $project_settings .= "modifieddate = UNIX_TIMESTAMP(),";
+                $PPer_checkout = true;
+            } else {
+                $PPer_checkout = false;
+            }
+
+            $where = sprintf(
+                "WHERE projectid='%s'",
+                DPDatabase::escape($this->projectid)
+            );
+            $sql = "
+                UPDATE projects SET
+                    $project_settings
+                    t_last_edit = UNIX_TIMESTAMP()
+                    $where
+            ";
+            DPDatabase::query($sql);
+
+            // Log the changes
+            $details1 = implode(' ', $changed_fields);
+            if ($details1 == '') {
+                // There are no changed fields.
+
+                // Don't just save '' for the details1 column, because then
+                // do_history() won't be able to distinguish this case (no
+                // changed fields) from old cases (edit occurred before we
+                // started recording changed fields). Instead, use a special value.
+                $details1 = 'NONE';
+            }
+            $this->log_project_event(User::current_username(), 'edit', $details1);
+            if ($PPer_checkout) {
+                // we fake the project transition...
+                $this->project->log_project_event(
+                    User::current_username(),
+                    'transition',
+                    PROJ_POST_FIRST_CHECKED_OUT,
+                    PROJ_POST_FIRST_CHECKED_OUT,
+                    $this->checkedoutby
+                );
+            }
+
+            // Update the MARC record
+            $this->update_marc_record();
+        } else {
+            // Creating a new project
+            $this->projectid = uniqid("projectID"); // The project ID
+
+            // Insert a new row into the projects table
+            $pid_setter = sprintf(
+                "projectid = '%s',",
+                DPDatabase::escape($this->projectid)
+            );
+            $state_setter = sprintf(
+                "state = '%s',",
+                DPDatabase::escape(PROJ_NEW)
+            );
+            $sql = "
+                INSERT INTO projects
+                SET
+                    $pid_setter
+                    $state_setter
+                    $project_settings
+                    t_last_edit = UNIX_TIMESTAMP(),
+                    modifieddate = UNIX_TIMESTAMP(),
+                    t_last_change_comments = UNIX_TIMESTAMP()
+            ";
+            DPDatabase::query($sql);
+
+            // Log that we've created the project
+            $this->log_project_event(User::current_username(), 'creation');
+
+            // Make the project directory
+            if (!mkdir($this->dir, 0777, true)) {
+                throw new RuntimeException("Unable to mkdir '$this->dir'");
+            }
+
+            // Make the project table
+            project_allow_pages($this->projectid);
+
+            // reload the object from the database to pick up initial
+            // values created or assigned from the database
+            $this->_load_from_db($this->projectid);
+        }
     }
 
     public function delete()
@@ -1323,6 +1482,9 @@ class Project
             DPDatabase::escape($this->projectid)
         );
         DPDatabase::query($sql);
+
+        // Update project's Dublin Core file
+        $this->create_dc_xml_oai($marc_record);
     }
 
     // Load the updated MARC record for this project
@@ -1347,6 +1509,32 @@ class Project
         $updated_record->load_yaz_array(unserialize(base64_decode($row["updated_array"])));
 
         return $updated_record;
+    }
+
+    // Update the project's MARC record from the current Project values
+    public function update_marc_record()
+    {
+        $marc_record = $this->load_marc_record();
+
+        // Mapping of Project field names to MARC field names
+        $marc_field_map = [
+            "nameofwork" => "title",
+            "authorsname" => "author",
+            "genre" => "literary_form",
+        ];
+
+        foreach ($marc_field_map as $project_field => $marc_field) {
+            if ($this->$project_field) {
+                $marc_record->$marc_field = $this->$project_field;
+            }
+        }
+
+        // Only pull out the primary language
+        if ($this->languages) {
+            $marc_record->language = langcode3_for_langname($this->languages[0]);
+        }
+
+        $this->save_marc_record($marc_record);
     }
 
     // check if project has entered a formatting round

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -13,9 +13,12 @@ function array_get($arr, $key, $default)
     }
 }
 
-function get_changed_fields_for_objects($new, $old)
+function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
 // Return an array whose values are the names of the properties
 // whose values differ between the two objects $new and $old.
+// If $remove_non_public is true, non-public values are not considered in
+// the comparison and not returned.
+// https://www.php.net/manual/en/language.types.array.php#language.types.array.casting
 {
     $old_as_array = (array)$old;
     $new_as_array = (array)$new;
@@ -26,6 +29,9 @@ function get_changed_fields_for_objects($new, $old)
     $changed_fields = [];
     foreach ($all_keys as $key) {
         if (@$new_as_array[$key] != @$old_as_array[$key]) {
+            if ($remove_non_public && $key[0] == "\0") {
+                continue;
+            }
             $changed_fields[] = $key;
         }
     }

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -129,7 +129,7 @@ function difficulty_list($difficulty_level)
     }
 
     foreach ($difficulty_list as $name => $label) {
-        echo "<label><input type='radio' name='difficulty_level' value='".attr_safe($name)."'";
+        echo "<label><input type='radio' name='difficulty' value='".attr_safe($name)."'";
         if (strtolower($difficulty_level) == $name) {
             echo " CHECKED";
         }
@@ -335,19 +335,4 @@ function description_field($description, $field_name)
     $enc_description = html_safe($description);
 
     echo "<textarea name='$field_name' cols='74' rows='6'>$enc_description</textarea>";
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-// returns an empty string if the possible user exists,
-// otherwise an error message
-function check_user_exists($possible_user, $description)
-{
-    $result = '';
-
-    if (!User::is_valid_user($possible_user)) {
-        $result = sprintf(_("%s must be an existing user - check case and spelling and ensure there is no trailing whitespace."),
-            $description) . "<br>";
-    }
-    return $result;
 }

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -38,11 +38,11 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
             // TRANSLATORS: PM = project manager
             metarefresh(0, "projectmgr.php", _("Save and Go To PM Page"), "");
         } elseif (isset($_POST['saveAndProject'])) {
-            metarefresh(0, "$code_url/project.php?id=$pih->projectid", _("Save and Go To Project"), "");
+            metarefresh(0, "$code_url/project.php?id={$pih->project->projectid}", _("Save and Go To Project"), "");
         }
     }
 
-    if (isset($pih->projectid)) {
+    if (isset($pih->project->projectid)) {
         $page_title = _("Edit a Project");
     } else {
         // we're creating a new project
@@ -57,8 +57,8 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
     output_header($page_title, NO_STATSBAR, $theme_args);
     echo "<h1>$page_title</h1>\n";
 
-    if ($errors != '') {
-        echo "<p class='error'>$errors</p>";
+    if ($errors) {
+        echo "<p class='error'>" . join("<br>", $errors) . "</p>";
     }
 
     $pih->show_form();
@@ -90,7 +90,7 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
 
         case 'clone':
             $page_title = _("Clone a Project");
-            $fatal_error = $pih->set_from_db(false);
+            $fatal_error = $pih->set_from_clone();
             break;
 
         case 'create_from_marc_record':
@@ -100,7 +100,7 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
 
         case 'edit':
             $page_title = _("Edit a Project");
-            $fatal_error = $pih->set_from_db(true);
+            $fatal_error = $pih->set_from_db();
             break;
 
         default:
@@ -130,365 +130,181 @@ class ProjectInfoHolder
     {
         global $pguser, $default_project_char_suites;
 
-        $this->nameofwork = '';
-        $this->authorsname = '';
-        $this->projectmanager = $pguser;
-        $this->checkedoutby = '';
-        $this->language = '';
-        $this->scannercredit = '';
-        $this->comments = '';
-        $this->comment_format = 'markdown';
-        $this->clearance = '';
-        $this->postednum = '';
+        $this->project = new Project();
+        $this->project->username = $pguser;
+        $this->project->image_preparer = $pguser;
+        $this->project->text_preparer = $pguser;
+        $this->project->difficulty = ($pguser == "BEGIN" ? "beginner" : "average");
         $this->charsuites = $default_project_char_suites;
-        $this->genre = '';
-        $this->difficulty_level = ($pguser == "BEGIN" ? "beginner" : "average");
-        $this->special_code = '';
-        $this->image_source = '';
-        $this->image_preparer = $pguser;
-        $this->text_preparer = $pguser;
-        $this->extra_credits = '';
-        $this->deletion_reason = '';
-        $this->custom_chars = '';
-        // $this->year          = '';
-        $this->state = '';
     }
 
     // -------------------------------------------------------------------------
 
     public function set_from_marc_record()
     {
-        global $pguser, $default_project_char_suites;
-
         $encoded_marc_array = array_get($_POST, "rec", "");
         if (!$encoded_marc_array) {
             return sprintf(_("No record selected. If no results are suitable, select '%s' to create the project manually."), _("No Matches"));
         }
 
-        $yaz_array = unserialize(base64_decode($encoded_marc_array));
-        if (!$yaz_array) {
-            return _("Unable to use selected record. Please contact a site administrator.");
-        }
-
-        $marc_record = new MARCRecord();
-        $marc_record->load_yaz_array($yaz_array);
-
-        $this->nameofwork = $marc_record->title;
-        $this->authorsname = $marc_record->author;
-        $this->projectmanager = $pguser;
-        $this->language = $marc_record->language;
-        $this->charsuites = $default_project_char_suites;
-        $this->genre = $marc_record->literary_form;
-
-        $this->checkedoutby = '';
-        $this->scannercredit = '';
-        $this->comments = '';
-        $this->comment_format = 'markdown';
-        $this->clearance = '';
-        $this->postednum = '';
-        $this->difficulty_level = ($pguser == "BEGIN" ? "beginner" : "average");
-        $this->special_code = '';
-        $this->image_source = '';
-        $this->image_preparer = $pguser;
-        $this->text_preparer = $pguser;
-        $this->extra_credits = '';
-        $this->deletion_reason = '';
-        $this->custom_chars = '';
-        $this->state = '';
+        $this->set_from_nothing();
+        $this->project->populate_from_marc_record($encoded_marc_array);
 
         $this->original_marc_array_encd = $encoded_marc_array;
     }
 
     // -------------------------------------------------------------------------
-    // edit an existing project, or create a new project by
-    // cloning an existing project
-    public function set_from_db($edit_existing, $projectid = '')
+
+    public function set_from_clone()
     {
-        if (!isset($_GET['project']) && $projectid == '') {
-            return sprintf(_("parameter '%s' is unset"), 'project');
+        $projectid = $_GET['project'];
+        $this->project = new Project($projectid);
+        $this->clone_projectid = $this->project->projectid;
+
+        // pull the original project's character suites out first
+        $this->charsuites = [];
+        foreach ($this->project->get_charsuites(false) as $project_charsuite) {
+            array_push($this->charsuites, $project_charsuite->name);
         }
 
-        if ($projectid == '') {
-            $projectid = $_GET['project'];
-        }
+        // reset project values that should not be cloned
+        $this->project->projectid = null;
+        $this->project->postednum = '';
+        $this->project->deletion_reason = '';
+        $this->project->state = '';
+    }
+
+    // edit an existing project
+    public function set_from_db()
+    {
+        $projectid = $_GET['project'];
         if ($projectid == '') {
             return sprintf(_("parameter '%s' is empty"), 'project');
         }
         validate_projectID($projectid);
 
         try {
-            $project = new Project($projectid);
+            $this->project = new Project($projectid);
         } catch (NonexistentProjectException $exception) {
             return $exception->getMessage();
         }
 
-        if (!$project->can_be_managed_by_current_user) {
+        if (!$this->project->can_be_managed_by_current_user) {
             return _("You are not authorized to manage this project.").": '$projectid'";
         }
 
-        $this->nameofwork = $project->nameofwork;
-        $this->projectmanager = $project->username;
-        $this->authorsname = $project->authorsname;
-        $this->checkedoutby = $project->checkedoutby;
-        $this->language = $project->language;
-        $this->scannercredit = $project->scannercredit;
-        $this->comments = $project->comments;
-        $this->comment_format = $project->comment_format;
-        $this->clearance = $project->clearance;
-        $this->genre = $project->genre;
-        $this->difficulty_level = $project->difficulty;
-        $this->special_code = $project->special_code;
-        $this->image_source = $project->image_source;
-        $this->image_preparer = $project->image_preparer;
-        $this->text_preparer = $project->text_preparer;
-        $this->extra_credits = $project->extra_credits;
-        if ($edit_existing) {
-            $this->projectid = $project->projectid;
-            $this->deletion_reason = $project->deletion_reason;
-            $this->posted = @$_GET['posted'];
-            $this->postednum = $project->postednum;
-            $this->state = $project->state;
-        } else {
-            // we're cloning, so leave projectid unset
-            $this->postednum = '';
-            $this->deletion_reason = '';
-            $this->clone_projectid = $project->projectid;
-            $this->state = '';
-        }
-        $project_charsuites = $project->get_charsuites(false);
+        // ProjectTransition routes users here when a project is posted to PG
+        $this->posted = @$_GET['posted'];
+
         $this->charsuites = [];
-        foreach ($project_charsuites as $project_charsuite) {
+        foreach ($this->project->get_charsuites(false) as $project_charsuite) {
             array_push($this->charsuites, $project_charsuite->name);
         }
-        $this->custom_chars = $project->custom_chars;
     }
 
     // -------------------------------------------------------------------------
 
     public function set_from_post()
     {
-        $errors = '';
+        global $pguser;
+
+        $errors = [];
 
         if (isset($_POST['projectid'])) {
             $projectid = get_projectID_param($_POST, 'projectid');
-            $this->projectid = $projectid;
 
             try {
-                $project = new Project($projectid);
+                $this->project = new Project($projectid);
             } catch (NonexistentProjectException $exception) {
                 return $exception->getMessage();
             }
 
-            if (!$project->can_be_managed_by_current_user) {
+            if (!$this->project->can_be_managed_by_current_user) {
                 return _("You are not authorized to manage this project.").": '$this->projectid'";
             }
         } elseif (isset($_POST['clone_projectid'])) {
             // we're creating a clone
             $clone_projectid = get_projectID_param($_POST, 'clone_projectid');
             $this->clone_projectid = $clone_projectid;
+
+            $this->set_from_clone($clone_projectid);
+        } else {
+            $this->project = new Project();
         }
 
-        $this->nameofwork = @$_POST['nameofwork'];
-        // we're using preg_match as this field will be space-normalised later
-        if (preg_match('/^\s*$/', $this->nameofwork)) {
-            $errors .= "Title is required.<br>";
+        $fields_to_set = [
+            // username (PM) is handled below
+            "nameofwork",
+            "authorsname",
+            // language is handled below
+            "genre",
+            "difficulty",
+            "special_code",
+            "clearance",
+            "comments",
+            "comment_format",
+            "image_source",
+            "scannercredit",  // deprecated but may exist for older projects
+            "checkedoutby",
+            "postednum",
+            "image_preparer",
+            "text_preparer",
+            "extra_credits",
+            "deletion_reason",
+            "custom_chars",
+        ];
+        foreach ($fields_to_set as $field) {
+            if (isset($_POST[$field])) {
+                $this->project->$field = $_POST[$field];
+            }
         }
 
-        $this->authorsname = @$_POST['authorsname'];
-        if (preg_match('/^\s*$/', $this->authorsname)) {
-            $errors .= "Author is required.<br>";
-        }
-
-        if (user_is_a_sitemanager()) {  // only SAs can change PM
-            $this->projectmanager = @$_POST['username'];
-            if ($this->projectmanager == '') {
-                $errors .= _("Project manager is required.") . "<br>";
+        // only SAs can change PM
+        if (user_is_a_sitemanager()) {
+            $this->project->username = @$_POST['username'];
+        } else {
+            // When cloning a project, the PM should be the same as that of the
+            // project being cloned, if the user isn't an SA
+            if (isset($this->clone_projectid)) {
+                $orig_project = new Project($this->clone_projectid);
+                $this->project->username = $orig_project->username;
             } else {
-                $errors .= check_user_exists($this->projectmanager, 'Project manager');
+                $this->project->username = $pguser;
             }
-            if (empty($errors) && !that_user_is_PM($this->projectmanager)) {
-                // TRANSLATORS: PM = project manager
-                $errors .= sprintf(_("%s is not a PM."), $this->projectmanager) . "<br>";
-            }
-        } else { // it'll be set when we save the info to the db
-            $this->projectmanager = '';
         }
 
-        $pri_language = @$_POST['pri_language'];
-        if ($pri_language == '') {
-            $errors .= _("Primary Language is required.")."<br>";
+        $this->project->languages = [
+            @$_POST['pri_language'], @$_POST['sec_language'],
+        ];
+
+        // some special days are ... specialer
+        if (startswith($this->project->special_code, "Otherday") ||
+            startswith($this->project->special_code, "Birthday")) {
+            $this->project->special_code .= " {$_POST['bdaymonth']}{$_POST['bdayday']}";
         }
 
-        $this->language = Project::encode_languages(
-            [
-                @$_POST['pri_language'], @$_POST['sec_language'],
-            ]
-        );
+        // validate fields managed by the Project class
+        $errors = array_merge($errors, $this->project->validate());
 
+        // set & validate meta fields
         $this->charsuites = [];
         foreach ($_POST['charsuites'] ?? [] as $charsuite) {
             array_push($this->charsuites, $charsuite);
         }
         if (sizeof($this->charsuites) == 0) {
-            $errors .= _("At least one Character Suite is required.")."<br>";
-        }
-
-        $this->genre = @$_POST['genre'];
-        if ($this->genre == '') {
-            $errors .= _("Genre is required.")."<br>";
-        }
-
-        // read post and set up
-
-        $this->image_source = @$_POST['image_source'];
-        if ($this->image_source == '') {
-            $errors .= _("Image Source is required. If the one you want isn't in list, you can propose to add it.")."<br>";
-            $this->image_source = '_internal';
-        }
-
-        /*
-            else
-            {
-                if ($this->image_source == 'OTHER')
-                {
-                    if (empty($_POST['imso_other']))
-                    {
-                        $errors .= "When Image Source is OTHER, details must be supplied.<br>";
-                    }
-                    else
-                    {
-                        $imso_other = $_POST['imso_other'];
-                        $this->image_source = "O:".$imso_other;
-                    }
-                }
-            }
-
-        */
-
-
-        $this->special_code = @$_POST['special_code'];
-        if ($this->special_code != '') {
-            if (startswith($this->special_code, 'Birthday') ||
-                 startswith($this->special_code, 'Otherday')
-            ) {
-                if (empty($_POST['bdayday']) or empty($_POST['bdaymonth'])) {
-                    $errors .= _("Month and Day are required for Birthday or Otherday Specials.")."<br>";
-                } else {
-                    $bdaymonth = $_POST['bdaymonth'];
-                    $bdayday = $_POST['bdayday'];
-                    if (!checkdate($bdaymonth, $bdayday, 2000)) {
-                        $errors .= _("Invalid date supplied for Birthday or Otherday Special.")."<br>";
-                    } else {
-                        if (strlen($this->special_code) == 8) {
-                            $this->special_code .= " ".$bdaymonth.$bdayday;
-                        }
-                    }
-                }
-            }
-        }
-
-        $this->checkedoutby = @$_POST['checkedoutby'];
-        // if it's an existing project, we want to know its state
-        if (isset($this->projectid)) {
-            // Somewhat kludgey to have to do this query here.
-            $sql = sprintf("
-                SELECT state, checkedoutby, username
-                FROM projects
-                WHERE projectid='%s'",
-                DPDatabase::escape($this->projectid)
-            );
-            $res = DPDatabase::query($sql);
-            [$state, $PPer, $PM] = mysqli_fetch_row($res);
-            $this->state = $state;
-
-            // don't allow an empty PPer/PPVer if the project is checked out
-            if (($this->state == PROJ_POST_FIRST_CHECKED_OUT ||
-                   $this->state == PROJ_POST_SECOND_CHECKED_OUT) &&
-                 $this->checkedoutby == '') {
-                $errors .= _("This project is checked out: you must specify a PPer/PPVer");
-                $this->checkedoutby = $PPer;
-            }
-            if ($this->projectmanager == '') {
-                $this->projectmanager = $PM;
-            }
-        } else {
-            $this->state = '';
-        }
-
-        if ($this->checkedoutby != '') {
-            // make sure the named PPer/PPVer actually exists
-            $errors .= check_user_exists($this->checkedoutby, 'PPer/PPVer');
-        }
-
-        $this->image_preparer = @$_POST['image_preparer'];
-        if ($this->image_preparer != '') {
-            $errors .= check_user_exists($this->image_preparer, 'Image Preparer') ;
-        }
-
-        $this->text_preparer = @$_POST['text_preparer'];
-        if ($this->text_preparer != '') {
-            $errors .= check_user_exists($this->text_preparer, 'Text Preparer') ;
-        }
-
-        $this->postednum = @$_POST['postednum'];
-        if ($this->postednum != '') {
-            if (! preg_match('/^[1-9][0-9]*$/', $this->postednum)) {
-                $errors .= sprintf(
-                    _("PG etext number \"%s\" is not of the correct format."),
-                    html_safe($this->postednum)) . "<br>";
-                // Occasionally, there will be a PG ebook that is still
-                // under U.S. copyright. This is indicated in their system
-                // by appending a 'C' to the etext number. The link to
-                // the etext, however, does not include the 'C', nor should
-                // the DP link. If this changes, update the pattern here.
-            }
+            $errors[] = _("At least one Character Suite is required.");
         }
 
         $this->posted = @$_POST['posted'];
         if ($this->posted) {
             // We are in the process of marking this project as posted.
-            if ($this->postednum == '') {
-                $errors .= _("PG etext number is required.")."<br>";
+            if ($this->project->postednum == '') {
+                $errors[] = _("PG etext number is required.");
             }
         }
 
-        $this->custom_chars = utf8_normalize(@$_POST['custom_chars']);
-        if ($this->custom_chars) {
-            $codepoints = utf8_codepoints_combining($this->custom_chars);
-
-            // all characters must be unique
-            if ($codepoints != array_unique($codepoints)) {
-                $errors .= _("The set of custom characters must be unique.")."<br>";
-            }
-
-            // only allow 32 characters
-            if (count($codepoints) > 32) {
-                $errors .= _("A maximum of 32 custom characters are allowed.")."<br>";
-            }
-
-            // prevent disallowed characters from being added
-            $disallowed_codepoints = array_intersect(get_disallowed_codepoints(), $codepoints);
-            if ($disallowed_codepoints != []) {
-                $errors .= sprintf(
-                    _("The following custom characters are not allowed: %s"),
-                    implode(", ", array_map('voku\helper\UTF8::hex_to_chr', $disallowed_codepoints))
-                )."<br>";
-            }
-        }
-
-        $this->scannercredit = @$_POST['scannercredit'];
-        $this->comments = @$_POST['comments'];
-        $this->comment_format = @$_POST['comment_format'];
-        $this->clearance = @$_POST['clearance'];
-        $this->difficulty_level = @$_POST['difficulty_level'];
         $this->original_marc_array_encd = @$_POST['rec'];
-        $this->extra_credits = @$_POST['extra_credits'];
-        $this->deletion_reason = @$_POST['deletion_reason'];
 
-        if ($this->difficulty_level == '') {
-            global $pguser;
-            $this->difficulty_level = ($pguser == "BEGIN" ? "beginner" : "average");
-        }
         return $errors;
     }
 
@@ -496,189 +312,26 @@ class ProjectInfoHolder
 
     public function save_to_db()
     {
-        global $projects_dir, $pguser;
+        global $pguser;
 
-        // enforce postednum being either NULL or a number
-        $postednum_str = ($this->postednum == "") ? "NULL" : sprintf("%d", $this->postednum);
+        // The project should have already passed validation, but confirm
+        // that here just before save.
+        $this->project->validate(true);
 
-        // Call DPDatabase::escape(XX) to escape all strings.
-
-        $common_project_settings = "
-            t_last_edit    = UNIX_TIMESTAMP(),
-            nameofwork     = '".DPDatabase::escape(utf8_normalize($this->nameofwork))."',
-            authorsname    = '".DPDatabase::escape(utf8_normalize($this->authorsname))."',
-            language       = '".DPDatabase::escape($this->language)."',
-            genre          = '".DPDatabase::escape($this->genre)."',
-            difficulty     = '".DPDatabase::escape($this->difficulty_level)."',
-            special_code   = '".DPDatabase::escape($this->special_code)."',
-            clearance      = '".DPDatabase::escape($this->clearance)."',
-            comments       = '".DPDatabase::escape(utf8_normalize($this->comments))."',
-            comment_format = '".DPDatabase::escape($this->comment_format)."',
-            image_source   = '".DPDatabase::escape($this->image_source)."',
-            scannercredit  = '".DPDatabase::escape($this->scannercredit)."',
-            checkedoutby   = '".DPDatabase::escape($this->checkedoutby)."',
-            postednum      = $postednum_str,
-            image_preparer = '".DPDatabase::escape($this->image_preparer)."',
-            text_preparer  = '".DPDatabase::escape($this->text_preparer)."',
-            extra_credits  = '".DPDatabase::escape(utf8_normalize($this->extra_credits))."',
-            deletion_reason= '".DPDatabase::escape($this->deletion_reason)."',
-            custom_chars   = '".DPDatabase::escape(utf8_normalize($this->custom_chars))."'
-        ";
-        $pm_setter = '';
-        if (user_is_a_sitemanager()) {
-            // can change PM
-            $pm_setter = sprintf("
-                username = '%s',
-            ", DPDatabase::escape($this->projectmanager));
-        } elseif (isset($this->clone_projectid)) {
-            // cloning a project. The PM should be the same as
-            // that of the project being cloned, if the user
-            // isn't an SA
-            $sql = sprintf("
-                SELECT username
-                FROM projects
-                WHERE projectid='%s'",
-                DPDatabase::escape($this->clone_projectid)
-            );
-            $res = DPDatabase::query($sql);
-            [$projectmanager] = mysqli_fetch_row($res);
-
-            $pm_setter = sprintf("
-                username = '%s',
-            ", DPDatabase::escape($projectmanager));
-        }
-
-        if (isset($this->projectid)) {
+        if (isset($this->project->projectid)) {
             // We are updating an already-existing project.
-
-            // needn't change $pm_setter, as there is no change if the user
-            // isn't an SA
-
-            // find out what we are changing from
-            $old_pih = new ProjectInfoHolder();
-            $fatal_error = $old_pih->set_from_db(true, $this->projectid);
-            if ($fatal_error != '') {
-                $fatal_error = _('Error') . ': ' . $fatal_error;
-                echo "<p class='error'>$fatal_error</p>";
-                exit;
-            }
-            $changed_fields = get_changed_fields_for_objects($this, $old_pih);
-
-            // We're particularly interested in knowing
-            // when the project comments change.
-            if (!in_array('comments', $changed_fields)) {
-                // no change
-                $tlcc_setter = '';
-            } else {
-                // changed!
-                $tlcc_setter = 't_last_change_comments = UNIX_TIMESTAMP(),';
-            }
-            // We also want to know if the edit is resulting in the project
-            // effectively being checked out to a new PPer
-            if ($old_pih->state == PROJ_POST_FIRST_CHECKED_OUT &&
-                 in_array('checkedoutby', $changed_fields)) {
-                $md_setter = 'modifieddate = UNIX_TIMESTAMP(),';
-                $PPer_checkout = true;
-            } else {
-                $md_setter = '';
-                $PPer_checkout = false;
-            }
-
-            // Update the projects database with the updated info
-            $where = sprintf(
-                "WHERE projectid='%s'",
-                DPDatabase::escape($this->projectid)
-            );
-            $sql = "
-                UPDATE projects SET
-                    $pm_setter
-                    $tlcc_setter
-                    $md_setter
-                    $common_project_settings
-                    $where
-            ";
-            DPDatabase::query($sql);
-
-            $project = new Project($this->projectid);
-            $details1 = implode(' ', $changed_fields);
-
-            if ($details1 == '') {
-                // There are no changed fields.
-
-                // Don't just save '' for the details1 column,
-                // because then do_history() won't be able to distinguish
-                // this case (no changed fields) from old cases
-                // (edit occurred before we started recording changed fields).
-                // Instead, use a special value.
-
-                $details1 = 'NONE';
-            }
-            $project->log_project_event($pguser, 'edit', $details1);
-            if ($PPer_checkout) {
-                // we fake the project transition...
-                $project->log_project_event($pguser, 'transition',
-                                            PROJ_POST_FIRST_CHECKED_OUT,
-                                            PROJ_POST_FIRST_CHECKED_OUT,
-                                            $this->checkedoutby);
-            }
-
-            // Update the MARC record with any info we've received.
-            $marc_record = $project->load_marc_record();
-            $this->update_marc_record_from_post($marc_record);
-            $project->save_marc_record($marc_record);
+            $this->project->save();
         } else {
-            // We are creating a new project
-            $this->projectid = uniqid("projectID"); // The project ID
-
-            if ('' == $pm_setter) {
-                $pm_setter = "username = '$pguser',";
-            }
-
-            // Insert a new row into the projects table
-            $pid_setter = sprintf(
-                "projectid = '%s',",
-                DPDatabase::escape($this->projectid)
-            );
-            $state_setter = sprintf(
-                "state = '%s',",
-                DPDatabase::escape(PROJ_NEW)
-            );
-            $sql = "
-                INSERT INTO projects
-                SET
-                    $pid_setter
-                    $pm_setter
-                    $state_setter
-                    modifieddate = UNIX_TIMESTAMP(),
-                    t_last_change_comments = UNIX_TIMESTAMP(),
-                    postcomments = '',
-                    $common_project_settings
-            ";
-            DPDatabase::query($sql);
-
-            $project = new Project($this->projectid);
-            $project->log_project_event($pguser, 'creation');
-
-            project_allow_pages($this->projectid);
-
-            // Make a directory in the projects_dir for this project
-            mkdir("$projects_dir/$this->projectid", 0777) or die("System error: unable to mkdir '$projects_dir/$this->projectid'");
-            chmod("$projects_dir/$this->projectid", 0777);
-
-
-            // Do MARC record manipulations
-            $project = new Project($this->projectid);
-            $marc_record = new MARCRecord();
+            // We're creating a new project
+            $this->project->save();
 
             // Save original MARC record, if provided
             $yaz_array = unserialize(base64_decode($this->original_marc_array_encd));
             if ($yaz_array !== false) {
+                $marc_record = new MARCRecord();
                 $marc_record->load_yaz_array($yaz_array);
-                $project->init_marc_record($marc_record);
-
-                // Update the MARC record with data from POST
-                $this->update_marc_record_from_post($marc_record);
-                $project->save_marc_record($marc_record);
+                $this->project->init_marc_record($marc_record);
+                $this->project->update_marc_record();
             }
 
             // Create the project's 'good word list' and 'bad word list'.
@@ -699,31 +352,17 @@ class ProjectInfoHolder
                     echo "$bad_words<br>\n";
                     $bad_words = [];
                 }
-            } else {
-                // We're creating a project by means other than cloning
-                // (from_nothing, from_marc_record).
-                // Initialize its GWL and BWL to empty.
 
-                $good_words = [];
-                $bad_words = [];
+                save_project_good_words($this->project->projectid, $good_words);
+                save_project_bad_words($this->project->projectid, $bad_words);
             }
-
-            save_project_good_words($this->projectid, $good_words);
-            save_project_bad_words($this->projectid, $bad_words);
         }
 
-        // Create/update the Dublin Core file for the project.
-        // When we get here, the project's database entry has been fully
-        // updated, so we can create a Project object and allow it
-        // to pull the relevant fields from the database.
-        $project = new Project($this->projectid);
-        $project->create_dc_xml_oai($marc_record);
-
-        $project->set_charsuites($this->charsuites);
+        $this->project->set_charsuites($this->charsuites);
 
         // If the project has been posted to PG, make the appropriate transition.
         if ($this->posted) {
-            $err = project_transition($this->projectid, PROJ_SUBMIT_PG_POSTED, $pguser);
+            $err = project_transition($this->project->projectid, PROJ_SUBMIT_PG_POSTED, $pguser);
             if ($err != '') {
                 echo "$err<br>\n";
                 exit;
@@ -771,13 +410,13 @@ class ProjectInfoHolder
         if (!empty($this->posted)) {
             echo "<input type='hidden' name='posted' value='1'>";
         }
-        if (!empty($this->projectid)) {
-            echo "<input type='hidden' name='projectid' value='$this->projectid'>";
+        if (!empty($this->project->projectid)) {
+            echo "<input type='hidden' name='projectid' value='{$this->project->projectid}'>";
         }
         if (!empty($this->clone_projectid)) {
             echo "<input type='hidden' name='clone_projectid' value='$this->clone_projectid'>";
         }
-        echo "<input type='hidden' name='comment_format' value='$this->comment_format'>";
+        echo "<input type='hidden' name='comment_format' value='{$this->project->comment_format}'>";
         echo "<input type='hidden' name='return' value='$return'>";
     }
 
@@ -791,71 +430,71 @@ class ProjectInfoHolder
 
         $can_edit_PPer = true;
         $is_checked_out = false;
-        if (!empty($this->projectid)) {
-            $this->row(_("Project ID"), 'just_echo', $this->projectid);
+        if (!empty($this->project->projectid)) {
+            $this->row(_("Project ID"), 'just_echo', $this->project->projectid);
 
             // do some things that depend on the project state
-            if ($this->state == PROJ_DELETE) {
-                $this->row(_("Reason for Deletion"), 'text_field', $this->deletion_reason, 'deletion_reason');
-            } elseif ($this->state == PROJ_POST_FIRST_CHECKED_OUT) {
+            if ($this->project->state == PROJ_DELETE) {
+                $this->row(_("Reason for Deletion"), 'text_field', $this->project->deletion_reason, 'deletion_reason');
+            } elseif ($this->project->state == PROJ_POST_FIRST_CHECKED_OUT) {
                 // once the project is in PP, PPer can only be changed by an SA, PF,
                 // or if it's checked out to the PM
                 $is_checked_out = true;
-                $can_edit_PPer = (($this->projectmanager == $this->checkedoutby) ||
+                $can_edit_PPer = (($this->project->username == $this->project->checkedoutby) ||
                                    user_is_a_sitemanager() ||
                                    user_is_proj_facilitator());
-            } elseif ($this->state == PROJ_POST_SECOND_CHECKED_OUT) {
+            } elseif ($this->project->state == PROJ_POST_SECOND_CHECKED_OUT) {
                 $is_checked_out = true;
                 $can_edit_PPer = user_is_a_sitemanager();
             }
         }
-        $this->row(_("Title"), 'text_field', $this->nameofwork, 'nameofwork', '', ["maxlength" => 255, "required" => true]);
-        $this->row(_("Author"), 'text_field', $this->authorsname, 'authorsname', '', ["maxlength" => 255, "required" => true]);
+        $this->row(_("Title"), 'text_field', $this->project->nameofwork, 'nameofwork', '', ["maxlength" => 255, "required" => true]);
+        $this->row(_("Author"), 'text_field', $this->project->authorsname, 'authorsname', '', ["maxlength" => 255, "required" => true]);
         if (user_is_a_sitemanager()) {
             // SAs are the only ones who can change this
-            $this->row(_("Project Manager"), 'DP_user_field', $this->projectmanager, 'username', sprintf(_("%s username only."), $site_abbreviation), ["required" => true]);
+            $this->row(_("Project Manager"), 'DP_user_field', $this->project->username, 'username', sprintf(_("%s username only."), $site_abbreviation), ["required" => true]);
         }
-        $this->row(_("Language"), 'language_list', $this->language);
+        $this->row(_("Language"), 'language_list', $this->project->language);
 
         $project_charsuites = [];
-        if (isset($this->projectid)) {
-            $project = new Project($this->projectid);
-            $project_charsuites = $project->get_charsuites(false);
+        if (isset($this->project->projectid)) {
+            $project_charsuites = $this->project->get_charsuites(false);
         }
         $this->row(_("Character Suites"), 'charsuite_list', $this->charsuites, $project_charsuites);
-        $this->row(_("Custom Characters"), 'text_field', $this->custom_chars, 'custom_chars');
+        $this->row(_("Custom Characters"), 'text_field', $this->project->custom_chars, 'custom_chars');
 
-        $this->row(_("Genre"), 'genre_list', $this->genre);
+        $this->row(_("Genre"), 'genre_list', $this->project->genre);
 
-        if ($this->difficulty_level == "beginner" && !$can_set_difficulty_tofrom_beginner) {
+        if ($this->project->difficulty == "beginner" && !$can_set_difficulty_tofrom_beginner) {
             // allow PF to edit a BEGIN project, but without altering the difficulty
             $this->row(_("Difficulty"), 'just_echo', _("Beginner"));
-            echo "<input type='hidden' name='difficulty_level' value='$this->difficulty_level'>";
+            echo "<input type='hidden' name='difficulty' value='$this->project->difficulty'>";
         } else {
-            $this->row(_("Difficulty"), 'difficulty_list', $this->difficulty_level);
+            $this->row(_("Difficulty"), 'difficulty_list', $this->project->difficulty);
         }
-        $this->row(_("Special Day"), 'special_list', $this->special_code);
+        $this->row(_("Special Day"), 'special_list', $this->project->special_code);
         if ($can_edit_PPer) {
-            $this->row(_("PPer/PPVer"), 'DP_user_field', $this->checkedoutby, 'checkedoutby', sprintf(_("Optionally reserve for a PPer. %s username only."), $site_abbreviation));
+            $this->row(_("PPer/PPVer"), 'DP_user_field', $this->project->checkedoutby, 'checkedoutby', sprintf(_("Optionally reserve for a PPer. %s username only."), $site_abbreviation));
         } else {
-            $this->row(_("PPer/PPVer"), 'just_echo', $this->checkedoutby);
+            $this->row(_("PPer/PPVer"), 'just_echo', $this->project->checkedoutby);
             echo "<input type='hidden' name='checkedoutby' value='$this->checkedoutby'>";
         }
-        $this->row(_("Image Source"), 'image_source_list', $this->image_source);
-        $this->row(_("Image Preparer"), 'DP_user_field', $this->image_preparer, 'image_preparer', sprintf(_("%s user who scanned or harvested the images."), $site_abbreviation));
-        $this->row(_("Text Preparer"), 'DP_user_field', $this->text_preparer, 'text_preparer', sprintf(_("%s user who prepared the text files."), $site_abbreviation));
+        $this->row(_("Image Source"), 'image_source_list', $this->project->image_source);
+        $this->row(_("Image Preparer"), 'DP_user_field', $this->project->image_preparer, 'image_preparer', sprintf(_("%s user who scanned or harvested the images."), $site_abbreviation));
+        $this->row(_("Text Preparer"), 'DP_user_field', $this->project->text_preparer, 'text_preparer', sprintf(_("%s user who prepared the text files."), $site_abbreviation));
         $this->row(_("Extra Credits<br>(to be included in list of names--no URLs)"),
-                                               'extra_credits_field', $this->extra_credits, null, '', '', true);
-        if ($this->scannercredit != '') {
-            $this->row(_("Scanner Credit (deprecated)"), 'text_field', $this->scannercredit, 'scannercredit');
+                                               'extra_credits_field', $this->project->extra_credits, null, '', '', true);
+        if ($this->project->scannercredit != '') {
+            $this->row(_("Scanner Credit (deprecated)"), 'text_field', $this->project->scannercredit, 'scannercredit');
         }
-        $this->row(_("Clearance Line"), 'text_field', $this->clearance, 'clearance');
-        $this->row(_("PG etext number"), 'text_field', $this->postednum, 'postednum', '', ["type" => "number"]);
-        $this->row(_("Project Comments Format"), 'proj_comments_format', $this->comment_format);
-        $this->row(_("Project Comments"), 'proj_comments_field', $this->comments);
+        $this->row(_("Clearance Line"), 'text_field', $this->project->clearance, 'clearance');
+        $this->row(_("PG etext number"), 'text_field', $this->project->postednum, 'postednum', '', ["type" => "number"]);
+        $this->row(_("Project Comments Format"), 'proj_comments_format', $this->project->comment_format);
+        $this->row(_("Project Comments"), 'proj_comments_field', $this->project->comments);
+
         // don't show the word list line if we're in the process of cloning
-        if (!empty($this->projectid)) {
-            $this->row(_("Project Dictionary"), 'word_lists', null, null, '', $this->projectid);
+        if (!empty($this->project->projectid)) {
+            $this->row(_("Project Dictionary"), 'word_lists', null, null, '', $this->project->projectid);
         }
     }
 
@@ -879,7 +518,7 @@ class ProjectInfoHolder
     public function preview()
     {
         // insert e.g. templates and biographies
-        $comments = parse_project_comments($this);
+        $comments = parse_project_comments($this->project);
 
         $a = _("The Guidelines give detailed instructions for working in this round.");
         $b = _('The instructions below are particular to this project, and <b>take precedence over those guidelines</b>.');
@@ -890,11 +529,11 @@ class ProjectInfoHolder
         echo "<h2 id='preview'>", _("Preview Project"), "</h2>";
         echo "<p>", _("This is a preview of your project and roughly how it will look to the proofreaders."), "</p>\n";
         echo "<table class='basic'>";
-        echo "<tr><th>", _("Title"), "</th><td>", html_safe($this->nameofwork), "</td></tr>\n";
-        echo "<tr><th>", _("Author"), "</th><td>", html_safe($this->authorsname), "</td></tr>\n";
+        echo "<tr><th>", _("Title"), "</th><td>", html_safe($this->project->nameofwork), "</td></tr>\n";
+        echo "<tr><th>", _("Author"), "</th><td>", html_safe($this->project->authorsname), "</td></tr>\n";
         if (user_is_a_sitemanager()) {
             // SAs are the only ones who can change this.
-            echo "<tr><th>", _("Project Manager"), "</th><td>", $this->projectmanager, "</td></tr>\n";
+            echo "<tr><th>", _("Project Manager"), "</th><td>", $this->project->username, "</td></tr>\n";
         }
         echo "<tr><th>", _("Last Proofread"), "</th><td>$now</td></tr>\n";
         echo "<tr><th>", _("Forum"), "</th><td>", _("Start a discussion about this project"), "</td></tr>\n";
@@ -916,30 +555,9 @@ class ProjectInfoHolder
     // In the project's text fields, replace sequences of space characters
     // with a unique space, and trim beginning and end space
     {
-        $this->nameofwork = preg_replace('/\s+/', ' ', trim($this->nameofwork));
-        $this->authorsname = preg_replace('/\s+/', ' ', trim($this->authorsname));
-        $this->clearance = preg_replace('/\s+/', ' ', trim($this->clearance));
-        $this->extra_credits = preg_replace('/\s+/', ' ', trim($this->extra_credits));
-    }
-
-    // Updates the *passed in* MARCRecord from $_POST
-    public function update_marc_record_from_post(&$marc_record)
-    {
-        //Update the Name of Work
-        if (!empty($_POST['nameofwork'])) {
-            $marc_record->title = $_POST['nameofwork'];
-        }
-
-        //Update the Authors Name
-        if (!empty($_POST['authorsname'])) {
-            $marc_record->author = $_POST['authorsname'];
-        }
-
-        //Update the Primary Language
-        $curr_lang = langcode3_for_langname($_POST['pri_language']);
-        $marc_record->language = $curr_lang;
-
-        //Update the Genre
-        $marc_record->literary_form = $_POST['genre'];
+        $this->project->nameofwork = preg_replace('/\s+/', ' ', trim($this->project->nameofwork));
+        $this->project->authorsname = preg_replace('/\s+/', ' ', trim($this->project->authorsname));
+        $this->project->clearance = preg_replace('/\s+/', ' ', trim($this->project->clearance));
+        $this->project->extra_credits = preg_replace('/\s+/', ' ', trim($this->project->extra_credits));
     }
 }


### PR DESCRIPTION
This is the big PR that all of the prior ones have been leading up to, and despite those smaller ones prior this is still a big one.

The overarching goal is to move the code that creates and updates project info from the `editproject.php` page to the `Project` class so it can be used both by the UI and the API. Indeed, I have a branch that builds on top of this one that adds project create and update code to the API.

I've added unit tests which cover basic project create, update, and delete functionality but the original Edit Project page is rife with interesting corner cases based on who is doing the editing (PM or SA) and testing this is going to be challenging. I've done a fair amount of testing already but I'd like a lot of eyes on this. If I've done my job right, this should behave virtually identical to what's currently live on TEST and any discrepancy is notable. (I say virtually because my branch keeps the project's Dublin Core file up-to-date on every project edit which was not happening before.)

Interesting use cases:
* As a PM:
  * Create a project from LoC search results
  * Create a project from scratch
  * Clone a project owned by the PM
  * Clone a project owned by another PM
  * Edit a project
* As an SA:
  * Create a project from scratch
  * Clone a project
  * Edit a project

This is available in the [project-save](https://www.pgdp.org/~cpeel/c.branch/project-save/) sandbox.

## A note on `ProjectInfoHolder`
In the original design, `ProjectInfoHolder` holds all project info as the project is edited. In the new model, `ProjectInfoHolder` object has a proper `Project` object (`$this->project`) that holds all of the first-level project information and is used to validate and save the data. `ProjectInfoHolder` still manages meta-level information (is the project posted, original cloned project id) and second-level project information (character suites, etc). This is why many of the changes to that file are changing `$this->blah` to `$this->project->blah`.

One of the things this changes is the names of the changed fields stored in the `project_events` table on edit. The `ProjectInfoHolder` class was used prior to calculate the field names and those fields don't all exactly match up to the ones in the `Project` class. 

Of note:
```txt
# ProjectInfoHolder name  => Project name
difficulty_level          => difficulty
projectmanager            => username
```

This means that going forward the Project field names will be used. The history on the Project page will show the proper name for both old and new fields but the database will use different values. This also means that only changes to first-level project fields will be recorded. Most notably this does not include a project's character suites since they are second-level fields.