### PR TITLE
Exclude clearance field for unauthorized users

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -250,6 +250,11 @@ function render_project_json($project)
         $return_array[$api_key] = $project->$project_key;
     }
 
+    // prevent clearance from being included for unauthorized users
+    if (!$project->clearance_line_can_be_seen_by_current_user()) {
+        unset($return_array["clearance"]);
+    }
+
     $charsuites = [];
     foreach ($project->get_charsuites(false) as $project_charsuite) {
         array_push($charsuites, $project_charsuite->name);


### PR DESCRIPTION
The clearance field is not available to all users -- restrict who has access to it in the API.

Testable with:
```bash
export API_KEY=review
curl -i -X GET "https://www.pgdp.org/~cpeel/c.branch/restrict-clearance-api-access/api/?url=v1/projects/projectID44de3936807f1" \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY"
```