### PR TITLE
Use escapeshellarg() to escape arguments

### DIFF
--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -241,7 +241,7 @@ function virus_check($file_path, $verbose)
     $av_test_result = [];
     $av_retval = 0;
 
-    $cmd = "$antivirus_executable -- " . escapeshellcmd($file_path);
+    $cmd = "$antivirus_executable -- " . escapeshellarg($file_path);
     exec($cmd, $av_test_result, $av_retval);
     // $av_retval == 0 is ok
     if ($av_retval == 1) {


### PR DESCRIPTION
The most secure way to escape shell arguments is `escapeshellarg()`, not `escapeshellcmd()`.

Testable in [dont-use-escapeshellcmd](https://www.pgdp.org/~cpeel/c.branch/dont-use-escapeshellcmd/)