### PR TITLE
Added updated verify para to pgdp-production

### DIFF
--- a/default.php
+++ b/default.php
@@ -141,6 +141,13 @@ echo "<p>"
     . "</p>"
     . "\n";
 
+echo "<p>"
+    . sprintf(
+        _("Distributed Proofreaders regrets that we are unable to verify court-ordered or any official government-related service that requires confirmation of identity. Also, because our system cannot adequately record time spent participating, we are unable to verify hours worked for other community services that require tracking of time spent. For more information, please see <a href='%s'>this page</a>."),
+        "$wiki_url/DP_Official_Documentation:General/Certification_of_Volunteer_Work")
+    . "</p>"
+    . "\n";
+
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 echo "\n"


### PR DESCRIPTION
The GM requested that the paragraph concerning volunteer service verification be expanded and updated. The original para has been removed from `master`. This PR adds the expanded para into the `pgdp-production` branch. See [updated-verify-para](https://www.pgdp.org/~srjfoo/c.branch/updated-verify-para/) for the updated text. I used `$wiki_url`, so that link will go to the nonexistent page in the TEST wiki; change `org` to `net` to see that the page for PROD does actually exist. This is a followup to PR #792.