### PR TITLE
Replace nonlocalized strftime()

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -157,7 +157,7 @@ function progress_snapshot_table($show_filtered_projects, $show_filtering_links,
     // start the table
     echo "<h2 id='progress_snapshot'>" . _("Site Progress Snapshot") . "</h2>";
 
-    echo "<p>" . sprintf(_("The following table provides an overview of what has been happening in the various stages of e-book production since midnight server-time. Current server-time is %s."), strftime("%H:%M")) . "</p>";
+    echo "<p>" . sprintf(_("The following table provides an overview of what has been happening in the various stages of e-book production since midnight server-time. Current server-time is %s."), date("H:i")) . "</p>";
 
     if ($show_beginner_help) {
         echo "<p>" . _("The left side of the table lists each production stage an e-book will go through, and indicates your ability to work in that stage. The \"Projects\" section, in the center of the table, shows the total number of projects in each stage, how many of these are waiting to be made available for work, how many are currently active and available for volunteers to work on, and finally, the number of projects that have completed that stage today.") . "</p>";

--- a/crontab/extend_site_tally_goals.php
+++ b/crontab/extend_site_tally_goals.php
@@ -27,13 +27,13 @@ $res2 = dpsql_query("
 $values_list = '';
 
 // Ensure that the table is defined for at least the next 35 days.
-$desired_max_date = strftime('%Y-%m-%d', strtotime('+35 days'));
+$desired_max_date = date('Y-m-d', strtotime('+35 days'));
 
 // What I'd *like* to be able to write:
 // for ( $d = $current_max_date+1; $d <= today() + 35; $d++ )
 
 for ($i = 1; ; $i++) {
-    $date = strftime('%Y-%m-%d', strtotime("$current_max_date + $i day"));
+    $date = date('Y-m-d', strtotime("$current_max_date + $i day"));
     if ($date > $desired_max_date) {
         break;
     }

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -33,13 +33,13 @@ $output = "Checking " . mysqli_num_rows($result) . " projects...\n";
 $any_work_done = false;
 
 // Used for checking smoothread_deadline within the loop
-$curr_time = strftime('%Y-%m-%d %H', time());
+$curr_time = date('Y-m-d H');
 
 while ($row = mysqli_fetch_assoc($result)) {
     $project = new Project($row);
 
     // Check if the time is right, with precision of an hour
-    $deadline = strftime('%Y-%m-%d %H', $project->smoothread_deadline);
+    $deadline = date('Y-m-d H', $project->smoothread_deadline);
 
     if ($curr_time == $deadline) {
         $output .= "$project->nameofwork\n";

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -13,7 +13,7 @@ $projects_by_PPer = get_pp_projects_past_threshold();
 
 // if the script is run before the 14th of the month, send out the first email
 // otherwise send out the second one
-if (strftime("%d", time()) < 14) {
+if (date("d") < 14) {
     $which_message = "first";
 } else {
     $which_message = "second";

--- a/faq/wordcheck-faq.php
+++ b/faq/wordcheck-faq.php
@@ -195,14 +195,11 @@ function createWordListTable($word_lists)
     echo "<th>" . _("Last modified") . "</th>";
     echo "</tr>";
 
-    // TRANSLATORS: This is a strftime-formatted string for the date with year and time
-    $datetime_format = _("%A, %B %e, %Y at %X");
-
     // loop through the word lists building rows as we go
     foreach ($word_lists as $word_list_file => $word_list_url) {
         $filename = basename($word_list_file);
         $word_count = count(explode("\n", file_get_contents($word_list_file))) - 1;
-        $modifiedString = strftime($datetime_format, filemtime($word_list_file));
+        $modifiedString = date('Y-m-d H:i', filemtime($word_list_file));
         echo "<tr>";
         echo "<td><a href=\"$word_list_url\">$filename</a></td>";
         echo "<td>$word_count</td>";

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -450,7 +450,7 @@ function do_upload($locale)
     }
 
     if (file_exists("messages.po")) {
-        $save = "messages_".strftime("%Y%m%d%H%M%S", filemtime("messages.po")).".po";
+        $save = "messages_".date("YmdHis", filemtime("messages.po")).".po";
     }
 
     assert(isset($_FILES['userfile']));
@@ -507,7 +507,7 @@ function do_merge($locale, $fuzzy)
 
     // Try to back up the existing translation
     assert(file_exists("messages.po"));
-    $save = "messages_".strftime("%Y%m%d%H%M%S", filemtime("messages.po")).".po";
+    $save = "messages_".date("YmdHis", filemtime("messages.po")).".po";
     if (!@copy("messages.po", $save)) {
         echo "<p>" . _("Could not save a copy of the previous file.")
             . " " . _("File was not updated.") . "</p>";

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -191,7 +191,7 @@ class Quiz
                 echo "<td class='$class'>$text</td>";
 
                 $date = $pages_required_results[$quiz_page_id] ? $pages_required_results[$quiz_page_id] : 0;
-                $text = ($date != 0) ? strftime("%d-%b-%y", $date) : _("Not attempted");
+                $text = ($date != 0) ? date("Y-m-d", $date) : _("Not attempted");
                 $max = $this->pass_requirements['maximum_age'];
                 $date_ok = ((time() - $date) < $max) || empty($max);
                 $class = $date_ok ? 'quiz-date-ok' : 'quiz-date-not-ok';

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -23,7 +23,7 @@ function archive_project($project, $dry_run)
 
     $projectid = $project->projectid;
 
-    $mod_time_str = strftime('%Y-%m-%d %H:%M:%S', $project->modifieddate);
+    $mod_time_str = date('Y-m-d H:i:s', $project->modifieddate);
     echo "$projectid ($mod_time_str) \"$project->nameofwork\"\n";
 
     if (!$project->pages_table_exists) {

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -68,7 +68,7 @@ function production_exception_handler($exception)
     if ($exception instanceof DBConnectionError && !$maintenance) {
         // We output the timestamp in the same format and timezone (UTC) as
         // the MySQL error log (sans microseconds) for easier correlation.
-        $error_message = gmstrftime("%FT%TZ") . " " .  $exception->getMessage();
+        $error_message = gmdate("Y-m-d") . "T" . gmdate("H:i:s") . "Z " .  $exception->getMessage();
 
         // Dump the error to the php error log
         error_log("base.inc - $error_message");

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -192,7 +192,7 @@ function do_session_query($query)
 
 function write_to_session_log($msg)
 {
-    $time = strftime('%Y-%m-%d %H:%M:%S');
+    $time = date('Y-m-d H:i:s');
     $f = fopen('/tmp/session_query_log', 'a');
     fwrite($f, "------\n$time\n$msg\n");
     fclose($f);

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -563,7 +563,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
         case 'curr_month':
             $start_timestamp = mktime(0, 0, 0, $curr_m, 1, $curr_y);
             $end_timestamp = mktime(0, 0, 0, $curr_m + 1, 1, $curr_y);
-            $year_month = strftime('%Y-%m', $start_timestamp);
+            $year_month = date('Y-m', $start_timestamp);
             $where_clause = "WHERE {year_month} = '$year_month'";
             $title_timeframe = strftime(_('%B %Y'), $now_timestamp);
             break;
@@ -571,7 +571,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
         case 'prev_month':
             $start_timestamp = mktime(0, 0, 0, $curr_m - 1, 1, $curr_y);
             $end_timestamp = mktime(0, 0, 0, $curr_m, 1, $curr_y);
-            $year_month = strftime('%Y-%m', $start_timestamp);
+            $year_month = date('Y-m', $start_timestamp);
             $where_clause = "WHERE {year_month} = '$year_month'";
             $title_timeframe = strftime(_('%B %Y'), $start_timestamp);
             break;
@@ -619,7 +619,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
 
         // The accumulated 'actual' for today and subsequent days is bogus,
         // so delete it.
-        $date_today = strftime('%Y-%m-%d', $now_timestamp);
+        $date_today = date('Y-m-d', $now_timestamp);
         for ($i = 0; $i < count($datax); $i++) {
             if ($datax[$i] >= $date_today) {
                 unset($datay1[$i]);
@@ -677,7 +677,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
                 $earliest_timestamp = $result["timestamp"];
             }
 
-            $average_lookup[strftime("%Y-%m-%d", $result["timestamp"])] = $result["sma"];
+            $average_lookup[date("Y-m-d", $result["timestamp"])] = $result["sma"];
         }
         mysqli_free_result($res);
 
@@ -688,7 +688,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
 
         // loop through each day in the graph and pull in the SMA if it exists
         for ($dateTimestamp = $start_timestamp; $dateTimestamp <= $end_timestamp; $dateTimestamp += (60 * 60 * 24)) {
-            $day = strftime('%Y-%m-%d', $dateTimestamp);
+            $day = date('Y-m-d', $dateTimestamp);
             if (isset($average_lookup[$day])) {
                 $moving_average[] = $average_lookup[$day];
             } else {
@@ -717,7 +717,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
 
         // iterate through the days of the specified month
         for ($dateTimestamp = $start_timestamp; $dateTimestamp <= $end_timestamp; $dateTimestamp += (60 * 60 * 24)) {
-            $datax[] = strftime('%Y-%m-%d', $dateTimestamp);
+            $datax[] = date('Y-m-d', $dateTimestamp);
             $datay1[] = 0;
         }
     }

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -166,7 +166,7 @@ function get_local_file_browser_cache_key($url)
         }
 
         if ($timestamp) {
-            $cache_fixer = "?" . strftime("%Y%m%d%H%M%S", $timestamp);
+            $cache_fixer = "?" . date("YmdHis", $timestamp);
         }
     }
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -393,7 +393,7 @@ function get_pages_per_day_for_past_n_days($tally_name, $holder_type, $holder_id
 
     $pages_per_day = [];
     foreach ($deltas as $timestamp => $tally_delta) {
-        $date = strftime("%Y-%m-%d", $timestamp - $SECONDS_TO_YESTERDAY);
+        $date = date("Y-m-d", $timestamp - $SECONDS_TO_YESTERDAY);
         $pages_per_day[$date] = $tally_delta;
     }
 

--- a/pinc/release_queue.inc
+++ b/pinc/release_queue.inc
@@ -1,8 +1,8 @@
 <?php
 // A place for shared functions dealing with release queues.
 
-$today_MMDD = strftime('%m%d', strtotime('today'));
-$tomorrow_MMDD = strftime('%m%d', strtotime('tomorrow'));
+$today_MMDD = date('md', strtotime('today'));
+$tomorrow_MMDD = date('md', strtotime('tomorrow'));
 
 function cook_project_selector($project_selector)
 // Expand certain sequences in $project_selector.

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -97,7 +97,7 @@ function output_footer($nameofpage, $show_statsbar = true)
 
     echo "<span id='buildtime'>";
     echo " &middot; ";
-    echo sprintf(_("Page built at %s in %0.3fs"), strftime("%Y-%m-%d %R %Z"), $totaltime);
+    echo sprintf(_("Page built at %s in %0.3fs"), date("Y-m-d H:i T"), $totaltime);
     echo "</span>";
 
     echo " &middot; ";
@@ -592,7 +592,7 @@ function show_tally_specific_stats($tally_name)
 
     // Put the whole thing in a div, just so we can put a box around it.
     echo "<div id='tally-stats'>\n";
-    echo "<p id='server-time'>" . _("Server Time") . ": " . strftime("%R") . "</p>\n";
+    echo "<p id='server-time'>" . _("Server Time") . ": " . date("H:i") . "</p>\n";
 
     // Show the site statistics
 
@@ -792,7 +792,7 @@ function show_birthdays()
             AND date_created < %s
             AND u_privacy != %d
         ORDER BY date_created ASC
-    ", strftime("%m-%d"), $oldest_activity, $timestamp_at_midnight, PRIVACY_ANONYMOUS);
+    ", date("m-d"), $oldest_activity, $timestamp_at_midnight, PRIVACY_ANONYMOUS);
 
     $result = mysqli_query(DPDatabase::get_connection(), $sql);
 

--- a/project.php
+++ b/project.php
@@ -29,8 +29,6 @@ include_once($relPath.'special_colors.inc'); // load_special_days
 // for strftime:
 // TRANSLATORS: This is a strftime-formatted string for the date with year and time
 $datetime_format = _("%A, %B %e, %Y at %X");
-// TRANSLATORS: This is a strftime-formatted string for the time
-$time_format = _("%X");
 
 error_reporting(E_ALL);
 
@@ -362,7 +360,7 @@ function do_blurb_box($blurb)
 
 function do_project_info_table()
 {
-    global $project, $code_url, $datetime_format, $time_format;
+    global $project, $code_url, $datetime_format;
     global $user_is_logged_in;
 
     $projectid = $project->projectid;
@@ -461,7 +459,7 @@ function do_project_info_table()
     // -------------------------------------------------------------------------
     // Current activity
 
-    $formatted_now = strftime($time_format, time());
+    $formatted_now = date("H:i:s");
     $ct = _("Current Time");
     $current_time_addition = "&nbsp;&nbsp;&nbsp;" . html_safe("($ct: $formatted_now)");
 
@@ -1126,7 +1124,7 @@ function do_history()
         echo(
             $event['timestamp'] == '?'
             ? '?'
-            : strftime('%Y-%m-%d %H:%M:%S', $event['timestamp'])
+            : date('Y-m-d H:i:s', $event['timestamp'])
         );
         echo "</td>\n";
 
@@ -1182,7 +1180,7 @@ function do_history()
             echo "<td>{$event['details1']}</td>\n";
             $spare_cols = 2;
             if (($event['details1'] == 'text available') || ($event['details1'] == 'deadline extended')) {
-                $deadline_f = strftime('%Y-%m-%d %H:%M:%S', $event['details2']);
+                $deadline_f = date('Y-m-d H:i:s', $event['details2']);
                 echo "<td>until $deadline_f</td>\n";
                 $spare_cols = 1;
             }

--- a/sitemap.php
+++ b/sitemap.php
@@ -31,7 +31,7 @@ foreach ($fixed_pages as $page => $frequency) {
     }
 
     $url = "$code_url/$page";
-    $lastmod = strftime("%Y-%m-%d", filemtime("$code_dir/$page"));
+    $lastmod = date("Y-m-d", filemtime("$code_dir/$page"));
     echo <<<URL
             <url>
                 <loc>$url</loc>
@@ -68,7 +68,7 @@ while ($row = mysqli_fetch_assoc($result)) {
     }
 
     $url = "$code_url/project.php?id=" . $row["projectid"];
-    $lastmod = strftime("%Y-%m-%d", $row["modifieddate"]);
+    $lastmod = date("Y-m-d", $row["modifieddate"]);
 
     echo <<<URL
             <url>

--- a/stats/misc_stats1.php
+++ b/stats/misc_stats1.php
@@ -17,8 +17,8 @@ $end = get_param_matching_regex($_GET, 'end', null, '/^\d{4}-\d{1,2}$/', true);
 // -----------------------------------
 
 $now_timestamp = time();
-$curr_year_month = strftime('%Y-%m', $now_timestamp);
-$curr_year = strftime('%Y', $now_timestamp);
+$curr_year_month = date('Y-m', $now_timestamp);
+$curr_year = date('Y', $now_timestamp);
 
 // -----------------------------------
 

--- a/tools/pending_access_requests.php
+++ b/tools/pending_access_requests.php
@@ -109,18 +109,17 @@ foreach ($activity_ids as $activity_id) {
         }
         $seconds = 60 * 60 * 24;
         $now = time();
-        $tformat = '%Y-%m-%d';
         while ([$username, $u_id, $t_latest_request, $t_latest_deny, $t_last_on_site] = mysqli_fetch_row($res)) {
             $member_stats_url = "$code_url/stats/members/mdetail.php?id=$u_id";
-            $t_latest_request_f = strftime($tformat, $t_latest_request);
+            $t_latest_request_f = date('Y-m-d', $t_latest_request);
             $t_latest_request_d = round(($now - $t_latest_request) / $seconds);
             $t_latest_deny_f = '';
             $t_latest_deny_d = -1;
             if ($t_latest_deny != 0) {
-                $t_latest_deny_f = strftime($tformat, $t_latest_deny);
+                $t_latest_deny_f = date('Y-m-d', $t_latest_deny);
                 $t_latest_deny_d = round(($now - $t_latest_deny) / $seconds);
             }
-            $t_last_on_site_f = strftime($tformat, $t_last_on_site);
+            $t_last_on_site_f = date('Y-m-d', $t_last_on_site);
             $t_last_on_site_d = round(($now - $t_last_on_site) / $seconds);
 
             echo "<tr>";

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -155,7 +155,7 @@ function output_project_label($nameofwork, $authorsname, $date = null)
     // TRANSLATORS: format is <title> by <author>.
     echo sprintf(_("%1\$s by %2\$s"), $nameofwork, $authorsname);
     if (!is_null($date)) {
-        $date = strftime("%Y-%m-%d %R %Z", $date);
+        $date = date("Y-m-d H:i T", $date);
         echo " ($date)";
     }
 }

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -167,7 +167,7 @@ if (mysqli_num_rows($res) == 0) {
 
         if (isset($colspecs['time'])) {
             echo "<td class='nowrap'>";
-            echo strftime('%Y-%m-%d %H:%M:%S', $row->max_timestamp);
+            echo date('Y-m-d H:i', $row->max_timestamp);
             echo "</td>\n";
         }
 

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -15,7 +15,7 @@ if (!user_is_a_sitemanager()) {
 }
 
 $title = _("Resend Account Activation Email");
-output_header($title);
+output_header($title, NO_STATSBAR);
 
 echo "<h1>$title</h1>";
 
@@ -66,7 +66,7 @@ if ($action == 'default') {
             echo "<td><a href='?action=get_user&username=".urlencode($row['username'])."'>{$row['username']}</a></td>\n";
             echo "<td>" . html_safe($row['real_name']) . "</td>\n";
             echo "<td>" . html_safe($row['email']) . "</td>\n";
-            echo "<td>" . strftime("%B %e, %Y, %H:%M", $row['date_created']) . "</td>\n";
+            echo "<td>" . date("Y-m-d H:i", $row['date_created']) . "</td>\n";
             echo "</tr>\n";
         }
         echo "</table>\n";

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -113,7 +113,7 @@ function show_toggles_form($username, $user_settings)
 
         $access_log_entry = get_latest_access_change_entry($username, $setting_name);
         if ($access_log_entry) {
-            $changed = strftime('%Y-%m-%d %H:%M', $access_log_entry["timestamp"]);
+            $changed = date('Y-m-d H:i', $access_log_entry["timestamp"]);
         } else {
             $changed = "<i>" . _("unknown") . "</i>";
         }

--- a/tools/site_admin/show_access_log.php
+++ b/tools/site_admin/show_access_log.php
@@ -88,7 +88,7 @@ if (!$username && !$activity && $since == 'all') {
     $query_limit = "LIMIT 200";
 }
 
-$t_min_fmt = strftime('%Y-%m-%d %H:%M', $t_min);
+$t_min_fmt = date('Y-m-d H:i', $t_min);
 
 // TRANSLATORS: %s is a time in the format YYYY-MM-DD HH:MM
 echo "<p>" . sprintf(_("The following table shows entries in the access_log table that have occurred since %s"), $t_min_fmt) . "</p>";


### PR DESCRIPTION
`strftime()` is deprecated in PHP 8.1. In many cases we don't need localization and can just use `date()` instead. This PR only takes care of the non-localized instances.

A few places were intentionally changed from what they were before:
* Seconds were removed from the timestamps on the My Projects page & WordCheck FAQ
* Quiz pages now show non-localized dates
* Some site admin pages now show non-localized dates

Testable in the [replace-nonlocalized-strftime](https://www.pgdp.org/~cpeel/c.branch/replace-nonlocalized-strftime/) sandbox.