### PR TITLE
correction to new URL() function

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -2,7 +2,7 @@
 /* exported ajax */
 
 function ajax(method, apiUrl, queryParams = {}, data = {}, fetchPromise = fetch) {
-    let url = new URL("/api/index.php", codeUrl);
+    let url = new URL(codeUrl + "/api/index.php");
     let searchParams = new URLSearchParams();
     searchParams.append("url", apiUrl);
     for (const key in queryParams) {


### PR DESCRIPTION
Everything except the 'base' is removed from the 2nd parameter
which is not what we want, but it works if by accessing the site origin, not the snadbox.