### PR TITLE
Allow client to specify fields for v1/projects results

### DIFF
--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -146,6 +146,17 @@ curl -i -X GET "https://www.pgdp.org/api/v1/projects?genre[]=Science&genre[]=Spo
     -H "X-API-KEY: $API_KEY"
 ```
 
+To limit which project fields are included, use the `field` parameter. Request
+multiple fields by appending `[]` to the parameter name and passing multiple
+of them.
+
+To return only the `projectid` and `title` fields:
+```bash
+curl -i -X GET "https://www.pgdp.org/api/v1/projects?field[]=projectid&field[]=title" \
+    -H "Accept: application/json" \
+    -H "X-API-KEY: $API_KEY"
+```
+
 ### Project details
 
 Get details about a specific project:

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -76,6 +76,13 @@ paths:
         in: query
         schema:
           type: string
+      - name: field
+        description: Field to return, if not set all fields are returned.
+          To request multiple fields, append with [] and pass one per desired
+          field (e.g. field[]=projectid&field[]=author).
+        in: query
+        schema:
+          type: string
       - name: page
         description: Page of results to return
         in: query

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -111,10 +111,16 @@ function api_v1_projects($method, $data, $query_params)
 
     api_send_pagination_header($query_params, $total_rows, $per_page, $page);
 
+    // restrict to list of desired fields, if set
+    $return_fields = array_get($query_params, "field", null);
+    if ($return_fields && !is_array($return_fields)) {
+        $return_fields = [$return_fields];
+    }
+
     $output = [];
     while ($row = mysqli_fetch_assoc($result)) {
         $project = new Project($row);
-        $output[] = render_project_json($project);
+        $output[] = render_project_json($project, $return_fields);
     }
 
     return $output;
@@ -245,7 +251,7 @@ function api_v1_project($method, $data, $query_params)
     }
 }
 
-function render_project_json($project)
+function render_project_json($project, $return_fields = null)
 {
     // We want to explicitly call out the parameters we want to return so
     // callers can know what to expect in this version of the API.
@@ -281,6 +287,13 @@ function render_project_json($project)
             "last_edit_time" => date(DATE_ATOM, $project->t_last_edit),
         ]
     );
+
+    // remove any fields that weren't requested
+    if ($return_fields) {
+        foreach (array_diff(array_keys($return_array), $return_fields) as $field) {
+            unset($return_array[$field]);
+        }
+    }
 
     return $return_array;
 }


### PR DESCRIPTION
Allow an API client to limit which fields are returned for project searches using the `v1/projects` endpoint. This is in preparation to support a PG use-case.

Testable with curl:
```bash
curl -i -X GET -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
    "https://www.pgdp.org/~cpeel/c.branch/limit-fields/api/?url=v1/projects&fields=projectid,title,author"
```