### PR TITLE
Enable project creation and update via the API

### DIFF
--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -76,14 +76,20 @@ HTTP status code with the JSON body:
 
 ## Pagination
 
-Some requests, like project searches, may return paginated results. Paginated
-responses will include the following HTTP headers to assist with navigating the
-result set:
+Some requests, like project searches, may return paginated results in the
+format of [RFC-8288](https://datatracker.ietf.org/doc/html/rfc8288) -- the same
+format used by GitHub APIs. The GitHub REST API docs include a great guide on
+[traversing with pagination](https://docs.github.com/en/rest/guides/traversing-with-pagination)
+using this format.
 
-* `X-Results-Total` - total number of entries available in the query set
-* `Link` - links to walk through the paginated results.
+Paginated responses will include the following HTTP headers:
 
-The `Link` format looks like (lines wrapped here for readability):
+* `X-Results-Total` - total number of entries available in the result set
+* `Link` - links to walk through the paginated results
+
+The `Link` header includes URLs labeled with metadata that can be used by
+clients to navigate the result set. The format looks like (lines wrapped here
+for readability):
 ```
 Link: <https://www.pgdp.org/api/v1/projects?per_page=20&page=1>; rel="first",
       <https://www.pgdp.org/api/v1/projects?per_page=20&page=2>; rel="next",

--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -153,6 +153,23 @@ curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/word
     -H "X-API-KEY: $API_KEY"
 ```
 
+Update the project's good wordlist with an entirely new set:
+
+```bash
+curl -i -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
+    -H "Content-Type: application/json" \
+    -H "X-API-KEY: $API_KEY" \
+    -d @data.json
+```
+
+Where `data.json` contains the new word list:
+```json
+[
+    "word1",
+    "word2"
+]
+```
+
 ### Project updates
 
 Update details about a specific project:

--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -121,7 +121,7 @@ curl -i -X GET "https://www.pgdp.org/api/v1/projects?title=Monster" \
 
 ### Project details
 
-Load details about a specific project:
+Get details about a specific project:
 
 ```bash
 curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
@@ -151,6 +151,48 @@ Get the good wordlist for a project:
 curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
     -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
+```
+
+### Project updates
+
+Update details about a specific project:
+```bash
+curl -i -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
+    -H "Content-Type: application/json" \
+    -H "X-API-KEY: $API_KEY" \
+    -d @data.json
+```
+
+Where `data.json` contains the fields you want to modify:
+```json
+{
+    "title": "Updated project title",
+    "difficulty": "hard"
+}
+```
+
+### Project creates
+
+Create a project:
+```bash
+curl -i -X POST "https://www.pgdp.org/api/v1/projects" \
+    -H "Content-Type: application/json" \
+    -H "X-API-KEY: $API_KEY" \
+    -d @data.json
+```
+
+Where `data.json` contains at least all the required fields:
+```json
+{
+    "title": "Project created from API",
+    "author": "API Joe",
+    "project_manager": "project_manager_name",
+    "languages": [ "English" ],
+    "difficulty": "average",
+    "genre": "Other",
+    "image_source": "_internal",
+    "character_suites": ["basic-latin"]
+}
 ```
 
 ### Project holds

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -23,9 +23,15 @@ paths:
     get:
       tags:
       - project
-      description: Search for projects. If different parameters are included
-        they are ANDed together. To send multiple values of the same parameter
-        to OR together, append the name with [] (e.g. projectid[]).
+      description: Search for projects.
+        <br><br>
+        If different parameters are included they are ANDed together. To
+        send multiple values of the same parameter to OR together, append
+        the name with [] (e.g. projectid[]).
+        <br><br>
+        Results are paginated with a default page size of 20 and can be
+        controlled with the `page` and `per_page` query parameters. See
+        also the `X-Results-Total` and `Links` headers in the response.
       parameters:
       - name: projectid
         in: query
@@ -70,6 +76,16 @@ paths:
         in: query
         schema:
           type: string
+      - name: page
+        description: Page of results to return
+        in: query
+        schema:
+          type: integer
+      - name: per_page
+        description: Number of entries per page
+        in: query
+        schema:
+          type: integer
       responses:
         200:
           description: List of projects found in search
@@ -80,14 +96,14 @@ paths:
                 items:
                   $ref: '#/components/schemas/project'
           headers:
-            Links:
-              schema:
-                type: string
-              description: Links for accessing paginated response
             X-Results-Total:
               schema:
                 type: integer
               description: Total number of projects matching query
+            Links:
+              schema:
+                type: string
+              description: Links for accessing paginated response in RFC-8288 format
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -96,6 +96,34 @@ paths:
           $ref: '#/components/responses/RateLimitExceeded'
         default:
           $ref: '#/components/responses/UnexpectedError'
+    post:
+      tags:
+      - project
+      description: Create a new project.
+      requestBody:
+        description: Project details
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/project'
+      responses:
+        200:
+          description: Created project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/project'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
 
   /projects/charsuites:
     get:
@@ -344,6 +372,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/project'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+    put:
+      tags:
+      - project
+      description: Update an existing project. A partial object can be sent
+        and only those fields included will be updated.
+      parameters:
+      - name: projectid
+        in: path
+        description: ID of project to update
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Project details
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/project'
+      responses:
+        200:
+          description: Updated project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/project'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -651,10 +715,18 @@ components:
       required:
       - projectid
       - title
+      - author
+      - languages
+      - genre
+      - difficulty
+      - project_manager
+      - image_source
+      - character_suites
       type: object
       properties:
         projectid:
           type: string
+          readOnly: true
         title:
           type: string
         author:
@@ -663,6 +735,8 @@ components:
           type: array
           items:
             type: string
+          minItems: 1
+          maxItems: 2
         genre:
           type: string
         difficulty:
@@ -673,22 +747,41 @@ components:
           type: string
         post_processor:
           type: string
+          readOnly: true
         post_process_verifier:
           type: string
+          readOnly: true
         image_preparer:
           type: string
         text_preparer:
           type: string
         image_source:
           type: string
-        pages_available:
-          type: integer
-        pages_total:
-          type: integer
         pg_ebook_number:
           type: integer
+          nullable: true
+        comments:
+          type: string
+        comment_format:
+          type: string
+          enum: [markdown, html]
+        clearance:
+          type: string
+        custom_characters:
+          type: string
+        character_suites:
+          type: array
+          items:
+            type: string
+          minItems: 1
         state:
           type: string
+          readOnly: true
+        pages_available:
+          type: integer
+          readOnly: true
+        pages_total:
+          type: integer
           readOnly: true
         last_state_change_time:
           type: string

--- a/api/index.php
+++ b/api/index.php
@@ -158,7 +158,7 @@ function api_send_pagination_header($query_params, $total_rows, $per_page, $page
         return;
     }
 
-    $total_pages = round($total_rows / $per_page);
+    $total_pages = ceil($total_rows / $per_page);
 
     // create the link base by parsing $query_params
     $params = [];

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -17,6 +17,7 @@ $router->add_validator(":pageroundid", "validate_page_round");
 
 // Add routes
 $router->add_route("GET", "v1/projects", "api_v1_projects");
+$router->add_route("POST", "v1/projects", "api_v1_project");
 $router->add_route("GET", "v1/projects/difficulties", "api_v1_projects_difficulties");
 $router->add_route("GET", "v1/projects/genres", "api_v1_projects_genres");
 $router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
@@ -27,6 +28,7 @@ $router->add_route("GET", "v1/projects/specialdays", "api_v1_projects_specialday
 $router->add_route("GET", "v1/projects/imagesources", "api_v1_projects_imagesources");
 $router->add_route("GET", "v1/projects/holdstates", "api_v1_projects_holdstates");
 $router->add_route("GET", "v1/projects/:projectid", "api_v1_project");
+$router->add_route("PUT", "v1/projects/:projectid", "api_v1_project");
 $router->add_route("GET", "v1/projects/:projectid/holdstates", "api_v1_project_holdstates");
 $router->add_route("PUT", "v1/projects/:projectid/holdstates", "api_v1_project_holdstates");
 $router->add_route("GET", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -116,37 +116,131 @@ function api_v1_projects($method, $data, $query_params)
 //---------------------------------------------------------------------------
 // projects/:projectid
 
+// Return a list of updatable project fields mapped from the API names
+// to the Project object names.
+function get_updatable_project_fields()
+{
+    return [
+        // API name => Project name
+        "title" => "nameofwork",
+        "author" => "authorsname",
+        "languages" => "languages",
+        "genre" => "genre",
+        "difficulty" => "difficulty",
+        "special_day" => "special_code",
+        "project_manager" => "username",
+        "image_source" => "image_source",
+        "image_preparer" => "image_preparer",
+        "text_preparer" => "text_preparer",
+        "pg_ebook_number" => "postednum",
+        "comments" => "comments",
+        "comment_format" => "comment_format",
+        "clearance" => "clearance",
+        "custom_characters" => "custom_chars",
+    ];
+}
+
+function create_or_update_project($project)
+{
+    // can the user manage the existing project?
+    if ($project->projectid && !$project->can_be_managed_by_current_user) {
+        throw new UnauthorizedError();
+    }
+
+    // can the user create new projects?
+    if (!$project->projectid && user_has_project_loads_disabled()) {
+        throw new UnauthorizedError();
+    }
+
+    // update all updatable fields
+    $updates = (array)api_get_request_body();
+    try {
+        foreach (get_updatable_project_fields() as $api_key => $project_key) {
+            // allow partial record updates by only updating specified values
+            if (isset($updates[$api_key])) {
+                $project->$project_key = $updates[$api_key];
+            }
+        }
+
+        $project->validate(true);
+    } catch (ValueError $error) {
+        throw new InvalidValue($error->getMessage());
+    }
+
+    // validate charsuites
+    if (!$project->projectid || isset($updates["character_suites"])) {
+        if (!is_array($updates["character_suites"])) {
+            throw new InvalidValue("character_suites must be an array.");
+        }
+
+        if (sizeof($updates["character_suites"]) == 0) {
+            throw new InvalidValue("At least one Character Suite is required.");
+        }
+
+        $invalid_charsuites = array_diff($updates["character_suites"],
+            array_extract_field(CharSuites::get_all(), "name"));
+        if ($invalid_charsuites) {
+            throw new InvalidValue(sprintf("%s is/are not valid Character Suites.", join(", ", $invalid_charsuites)));
+        }
+    }
+
+    $project->save();
+
+    if (isset($updates["character_suites"])) {
+        $project->set_charsuites($updates["character_suites"]);
+    }
+
+    return $project;
+}
+
 function api_v1_project($method, $data, $query_params)
 {
-    return render_project_json($data[":projectid"]);
+    if ($method == "GET") {
+        return render_project_json($data[":projectid"]);
+    } elseif ($method == "PUT") {
+        $project = $data[":projectid"];
+        return render_project_json(create_or_update_project($project));
+    } elseif ($method == "POST") {
+        $project = create_or_update_project(new Project());
+        // reload the project to fetch defaults managed by the database
+        $project = new Project($project->projectid);
+        return render_project_json($project);
+    }
 }
 
 function render_project_json($project)
 {
     // We want to explicitly call out the parameters we want to return so
     // callers can know what to expect in this version of the API.
-    return [
+    $return_array = [
         "projectid" => $project->projectid,
-        "state" => $project->state,
-        "title" => $project->nameofwork,
-        "author" => $project->authorsname,
-        "languages" => $project->languages,
-        "genre" => $project->genre,
-        "difficulty" => $project->difficulty,
-        "special_day" => $project->special_code,
-        "project_manager" => $project->username,
-        "post_processor" => $project->PPer,
-        "post_process_verifier" => $project->PPVer,
-        "image_source" => $project->image_source,
-        "image_preparer" => $project->image_preparer,
-        "text_preparer" => $project->text_preparer,
-        "pages_available" => $project->n_available_pages,
-        "pages_total" => $project->n_pages,
-        "pg_ebook_number" => $project->postednum,
-        "last_state_change_time" => date(DATE_ATOM, $project->modifieddate),
-        "last_page_done_time" => date(DATE_ATOM, $project->t_last_page_done),
-        "last_edit_time" => date(DATE_ATOM, $project->t_last_edit),
     ];
+
+    foreach (get_updatable_project_fields() as $api_key => $project_key) {
+        $return_array[$api_key] = $project->$project_key;
+    }
+
+    $charsuites = [];
+    foreach ($project->get_charsuites(false) as $project_charsuite) {
+        array_push($charsuites, $project_charsuite->name);
+    }
+    $return_array["character_suites"] = $charsuites;
+
+    $return_array = array_merge(
+        $return_array,
+        [
+            "post_processor" => $project->PPer,
+            "post_process_verifier" => $project->PPVer,
+            "state" => $project->state,
+            "pages_available" => $project->n_available_pages,
+            "pages_total" => $project->n_pages,
+            "last_state_change_time" => date(DATE_ATOM, $project->modifieddate),
+            "last_page_done_time" => date(DATE_ATOM, $project->t_last_page_done),
+            "last_edit_time" => date(DATE_ATOM, $project->t_last_edit),
+        ]
+    );
+
+    return $return_array;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This enables creating and updating projects through the API. Virtually all of the heavy lifting was done in https://github.com/DistributedProofreaders/dproofreaders/pull/754, this just exposes it via the API.

The [api-update-project](https://www.pgdp.org/~cpeel/c.branch/api-update-project/) sandbox has the live code. This is testable via `curl` (as covered in the `USERS_GUIDE.md`) and also via the [Swagger Editor](https://editor.swagger.io/) (be sure to upload the new `dp-openapi.yml` file) via the `https://www.pgdp.org/api-dev/v1` development endpoint.