### PR TITLE
Upgrade portable-utf8 to 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ezyang/htmlpurifier" : "v4.*",
         "erusev/parsedown": "1.8.0-beta-7",
         "erusev/parsedown-extra": "0.8.0",
-        "voku/portable-utf8": "^5.4"
+        "voku/portable-utf8": "^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37c5becbb8ed2d5c292bfa0ca2b082b6",
+    "content-hash": "cefef2d574c51f362afc1e4f859793be",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -246,16 +246,16 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "1.5.6",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "80953678b19901e5165c56752d087fc11526017c"
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/80953678b19901e5165c56752d087fc11526017c",
-                "reference": "80953678b19901e5165c56752d087fc11526017c",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b56450eed252f6801410d810c8e1727224ae0743",
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743",
                 "shasum": ""
             },
             "require": {
@@ -292,7 +292,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/1.5.6"
+                "source": "https://github.com/voku/portable-ascii/tree/2.0.1"
             },
             "funding": [
                 {
@@ -316,20 +316,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-12T00:07:28+00:00"
+            "time": "2022-03-08T17:03:00+00:00"
         },
         {
             "name": "voku/portable-utf8",
-            "version": "5.4.51",
+            "version": "6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-utf8.git",
-                "reference": "578f5266725dc9880483d24ad0cfb39f8ce170f7"
+                "reference": "6c764c2c4fcad451a0f6622260a4934cfea08aa4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/578f5266725dc9880483d24ad0cfb39f8ce170f7",
-                "reference": "578f5266725dc9880483d24ad0cfb39f8ce170f7",
+                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/6c764c2c4fcad451a0f6622260a4934cfea08aa4",
+                "reference": "6c764c2c4fcad451a0f6622260a4934cfea08aa4",
                 "shasum": ""
             },
             "require": {
@@ -339,7 +339,7 @@
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php72": "~1.0",
-                "voku/portable-ascii": "~1.5.6"
+                "voku/portable-ascii": "~2.0.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
@@ -391,7 +391,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-utf8/issues",
-                "source": "https://github.com/voku/portable-utf8/tree/5.4.51"
+                "source": "https://github.com/voku/portable-utf8/tree/6.0.5"
             },
             "funding": [
                 {
@@ -415,7 +415,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-02T01:58:49+00:00"
+            "time": "2022-08-10T12:32:31+00:00"
         }
     ],
     "packages-dev": [

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -644,7 +644,7 @@ function get_normalize_page_text_changes($text, $projectid)
         $invalid_char_names = [];
         foreach (array_keys($invalid_chars) as $char) {
             // in case its a combined character
-            $codepoints = UTF8::split($char);
+            $codepoints = UTF8::str_split($char);
             $base_codepoint = $codepoints[0];
             // if not defined or is a control character or soft hyphen
             if (!IntlChar::isdefined($base_codepoint) || IntlChar::iscntrl($base_codepoint) || ($base_codepoint === "\x{ad}")) {

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -48,7 +48,7 @@ function utf8_string_scripts($string)
     // Fall back to character by character to make sure we have everything.
     // Most cases will skip this.
     if ($string) {
-        foreach (UTF8::split($string) as $char) {
+        foreach (UTF8::str_split($string) as $char) {
             $scripts[] = utf8_char_script($char);
         }
     }
@@ -67,8 +67,8 @@ function get_nonnormalized_codepoints($codepoints)
     foreach ($characters as $character) {
         $norm_character = utf8_normalize($character);
         if ($character != $norm_character) {
-            $norm_codepoint = implode('>', array_map('voku\helper\UTF8::chr_to_hex', UTF8::split($norm_character)));
-            $orig_codepoint = implode('>', array_map('voku\helper\UTF8::chr_to_hex', UTF8::split($character)));
+            $norm_codepoint = implode('>', array_map('voku\helper\UTF8::chr_to_hex', UTF8::str_split($norm_character)));
+            $orig_codepoint = implode('>', array_map('voku\helper\UTF8::chr_to_hex', UTF8::str_split($character)));
             $nonnorm_codepoints[$orig_codepoint] = $norm_codepoint;
         }
     }
@@ -79,7 +79,7 @@ function get_nonnormalized_codepoints($codepoints)
 function utf8_character_name($characters)
 {
     $title_pieces = [];
-    foreach (UTF8::split($characters) as $char) {
+    foreach (UTF8::str_split($characters) as $char) {
         $title_pieces[] = IntlChar::charName($char);
     }
     return implode(" + ", $title_pieces);

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -68,7 +68,7 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
                    "</style>";
     $returnString .= "<pre class='proofingfont'>\n";
 
-    $puncArray = UTF8::split($puncCharacters);
+    $puncArray = UTF8::str_split($puncCharacters);
 
     // initialize the wordCount and the numBadWords
     $numBadWords = 0;


### PR DESCRIPTION
Upgrade portable-utf8 to 6.x to keep us up-to-date. The only major change with 6.0.0 is that it removed deprecated aliases for many functions. The only one we use is `split()` -> `str_split()`. See its full [changelog](https://github.com/voku/portable-utf8/blob/master/CHANGELOG.md) for details.

I put this up as a separate PR since it is a major component of our Unicode functionality and seemed to warrant the option of a more reasonable test pass.

Testable in the [upgrade-portable-utf8](https://www.pgdp.org/~cpeel/c.branch/upgrade-portable-utf8/) sandbox.

Note that the `charsuites.php` page throws an error for a missing include. This is currently a problem on `master` but not `pgdp-production` (and thus PROD and TEST) so the `project.inc` file is getting pulled in from somewhere else. This is fixed on the PHP8 branch so it would probably best if we prioritized https://github.com/DistributedProofreaders/dproofreaders/pull/828 and I can then rebase this branch and sandbox.