### PR TITLE
Remove project->t_retrieved

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -124,7 +124,6 @@ class Project
         if (!$row) {
             throw new NonexistentProjectException(sprintf(_("There is no project with projectid '%s'"), $projectid));
         }
-        $row['t_retrieved'] = time();
         foreach ($row as $key => $value) {
             $this->$key = $value;
         }

--- a/project.php
+++ b/project.php
@@ -102,8 +102,7 @@ if (!$user_is_logged_in) {
 }
 
 if ($user_is_logged_in) {
-    upi_set_t_latest_home_visit(
-        $pguser, $project->projectid, $project->t_retrieved);
+    upi_set_t_latest_home_visit($pguser, $project->projectid, time());
 }
 
 if ($detail_level == 1) {


### PR DESCRIPTION
Project object load time (`t_retrieved`) is only used in one place and isn't used appropriately there. This fixes the edgecase during project edit when the `t_retrieved` value differs between the source and compare objects resulting in an entry in `project_events`.

Testable in [remove-t_retrieved](https://www.pgdp.org/~cpeel/c.branch/remove-t_retrieved/) sandbox.