### PR TITLE
Replace localized strftime() usage with icu_date()

### DIFF
--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -41,8 +41,8 @@ function send_pp_reminders($PPer, $projects, $which_message)
         $nameofwork = $project["nameofwork"];
         $authorsname = $project["authorsname"];
         $projectid = $project["projectid"];
-        $modifieddate = strftime("%e %B %Y", $project["modifieddate"]);
-        $lastvisitdate = strftime("%e %B %Y", $project["lastvisitdate"]);
+        $modifieddate = icu_date_template("short", $project["modifieddate"], $user);
+        $lastvisitdate = icu_date_template("short", $project["lastvisitdate"], $user);
 
         // TRANSLATORS: %1$s is a project title, %2$s is the author, %3%s is the projectid
         $work_details = sprintf(_('%1$s by %2$s (%3$s)'), $nameofwork, $authorsname, $projectid);

--- a/faq/translate.php
+++ b/faq/translate.php
@@ -173,11 +173,11 @@ Server MPM:     Prefork
 
 <p>Although there should not be any, if there are spaces at the beginning or the end of a line, keep them.</p>
 
-<h4>strftime&mdash;time and dates</h4>
+<h4>ICU-formatted times and dates</h4>
 
-<p>Strings passed to PHP's <b>strftime</b> function contain, or consist entirely of "tags" prefixed by %, followed by a letter (%A, %B, etc.). When viewed on the website by the end-user, these tags are replaced with already translated time-related terms (day names, month names, etc.)&mdash;you don't need to translate them yourself! For example, %B expands to month name (e.g. August), and %Y expands to display the full year (e.g. 2004).</p>
+<p>PHP code can localize dates and times using <a href='https://unicode-org.github.io/icu/userguide/format_parse/datetime/'>ICU-formatted strings.</a></p>
 
-<p>It might be neccesary to reorganise the tags so that they form a date which is more natural for your language. For examples, "%A, %B %e, %Y" becomes "Friday, August 13 2004" while "%A, %e. %B %Y." becomes "Friday, 13. August 2004.". For a full list of all tags and a more detailed explanation, you can see <a href='http://www.php.net/manual/en/function.strftime.php' class='external' title="http://www.php.net/manual/en/function.strftime.php">strftime</a> in PHP's manual.</p>
+<p>It might be necessary to reorganize the tags so that they form a date which is more natural for your language. For examples, <kbd>EEEE, MMMM d y</kbd> becomes "Friday, August 6 2004" while <kbd>EEEE, d. MMMM y.</kbd> becomes "Friday, 6. August 2004.".</p>
 
 <h4>sprintf</h4>
 
@@ -185,7 +185,7 @@ Server MPM:     Prefork
 
 <p>Some sprintf-formatted strings have more than one substitution variable. For example: "&lt;a href='%1$s'&gt;%2$s&lt;/a&gt;". Treat the %1$s and similar strings as placeholders and keep them intact. If necessary, you can change the order of the placeholders in the string to better suit the destination language.</p>
 
-<p>If you need to insert a % sign in either strftime or sprintf strings for a translation, use two in a row (%%). If the string is not a strftime or sprintf string (ie: it doesn't have any formatting characters or placeholders already) a single % should be used as needed.</p>
+<p>If you need to insert a % sign in a sprintf string for a translation, use two in a row (%%). If the string is not a sprintf string (ie: it doesn't have any formatting characters or placeholders already) a single % should be used as needed.</p>
 
 <h4>Quotes</h4>
 <p>If the original string has quotes (eg: ' or ") in HTML attributes, use the same quotes in the translated string. If the quotes are part of a paragraph, you are welcome to use the language's quote characters in their place.</p>

--- a/pastnews.php
+++ b/pastnews.php
@@ -44,7 +44,7 @@ if (mysqli_num_rows($result) == 0) {
     echo "<p>" . sprintf(_("No recent news items for %s"), $news_subject) . "</p>";
 } else {
     while ($news_item = mysqli_fetch_array($result)) {
-        $date_posted = strftime(_("%A, %B %e, %Y"), $news_item['date_posted']);
+        $date_posted = icu_date_template("long", $news_item['date_posted']);
         echo "<br><a name='".$news_item['id']."'><b>$date_posted</b><br>".$news_item['content']."<br><hr class='center-align' style='width: 75%'><br>";
     }
 }

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -159,8 +159,7 @@ class TimeColumn extends Column
                 echo sprintf("%.1f", (time() - $data) / 86400);
                 break;
             default: // case 'date':
-                // TRANSLATORS: This is a strftime-formatted string for the date with year
-                echo "<span class='nowrap'>" . strftime(_("%b %e, %Y"), $data) . "</span>";
+                echo "<span class='nowrap'>" . icu_date_template("short", $data) . "</span>";
                 break;
             }
         }

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -156,8 +156,6 @@ function icu_date_template($template, $timestamp = null, $user = null)
         "long" => _("EEEE, MMMM d, y"),
         // TRANSLATORS: ICU-formatted date in long form with time
         "long+time" => _("EEEE, MMMM d, y 'at' HH:mm"),
-        // TRANSLATORS: ICU-formatted date in medium form
-        "medium" => _("EEE, MMM d, y"),
         // TRANSLATORS: ICU-formatted date in short form
         "short" => _("MMM d, y"),
     ];

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -76,13 +76,11 @@ function configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_
     }
 }
 
