### PR TITLE
Add quiz pass requirements for applying for P3

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -10,10 +10,10 @@ include_once($relPath.'User.inc');
 
 $ACCESS_CRITERIA = [
     'days since reg' => _('Days since registration'),
-    'quiz/p_basic' => sprintf(_('Successfully complete the <a href="%1$s">basic proofreading quiz</a>'), "$code_url/quiz/start.php?show_level=P_BASIC"),
-    'quiz/p_mod1' => sprintf(_('Successfully complete the <a href="%1$s">moderate proofreading quiz %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 1),
-    'quiz/p_mod2' => sprintf(_('Successfully complete the <a href="%1$s">moderate proofreading quiz %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 2),
-    'quiz/f_only' => sprintf(_("Successfully complete the <a href='%s'>formatting quiz</a>"), "$code_url/quiz/start.php?show_only=format"),
+    'quiz/p_basic' => sprintf(_('Up-to-date completion of the <a href="%1$s">Basic Proofreading Quiz</a>'), "$code_url/quiz/start.php?show_level=P_BASIC"),
+    'quiz/p_mod1' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 1),
+    'quiz/p_mod2' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 2),
+    'quiz/f_only' => sprintf(_("Up-to-date completion of the <a href='%s'>Formatting Quiz</a>"), "$code_url/quiz/start.php?show_only=format"),
 ];
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -139,16 +139,12 @@ class Quiz
                 // all of the requirements to do so, point them in the right direction
                 if (!$uao->can_access && $uao->all_minima_satisfied) {
                     echo "<div class='callout'>";
-                    echo "<div class='calloutheader'>";
-                    echo _("You can now work in $stage_id!");
-                    echo "</div>";
-
                     echo "<p>";
-                    echo sprintf(_("You've satisfied all requirements to work in %s!"), $stage_id);
+                    echo sprintf(_("You've completed the quiz requirements to work in %s!"), $stage_id);
 
                     echo " ";
 
-                    echo sprintf(_("Continue to the <a href='%1\$s'>%2\$s page</a> to access this activity and get started."), "$code_url/$stage->relative_url#Entrance_Requirements", $stage_id);
+                    echo sprintf(_("Continue to the <a href='%1\$s'>%2\$s page</a>."), "$code_url/$stage->relative_url#Entrance_Requirements", $stage_id);
                     echo "</p>";
                     echo "</div>";
                     echo "<br>";

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -75,7 +75,7 @@ new Round(
 new Round(
     'P2',
     _('Proofreading Round 2'),
-    ['P1' => 300, 'days since reg' => 21, 'quiz/p_mod1' => 1],
+    ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
     'REQ-AUTO',
     '',
     null, // access_change_callback
@@ -116,7 +116,7 @@ new Round(
 new Round(
     'P3',
     _('Proofreading Round 3'),
-    ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_mod2' => 1],
+    ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
     'REQ-HUMAN',
     _("Once you have met the requirements and requested access to P3, an evaluator will check over at least 50 of your recent P2 pages that have been completed in P3. If you proofread them to P3 standards, you'll be granted access."),
     null, // access_change_callback


### PR DESCRIPTION
Those applying for P3 should re-take and pass any of the required proofreading quizzes that have expired per task 2028. At a later request, also added requirement for up-to-date Basic quiz pass for P2.

Because this is being merged into `master` and there are PROD hacks that are needed to do adequate testing, testing should be done in the [add-p3-prereq-hacked](https://www.pgdp.org/~srjfoo/c.branch/add-p3-prereq-hacked/) sandbox.

A large part if this is rewording the generic messages so that they at least mostly make sense for all users who will see them, since only the round information changes, and the rest of the message is not customizable per round.