### PR TITLE
Correct Author's DB column name in v1/projects

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -18,7 +18,7 @@ function api_v1_projects($method, $data, $query_params)
         "projectid" => "projectid",
         "state" => "state",
         "title" => "nameofwork",
-        "author" => "authorname",
+        "author" => "authorsname",
         "languages" => "language",
         "genre" => "genre",
         "difficulty" => "difficulty",


### PR DESCRIPTION
The Author's DB column name was incorrect resulting in an inability to search by author in the `v1/projects` endpoint. Thanks to @70ray and @srjfoo (oops, Roger & Sharon rather) for finding this bug!

Testable at:
```bash
curl -i -X GET -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
  "https://www.pgdp.org/~cpeel/c.branch/fix-api-author-search/api/?url=v1/projects&author=Long"
```