-// Configure gettext for a specific user, useful for sending emails. $user
-// can be a User object or a username. If $user is NULL, the current user's
-// locale is configured.
-function configure_gettext_for_user($user = null)
+// Get the language (locale) for the specified user.
+// $user can be a User object or a username.
+// If $user is NULL, the current user's locale is returned.
+function get_user_language($user = null)
 {
-    global $charset, $dyn_locales_dir, $system_locales_dir;
-
     if (!$user) {
         $locale = get_desired_language();
     } else {
@@ -91,6 +89,15 @@ function configure_gettext_for_user($user = null)
         }
         $locale = get_valid_locale_for_translation($user->u_intlang);
     }
+    return $locale;
+}
+
+// Configure gettext for a specific user, useful for sending emails.
+function configure_gettext_for_user($user = null)
+{
+    global $charset, $dyn_locales_dir, $system_locales_dir;
+
+    $locale = get_user_language($user);
     configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_dir);
 }
 
@@ -125,4 +132,35 @@ if (!function_exists('pgettext')) {
             return $translation;
         }
     }
+}
+
+// Return a localized date/time string for a date where $pattern is in ICU
+// format (https://unicode-org.github.io/icu/userguide/format_parse/datetime/).
+function icu_date($pattern, $timestamp = null, $user = null)
+{
+    $locale = get_user_language($user);
+    if (!$timestamp) {
+        $timestamp = time();
+    }
+
+    $idf = new IntlDateFormatter($locale, null, null);
+    $idf->setPattern($pattern);
+    return $idf->format($timestamp);
+}
+
+// Return a localized date from a predefined template
+function icu_date_template($template, $timestamp = null, $user = null)
+{
+    $templates = [
+        // TRANSLATORS: ICU-formatted date in long form
+        "long" => _("EEEE, MMMM d, y"),
+        // TRANSLATORS: ICU-formatted date in long form with time
+        "long+time" => _("EEEE, MMMM d, y 'at' HH:mm"),
+        // TRANSLATORS: ICU-formatted date in medium form
+        "medium" => _("EEE, MMM d, y"),
+        // TRANSLATORS: ICU-formatted date in short form
+        "short" => _("MMM d, y"),
+    ];
+
+    return icu_date($templates[$template], $timestamp, $user);
 }

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -565,7 +565,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
             $end_timestamp = mktime(0, 0, 0, $curr_m + 1, 1, $curr_y);
             $year_month = date('Y-m', $start_timestamp);
             $where_clause = "WHERE {year_month} = '$year_month'";
-            $title_timeframe = strftime(_('%B %Y'), $now_timestamp);
+            $title_timeframe = icu_date('MMM y', $now_timestamp);
             break;
 
         case 'prev_month':
@@ -573,7 +573,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
             $end_timestamp = mktime(0, 0, 0, $curr_m, 1, $curr_y);
             $year_month = date('Y-m', $start_timestamp);
             $where_clause = "WHERE {year_month} = '$year_month'";
-            $title_timeframe = strftime(_('%B %Y'), $start_timestamp);
+            $title_timeframe = icu_date('MMM y', $start_timestamp);
             break;
 
         case 'all_time':

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -129,8 +129,7 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
         $title = $project['nameofwork'];
         $language = $project['language'];
         $pagecount = $project['n_pages'];
