### PR TITLE
Allow pg-automation user to view clearances

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -32,7 +32,8 @@ function api_v1_projects($method, $data, $query_params)
     // Allow SAs and PFs to search on clearance. We can't allow PMs to do so
     // without opening up the ability for value-fishing as PMs can only see
     // clearances for their own projects.
-    if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
+    // Also allow pg-automation to see clearances
+    if (user_is_a_sitemanager() || user_is_proj_facilitator() || User::current_username() == 'pg-automation') {
         $valid_fields["clearance"] = "clearance";
     }
 

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -901,6 +901,7 @@ class Project
             $this->can_be_managed_by_current_user
             || $this->PPVer_is_current_user
             || ($this->PPer_is_current_user && user_has_DU_access())
+            || User::current_username() == 'pg-automation'
         );
     }
 


### PR DESCRIPTION
Allow Project Gutenberg's `pg-automation` account to view clearances. Note that this is going into the `pgdp-production` branch.

Testable with:
```bash
curl -i -X GET -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
   "https://www.pgdp.org/~cpeel/c.branch/allow-pg-automation-clearance/api/?url=v1/projects&clearance=do-not-upload-to-PG"
```

If you use a regular user's `API_KEY` this will ignore the `clearance` field and not show the field in the output. If you use the `pg-automation` user's `API_KEY` this should return projects with the desired clearance *and* show them in the output.