### PR TITLE
Prepare for the R202202 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,11 +7,19 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
-## R??????
+## R202202
 Scripts supporting this upgrade are in `SETUP/upgrade/17`
 
-* Removed jpgraph and GD dependencies (chrismiceli)
+**This is the last release to include support for the incomplete Metadata
+and Corrections features.**
+
+* Improved security for session cookies (chrismiceli)
 * Graphs now rendered via client-side Javascript as themed SVGs (chrismiceli)
+* Removed jpgraph and GD dependencies (chrismiceli)
+* Image Browser improvements (70ray)
+* Format Preview footnote improvements (70ray)
+* DP API additions: character suites, special days, image sources (cpeel)
+* Minor code speed optimizations (cpeel)
 * Updated minimum browser versions, see [INSTALL.md](INSTALL.md).
 
 ## R202109

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -100,11 +100,18 @@ Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/15/
 * c/SETUP/upgrade/16/
+* c/SETUP/upgrade/17/
 
 ### Upgrading from release R202102
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/16/
+* c/SETUP/upgrade/17/
+
+### Upgrading from release R202109
+Run the scripts in the following directories in order
+
+* c/SETUP/upgrade/17/
 
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.


### PR DESCRIPTION
This prepares for the upcoming R202202 release. I've updated the changelog with the notable changes I'm aware of after reviewing the git log since R202109. Devs, what have I missed?

Of note, this includes a message in the changelog about removing the code for the incomplete metadata and corrections features in the future.