### PR TITLE
Updates for PHP 8

### DIFF
--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -24,6 +24,7 @@ Ubuntu system package names.
 * mbstring - php-mbstring
 * memcached - php-memcached (to enable API rate limiting)
 * MySQL - php-mysql
+* xml - php-xml (used by packages installed with composer)
 * zip - php-zip
 
 ### Composer

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -16,7 +16,8 @@ The following lists supported versions for the four primary middleware
 components.
 
 ### PHP
-PHP version 7.4 is the minimum supported version. PHP 8.0 has not been tested.
+PHP version 7.4 is the minimum supported version. Limited testing has been done
+on PHP 8.0 and 8.1.
 
 The following PHP extensions are required. They are listed below with their
 Ubuntu system package names.

--- a/feeds/backend.php
+++ b/feeds/backend.php
@@ -13,9 +13,9 @@ $limit = 20; // Number of rows we query from the table, number of items in RSS f
 // Determine if we should display a 0.91 compliant RSS feed or our own feed
 $intlang = get_desired_language();
 if (isset($_GET['type'])) {
-    $xmlfile = "$xmlfeeds_dir/${content}_rss.$intlang.xml";
+    $xmlfile = "$xmlfeeds_dir/{$content}_rss.$intlang.xml";
 } else {
-    $xmlfile = "$xmlfeeds_dir/${content}.$intlang.xml";
+    $xmlfile = "$xmlfeeds_dir/{$content}.$intlang.xml";
 }
 
 // If the file does not exist or is stale, let's (re)create it

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -53,7 +53,7 @@ if ($func == "download" || $func == "view") {
 
         if ($func == "download") {
             $output_fname =
-                ($locale == 'template') ? "messages.pot" : "${locale}_messages.po";
+                ($locale == 'template') ? "messages.pot" : "{$locale}_messages.po";
             header("Content-Disposition: attachment; filename=\"$output_fname\"");
             header("Content-Length: ".filesize($filename));
         }

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -169,10 +169,10 @@ final class DPDatabase
     protected function __clone()
     {
     }
-    protected function __sleep()
+    public function __sleep()
     {
     }
-    protected function __wakeup()
+    public function __wakeup()
     {
     }
 }

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -176,7 +176,7 @@ class POFileIterator implements Iterator
         $this->po_filename = $po_filename;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->file_handle) {
             fseek($this->file_handle, 0);
@@ -187,17 +187,17 @@ class POFileIterator implements Iterator
         $this->next();
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->current_block;
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->block_count;
     }
 
-    public function next()
+    public function next(): void
     {
         if (!$this->file_handle) {
             return;
@@ -224,7 +224,7 @@ class POFileIterator implements Iterator
         $this->file_handle = null;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return ($this->current_block != null);
     }

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -353,7 +353,7 @@ class OptionsColumn extends Column
             }
             if ($project->state == PROJ_POST_SECOND_CHECKED_OUT ||
                 $project->state == PROJ_POST_COMPLETE) {
-                $actions[] = "<a href=\"$project->url/${projectid}_second.zip\">" . _("Download") . "</a>";
+                $actions[] = "<a href=\"$project->url/{$projectid}_second.zip\">" . _("Download") . "</a>";
             }
         }
         if ($actions) {

--- a/pinc/ThemedTable.inc
+++ b/pinc/ThemedTable.inc
@@ -35,7 +35,7 @@ class ThemedTable
         }
 
         echo "\n";
-        echo "<table class='$class' style='border-width: ${border}px; ${width}'>";
+        echo "<table class='$class' style='border-width: {$border}px; {$width}'>";
 
         {
             $possible_subtitle =

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -377,12 +377,12 @@ function save_raw_data($pguser, $data_name, $data)
 
 function get_saved_data($pguser, $filter_type)
 {
-    return unserialize(get_raw_saved_data($pguser, "${filter_type}_data"));
+    return unserialize(get_raw_saved_data($pguser, "{$filter_type}_data"));
 }
 
 function get_project_filter_display($pguser, $filter_type)
 {
-    return get_raw_saved_data($pguser, "${filter_type}_display");
+    return get_raw_saved_data($pguser, "{$filter_type}_display");
 }
 
 function get_raw_saved_data($pguser, $data_name)

--- a/pinc/forum_interface.inc
+++ b/pinc/forum_interface.inc
@@ -203,8 +203,6 @@ function login_forum_user($username, $password)
         $persist_login = true;
         $results = $auth->login($username, $password, $persist_login);
 
-        define('IN_PHPBB', false);
-
         $success = $results["status"] == LOGIN_SUCCESS;
         $reason = '';
         switch ($results["status"]) {
@@ -261,10 +259,9 @@ function logout_forum_user()
 
         include($phpbb_root_path . 'common.' . $phpEx);
 
-        $user->session_kill();
+        // Re-initialize phpBB session object in $user so we can kill it
         $user->session_begin();
-
-        define('IN_PHPBB', false);
+        $user->session_kill();
     }
 }
 