-        // TRANSLATORS: this is a strftime-formatted string
-        $moddate = strftime(_("%A, %B %e, %Y"), $project['modifieddate']);
+        $moddate = icu_date_template("long", $project['modifieddate']);
         $postednum = $project['postednum'];
 
 

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -597,8 +597,7 @@ function echo_cells_for_round($round, $diff_round_num, // <- These are the only 
     if ($R_time == 0) {
         $R_time_str = '';
     } else {
-        // TRANSLATORS: This is an strftime-formatted string
-        $R_time_str = strftime(_("%Y %b %e %H:%M"), $R_time);
+        $R_time_str = date("Y-m-d H:i", $R_time);
     }
     echo "<td>$R_time_str</td>\n";
 

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -107,8 +107,7 @@ function show_news_for_page($news_page_id)
         if (is_null($date_changed)) {
             // This probably shouldn't happen.
         } else {
-            // TRANSLATORS: this is a strftime-formatted string
-            $formatted_date = strftime(_("%A, %B %e, %Y"), $date_changed);
+            $formatted_date = icu_date_template("long", $date_changed);
             echo sprintf(_("last changed %s"), $formatted_date);
         }
         echo "</small>";

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -330,9 +330,6 @@ function can_user_get_pages_in_project($username, $project, $round)
         $page_tally_threshold = 500;
         $days_on_site_threshold = 21;
 
-        // TRANSLATORS: This is a strftime-formatted string for the date with year and time
-        $datetime_format = _("%A, %B %e, %Y at %X");
-
         $t_release = $project->modifieddate;
         $t_generally_available =
             $t_release + $n_days_of_reserve * 24 * 60 * 60;
@@ -374,7 +371,7 @@ function can_user_get_pages_in_project($username, $project, $round)
                         . "<br>" .
                         sprintf(
                             _('It will become generally available %s.'),
-                            strftime($datetime_format, $t_generally_available)
+                            icu_date_template("long+time", $t_generally_available)
                         )
                     ;
                 }

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -609,7 +609,7 @@ function show_tally_specific_stats($tally_name)
     echo "</tr>";
     show_tally_vs_goal(_("Today"), $site_stats->curr_day_goal, $site_stats->curr_day_actual);
     show_tally_vs_goal(_("Yesterday"), $site_stats->prev_day_goal, $site_stats->prev_day_actual);
-    show_tally_vs_goal(strftime("%B"), $site_stats->curr_month_goal, $site_stats->curr_month_actual);
+    show_tally_vs_goal(icu_date("MMMM"), $site_stats->curr_month_goal, $site_stats->curr_month_actual);
     echo "</table>";
 
     // Number of users
@@ -838,8 +838,7 @@ function show_completed_projects($terse = false)
         $begindate = mktime(0, 0, 0, $thismonth - $months_ago, 1, $thisyear);
         $enddate = mktime(0, 0, 0, $thismonth - $months_ago + 1, 1, $thisyear);
 
