### PR TITLE
Remove para about verifying volunteering

### DIFF
--- a/default.php
+++ b/default.php
@@ -106,11 +106,6 @@ echo "<p>"
     . "</p>"
     . "\n";
 
-echo "<p>"
-    . _("Distributed Proofreaders regrets that we are unable to verify court-ordered community service because our system cannot adequately record time spent participating.")
-    . "</p>"
-    . "\n";
-
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 echo "\n"


### PR DESCRIPTION
This para is being removed from `master` and will be expanded and added to `pgdp-production`. Compare [remove-verify-para](https://www.pgdp.org/~srjfoo/c.branch/remove-verify-para/) with [the main test server](https://www.pgdp.org/).