### PR TITLE
Correctly detect expired quiz attempts

### DIFF
--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -83,7 +83,7 @@ class Quiz
 
             if ($use_pass_requirements && isset($this->pass_requirements['maximum_age'])) {
                 if ((time() - $attempt->date) > $this->pass_requirements['maximum_age']) {
-                    $pages_required_results[$quiz_page_id] = null;
+                    $pages_required_results[$attempt->quiz_page] = null;
                 }
             }
         }


### PR DESCRIPTION
When evaluating if a user has passed a quiz, correctly reject quiz passes that are too old. This bug was introduced in 8cf7ce568. Big thanks to @srjfoo for tracking down the problem and providing a super-focused repro.

Testable in the [fix-quiz-pass-detection](https://www.pgdp.org/~cpeel/c.branch/fix-quiz-pass-detection/) sandbox.