### PR TITLE
expand ranges and add titles in pickerset

### DIFF
--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -11,7 +11,21 @@ class PickerSet
 
     public function add_subset($name, $codepoints, $title = null)
     {
-        $this->subsets[$name] = $codepoints;
+        $char_title_rows = [];
+        foreach ($codepoints as $codepoint_row) {
+            $chars = convert_codepoint_ranges_to_characters($codepoint_row);
+            $char_title_row = [];
+            foreach ($chars as $char) {
+                if (null == $char) {
+                    $char_title = [null, null];
+                } else {
+                    $char_title = [$char, utf8_character_name($char)];
+                }
+                $char_title_row[] = $char_title;
+            }
+            $char_title_rows[] = $char_title_row;
+        }
+        $this->subsets[$name] = $char_title_rows;
 
         if ($title) {
             $this->titles[$name] = $title;

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -35,8 +35,8 @@ class CharacterSelector
                 $title = $prefix . $picker_set->get_title($code);
                 $selector_string .= "<button type='button' id='_$safe_code' class='selector_button' title='$title'>" . html_safe($code) . "</button>";
                 $row_string .= "<div class='_$safe_code key-block'>\n";
-                foreach ($picker as $row) {
-                    $row_string .= $this->draw_row(convert_codepoint_ranges_to_characters($row));
+                foreach ($picker as $row_chars) {
+                    $row_string .= $this->draw_row($row_chars);
                 }
                 $row_string .= "</div>\n";
             }
@@ -48,16 +48,16 @@ class CharacterSelector
         echo "<div id='char-selector' class='nowrap'>$selector_string$row_string</div>\n";
     }
 
-    public function draw_row($chars)
+    public function draw_row($row_chars)
     {
         $row = "<div class='table-row'>";
 
-        foreach ($chars as $character) {
+        foreach ($row_chars as [$character, $title]) {
             $row .= "<div class='table-cell'>";
             if (null == $character) {
                 $row .= "<button type='button' class='picker invisible'></button>";
             } else {
-                $title_string = attr_safe(utf8_character_name($character));
+                $title_string = attr_safe($title);
                 $row .= "<button type='button' class='picker' title='$title_string'>" . html_safe($character) . "</button>";
             }
             $row .= "</div>";

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -140,7 +140,7 @@ function output_pickerset($pickerset, $all_codepoints)
         echo "<table class='basic'>";
         foreach ($coderows as $row) {
             echo "<tr>";
-            $characters = convert_codepoint_ranges_to_characters($row);
+            $characters = array_column($row, 0);
             $picker_characters = array_merge($picker_characters, $characters);
             output_characters_slice($characters);
             echo "</tr>";


### PR DESCRIPTION
This incorporates the character names (titles) in the picker set so they can be used via an API. PHP has a function for getting the names from the character codes but other languages such as javascript do not. It would be possible to incorporate them in the api function by breaking down the pickerset and building it up again, but putting the names in when it is first built seems a better option and only needs some small changes to existing code.