### PR TITLE
make DPDatabase::affected_rows() function

### DIFF
--- a/crontab/onoff_special_event_queues.php
+++ b/crontab/onoff_special_event_queues.php
@@ -107,7 +107,7 @@ foreach (['open', 'close'] as $which) {
         if (!$testing_this_script) {
             mysqli_query(DPDatabase::get_connection(), $update_query) or die(DPDatabase::log_error());
 
-            $n = mysqli_affected_rows(DPDatabase::get_connection());
+            $n = DPDatabase::affected_rows();
             echo "
                 $n queues $which'd.
             ";

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -86,6 +86,11 @@ final class DPDatabase
         return $result;
     }
 
+    public static function affected_rows()
+    {
+        return  mysqli_affected_rows(self::$_connection);
+    }
+
     public static function log_error($backtrace_level = 0)
     {
         // Log the SQL error to the PHP error log and return a generic error

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -166,7 +166,7 @@ function move_project_rows_to_archive_db($projectid, $table_name, $indent, $dry_
         FROM $table_name
         WHERE projectid='$projectid'
     ") or die(DPDatabase::log_error());
-    $n_copied = mysqli_affected_rows(DPDatabase::get_connection());
+    $n_copied = DPDatabase::affected_rows();
     echo sprintf("%4d rows copied", $n_copied);
 
     if ($n_copied == 0) {
@@ -179,7 +179,7 @@ function move_project_rows_to_archive_db($projectid, $table_name, $indent, $dry_
         FROM $table_name
         WHERE projectid='$projectid'
     ") or die(DPDatabase::log_error());
-    $n_deleted = mysqli_affected_rows(DPDatabase::get_connection());
+    $n_deleted = DPDatabase::affected_rows();
     if ($n_deleted == $n_copied) {
         echo " and deleted";
     } else {

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -591,7 +591,7 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
         echo html_safe($query) . "\n";
         if ($for_real) {
             DPDatabase::query($query);
-            $n = mysqli_affected_rows(DPDatabase::get_connection());
+            $n = DPDatabase::affected_rows();
             echo sprintf(_("%d rows inserted."), $n) . "\n";
             if ($n != 1) {
                 die("unexpected number of rows inserted");
@@ -652,7 +652,7 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
         echo "<code>" . html_safe($query) . "</code>";
         if ($for_real) {
             DPDatabase::query($query);
-            $n = mysqli_affected_rows(DPDatabase::get_connection());
+            $n = DPDatabase::affected_rows();
             echo "<p>" . sprintf(_("%d rows updated."), $n) . "</p>\n";
         }
     }

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -350,7 +350,7 @@ switch ($submit_button) {
                 echo $query;
                 if ($for_real) {
                     mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
-                    $n = mysqli_affected_rows(DPDatabase::get_connection());
+                    $n = DPDatabase::affected_rows();
                     echo "
                         $n rows affected.
                     ";


### PR DESCRIPTION
Make DPDatabase::affected_rows() function and use it in existing code before new use.
The changed files have other database functions that could be updated. Should I do this in this branch to avoid them being in a partially updated state?

Sandbox at https://www.pgdp.org/~rp31/c.branch/affected_rows_function

I don't know why making less is needed to avoid erroring.