### PR TITLE
Fix minor PHP messages from Detectify run

### DIFF
--- a/crontab/onoff_special_event_queues.php
+++ b/crontab/onoff_special_event_queues.php
@@ -84,7 +84,7 @@ foreach (['open', 'close'] as $which) {
     ";
     echo $specials_query, "\n";
 
-    $res = mysqli_query(DPDatabase::get_connection(), $specials_query) or die(DPDatabase::log_error());
+    $res = DPDatabase::query($specials_query);
     $n = mysqli_num_rows($res);
     echo "
         Found $n special events which '$which' now.
@@ -95,6 +95,7 @@ foreach (['open', 'close'] as $which) {
             Looking for queues that deal with special event '$spec_code'...
         ";
         $w = '[[:space:]]*';
+        $spec_code = preg_quote(DPDatabase::escape($spec_code));
         $selector_pattern = "{$w}special_code{$w}={$w}[\"\\']{$spec_code}[\"\\']";
         $update_query = "
             UPDATE queue_defns
@@ -105,7 +106,7 @@ foreach (['open', 'close'] as $which) {
         echo $update_query, "\n";
 
         if (!$testing_this_script) {
-            mysqli_query(DPDatabase::get_connection(), $update_query) or die(DPDatabase::log_error());
+            DPDatabase::query($update_query);
 
             $n = DPDatabase::affected_rows();
             echo "

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -107,6 +107,11 @@ class ProjectSearchWidget
 
             $contribution = $this->sql_from_multi($values, $column_name, $comparator);
         } else {
+            // if $value is an array, someone is mucking with URL
+            if (is_array($value)) {
+                return null;
+            }
+
             $value = DPDatabase::escape($value);
             if ($comparator == '=') {
                 $contribution = "$column_name = '$value'";
@@ -120,6 +125,13 @@ class ProjectSearchWidget
 
     public function sql_from_multi($values, $column_name, $comparator)
     {
+        // if any $value is an array, someone is mucking with the URL
+        foreach ($values as $value) {
+            if (is_array($value)) {
+                return null;
+            }
+        }
+
         $values = array_map("DPDatabase::escape", $values);
         $inv = isset($_GET[$this->id . "_inv"]) ? " NOT " : "";
         if ($comparator == '=') {
@@ -137,6 +149,13 @@ class SpecialDayWidget extends ProjectSearchWidget
 {
     public function sql_from_multi($values, $column_name, $comparator)
     {
+        // if any $value is an array, someone is mucking with the URL
+        foreach ($values as $value) {
+            if (is_array($value)) {
+                return null;
+            }
+        }
+
         $values = array_map("DPDatabase::escape", $values);
         $contributions = [];
         foreach ($values as $value) {

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -212,7 +212,7 @@ class GenreColumn extends Column
             "hard" => _("HARD"),
         ];
         $genre = $project->trans_genre;
-        $prefix = $diff_prefix[$project->difficulty];
+        $prefix = $diff_prefix[$project->difficulty] ?? "";
         if ($prefix != "") {
             $genre = $prefix." ".$genre;
         }

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -130,37 +130,20 @@ function mysql_session_select($sid)
 function mysql_session_write($sid, $value)
 {
     $expiration = time() + ini_get("session.cookie_lifetime");
-    $result = do_session_query(sprintf(
-        "SELECT COUNT(*) FROM sessions WHERE sid = '%s'",
-        DPDatabase::escape($sid)
-    ));
-    [$SessionExists] = mysqli_fetch_row($result);
-    // The table has a uniqueness constraint on 'sid',
-    // so $SessionExists must be 0 or 1.
 
-
-    if ($SessionExists == 0) {
-        $query = sprintf("
-            INSERT INTO sessions
-                (sid, expiration, value)
-            VALUES
-                ('%s', %d, '%s')",
-            DPDatabase::escape($sid),
-            $expiration,
-            DPDatabase::escape($value));
-    } else {
-        $query = sprintf("
-            UPDATE sessions
-            SET
-                expiration = %d,
-                value = '%s'
-            WHERE sid = '%s' AND expiration > %d",
-            $expiration,
-            DPDatabase::escape($value),
-            DPDatabase::escape($sid),
-            time())
-            ;
-    }
+    $query = sprintf("
+        INSERT INTO sessions
+            (sid, expiration, value)
+        VALUES
+            ('%s', %d, '%s')
+        ON DUPLICATE KEY UPDATE
+            expiration = %d,
+            value = '%s'",
+        substr(DPDatabase::escape($sid), 0, 32), // truncate to column size
+        $expiration,
+        DPDatabase::escape($value),
+        $expiration,
+        DPDatabase::escape($value));
     $result = do_session_query($query);
     return $result;
 }

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -303,7 +303,7 @@ class LanguageSearchElement extends ProjectSearchElement
     public function construct_sql($values)
     {
         // some languages have regex special chars which need escaping
-        $values = array_map('quotemeta', $values);
+        $values = array_map('preg_quote', $values);
         $langstring = DPDatabase::escape(implode("|", $values));
         // for primary language match strings starting with it
         // for primary only match end also


### PR DESCRIPTION
The monthly Detectify security run against TEST did not find any new security errors (🎉) but there were many warnings in the `php_errors` log for  things that we could have caught and handled slightly better. This PR pulls all of those in together. 

In short:
* For project searches, validate that none of the search terms are arrays. This is the "feature" of PHP where any URL params *and values* that end in `[]` are converted to an array in `$_GET`. So `?language[]=English[]` comes into PHP as `language = [English[]]` rather than `language=["English"]`.
* For project language searches (which use regex) use a better regex escaping function to catch all characters.
* Fully escape special day codes in the nightly queue cronjob.
* When inserting / updating values in the `sessions` table, do so atomically. This avoids a very very rare edgecase where two HTTP requests with identical `sid`s come in. Also ensure that the `sid` value is not longer than the database column. This is largely an artifact of the Detectify run but it's an easy fix to make.

There should be zero functional changes, just backend changes.

Testable in [fix-minor-php-error-messages](https://www.pgdp.org/~cpeel/c.branch/fix-minor-php-error-messages/) sandbox.