### PR TITLE
Allow PFs to edit a project without changing the PM

### DIFF
--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -279,6 +279,9 @@ class ProjectInfoHolder
         // only SAs can change PM
         if (user_is_a_sitemanager()) {
             $this->project->username = @$_POST['username'];
+        } elseif (user_is_proj_facilitator()) {
+            // PFs can edit a project that isn't theirs but they can't
+            // change the PM, nor should it be set to themselves.
         } else {
             // When cloning a project, the PM should be the same as that of the
             // project being cloned, if the user isn't an SA


### PR DESCRIPTION
PFs are allowed to edit projects but not change the PM. This fixes a regression introduced in a71d4e30a.

Testable in [fix-project-edit-bug](https://www.pgdp.org/~cpeel/c.branch/fix-project-edit-bug/) sandbox.