### PR TITLE
Restrict access to the shared postednums script

### DIFF
--- a/tools/site_admin/shared_postednums.php
+++ b/tools/site_admin/shared_postednums.php
@@ -4,8 +4,13 @@ include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'dpsql.inc');
+include_once($relPath.'user_is.inc');
 
 require_login();
+
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
 
 slim_header("Same postednum");
 


### PR DESCRIPTION
The script is somewhat resource intensive, and only site admins are able to deal with any new issues as they occur (and probably should have been restricted to SAs all along).

Testable: [restrict-dup-posteds](https://www.pgdp.org/~srjfoo/c.branch/restrict-dup-posteds).