### PR TITLE
Fix autorelease logic

### DIFF
--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -24,16 +24,16 @@ function attempt_to_release($round, $project, $queue_name)
 {
     $projectid = $project['projectid'];
 
-    $errors = project_pre_release_check($project, $round);
+    $project_obj = new Project($projectid);
+    $errors = project_pre_release_check($project_obj, $round);
 
     if ($errors) {
-        $project = new Project($projectid);
-        configure_gettext_for_user($project->username);
+        configure_gettext_for_user($project_obj->username);
         $body_blurb_messages[] = _("Some errors have been found:");
-        $body_blurb_messages[] = $errors;
+        $body_blurb_messages[] = implode("\n", $errors);
         $body_blurb_messages[] = _("Please correct the errors and put the project back into Waiting for Release.");
         $body_blurb = implode("\n", $body_blurb_messages);
-        maybe_mail_project_manager($project, $body_blurb, _("Errors Before Release"));
+        maybe_mail_project_manager($project_obj, $body_blurb, _("Errors Before Release"));
         $new_state = $round->project_bad_state;
     } else {
         $new_state = $round->project_available_state;


### PR DESCRIPTION
There was a bug in `attempt_to_release()` when called from `automodify.php` where it was passed a `$project` array but was expecting a `$project` *object*. This caused `project_pre_release_check()` to return an error (because it, too, was expecting an object). This resulted in every evaluated project being flagged as bad, and an email sent to the PM.

This creates the necessary project object for `project_pre_release_check()` and use in the error case for the emails as well.

This is the code code is hotfixed on PROD.