### PR TITLE
detect all '<' characters

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -496,4 +496,44 @@ QUnit.module("Format preview test", function() {
         assert.strictEqual(procText, "xy]zaef");
     });
 
+    function getMessage(messageCode) {
+        return messageCode;
+    }
+
+    let previewStyles = {
+        t: {bg: "#fffcf4", fg: "#000000"},
+        i: {bg: "", fg: "#0000ff"},
+        b: {bg: "", fg: "#c55a1b"},
+        g: {bg: "", fg: "#8a2be2"},
+        sc: {bg: "", fg: "#009700"},
+        f: {bg: "", fg: "#ff0000"},
+        u: {bg: "", fg: ""},
+        etc: {bg: "#ffcaaf", fg: ""},
+        err: {bg: "#ff0000", fg: ""},
+        hlt: {bg: "#ceff09", fg: ""},
+        color: true, // colour the markup or not
+        allowUnderline: false,
+        defFontIndex: 0,
+        suppress: {},
+        initialViewMode: "no_tags",
+        allowMathPreview: false
+    };
+
+    QUnit.test("Check bad tag is converted to valid html", function (assert) {
+        let text = "<i&>";
+        let preview = makePreview(text, false, false, previewStyles, getMessage);
+        assert.strictEqual(preview.ok, true);
+        assert.strictEqual(preview.issues, 0);
+        assert.strictEqual(preview.possIss, 1);
+        assert.strictEqual(preview.txtout, "<span style=\"background-color:#ceff09;\"title='unRecTag'>&lt;</span>i&amp;&gt;");
+    });
+
+    QUnit.test("Check html entity is encoded", function (assert) {
+        let text = "&copy;";
+        let preview = makePreview(text, false, false, previewStyles, getMessage);
+        assert.strictEqual(preview.ok, true);
+        assert.strictEqual(preview.issues, 0);
+        assert.strictEqual(preview.possIss, 0);
+        assert.strictEqual(preview.txtout, "&amp;copy;");
+    });
 });

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -102,8 +102,8 @@ QUnit.module("Format preview test", function() {
     QUnit.test("unrecognised tag, u not enabled", function (assert) {
         text = "ab <u>cd</u>";
         issArray = analyse(text, configuration).issues;
-        issueTest(assert, 0, 3, 3, "unRecTag", 0);
-        issueTest(assert, 1, 8, 4, "unRecTag", 0);
+        issueTest(assert, 0, 3, 1, "unRecTag", 0);
+        issueTest(assert, 1, 8, 1, "unRecTag", 0);
     });
 
     QUnit.test("u tag enabled", function (assert) {

--- a/styles/preview.css
+++ b/styles/preview.css
@@ -142,22 +142,3 @@
     margin-right: 1em;
     white-space: pre-wrap;
 }
-
-/* issue markings */
-.err span {
-    font: 1em Arial;
-    display: none;
-    padding: 4px;
-    margin-top: 1.2em;
-    margin-left: 0;
-    border-radius: 4px;
-    box-shadow: 5px 5px 8px #C0C0C0;
-}
-.err:hover span {
-    display: inline;
-    position: absolute;
-    z-index: 10;
-    color: #111;
-    border: 1px solid #DCA;
-    background: #fffAF0;
-}

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -811,7 +811,6 @@ $(function () {
     for colouring and issue highlighting.
     It can be used alone with a simple html interface for testing.
     getMessage is a function to get a translated message.
-    previewControl.adjustMargin() is defined in previewControl.js
     txt is the text to analyse.
     viewMode determines if the inline tags are to be shown or hidden
     wrapMode whether to re-wrap the text.
@@ -841,10 +840,6 @@ $(function () {
                 str = ' style="' + str + '"';
             }
             return str;
-        }
-
-        function makeErrStr(st1) {
-            return '<span class="err" onmouseenter="previewControl.adjustMargin(this)"' + makeColourStyle(st1) + '><span>';
         }
 
         function htmlEncode(s) {
@@ -1100,18 +1095,13 @@ $(function () {
         // ok true if no errors which would cause showstyle() or reWrap() to fail
         let ok = (issues === 0);
 
-        // make texts to be inserted to mark issues
         let issueStarts = [];
         let issueEnds = [];
-        let errorString;
         issArray.forEach(function(issue) {
-            if (issue.type === 0) {
-                errorString = makeErrStr("hlt");
-            } else {
-                errorString = makeErrStr("err");
-            }
+            let issueStyle = (issue.type === 0) ? "hlt" : "err";
+            let colorStyle = makeColourStyle(issueStyle);
             let message = getMessage(issue.code).replace("%s", issue.subText);
-            issueStarts.push({start: issue.start, text: errorString + message + endSpan});
+            issueStarts.push({start: issue.start, text: `<span${colorStyle}title='${message}'>`});
             issueEnds.push({start: issue.start + issue.len, text: endSpan});
         });
 

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -1,5 +1,5 @@
 /* exported makePreview analyse processExMath */
-/* global $ previewMessages XRegExp */
+/* global $ XRegExp */
 
 // The formatting rules are applied as if proofers' notes were
 // invisible so remove them first and save for later. But first check if they
@@ -810,14 +810,14 @@ $(function () {
     This function checks the text for formatting issues and adds the markup
     for colouring and issue highlighting.
     It can be used alone with a simple html interface for testing.
-    previewMessages are translated strings in header args.
+    getMessage is a function to get a translated message.
     previewControl.adjustMargin() is defined in previewControl.js
     txt is the text to analyse.
     viewMode determines if the inline tags are to be shown or hidden
     wrapMode whether to re-wrap the text.
     styler is an object containing colour and font options.
     */
-    makePreview = function (txt, viewMode, wrapMode, styler) {
+    makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
         const ILTags = getILTags(styler);
         const endSpan = "</span>";
 
@@ -1110,7 +1110,7 @@ $(function () {
             } else {
                 errorString = makeErrStr("err");
             }
-            let message = previewMessages[issue.code].replace("%s", issue.subText);
+            let message = getMessage(issue.code).replace("%s", issue.subText);
             issueStarts.push({start: issue.start, text: errorString + message + endSpan});
             issueEnds.push({start: issue.start + issue.len, text: endSpan});
         });

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -300,24 +300,6 @@ $( function() {
     }
 
     previewControl = {
-        // this is used inside the "hover" markup to move the hover box
-        // (by adjusting its margin) so it does not disappear
-        // off the edge of the screen
-        adjustMargin: function (el) {
-            var hov = el.firstElementChild;
-            var hovBox = hov.getBoundingClientRect();
-            var container = outerPrev.getBoundingClientRect();
-            if (hovBox.right >= container.right) {
-                hov.style.marginLeft = -hovBox.width + "px";
-            }
-            if (hovBox.left <= container.left) {
-                hov.style.marginLeft = "0";
-            }
-            if (hovBox.bottom + 17 >= container.bottom) { // 17 allows for scrollbar
-                hov.style.marginTop = "-2em";
-            }
-        },
-
         reSizeText: function (ratio) {
             font_size *= ratio;
             prevWin.style.fontSize = font_size.toFixed(1) + "px";

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define, camelcase */
 /* exported previewControl, initPrev */
-/* global $ makePreview, fontStyles fontFamilies MathJax validateText tagNames previewStrings */
+/* global $ makePreview, fontStyles fontFamilies MathJax validateText tagNames previewStrings
+previewMessages */
 /*
 This file controls the user interface functions. Initially nothing is displayed
 because "prevdiv" has diplay:none; which means it is not displayed and the page
@@ -76,9 +77,13 @@ $( function() {
     var font_size;
     var preview;
 
+    function getMessage(index) {
+        return previewMessages[index];
+    }
+
     function writePreviewText() {
         // makePreview is defined in preview.js
-        preview = makePreview(txtarea.value, viewMode, wrapMode, previewStyles);
+        preview = makePreview(txtarea.value, viewMode, wrapMode, previewStyles, getMessage);
         prevWin.style.whiteSpace = (
             (preview.ok && wrapMode)
                 ? "normal"
@@ -228,7 +233,7 @@ $( function() {
     function testDraw() {
         testDiv.style.backgroundColor = tempStyle.t.bg;
         testDiv.style.color = tempStyle.t.fg;
-        preview = makePreview(previewStrings.previewDemo, 'no_tags', false, tempStyle);
+        preview = makePreview(previewStrings.previewDemo, 'no_tags', false, tempStyle, getMessage);
         testDiv.innerHTML = preview.txtout;
     }
 


### PR DESCRIPTION
and mark as possible unrecognised tags, encode &, <, >  so output is valid html and browsers do not leave anything out.
This addresses the issue found in https://www.pgdp.net/phpBB3/viewtopic.php?f=34&t=61794&p=1273703#p1273703
