### PR TITLE
Local regex

### DIFF
--- a/SETUP/tests/jsTests/characterValidation.js
+++ b/SETUP/tests/jsTests/characterValidation.js
@@ -1,45 +1,45 @@
-/* global QUnit testText makeValidCharRegex */
-/* exported validCharRegex */
+/* global QUnit testText */
+/* exported validCharacterPattern */
 
-var validCharRegex;
+var validCharacterPattern;
 
 QUnit.module("Character validation test", function() {
 
     let basicLatin = "^(?:[\n\r -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$";
 
     QUnit.test("In basic latin basic latin character is valid", function (assert) {
-        validCharRegex = makeValidCharRegex(basicLatin);
+        validCharacterPattern = basicLatin;
         assert.strictEqual(testText("abc"), true);
     });
 
     QUnit.test("In basic latin tabulate character is invalid", function (assert) {
-        validCharRegex = makeValidCharRegex(basicLatin);
+        validCharacterPattern = basicLatin;
         assert.strictEqual(testText("\tabc"), false);
     });
 
     QUnit.test("In basic latin Greek Α is invalid", function (assert) {
-        validCharRegex = makeValidCharRegex(basicLatin);
+        validCharacterPattern = basicLatin;
         assert.strictEqual(testText("Αabc"), false);
     });
 
     QUnit.test("In basic latin Astral char. is invalid", function (assert) {
-        validCharRegex = makeValidCharRegex(basicLatin);
+        validCharacterPattern = basicLatin;
         assert.strictEqual(testText("ab\u{1F702}c"), false);
     });
 
     QUnit.test("In basic latin A with combining diaresis is valid when normalised, b is not", function (assert) {
-        validCharRegex = makeValidCharRegex(basicLatin);
+        validCharacterPattern = basicLatin;
         assert.strictEqual(testText("a\u0308bc"), true);
         assert.strictEqual(testText("ab\u0308c"), false);
     });
 
     QUnit.test("In basic Greek, Greek Α is valid", function (assert) {
-        validCharRegex = makeValidCharRegex("^(?:[\n\rΑ-ΡΣ-Ωα-ω -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$");
+        validCharacterPattern = "^(?:[\n\rΑ-ΡΣ-Ωα-ω -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$";
         assert.strictEqual(testText("Αabc"), true);
     });
 
     QUnit.test("characters with combining marks", function (assert) {
-        validCharRegex = makeValidCharRegex("^(?:S̤|T̤|Z̤|s̤|t̤|z̤|[\n\r Ā-āĒ-ēĪ-īŌ-ōŚ-śŠ-šŪ-ūʾ-ʿḌ-ḍḤ-ḥḪ-ḫḲ-ḳḷḹṀ-ṇṚ-ṝṢ-ṣṬ-ṭẒ-ẖ])$");
+        validCharacterPattern = "^(?:S̤|T̤|Z̤|s̤|t̤|z̤|[\n\r Ā-āĒ-ēĪ-īŌ-ōŚ-śŠ-šŪ-ūʾ-ʿḌ-ḍḤ-ḥḪ-ḫḲ-ḳḷḹṀ-ṇṚ-ṝṢ-ṣṬ-ṭẒ-ẖ])$";
         assert.strictEqual(testText("S\u0324"), true); // S with macron below
         assert.strictEqual(testText("U\u0324"), false); // U with macron below
         assert.strictEqual(testText("\u1e72"), false); // U with macron below normalised
@@ -48,7 +48,7 @@ QUnit.module("Character validation test", function() {
     });
 
     QUnit.test("Astral plane", function (assert) {
-        validCharRegex = makeValidCharRegex("^(?:[\n\r 𓀀-𓀂])$");
+        validCharacterPattern = "^(?:[\n\r 𓀀-𓀂])$";
         assert.strictEqual(testText("𓀀"), true);
         assert.strictEqual(testText("\u{13000}"), true);
         assert.strictEqual(testText("𓀂"), true);

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -30,7 +30,6 @@ $valid_character_pattern = build_character_regex_filter($quiz->get_valid_codepoi
 
 $header_args = [
     "js_files" => [
-        "$code_url/scripts/character_test.js",
         "$code_url/tools/proofers/process_diacritcal_markup.js",
     ],
     "js_data" => "

--- a/scripts/character_test.js
+++ b/scripts/character_test.js
@@ -1,37 +1,22 @@
-/*global $ validCharacterPattern XRegExp */
+/*global validCharacterPattern XRegExp */
 /* exported testText */
 
-// regex unicode property escape is supported in Chrome and Safari (Feb 2020)
-// but not in Firefox or Edge. Use 3rd party http://xregexp.com/ instead
+// regex unicode property escape is supported in Chrome 64, Safari 11.1
+// Firefox 78, Edge 79, Opera 51. Use 3rd party http://xregexp.com/ instead
 
 // this matches any character: non-mark codepoint followed by 0 or more marks
 const charMatch = XRegExp("\\PM\\pM*", "Ag");
 
-// this regular expression (constructed below) matches individual good characters
-var validCharRegex;
-
-function makeValidCharRegex(characterPattern) {
-    // need the u flag for Astral plane characters.
-    return XRegExp(characterPattern, "Au");
-}
-
-$(function () {
-    // need to define this after the page has loaded so validCharacterPattern
-    // is available
-    validCharRegex = makeValidCharRegex(validCharacterPattern);
-});
-
-function testChar(character) {
-    return validCharRegex.test(character);
-}
-
 // return false if text contains any bad characters
 function testText(text) {
+    // this regular expression matches individual good characters
+    // unicode support in Chrome 50, Edge 12, Firefox 46, Safari 10, Opera 37
+    let validCharRegex = new RegExp(validCharacterPattern, "u");
     text = text.normalize("NFC");
     let result;
     charMatch.lastIndex = 0;
     while(null != (result = charMatch.exec(text))) {
-        if(!testChar(result[0])) {
+        if(!validCharRegex.test(result[0])) {
             return false;
         }
     }

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -1,4 +1,4 @@
-/*global $ charMatch testChar */
+/*global $ validCharacterPattern charMatch */
 /* exported validateText */
 
 // charMatch (constructed in character_test.js) matches any unicode character
@@ -25,13 +25,14 @@ var validateText;
 
 $(function () {
     var textArea = document.getElementById("text_data");
+    let validCharRegex = new RegExp(validCharacterPattern, "u");
 
     // check each character, if bad mark or remove it
     function processText(text, clean) {
         var bad = false;
 
         function charReplacer(match) {
-            if(testChar(match)) {
+            if(validCharRegex.test(match)) {
                 return match;
             }
             if(clean) {

--- a/tools/proofers/process_diacritcal_markup.js
+++ b/tools/proofers/process_diacritcal_markup.js
@@ -77,10 +77,6 @@ $(function () {
                 maybeSubstitute();
                 return;
             }
-            // IE HACK - IE11 does not support string normalization
-            if(!(String.prototype.normalize)) {
-                return;
-            }
             let char1 = text[char1Index];
             let char2 = text[endIndex - 2];
             var code = above[char1];

--- a/tools/proofers/process_diacritcal_markup.js
+++ b/tools/proofers/process_diacritcal_markup.js
@@ -1,7 +1,8 @@
-/*global $ testChar */
+/*global $ validCharacterPattern */
 
 $(function () {
     var textArea = document.getElementById("text_data");
+    let validCharRegex = new RegExp(validCharacterPattern, "u");
 
     var above = {
         "=": "\u0304", // macron
@@ -54,7 +55,7 @@ $(function () {
         function maybeSubstitute() {
             // if replaceChar is good use it
             // this uses the local variables of the containing function
-            if(testChar(replaceChar)) {
+            if(validCharRegex.test(replaceChar)) {
                 // replace markup with character and move caret back 4 places
                 // and forward by length of replaceChar
                 let newCaret = char0Index + replaceChar.length;


### PR DESCRIPTION
make validCharRegex when needed and use native javascript to make validCharRegex since unicode regex now in supported browsers. So don't need $(document).ready() in character_test.js which causes a problem in unit tests if another test uses promises.