@@ -427,7 +424,7 @@ function get_forum_email_address($username)
 {
     $user_details = get_forum_user_details($username);
 
-    return $user_details["email"];
+    return $user_details["email"] ?? "";
 }
 
 function get_url_to_compose_message_to_user($username)

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -142,7 +142,7 @@ function icu_date($pattern, $timestamp = null, $user = null)
         $timestamp = time();
     }
 
-    $idf = new IntlDateFormatter($locale, null, null);
+    $idf = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE);
     $idf->setPattern($pattern);
     return $idf->format($timestamp);
 }

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -41,8 +41,7 @@ function get_desired_language()
         $locale = $_COOKIE['language'];
     } elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
         // Attempt to guess locale based on browser settings
-        $test_locale = \
-            get_locale_matching_browser_accept_language($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        $test_locale = get_locale_matching_browser_accept_language($_SERVER['HTTP_ACCEPT_LANGUAGE']);
         if ($test_locale) {
             $locale = $test_locale;
         }

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -355,6 +355,9 @@ function html_safe($string, $flags = ENT_QUOTES)
     if (!@$charset) {
         $charset = ini_get("default_charset");
     }
+    if ($string === null) {
+        return "";
+    }
     return htmlspecialchars($string, $flags, $charset);
 }
 
@@ -391,6 +394,9 @@ function attr_safe($string)
 //      Nom de l&#39;&amp;oelig;uvre
 {
     global $charset;
+    if ($string === null) {
+        return "";
+    }
     return htmlspecialchars($string, ENT_QUOTES, $charset,
                             false /* $double_encode */);
 }
