### PR TITLE
Link to a translated guideline entry

### DIFF
--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -319,7 +319,7 @@ function qp_echo_error_html($message_id)
 
         $guidelines_url = get_faq_url($guidelines_doc) . "#$anchor";
         $guidelines_attrs = "href='$guidelines_url' target='_blank'";
-        $rule = RandomRule::load_from_anchor($guidelines_doc, $anchor);
+        $rule = RandomRule::load_from_anchor($guidelines_doc, $anchor, substr(get_desired_language(), 0, 2));
         if ($rule) {
             $guidelines_link = "<a $guidelines_attrs>$rule->subject</a>";
 


### PR DESCRIPTION
When linking to a named guideline in the wiki, use the translated name if its available. We get the translated names via the RandomRule interface which parses the wiki pages to populate the Random Rule feature on the proofreading pages. Yes, this is all a very odd implementation.

Testable in the [link-to-translated-random-rule](https://www.pgdp.org/~cpeel/c.branch/link-to-translated-random-rule/) sandbox.