### PR TITLE
Better project validation

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -197,6 +197,14 @@ class ProjectTest extends PHPUnit\Framework\TestCase
         $this->assertStringContainsString("required", $errors[0]);
     }
 
+    public function test_validate_nameofwork_wrong_type()
+    {
+        $project = new Project($this->valid_project_data);
+        $project->nameofwork = [];
+        $errors = $project->validate();
+        $this->assertStringContainsString("should be of type", $errors[0]);
+    }
+
     public function test_validate_authorsname_missing()
     {
         $project = new Project($this->valid_project_data);

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -162,6 +162,7 @@ class Project
             "genre",
             "image_source",
             "difficulty",
+            "comment_format",
         ];
 
         foreach ($required_fields as $field) {
@@ -228,6 +229,10 @@ class Project
                     $errors[] = sprintf(_("%s is not a valid special day."), $this->special_code);
                 }
             }
+        }
+
+        if ($this->comment_format && !in_array($this->comment_format, ["markdown", "html"])) {
+            $errors[] = sprintf(_("%s is not a valid comment format."), $this->comment_format);
         }
 
         // don't allow an empty PPer/PPVer if the project is checked out

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -98,7 +98,7 @@ class Project
             "extra_credits" => "",
             "deletion_reason" => "",
             "custom_chars" => "",
-            "state" => "",
+            "state" => null,
         ];
     }
 
@@ -307,7 +307,10 @@ class Project
             throw new ProjectException("Saving a Project object from an array source is disallowed.");
         }
 
+        // handle possibly-null fields
         $postednum_str = ($this->postednum == null) ? "NULL" : sprintf("%d", $this->postednum);
+        $ppverifier_str = ($this->ppverifier == null) ? "NULL" : "'" . DPDatabase::escape($this->ppverifier) . "'";
+
         $project_settings = "
             username       = '".DPDatabase::escape($this->username)."',
             nameofwork     = '".DPDatabase::escape(utf8_normalize($this->nameofwork))."',
@@ -321,7 +324,7 @@ class Project
             comment_format = '".DPDatabase::escape($this->comment_format)."',
             postcomments   = '".DPDatabase::escape(utf8_normalize($this->postcomments))."',
             postproofer    = '".DPDatabase::escape($this->postproofer)."',
-            ppverifier     = '".DPDatabase::escape($this->ppverifier)."',
+            ppverifier     = $ppverifier_str,
             image_source   = '".DPDatabase::escape($this->image_source)."',
             scannercredit  = '".DPDatabase::escape($this->scannercredit)."',
             checkedoutby   = '".DPDatabase::escape($this->checkedoutby)."',

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -205,7 +205,7 @@ class Project
             $errors[] = sprintf(_("%s is not a valid genre."), $this->genre);
         }
 
