### PR TITLE
Fix two project edit bugs

### DIFF
--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -490,7 +490,7 @@ class ProjectInfoHolder
         if ($this->project->difficulty == "beginner" && !$can_set_difficulty_tofrom_beginner) {
             // allow PF to edit a BEGIN project, but without altering the difficulty
             $this->row(_("Difficulty"), 'just_echo', _("Beginner"));
-            echo "<input type='hidden' name='difficulty' value='$this->project->difficulty'>";
+            echo "<input type='hidden' name='difficulty' value='{$this->project->difficulty}'>";
         } else {
             $this->row(_("Difficulty"), 'difficulty_list', $this->project->difficulty);
         }
@@ -499,7 +499,7 @@ class ProjectInfoHolder
             $this->row(_("PPer/PPVer"), 'DP_user_field', $this->project->checkedoutby, 'checkedoutby', sprintf(_("Optionally reserve for a PPer. %s username only."), $site_abbreviation));
         } else {
             $this->row(_("PPer/PPVer"), 'just_echo', $this->project->checkedoutby);
-            echo "<input type='hidden' name='checkedoutby' value='$this->project->checkedoutby'>";
+            echo "<input type='hidden' name='checkedoutby' value='{$this->project->checkedoutby}'>";
         }
         $this->row(_("Image Source"), 'image_source_list', $this->project->image_source);
         $this->row(_("Image Preparer"), 'DP_user_field', $this->project->image_preparer, 'image_preparer', sprintf(_("%s user who scanned or harvested the images."), $site_abbreviation));

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -172,6 +172,11 @@ class ProjectInfoHolder
 
         // reset project values that should not be cloned
         $this->project->projectid = null;
+        $this->project->archived = 0;
+        $this->project->topic_id = null;
+        $this->project->postproofer = '';
+        $this->project->ppverifier = null;
+        $this->project->postcomments = '';
         $this->project->postednum = null;
         $this->project->deletion_reason = '';
         $this->project->state = '';


### PR DESCRIPTION
This fixes two bugs that have been found on the edit project page that came in with a71d4e30a:
* Correctly output a multi-level variable reference within a string. If we don't wrap it in `{}` only the part is used which is an object which raises an error and breaks the page.
* Remove PP-centric fields from cloned projects. These are being incorrectly cloned.

Testable in the [edit-project-updates](https://www.pgdp.org/~cpeel/c.branch/edit-project-updates/) sandbox.