### PR TITLE
change structure of pickerset

### DIFF
--- a/SETUP/lint_charsuites.php
+++ b/SETUP/lint_charsuites.php
@@ -57,7 +57,7 @@ foreach (CharSuites::get_all() as $charsuite) {
     validate_hex_codes_lowercase($charsuite->codepoints, "uppercase hex values found in charsuite codepoints");
 
     // Validate pickersets only contain characters within the suite
-    foreach ($charsuite->pickerset->get_subsets() as $title => $picker_subset) {
+    foreach ($charsuite->pickerset->get_subsets() as  [$title, $long_title, $picker_subset]) {
         foreach ($picker_subset as $codepoints) {
             $string = implode("", convert_codepoint_ranges_to_characters($codepoints));
             $invalid_chars = get_invalid_characters($string, $charsuite->codepoints);

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -11,23 +11,15 @@ class PickerSet
 
     public function add_subset($name, $codepoints, $title = null)
     {
-        $this->subsets[$name] = $codepoints;
-
-        if ($title) {
-            $this->titles[$name] = $title;
-        } else {
-            $this->titles[$name] = $name;
+        if (!$title) {
+            $title = $name;
         }
+        $this->subsets[] = [$name, $title, $codepoints];
     }
 
     public function get_subsets()
     {
         return $this->subsets;
-    }
-
-    public function get_title($name)
-    {
-        return $this->titles[$name];
     }
 }
 

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -30,9 +30,9 @@ class CharacterSelector
                 $prefix = "$picker_set->name: ";
             }
 
-            foreach ($picker_set->get_subsets() as $code => $picker) {
+            foreach ($picker_set->get_subsets() as [$code, $title, $picker]) {
                 $safe_code = bin2hex($code);
-                $title = $prefix . $picker_set->get_title($code);
+                $title = $prefix . $title;
                 $selector_string .= "<button type='button' id='_$safe_code' class='selector_button' title='$title'>" . html_safe($code) . "</button>";
                 $row_string .= "<div class='_$safe_code key-block'>\n";
                 foreach ($picker as $row) {

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -127,9 +127,8 @@ function output_pickerset($pickerset, $all_codepoints)
     echo "<p>" . _("The following groupings represent sets of characters available in the character picker within the proofreading interface for projects using this character suite. Each grouping is labeled by a one- to four-character string that is used for the grouping's menu within the character picker.") . "</p>";
     $set = $pickerset->get_subsets();
     $picker_characters = [];
-    foreach ($set as $menu => $coderows) {
+    foreach ($set as [$menu, $title, $coderows]) {
         $header = $menu;
-        $title = $pickerset->get_title($menu);
         if ($menu != $title) {
             $header .= " - $title";
         }


### PR DESCRIPTION
so subsets are in a numerically keyed array
rather than keyed by name.
This will ensure order is preserved if json encoded

If we use the pickerset in an api we would also have to incorporate the utf8_character_names into it but this is not done in this request.