-        if ($this->image_source && !in_array($this->image_source, array_keys(load_image_sources()))) {
+        if ($this->image_source && !in_array($this->image_source, array_extract_field(load_image_sources(), "code_name"))) {
             $errors[] = sprintf(_("%s is not a valid image source."), $this->image_source);
         }
 
@@ -1839,10 +1839,30 @@ function get_page_image_param($arr, $key, $allownull = false)
 
 function load_image_sources()
 {
+    global $site_abbreviation, $code_url;
+
     static $image_sources = [];
     if ($image_sources) {
         return $image_sources;
     }
+
+    // TRANSLATORS: %s is the site abbreviation
+    $internal_name = sprintf(_("%s Internal"), $site_abbreviation);
+
+    $image_sources = [
+        "_internal" => [
+            "code_name" => "_internal",
+            "display_name" => $internal_name,
+            "full_name" => $internal_name,
+            "info_page_visibility" => 3,
+            "is_active" => 1,
+            "url" => $code_url,
+            "ok_show_images" => -1,
+            "ok_keep_images" => -1,
+            "public_comment" => "",
+            "internal_comment" => "",
+        ],
+    ];
 
     $sql = "
         SELECT *

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -70,11 +70,11 @@ class Project
     // -------------------------------------------------------------------------
     // Load & Validate
 
-    private function _init_fields_to_defaults()
+    private function _get_field_defaults()
     {
-        // Initialize Project with core fields and default values.
-        // These alone aren't sufficient to validate() and persist the project.
-        $fields = [
+        // Return a list of default fields with their values. Note that the
+        // value types given here are enforced in validate() except for nulls.
+        return [
             "projectid" => null,
             "nameofwork" => "",
             "authorsname" => "",
@@ -85,10 +85,10 @@ class Project
             "comments" => "",
             "comment_format" => "markdown",
             "postproofer" => "",
-            "ppverifier" => "",
+            "ppverifier" => null,
             "postcomments" => "",
             "clearance" => "",
-            "postednum" => "",
+            "postednum" => null,
             "genre" => "",
             "difficulty" => "",
             "special_code" => "",
@@ -100,7 +100,13 @@ class Project
             "custom_chars" => "",
             "state" => "",
         ];
-        foreach ($fields as $key => $value) {
+    }
+
+    private function _init_fields_to_defaults()
+    {
+        // Initialize Project with core fields and default values.
+        // These alone aren't sufficient to validate() and persist the project.
+        foreach ($this->_get_field_defaults() as $key => $value) {
             $this->$key = $value;
         }
     }
@@ -154,6 +160,13 @@ class Project
             }
         }
 
+        // validate types
+        foreach ($this->_get_field_defaults() as $field => $value) {
+            if ($value !== null && gettype($value) != gettype($this->$field)) {
+                $errors[] = "Field $field should be of type " . gettype($value);
+            }
+        }
+
         $required_fields = [
             "nameofwork",
             "authorsname",
@@ -166,7 +179,7 @@ class Project
         ];
 
         foreach ($required_fields as $field) {
-            if (preg_match('/^\s*$/', $this->$field)) {
+            if (!$this->$field || preg_match('/^\s*$/', $this->$field)) {
                 $errors[] = sprintf(_("%s is required."), $labels[$field]);
             }
         }
@@ -294,7 +307,7 @@ class Project
             throw new ProjectException("Saving a Project object from an array source is disallowed.");
         }
 
-        $postednum_str = ($this->postednum == "") ? "NULL" : sprintf("%d", $this->postednum);
+        $postednum_str = ($this->postednum == null) ? "NULL" : sprintf("%d", $this->postednum);
         $project_settings = "
             username       = '".DPDatabase::escape($this->username)."',
             nameofwork     = '".DPDatabase::escape(utf8_normalize($this->nameofwork))."',

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -595,6 +595,10 @@ class Project
 
     public static function encode_languages($languages)
     {
+        if (!is_array($languages)) {
+            throw new ValueError("languages must be an array");
+        }
+
         // handle the case where the second language is empty
         if (count($languages) == 2 && $languages[1] == '') {
             return $languages[0];

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -13,6 +13,20 @@ function array_get($arr, $key, $default)
     }
 }
 
+function array_extract_field($array, $field)
+// Given an array of arrays/objects, return the values of the desired field.
+{
+    $values = [];
+    foreach ($array as $entity) {
+        if (is_object($entity)) {
+            $values[] = $entity->$field;
+        } else {
+            $values[] = $entity[$field];
+        }
+    }
+    return $values;
+}
+
 function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
 // Return an array whose values are the names of the properties
 // whose values differ between the two objects $new and $old.

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -234,10 +234,7 @@ function image_source_list($image_source)
 {
     global $site_abbreviation;
 
-    $imso_array = [
-        // TRANSLATORS: %s is the site abbreviation
-        "_internal" => sprintf(_("%s Internal"), $site_abbreviation),
-    ];
+    $imso_array = [];
     foreach (load_image_sources() as $code => $source) {
         if (($source["is_active"] == 1 && can_user_see_image_source($source)) ||
             $code == $image_source) {

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -172,7 +172,7 @@ class ProjectInfoHolder
 
         // reset project values that should not be cloned
         $this->project->projectid = null;
-        $this->project->postednum = '';
+        $this->project->postednum = null;
         $this->project->deletion_reason = '';
         $this->project->state = '';
     }
@@ -249,7 +249,7 @@ class ProjectInfoHolder
             "image_source",
             "scannercredit",  // deprecated but may exist for older projects
             "checkedoutby",
-            "postednum",
+            // postednum is handled below
             "image_preparer",
             "text_preparer",
             "extra_credits",
@@ -259,6 +259,15 @@ class ProjectInfoHolder
         foreach ($fields_to_set as $field) {
             if (isset($_POST[$field])) {
                 $this->project->$field = $_POST[$field];
+            }
+        }
+
+        // postednum needs to either be a valid number or null, not an empty string
+        if (isset($_POST["postednum"])) {
+            if ($_POST["postednum"] == "") {
+                $this->project->postednum = null;
+            } else {
+                $this->project->postednum = (int)$_POST["postednum"];
             }
         }
 
@@ -301,7 +310,7 @@ class ProjectInfoHolder
         $this->posted = @$_POST['posted'];
         if ($this->posted) {
             // We are in the process of marking this project as posted.
-            if ($this->project->postednum == '') {
+            if (!$this->project->postednum) {
                 $errors[] = _("PG etext number is required.");
             }
         }


### PR DESCRIPTION
Sharon's testing in #783 showed that we are missing some validation corner cases. I thought it would be best if I pulled those out to address separately.

Specifically this:
* Validates `comment_format` value (originally in 783 but is better here)
* Correctly validates `image_source` -- the prior code was simply wrong
* Validates Project field types during `validate()`. This is most notable through the API where we can assign an array to a string field which can confuse some other parts of the `validate()` checks and causes warnings as PHP casts the array into a string during `save()`.
* Updates the default value for `postednum` to be `null`. This matches what is actually in the database (NULL) but requires some massaging in the Edit Project page. This is, coincidentally, the only non-string value we allow users to update.

Testable in the [better-project-validation](https://www.pgdp.org/~cpeel/c.branch/better-project-validation/) sandbox.

Suggestions for testing is to ensure setting (and unsetting) `postednum` via the Edit Project page works as expected.