### PR TITLE
Remove smooth dir on archive

### DIFF
--- a/crontab/archive_projects.php
+++ b/crontab/archive_projects.php
@@ -19,15 +19,16 @@ if ($dry_run) {
     echo "This is a dry run.\n";
 }
 
-$result = mysqli_query(DPDatabase::get_connection(), "
+$sql = sprintf("
     SELECT *
     FROM projects
     WHERE
         modifieddate <= UNIX_TIMESTAMP() - (24 * 60 * 60) * $DAYS_TO_RETAIN
         AND archived = '0'
-        AND state = '".PROJ_SUBMIT_PG_POSTED."'
+        AND state = '%s'
     ORDER BY modifieddate
-") or die(DPDatabase::log_error());
+", DPDatabase::escape(PROJ_SUBMIT_PG_POSTED));
+$result = DPDatabase::query($sql);
 
 echo "Archiving page-tables for ", mysqli_num_rows($result), " projects...\n";
 

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -31,10 +31,11 @@ function archive_project($project, $dry_run)
     } elseif ($dry_run) {
         echo "    Move table $projectid to $archive_db_name.\n";
     } else {
-        mysqli_query(DPDatabase::get_connection(), "
+        $sql = "
             ALTER TABLE $projectid
             RENAME AS $archive_db_name.$projectid
-        ") or die(DPDatabase::log_error());
+        ";
+        DPDatabase::query($sql);
     }
 
     $project_dir = $project->dir;
@@ -58,11 +59,12 @@ function archive_project($project, $dry_run)
     if ($dry_run) {
         echo "    Mark project as archived.\n";
     } else {
-        mysqli_query(DPDatabase::get_connection(), "
+        $sql = sprintf("
             UPDATE projects
             SET archived = '1'
-            WHERE projectid='$projectid'
-        ") or die(DPDatabase::log_error());
+            WHERE projectid = '%s'
+        ", DPDatabase::escape($projectid));
+        DPDatabase::query($sql);
 
         $project->log_project_event('[archiver]', 'archive');
     }
@@ -101,13 +103,15 @@ function archive_ancillary_data_for_project_etc($project, $indent, $dry_run)
 
     // Check for any deleted projects that were merged into this project,
     // and archive their ancillary info too.
-    $res2 = mysqli_query(DPDatabase::get_connection(), "
+    $sql = sprintf("
         SELECT projectid, modifieddate, state
         FROM projects
-        WHERE state = '".PROJ_DELETE."'
-        AND deletion_reason = 'merged into $project->projectid'
+        WHERE state = '%s'
+        AND deletion_reason = '%s'
         ORDER BY modifieddate
-    ") or die(DPDatabase::log_error());
+    ", DPDatabase::escape(PROJ_DELETE),
+        DPDatabase::escape("merged into $project->projectid"));
+    $res2 = DPDatabase::query($sql);
     while ($project2 = mysqli_fetch_object($res2)) {
         archive_ancillary_data_for_project($project2, $indent, $dry_run);
     }
@@ -160,12 +164,13 @@ function move_project_rows_to_archive_db($projectid, $table_name, $indent, $dry_
     $watch = new Stopwatch();
     $watch->start();
 
-    mysqli_query(DPDatabase::get_connection(), "
+    $sql = sprintf("
         INSERT INTO $archive_db_name.$table_name
         SELECT *
         FROM $table_name
-        WHERE projectid='$projectid'
-    ") or die(DPDatabase::log_error());
+        WHERE projectid = '%s'
+    ", DPDatabase::escape($projectid));
+    DPDatabase::query($sql);
     $n_copied = DPDatabase::affected_rows();
     echo sprintf("%4d rows copied", $n_copied);
 
@@ -174,11 +179,12 @@ function move_project_rows_to_archive_db($projectid, $table_name, $indent, $dry_
         return;
     }
 
-    mysqli_query(DPDatabase::get_connection(), "
+    $sql = sprintf("
         DELETE 
         FROM $table_name
-        WHERE projectid='$projectid'
-    ") or die(DPDatabase::log_error());
+        WHERE projectid = '%s'
+    ", DPDatabase::escape($projectid));
+    DPDatabase::query($sql);
     $n_deleted = DPDatabase::affected_rows();
     if ($n_deleted == $n_copied) {
         echo " and deleted";

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -26,16 +26,26 @@ function archive_project($project, $dry_run)
     $mod_time_str = strftime('%Y-%m-%d %H:%M:%S', $project->modifieddate);
     echo "$projectid ($mod_time_str) \"$project->nameofwork\"\n";
 
-    if (!does_project_page_table_exist($projectid)) {
+    if (!$project->pages_table_exists) {
         echo "    Table $projectid does not exist.\n";
     } elseif ($dry_run) {
         echo "    Move table $projectid to $archive_db_name.\n";
     } else {
+        validate_projectID($projectid);
         $sql = "
             ALTER TABLE $projectid
             RENAME AS $archive_db_name.$projectid
         ";
         DPDatabase::query($sql);
+    }
+
+    $smooth_dir = "$project->dir/smooth";
+    if (is_dir($smooth_dir)) {
+        if ($dry_run) {
+            echo "    Remove $smooth_dir directory.\n";
+        } else {
+            exec("rm -rf $smooth_dir");
+        }
     }
 
     $project_dir = $project->dir;


### PR DESCRIPTION
When a project is archived, remove the `smooth/` directory. This directory contains redundant copies of existing files as a convenience to smooth readers and does not need to be retained. [Task 2017](https://www.pgdp.net/c/tasks.php?task_id=2017)

I also updated the archiving files to use the DPDatabase functions which is frankly the bulk of the PR.

I will provide testing instructions directly to @srjfoo.