### PR TITLE
Fix logging bug in Project.save()

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -365,7 +365,7 @@ class Project
             $this->log_project_event(User::current_username(), 'edit', $details1);
             if ($PPer_checkout) {
                 // we fake the project transition...
-                $this->project->log_project_event(
+                $this->log_project_event(
                     User::current_username(),
                     'transition',
                     PROJ_POST_FIRST_CHECKED_OUT,


### PR DESCRIPTION
This bug was introduced in a71d4e30 when the `save()` logic was moved from `editproject.php`.

Testable in the [fix-project-save-bug](https://www.pgdp.org/~cpeel/c.branch/fix-project-save-bug/) sandbox.