### PR TITLE
Manage project holds via API

### DIFF
--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -152,3 +152,36 @@ curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/word
     -H "Accept: application/json" \
     -H "X-API-KEY: $API_KEY"
 ```
+
+### Project holds
+
+Get a list of all holdable project states:
+```bash
+curl -i -X GET "https://www.pgdp.org/api/v1/projects/holdstates" \
+    -H "Accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
+Get the current hold states for a project:
+```bash
+curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/holdstates" \
+    -H "Accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
+Set a project's hold states:
+```bash
+curl -i -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/holdstates" \
+    -H "Accept: application/json" \
+    -H "X-API-KEY: $API_KEY" \
+    -d @data.json
+```
+
+Where `data.json` contains a list of new hold states which will override all
+current holds for the project:
+```json
+[
+    "P1.proj_waiting",
+    "P1.proj_avail"
+]
+```

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -302,6 +302,29 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/holdstates:
+    get:
+      tags:
+      - project
+      description: Returns a list of holdable project states
+      responses:
+        200:
+          description: List of holdable states
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/{projectid}:
     get:
       tags:
@@ -321,6 +344,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/project'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/holdstates:
+    get:
+      tags:
+      - project
+      description: Returns a list of hold states for the project
+      parameters:
+      - name: projectid
+        in: path
+        description: ID of project
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of current project hold states
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+    put:
+      tags:
+      - project
+      description: Sets the holdable states for a project
+      parameters:
+      - name: projectid
+        in: path
+        description: ID of project
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: List of holdable states to set
+        required: true
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+      responses:
+        200:
+          description: List of current project hold states
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+        '400':
+          $ref: '#/components/responses/InvalidValue'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -832,6 +921,12 @@ components:
             $ref: '#/components/schemas/Error'
     Unauthorized:
       description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InvalidValue:
+      description: Invalid Value
       content:
         application/json:
           schema:

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -17,9 +17,6 @@ $router->add_validator(":pageroundid", "validate_page_round");
 
 // Add routes
 $router->add_route("GET", "v1/projects", "api_v1_projects");
-$router->add_route("GET", "v1/projects/:projectid", "api_v1_project");
-$router->add_route("GET", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
-$router->add_route("PUT", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
 $router->add_route("GET", "v1/projects/difficulties", "api_v1_projects_difficulties");
 $router->add_route("GET", "v1/projects/genres", "api_v1_projects_genres");
 $router->add_route("GET", "v1/projects/languages", "api_v1_projects_languages");
@@ -28,6 +25,12 @@ $router->add_route("GET", "v1/projects/pagerounds", "api_v1_projects_pagerounds"
 $router->add_route("GET", "v1/projects/charsuites", "api_v1_projects_charsuites");
 $router->add_route("GET", "v1/projects/specialdays", "api_v1_projects_specialdays");
 $router->add_route("GET", "v1/projects/imagesources", "api_v1_projects_imagesources");
+$router->add_route("GET", "v1/projects/holdstates", "api_v1_projects_holdstates");
+$router->add_route("GET", "v1/projects/:projectid", "api_v1_project");
+$router->add_route("GET", "v1/projects/:projectid/holdstates", "api_v1_project_holdstates");
+$router->add_route("PUT", "v1/projects/:projectid/holdstates", "api_v1_project_holdstates");
+$router->add_route("GET", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
+$router->add_route("PUT", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
 $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -183,6 +183,46 @@ function api_v1_project_wordlists($method, $data, $query_params)
 }
 
 //---------------------------------------------------------------------------
+// projects/:projectID/holdstates
+
+function api_v1_project_holdstates($method, $data, $query_params)
+{
+    $project = $data[":projectid"];
+
+    // handle GET and PUT requests
+    if ($method == "GET") {
+        // everyone can get hold states
+        return $project->get_hold_states();
+    } elseif ($method == "PUT") {
+        // can the user manage the project?
+        if (!$project->can_be_managed_by_current_user) {
+            throw new UnauthorizedError();
+        }
+
+        $desired_states = api_get_request_body();
+
+        // confirm that all of the desired states are valid
+        if (array_diff($desired_states, Project::get_holdable_states()) != []) {
+            throw new BadRequest("Invalid hold state specified.");
+        }
+
+        $current_holds = $project->get_hold_states();
+
+        $remove_holds = array_diff($current_holds, $desired_states);
+        if ($remove_holds) {
+            $project->remove_holds($remove_holds);
+        }
+
+        $add_holds = array_diff($desired_states, $current_holds);
+        if ($add_holds) {
+            $project->add_holds($add_holds);
+        }
+
+        return $project->get_hold_states();
+    }
+}
+
+//---------------------------------------------------------------------------
 // projects/:projectid/pages
 
 function api_v1_project_pages($method, $data, $query_params)
@@ -403,4 +443,12 @@ function api_v1_projects_imagesources($method, $data, $query_params)
     }
 
     return $return_data;
+}
+
+//---------------------------------------------------------------------------
+// projects/holdstates
+
+function api_v1_projects_holdstates($method, $data, $query_params)
+{
+    return Project::get_holdable_states();
 }


### PR DESCRIPTION
Allow project holds to be managed through the API. This is part of [Task 2011](https://www.pgdp.net/c/tasks.php?action=show&task_id=2011).

I vacillated if the per-project endpoint should be `/holds` or `/holdstates` but `v1/projects/holds` didn't seem right and I went with `/holdstates` for both.

This is most readily testable via curl against the test sandbox:
```
export API_KEY=your_api_key
```

```bash
curl -i -X GET "https://www.pgdp.org/~cpeel/c.branch/api-project-holds/api/index.php?url=v1/projects/holdstates" \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY"
```

```bash
curl -i -X GET "https://www.pgdp.org/~cpeel/c.branch/api-project-holds/api/index.php?url=v1/projects/projectID44de3936807f1/holdstates" \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY"
```

```bash
curl -i -X GET "https://www.pgdp.org/~cpeel/c.branch/api-project-holds/api/index.php?url=v1/projects/projectID44de3936807f1/holdstates" \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY" \
    -d @data.json
```

With a `data.json` file like:
```json
[
    "P1.proj_waiting",
    "P1.proj_avail"
]
```