### PR TITLE
Add  an access-change email for new P2s

### DIFF
--- a/pinc/access_change_emails.inc
+++ b/pinc/access_change_emails.inc
@@ -56,6 +56,96 @@ function pp_access_change_email($user, $access_change)
     configure_gettext_for_user();
 }
 
+function p2_access_change_email($user, $access_change)
+{
+    global $site_name, $site_abbreviation, $Round_for_round_id_;
+
+    $daily_limit = $Round_for_round_id_['P2']->daily_page_limit;
+
+    // only send emails on grant
+    if ($access_change != "grant") {
+        return;
+    }
+
+    // configure gettext to translate user email
+    configure_gettext_for_user($user);
+
+    // TRANSLATORS: %s is the site abbreviation (eg: 'DP')
+    $subject = sprintf(_("%s: Welcome to P2 Proofreading"), $site_abbreviation);
+
+    $message[] = sprintf(_("Hello %s,"), $user->username);
+
+    $message[] = _("Congratulations! You may now work in P2, the second proofreading round.");
+
+    $message[] = "== " . _("Compared to P1, what remains the same?") . " ==";
+
+    $message[] = _("The Proofreading Guidelines are exactly the same, and you still need to comply with the Project Comments and Project Discussion guidance for every project.");
+
+    $message[] = _("Please keep aiming to leave every page as perfect as you can.");
+
+    $message[] = "== " . _("What is expected in P2?") . " ==";
+
+    $message[] = "- " . sprintf(_("Using WordCheck is compulsory in P2 and P3, and pages that have not been WordChecked may be removed from your record. See  %s for information about WordCheck"),
+        "https://www.pgdp.net/wiki/DP_Official_Documentation:Proofreading/WordCheck_FAQ");
+
+    $message[] = _("It is important to be aware that, when you work in P2, you set an example to P1 proofreaders: they will be checking their diffs to see how you changed their work. Make sure that you don't mislead them.");
+
+    $message[] = _("If you remember how your mentor guided you when you started, you may consider giving gentle feedback in a private message to new proofreaders when you see them making repeated errors.");
+
+    $message[] = _("The text you worked on in P1 was generated from the page images by means of software tools. When you work in P2, however, you are working on text that someone else has already proofread. Nevertheless, please check every character and word carefully, since new P1s, unfamiliar with our guidelines, may have left errors.");
+
+    if ($daily_limit) {
+        $message[] = sprintf(_("Please keep in mind that we currently have a limit in P2 of no more than %d pages per day. This is a daily limit, not an average; the limit is there to make sure that we have a variety of projects available in the round at all times."), $daily_limit);
+        // The above paragraph will be added to the email only if the daily limit
+        // is a positive integer. Currently, if the daily limit value is zero or
+        // NULL, the paragraph is not added. This code will need to be adjusted
+        // if there is ever a need for them to be treated differently.
+    }
+
+    $message[] = "== " . _("What resources are available?") . " ==";
+
+    $message[] = "- " . sprintf(_("You may ask for help at dp-feedback ( %s ), giving the name of the project, the round you worked in, and the png numbers of the pages you would like to have reviewed."), "https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose&u=37603");
+
+    $message[] = "- " . sprintf(_("If you haven't yet, try using DP's Proofreading Font: %s"), "https://www.pgdp.net/c/faq/font_sample.php");
+
+    $message[] = "- " . sprintf(_("When the diffs for your pages become available, check your diffs: %1\$s . You can easily check diffs with the Review Work tool: %2\$s"), "https://www.pgdp.net/wiki/DP_Official_Documentation:Proofreading/Checking_your_diffs", "https://www.pgdp.net/c/tools/proofers/review_work.php?work_round_id=P2&review_round_id=P3&days=100&sample_limit=0");
+
+    $message[] = "- " . sprintf(_("For a quick refresher, consider redoing the proofreading quizzes: %s"), "https://www.pgdp.net/c/quiz/start.php?show_only=PQ");
+
+    $message[] = _("If you have questions, there are several options:");
+
+    $message[] = "- " . _("For questions specific to a project you're working on, please post your question in the project's Project Discussion. There's a link to this on each project's main Project Page on the line reading \"Forum\".");
+
+    $message[] = "- " . sprintf(_("If you have a general question, you can post in the \"Common Proofreading Q&A\" Forum: %s"),
+        "https://www.pgdp.net/phpBB3/viewforum.php?f=19");
+
+    $message[] = "- " . _("If you don't know whether the question is a general question or specific to the project, you should start by asking in the Project Discussion.");
+
+    $message[] = "- " . _("If you'd rather ask a question privately or would like more information on proofreading in general, you can send a Private Message to one of the following volunteers:") .
+        "\n    Bess (Bess): https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose&u=101542" .
+        "\n    jjz (Jacqueline): https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose&u=15578";
+
+    $message[] = "== " . _("What could possibly go wrong?") . " ==";
+
+    $message[] = "- " . _("Getting the Proofreading and Formatting Guidelines mixed up.");
+
+    $message[] = "- " . _("Proofreading too fast! Proofread each page slowly enough to carefully compare the original scan with the proofing text.");
+
+    $message[] = "- " . _("Forgetting to read the specific project comments, and not checking for new posts in the project discussion.");
+
+    $message[] = "- " . _("Forgetting to use WordCheck.");
+
+    // TRANSLATORS: %s is the site name (eg: 'Distributed Proofreaders')
+    $message[] = sprintf(_("Again, please don't hesitate to ask if you have questions, and thanks for volunteering at %s."), $site_name);
+
+    $email = $user->email;
+    $message_string = implode("\n\n", $message);
+
+    $mail_accepted = maybe_mail($email, $subject, $message_string);
+
+    // restore gettext to current user's locale
+    configure_gettext_for_user();
+}
 
 function f1_access_change_email($user, $access_change)
 {
@@ -86,7 +176,7 @@ function f1_access_change_email($user, $access_change)
         $message[] = "***" . sprintf(_("Please keep in mind that we currently have a limit in F1 of no more than %d pages per day."), $daily_limit) . "*** " .
             _("(This is a daily limit, not an average.) The limit is there to make sure that we have a variety of projects available in the round at all times.");
         // The above paragraph will be added to the email only if the daily limit
-        // is a postiive integer. Currently, if the daily limit value is zero or
+        // is a positive integer. Currently, if the daily limit value is zero or
         // NULL, the paragraph is not added. This code will need to be adjusted
         // if there is ever a need for them to be treated differently.
     }
