### PR TITLE
Robustly escape all non-literals in shell commands

### DIFF
--- a/crontab/clean_tmp.php
+++ b/crontab/clean_tmp.php
@@ -7,7 +7,14 @@ require_localhost_request();
 
 // remove temporary spellcheck files older than 1 day
 unset($output);
-exec("/usr/bin/find '$aspell_temp_dir' -type f -mtime +1 -delete", $output, $return);
+$cmd = join(" ", [
+    "/usr/bin/find",
+    escapeshellarg($aspell_temp_dir),
+    "-type f",
+    "-mtime +1",
+    "-delete",
+]);
+exec($cmd, $output, $return);
 if ($return != 0) {
     echo "An error occurred while cleaning up files.\n";
     echo "Return value: $return\n";

--- a/crontab/clean_uploads_trash.php
+++ b/crontab/clean_uploads_trash.php
@@ -12,7 +12,14 @@ if (!$trash_dir) {
 
 // remove files from TRASH subdirectory older than 30 days
 unset($output);
-exec("/usr/bin/find '$trash_dir' -type f -mtime +30 -delete", $output, $return);
+$cmd = join(" ", [
+    "/usr/bin/find",
+    escapeshellarg($trash_dir),
+    "-type f",
+    "-mtime +30",
+    "-delete",
+]);
+exec($cmd, $output, $return);
 if ($return != 0) {
     echo "An error occurred while cleaning up files.\n";
     echo "Return value: $return\n";
@@ -24,7 +31,14 @@ if ($return != 0) {
 
 // remove empty directories
 unset($output);
-exec("/usr/bin/find '$trash_dir' -type d -empty -delete", $output, $return);
+$cmd = join(" ", [
+    "/usr/bin/find",
+    escapeshellarg($trash_dir),
+    "-type d",
+    "-empty",
+    "-delete",
+]);
+exec($cmd, $output, $return);
 if ($return != 0) {
     echo "An error occurred while cleaning up files.\n";
     echo "Return value: $return\n";

--- a/crontab/import_pg_catalog.php
+++ b/crontab/import_pg_catalog.php
@@ -95,7 +95,16 @@ if ($start_from_scratch) {
     }
 
     trace("Extracting files from $local_compressed_file to $local_catalog_dir...");
-    system("tar --extract --bzip2 --file=$local_compressed_file --strip-components=3 --directory=$local_catalog_dir --overwrite", $ret);
+    $cmd = join(" ", [
+        "tar",
+        "--extract",
+        "--bzip2",
+        "--file=" . escapeshellarg($local_compressed_file),
+        "--strip-components=3",
+        "--directory=" . escapeshellarg($local_catalog_dir),
+        "--overwrite",
+    ]);
+    system($cmd, $ret);
     // Each file in the tar archive describes one ebook in the PG collection,
     // and has a path of the form:
     //     cache/epub/NNN/pgNNN.rdf

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -142,7 +142,7 @@ elseif ($func == "newtranslation2") {
 elseif ($func == "delete") {
     $locale = validate_locale($_REQUEST['locale']);
     assert(is_dir("$dyn_locales_dir/$locale"));
-    exec("rm -r $dyn_locales_dir/$locale");
+    exec("rm -r " . escapeshellarg("$dyn_locales_dir/$locale"));
 
     echo "<p>" . sprintf(_("Locale %s deleted."), $locale) . "</p>";
 
@@ -173,9 +173,9 @@ elseif ($func == "xgettext") {
         die("Unable to change to requested directory.");
     }
 
-    $xgettext_arguments = [
+    $cmd = join(" ", [
         $xgettext_executable,
-        "--output-dir=$dyn_locales_dir/",
+        "--output-dir=" . escapeshellarg("$dyn_locales_dir/"),
         "--output=messages.pot",
         "--language=PHP",
         "--keyword=_",
@@ -185,8 +185,8 @@ elseif ($func == "xgettext") {
         "--sort-by-file",
         "`find -name '*.php' -o -name '*.inc'`",
         "2>&1",
-    ];
-    exec(implode(" ", $xgettext_arguments), $exec_out, $ret_var);
+    ]);
+    exec($cmd, $exec_out, $ret_var);
     if ($ret_var) {
         echo "<p class='center-align'>" . _("Strings <b>not</b> rebuilt!") . "<br>"
             . _("This is the <code>xgettext</code> output:") . "</p>";

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -113,11 +113,14 @@ class POFile
 
     public function create_from_template($pot_filename, $locale)
     {
-        exec("msginit --no-translator " .
-                     "--input='$pot_filename' " .
-                     "--output-file='$this->po_filename' " .
-                     "--locale=$locale",
-             $exec_out, $return_value);
+        $cmd = join(" ", [
+            "msginit",
+            "--no-translator",
+            "--input=" . escapeshellarg($pot_filename),
+            "--output-file=" . escapeshellarg($this->po_filename),
+            "--locale=" . escapeshellarg($locale),
+        ]);
+        exec($cmd, $exec_out, $return_value);
 
         if ($return_value != 0) {
             throw new Exception(implode("\n", $exec_out));
@@ -126,14 +129,16 @@ class POFile
 
     public function merge_from_template($template, $fuzzy = false)
     {
-        if ($fuzzy) {
-            $fuzzy_option = "";
-        } else {
-            $fuzzy_option = "-N";
-        }
-
-        exec("msgmerge --sort-by-file -U $fuzzy_option '$this->po_filename' '$template' 2>&1",
-            $exec_out, $return_value);
+        $cmd = join(" ", [
+            "msgmerge",
+            "--sort-by-file",
+            "-U ",
+            ($fuzzy ? "" : "-N"),
+            escapeshellarg($this->po_filename),
+            escapeshellarg($template),
+            "2>&1",
+        ]);
+        exec($cmd, $exec_out, $return_value);
 
         if ($return_value != 0) {
             throw new Exception(implode("\n", $exec_out));
@@ -144,8 +149,13 @@ class POFile
     {
         $compiled_filename = str_replace(".po", ".mo", $this->po_filename);
 
-        exec("msgfmt '$this->po_filename' -o '$compiled_filename' 2>&1",
-            $exec_out, $return_value);
+        $cmd = join(" ", [
+            "msgfmt",
+            escapeshellarg($this->po_filename),
+            "-o " . escapeshellarg($compiled_filename),
+            "2>&1",
+        ]);
+        exec($cmd, $exec_out, $return_value);
 
         if ($return_value != 0) {
             throw new Exception(implode("\n", $exec_out));

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -44,7 +44,7 @@ function archive_project($project, $dry_run)
         if ($dry_run) {
             echo "    Remove $smooth_dir directory.\n";
         } else {
-            exec("rm -rf $smooth_dir");
+            exec("rm -rf " . escapeshellarg($smooth_dir));
         }
     }
 

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -259,7 +259,16 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
                 // run aspell using this language
 
                 // create the aspell command
-                $aspell_command = "cat $tmp_file_path | {$aspell_executable} list --prefix={$aspell_prefix} -d $dict_file --encoding {$charset}";
+                $aspell_command = join(" ", [
+                    "cat",
+                    escapeshellarg($tmp_file_path),
+                    "|",
+                    $aspell_executable,
+                    "list",
+                    "--prefix=" . escapeshellarg($aspell_prefix),
+                    "-d " . escapeshellarg($dict_file),
+                    "--encoding " . escapeshellarg($charset),
+                ]);
                 //echo "<!-- aspell command: $aspell_command -->\n"; // Very useful for debugging
                 // build our list of possible misspellings
                 $misspellings[$langcode] = explode("\n",

--- a/tools/project_manager/show_project_stealth_scannos.php
+++ b/tools/project_manager/show_project_stealth_scannos.php
@@ -196,7 +196,13 @@ function _get_word_list($projectid)
     unset($all_page_text);
 
     // make external call to wdiff
-    exec("wdiff -3 $ocr_filename $latest_filename", $wdiff_output, $return_code);
+    $cmd = join(" ", [
+        "wdiff",
+        "-3",
+        escapeshellarg($ocr_filename),
+        escapeshellarg($latest_filename),
+    ]);
+    exec($cmd, $wdiff_output, $return_code);
 
     // check to see if wdiff wasn't found to execute
     if ($return_code == 127) {

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -36,7 +36,15 @@ if (!is_null($zip_type)) {
     header("Content-Disposition: attachment; filename=\"$zipfile\"");
     header("Cache-Control: no-cache, must-revalidate");
     header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
-    passthru("cat $list_name |zip -@ -");
+    $cmd = join(" ", [
+        "cat",
+        escapeshellarg($list_name),
+        "|",
+        "zip",
+        "-@",
+        "-",
+    ]);
+    passthru($cmd);
     unlink($list_name);
     exit();
 } else {


### PR DESCRIPTION
We already use `escapeshellarg()` in all places that accept user input. However, it is a best practice to always escape variables being injected into `exec()`, `shell_exec()`, and `system()` (also in backticks, but I confirmed we do not run commands via those in our code). This updates all instances of those to escape all non-literals.

Testable in the [better-exec-escaping](https://www.pgdp.org/~cpeel/c.branch/better-exec-escaping/) sandbox. I have tested the cronjobs, downloading images, running WordCheck, stealth scanno checks, and regenerating the xgettext sample.