-        // TRANSLATORS: This is an strftime-formatted string
-        $displaydate = strftime(_("%b %Y"), $begindate);
+        $displaydate = icu_date("MMM y", $begindate);
 
         $result = mysqli_query(DPDatabase::get_connection(), "
             SELECT COUNT(*) as totalprojects
@@ -853,8 +852,7 @@ function show_completed_projects($terse = false)
 
         if ($terse) {
             // TRANSLATORS: string is in the format: $totalprojects in $date
-            // where $date is an already-translated strftime()-formatted string
-            // with the month and year
+            // where $date is a localized string with the month and year
             echo sprintf(_('%1$d in %2$s'), $totalprojects, $displaydate) . "&nbsp;&mdash;&nbsp;";
         } else {
             echo "<tr>";

--- a/project.php
+++ b/project.php
@@ -26,10 +26,6 @@ include_once($relPath.'special_colors.inc'); // load_special_days
 
 // If the requestor is not logged in, we refer to them as a "guest".
 
-// for strftime:
-// TRANSLATORS: This is a strftime-formatted string for the date with year and time
-$datetime_format = _("%A, %B %e, %Y at %X");
-
 error_reporting(E_ALL);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -194,7 +190,7 @@ function do_expected_state()
 
 function decide_blurbs()
 {
-    global $project, $pguser, $datetime_format;
+    global $project, $pguser;
 
     [$code, $msg] = $project->can_be_proofed_by_current_user();
     if ($code != $project->CBP_OKAY) {
@@ -269,7 +265,7 @@ function decide_blurbs()
 
         // When were the project comments last modified?
         $comments_timestamp = $project->t_last_change_comments;
-        $comments_time_str = strftime($datetime_format, $comments_timestamp);
+        $comments_time_str = icu_date_template("long+time", $comments_timestamp);
         $comments_last_modified_blurb = _("Project Comments last modified:") . " " . $comments_time_str;
 
         // Other possible components of blurbs:
@@ -360,7 +356,7 @@ function do_blurb_box($blurb)
 
 function do_project_info_table()
 {
-    global $project, $code_url, $datetime_format;
+    global $project, $code_url;
     global $user_is_logged_in;
 
     $projectid = $project->projectid;
@@ -381,8 +377,7 @@ function do_project_info_table()
         $extra = $round->description;
         $right = "$right ($extra)";
     } elseif ($available_for_SR) {
-        $sr_deadline_str = strftime(
-            $datetime_format, $project->smoothread_deadline);
+        $sr_deadline_str = icu_date_template("long+time", $project->smoothread_deadline);
         $sr_sentence = sprintf(
             _('This project has been made available for Smooth Reading until %s server time.'),
             "<b>$sr_deadline_str</b>"
@@ -459,24 +454,24 @@ function do_project_info_table()
     // -------------------------------------------------------------------------
     // Current activity
 
-    $formatted_now = date("H:i:s");
+    $formatted_now = date("H:i");
     $ct = _("Current Time");
     $current_time_addition = "&nbsp;&nbsp;&nbsp;" . html_safe("($ct: $formatted_now)");
 
     echo_row_a(
         _("Last Edit of Project Info"),
-        strftime($datetime_format, $project->t_last_edit)
+        icu_date_template("long+time", $project->t_last_edit)
         . $current_time_addition);
 
     echo_row_a(
         _("Last State Change"),
-        strftime($datetime_format, $project->modifieddate),
+        icu_date_template("long+time", $project->modifieddate),
         true);
 
     if ($round) {
         $last_proofread_time = $project->get_last_proofread_time($round);
         if ($last_proofread_time) {
-            $lastproofed = strftime($datetime_format, $last_proofread_time);
+            $lastproofed = icu_date_template("long+time", $last_proofread_time);
         } else {
             $lastproofed = _("Project has not been proofread in this round.");
         }
@@ -497,7 +492,7 @@ function do_project_info_table()
             $f = get_project_word_file($projectid, $gb);
             if ($f->size > 0) {
                 $links .= new_window_link($f->abs_url, $label);
-                $links .= " - " . _("Last modified") . ": " . strftime($datetime_format, $f->mod_time);
+                $links .= " - " . _("Last modified") . ": " . icu_date_template("long+time", $f->mod_time);
             } else {
                 $links .= $label . " " . _("(empty)");
             }
@@ -535,7 +530,7 @@ function do_project_info_table()
     $topic_id = $project->topic_id;
     if (!empty($topic_id)) {
         $last_post_date = get_last_post_time_in_topic($topic_id);
-        $last_post_date = strftime($datetime_format, $last_post_date);
+        $last_post_date = icu_date_template("long+time", $last_post_date);
         echo_row_a(_("Last Forum Post"), $last_post_date, true);
     }
 
@@ -650,7 +645,7 @@ function do_project_info_table()
                 );
             $b = _('The instructions below are particular to this project, and <b>take precedence over those guidelines</b>.');
 
-            $time_str = strftime($datetime_format, $project->t_last_change_comments);
+            $time_str = icu_date_template("long+time", $project->t_last_change_comments);
             $c = "(" . _("Last modified") . ": " . $time_str . ")";
 
             $comments_blurb = "$a<br>$b<br>$c";
@@ -778,8 +773,8 @@ function recentlyproofed($wlist)
             }
             echo "<td class='center-align'>";
             echo "<a href=\"$eURL\">";
-            // TRANSLATORS: This is an strftime-formatted string
-            echo strftime(_("%b %d"), $timestamp) . ": " . $imagefile;
+            // TRANSLATORS: This is an ICU-formatted string
+            echo icu_date(_("MMM dd"), $timestamp) . ": " . $imagefile;
             echo "</a>$wordcheck_status";
             echo "</td>";
             $colnum++;
@@ -1607,10 +1602,8 @@ function echo_download_zip($link_text, $discriminator)
 
 function echo_last_modified($last_modified)
 {
-    global $datetime_format;
-
     if (isset($last_modified)) {
-        echo " (", strftime($datetime_format, $last_modified), ")";
+        echo " (", icu_date_template("long+time", $last_modified), ")";
     }
 }
 
@@ -1645,7 +1638,7 @@ function do_postcomments()
 
 function do_smooth_reading()
 {
-    global $project, $code_url, $pguser, $datetime_format;
+    global $project, $code_url, $pguser;
 
     if ($project->state != PROJ_POST_FIRST_CHECKED_OUT) {
         return;
@@ -1677,8 +1670,7 @@ function do_smooth_reading()
     } else {
         // Project has been made available for SR
         if ($project->is_available_for_smoothreading()) {
-            $sr_deadline_str = strftime(
-                $datetime_format, $project->smoothread_deadline);
+            $sr_deadline_str = icu_date_template("long+time", $project->smoothread_deadline);
             $sr_sentence = sprintf(
                 _('This project has been made available for Smooth Reading until %s server time.'),
                 "<b>$sr_deadline_str</b>"

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -557,8 +557,7 @@ class ProjectInfoHolder
         $a = _("The Guidelines give detailed instructions for working in this round.");
         $b = _('The instructions below are particular to this project, and <b>take precedence over those guidelines</b>.');
 
-        // TRANSLATORS: This is a strftime-formatted string for the date with year and time
-        $now = strftime(_("%A, %B %e, %Y at %X"));
+        $now = icu_date_template("long+time");
 
         echo "<h2 id='preview'>", _("Preview Project"), "</h2>";
         echo "<p>", _("This is a preview of your project and roughly how it will look to the proofreaders."), "</p>\n";

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -11,9 +11,6 @@ include_once("./word_freq_table.inc"); // echo_cutoff_text(), printTableFrequenc
 
 require_login();
 
-// TRANSLATORS: This is a strftime-formatted string for the date with year and time
-$datetime_format = _("%A, %B %e, %Y at %X");
-
 $watch = new Stopwatch();
 $watch->start();
 
@@ -121,7 +118,7 @@ if ($timeCutoff == -1) {
 } elseif ($timeCutoff == 0) {
     $time_cutoff_text = _("<b>All proofreader suggestions</b> are included in the results.");
 } else {
-    $time_cutoff_text = sprintf(_("Only proofreader suggestions made <b>after %s</b> are included in the results."), strftime($datetime_format, $timeCutoff));
+    $time_cutoff_text = sprintf(_("Only proofreader suggestions made <b>after %s</b> are included in the results."), icu_date_template("long+time", $timeCutoff));
 }
 
 echo "<p>" . $time_cutoff_text . "</p>";

--- a/tools/project_manager/show_good_word_suggestions.php
+++ b/tools/project_manager/show_good_word_suggestions.php
@@ -10,8 +10,6 @@ include_once("./word_freq_table.inc");
 
 require_login();
 
-$datetime_format = "%A, %B %e, %Y %X";
-
 set_time_limit(0); // no time limit
 
 $projectid = get_projectID_param($_REQUEST, 'projectid');
@@ -24,7 +22,7 @@ enforce_edit_authorization($projectid);
 if ($timeCutoff == 0) {
     $time_cutoff_text = _("<b>All proofreader suggestions</b> are included in the results.");
 } else {
-    $time_cutoff_text = sprintf(_("Only proofreader suggestions made <b>after %s</b> are included in the results."), strftime($datetime_format, $timeCutoff));
+    $time_cutoff_text = sprintf(_("Only proofreader suggestions made <b>after %s</b> are included in the results."), icu_date_template("long+time", $timeCutoff));
 }
 
 

--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -17,9 +17,6 @@ include_once("./word_freq_table.inc");
 
 require_login();
 
-// TRANSLATORS: This is a strftime-formatted string for the date with year and time
-$datetime_format = _("%A, %B %e, %Y at %X");
-
 $watch = new Stopwatch();
 $watch->start();
 
@@ -98,7 +95,7 @@ foreach ($word_suggestions as $suggestion) {
         continue;
     }
 
-    echo "<p><b>" . _("Date") . "</b>: " . strftime($datetime_format, $time) . "<br>";
+    echo "<p><b>" . _("Date") . "</b>: " . icu_date_template("long+time", $time) . "<br>";
     echo "<b>" . _("Round") . "</b>: $round &nbsp; | &nbsp; ";
     echo "<b>" . _("Proofreader") . "</b>: " . private_message_link($proofer) . "<br>";
     echo "<b>" . _("Page") . "</b>: <a href='javascript:void(0)' class='page-select' data-value='$page'>$page</a><br>";

--- a/tools/project_manager/show_specials.php
+++ b/tools/project_manager/show_specials.php
@@ -35,7 +35,7 @@ foreach ($special_days as $row) {
     if ($month != $current_month) {
         $current_month = $month;
         echo "<tr class='month'><td colspan='5'><h2>";
-        echo strftime("%B", mktime(0, 0, 0, $row['open_month'], 10)) . "</h2></td></tr>\n";
+        echo icu_date("MMMM", mktime(0, 0, 0, $row['open_month'], 10)) . "</h2></td></tr>\n";
         output_column_headers();
     }
 

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -166,7 +166,7 @@ class SpecialDay
             output_table_headers();
         } elseif ($this->open_month != $current_month) {
             echo "<tr class='month'><td colspan='9'><h2>";
-            echo strftime("%B", mktime(0, 0, 0, $this->open_month, 10));
+            echo icu_date("MMMM", mktime(0, 0, 0, $this->open_month, 10));
             echo "</h2></td></tr>";
             output_table_headers();
         }

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -45,8 +45,7 @@ if (isset($news_page_id)) {
     echo "<h1>$title</h1>";
 
     $date_changed = get_news_page_last_modified_date($news_page_id);
-    // TRANSLATORS: this is a strftime-formatted string
-    $last_modified = strftime(_("%A, %B %e, %Y"), $date_changed);
+    $last_modified = icu_date_template("long", $date_changed);
     echo "<p>" . _("Last modified") . ": ".$last_modified . "</p>";
 
     show_item_editor($news_page_id, $action, $item_id);
@@ -67,8 +66,7 @@ if (isset($news_page_id)) {
 
         $date_changed = get_news_page_last_modified_date($news_page_id);
         if (!is_null($date_changed)) {
-            // TRANSLATORS: this is a strftime-formatted string
-            $last_modified = strftime(_("%A, %B %e, %Y"), $date_changed);
+            $last_modified = icu_date_template("long", $date_changed);
             echo "<br>". _("Last modified").": ".$last_modified;
         }
         echo "<br><br>";
@@ -375,7 +373,7 @@ function show_all_news_items_for_page($news_page_id)
             echo "<tr>";
             echo "<td class='commands'>";
             echo "<p><b>" . _("Posted") . ":</b><br>";
-            echo strftime(_("%B %e, %Y"), $news_item['date_posted']) . "</b>";
+            echo icu_date_template("medium", $news_item['date_posted']) . "</b>";
             if ($news_item['locale']) {
                 echo "<br><b>" . _("Locale") . ":</b><br>" . $news_item['locale'];
             }

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -373,7 +373,7 @@ function show_all_news_items_for_page($news_page_id)
             echo "<tr>";
             echo "<td class='commands'>";
             echo "<p><b>" . _("Posted") . ":</b><br>";
-            echo icu_date_template("medium", $news_item['date_posted']) . "</b>";
+            echo icu_date_template("short", $news_item['date_posted']) . "</b>";
             if ($news_item['locale']) {
                 echo "<br><b>" . _("Locale") . ":</b><br>" . $news_item['locale'];
             }


### PR DESCRIPTION
[More work to get us off `strftime()` in prep for its deprecation in PHP 8.1.]

Introduce an `icu_date()` function to localize date/time strings using `IntlDateFormatter`. This function can either take an ICU-formatted pattern, or use one of the presets. Using presets helps ensure consistent localized date formatting across the site.

One could argue that I've overloaded a single function where 2 would be better (one for ICU-formatted dates, one for templated dates). I welcome thoughts on that.

Testable in the [replace-localized-strftime](https://www.pgdp.org/~cpeel/c.branch/replace-localized-strftime/) sandbox.