@@ -95,7 +185,7 @@ function f1_access_change_email($user, $access_change)
         "https://www.pgdp.net/wiki/DP_Official_Documentation:Formatting/Formatting_Guidelines",
         "https://www.pgdp.net/c/faq/formatting_summary.pdf");
 
-    $message[] = _("If you have questions, you have several options:");
+    $message[] = _("If you have questions, there are several options:");
 
     $message[] = "- " . _("For questions specific to a project you're working on, please post your question in the project's Project Discussion. There's a link to this on each project's main Project Page on the line reading \"Forum.\"");
 
@@ -105,11 +195,11 @@ function f1_access_change_email($user, $access_change)
     $message[] = "- " . _("If you don't know whether the question is a general question or specific to the project, start by asking in the Project Discussion.");
 
     $message[] = "- " . _("If you'd rather ask a question privately or would like more information on formatting in general, you can send a Private Message to one of our F2 Evaluators:") .
-        sprintf("\ncmspence (Carol): %1\$s\nK7UQT (Lisa): %2\$s",
-            "https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose&u=69533",
-            "https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose&u=24945");
+        "\n    cmspence (Carol): https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose&u=69533" .
+        "\n    K7UQT (Lisa): https://www.pgdp.net/phpBB3/ucp.php?i=pm&mode=compose&u=24945";
 
-    $message[] = "==" . _("Here is a list of important tips and resources to get you started:") . "==";
+
+    $message[] = "== " . _("Here is a list of important tips and resources to get you started:") . " ==";
 
     $message[] = "- ***" . _("Please use the Format Preview tool on each page.") . "*** " .
         sprintf(_("Each time you format a page (but before you save it as Done), click on the Format Preview button. This will highlight many common formatting problems so that you may fix them before saving the page. The Format Preview button is labelled \"Preview\" and is found in the rows of buttons below the formatting window. (If your buttons display as icons, the Format Preview icon is a red \"F\" with checkmark.) For more information about this tool, see: %s"),
@@ -125,7 +215,7 @@ function f1_access_change_email($user, $access_change)
     $message[] = "- " . sprintf(_("Once you've become familiar with the Formatting Guidelines, you may want to look through our Library of Formatting Examples (LoFE), which is found in the Formatting forums here: %s . While the LoFE should not be used in place of the Guidelines, it's a useful resource for common formatting issues that may not be covered completely by the Guidelines."),
         "https://www.pgdp.net/phpBB3/viewtopic.php?f=34&t=47569");
 
-    $message[] = "- " . sprintf(_("It's good practice to check your 'diffs' each day to see what changes have been made on your pages after they've been reviewed in F2 so that you can improve your skills. You can easily check diffs with the Review Work Tool: %s"),
+    $message[] = "- " . sprintf(_("It's good practice to check your 'diffs' each day to see what changes have been made on your pages after they've been reviewed in F2 so that you can improve your skills. You can easily check diffs with the Review Work tool: %s"),
         "https://www.pgdp.net/c/tools/proofers/review_work.php?work_round_id=F1&review_round_id=F2&days=100&sample_limit=0");
 
     // TRANSLATORS: %s is the site name (eg: 'Distributed Proofreaders')

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -79,7 +79,7 @@ new Round(
     ['P1' => 300, 'days since reg' => 21, 'quiz/p_mod1' => 1],
     'REQ-AUTO',
     '',
-    null, // access_change_callback
+    "p2_access_change_email", // access_change_callback
     _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
     'proofreading_guidelines.php',
     $pi_tools_for_P,


### PR DESCRIPTION
Requested by the GM and the P3 evaluators. This is site-specific (as are the other access-change emails) and going in the pgdp-production branch. Adds a new access-change email that will be sent to all new P2 proofreaders. Also some minor layout changes for the F1 access-change email.

Test in [add-p2-access-email](https://www.pgdp.org/~srjfoo/c.branch/add-p2-access-email); in your user stats page, revoke P2 (and F1, if you wish), and then grant them again. You should see the text of the emails displayed.