@@ -497,6 +503,9 @@ function normalize_whitespace($str)
 function xmlencode($string)
 {
     global $charset;
+    if ($string === null) {
+        return "";
+    }
     return htmlspecialchars($string, ENT_COMPAT, $charset);
 }
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -715,6 +715,7 @@ function show_tally_specific_stats($tally_name)
 
 function show_tally_vs_goal($label, $goal, $actual)
 {
+    $goal = $goal == null ? 0 : $goal;
     $percent = $actual == 0 ? 0 : $actual / $goal * 100;
     echo "<tr>";
     echo "<th>$label</th>";

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -310,12 +310,6 @@ function showForumProfile($username)
             "_new",
         ],
         [
-            "Google+",
-            @$bb_user["googleplus"],
-            "https://plus.google.com/" . (preg_match('/^\d{20,}$/', trim(@$bb_user["googleplus"])) ? "" : "+") . @$bb_user["googleplus"],
-            "_new",
-        ],
-        [
             "Skype",
             @$bb_user["skype"],
             "skype:" . @$bb_user["skype"] . "?userinfo",

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -1099,10 +1099,10 @@ function show_form($action, $cdrp, $form_content, $submit_label)
     // Display a div with a form containing action and cdrp hidden inputs; some content,
     // which can be abritrary HTML/other inputs; and finally a labeled submit button
     echo "<div id='$action' style='border: 1px solid grey; margin-left: .5em; padding: .25em;'>\n";
-    echo "<form id='${action}_form' style='margin: 0em;' action='?' method='POST' enctype='multipart/form-data'>\n";
+    echo "<form id='{$action}_form' style='margin: 0em;' action='?' method='POST' enctype='multipart/form-data'>\n";
     echo "<input type='hidden' name='action' value='" . attr_safe($action) . "'>\n";
     echo "<input type='hidden' name='cdrp' value='" . attr_safe($cdrp) . "'>\n";
-    echo "$form_content&nbsp;<input id='${action}_submit' type='submit' value='$submit_label'>\n";
+    echo "$form_content&nbsp;<input id='{$action}_submit' type='submit' value='$submit_label'>\n";
     echo "</form>\n";
     echo "</div>\n";
 }

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -205,7 +205,7 @@ function printTableFrequencies($initialFreq, $cutoffOptions, $wordCount, $instan
         if (!$printedTbody) {
 
             // hide any span sections past our initialFreq
-            echo "<tbody id='${freqCutoff}_${instance}'";
+            echo "<tbody id='{$freqCutoff}_{$instance}'";
             if ($freqCutoff < $initialFreq) {
                 echo " style='display: none;'";
             }

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -509,7 +509,7 @@ function show_page_menu($all_view_modes, $round_view, $username, $key)
         if ($round_view == $setting) {
             echo "<li class='current-tab'><a>$label</a></li>";
         } else {
-            echo "<li><a href='?${qs_username}${key}=$setting#$key'>$label</a></li>";
+            echo "<li><a href='?{$qs_username}{$key}=$setting#$key'>$label</a></li>";
         }
     }
 

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -309,7 +309,7 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
     validate_projectID($projectid);
     $sql = sprintf("
         SELECT COUNT(*)
-        FROM ${projectid}
+        FROM {$projectid}
         WHERE {$work_round->user_column_name} = '%s' AND
               {$work_round->time_column_name} > %d
         ", DPDatabase::escape($username),

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -196,12 +196,12 @@ function do_radio_button_pair($prompt, $input_name, $repeating, $first_is_checke
     echo "<tr><td></td><td>\n";
     echo "<fieldset>\n";
     echo "<legend>$prompt</legend>\n";
-    echo "<input type='radio' name='$input_name' id='${input_name}-1' value='1' $checked1>\n";
-    echo "<label for='${input_name}-1'>" . _("Yes") . "</label>\n";
+    echo "<input type='radio' name='$input_name' id='{$input_name}-1' value='1' $checked1>\n";
+    echo "<label for='{$input_name}-1'>" . _("Yes") . "</label>\n";
     echo "&nbsp;&nbsp;&nbsp;&nbsp; ";
 
-    echo "<input type='radio' name='$input_name' id='${input_name}-2' value='0' $checked2>\n";
-    echo "<label for='${input_name}-2'>" . _("No") . "</label>\n";
+    echo "<input type='radio' name='$input_name' id='{$input_name}-2' value='0' $checked2>\n";
+    echo "<label for='{$input_name}-2'>" . _("No") . "</label>\n";
     echo "</fieldset>\n";
     echo "</td></tr>\n";
 }

--- a/tools/site_admin/manage_random_rules.php
+++ b/tools/site_admin/manage_random_rules.php
@@ -13,7 +13,7 @@ if (!(user_is_a_sitemanager())) {
 $action = array_get($_POST, "action", null);
 $document = get_enumerated_param($_POST, "document", null, array_keys(RandomRule::$document_values), true);
 $url = array_get($_POST, "url", null);
-$langcode = strtolower(array_get($_POST, "langcode", null));
+$langcode = strtolower(array_get($_POST, "langcode", ""));
 
 $title = _("Manage Random Rules");
 

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -393,11 +393,11 @@ class SpecialDay
 
 function make_link($url, $label)
 {
-    $start = substr($url, 0, 3);
-    $label = html_safe($label);
-    if ($url == '') {
+    if (!$url) {
         return '';
     }
+    $start = substr($url, 0, 3);
+    $label = html_safe($label);
     if ($start != 'htt') {
         $url = "http://" . $url;
     }

--- a/userprefs.php
+++ b/userprefs.php
@@ -941,7 +941,7 @@ function _show_text_input_field($field_type, $field_name, $current_value, $extra
     } else {
         $min_attr = "";
     }
-    echo "<input type='$field_type' style='width: ${size}' name='$field_name' value='$current_value_esc' $min_attr $required>$rest";
+    echo "<input type='$field_type' style='width: {$size}' name='$field_name' value='$current_value_esc' $min_attr $required>$rest";
 }
 
 function _show_textfield($field_name, $current_value, $extras)


### PR DESCRIPTION
These are some updates that, after limited testing, appear to make the code work cleanly with PHP 8.0 and 8.1. Thankfully our code is modern enough that we don't need any major changes.

This code should work on PHP 7.4, 8.0, and 8.1. Accordingly there are two sandboxes available:
* The [updates-for-php8](https://www.pgdp.org/~cpeel/c.branch/updates-for-php8/) on TEST which is running PHP 7.4
* ~The [updates-for-php8](https://100.22.14.219/~cpeel/c.branch/updates-for-php8/) on a separate EC2 instance running PHP 8.1 (the cert does not match so you will get an SSL error in your browser)~