### PR TITLE
mysqli improvements

### DIFF
--- a/SETUP/document_database.php
+++ b/SETUP/document_database.php
@@ -230,7 +230,7 @@ function update_file_for_table(string $table_name, string $file_path, string $di
  */
 function query_columns_for_table(string $table_name): array
 {
-    $result = mysqli_query(DPDatabase::get_connection(), "DESCRIBE $table_name");
+    $result = DPDatabase::query("DESCRIBE $table_name");
 
     if (!$result) {
         echo "Failed to fetch column information for table '$table_name'.\n";
@@ -270,7 +270,7 @@ function prepare_project_template_table()
 
     // attempt to delete an existing table but continue of it doesn't exist
     $sql = "DROP TABLE $PROJECT_TEMPLATE_TABLE";
-    $result = mysqli_query(DPDatabase::get_connection(), $sql);
+    $result = DPDatabase::query($sql);
 
     // now create a new one
     project_allow_pages($PROJECT_TEMPLATE_TABLE);

--- a/SETUP/install_db.php
+++ b/SETUP/install_db.php
@@ -16,12 +16,8 @@ if (!DPDatabase::get_connection()) {
     die("Unable to connect to database");
 }
 
-mysqli_query(DPDatabase::get_connection(), "
-    CREATE DATABASE IF NOT EXISTS $db_name
-") or die(mysqli_error(DPDatabase::get_connection()));
-mysqli_query(DPDatabase::get_connection(), "
-    USE $db_name
-") or die(mysqli_error(DPDatabase::get_connection()));
+DPDatabase::query("CREATE DATABASE IF NOT EXISTS $db_name");
+DPDatabase::query("USE $db_name");
 
 // Declare all variables
 $db_schema = "db_schema.sql";
@@ -38,16 +34,20 @@ while ($lines = array_shift($db_schema)) {
 }
 
 // Remove all line breaks
-$sql_create_tables = str_replace("\r\n", "", $sql_create_tables);
+$sql_create_tables = str_replace("\n", "", $sql_create_tables);
 
 // Explode the string into sub-strings for each table
 $array = explode(';', $sql_create_tables);
 
 // Loop through the array/substrings and add them to the database
 while ($lines = array_shift($array)) {
-    $result = mysqli_query(DPDatabase::get_connection(), "$lines");
-    echo mysqli_error(DPDatabase::get_connection()) . "\n";
+    // skip empty stanzas
+    if (!trim($lines)) {
+        continue;
+    }
+
+    echo "Running stanza: " . substr(trim($lines), 0, 50) . " ...\n";
+    DPDatabase::query($lines);
 }
 
-echo "Tables have been created.";
-?> 
+echo "Tables have been created.\n";

--- a/SETUP/tests/NonactivatedUserTest.php
+++ b/SETUP/tests/NonactivatedUserTest.php
@@ -28,7 +28,7 @@ class NonactivatedUserTest extends PHPUnit\Framework\TestCase
                 DELETE FROM non_activated_users
                 WHERE username = '$username'
             ";
-            $result = DPDatabase::query($sql);
+            DPDatabase::query($sql);
         }
     }
 

--- a/SETUP/tests/NonactivatedUserTest.php
+++ b/SETUP/tests/NonactivatedUserTest.php
@@ -28,7 +28,7 @@ class NonactivatedUserTest extends PHPUnit\Framework\TestCase
                 DELETE FROM non_activated_users
                 WHERE username = '$username'
             ";
-            $result = mysqli_query(DPDatabase::get_connection(), $sql);
+            $result = DPDatabase::query($sql);
         }
     }
 

--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -12,7 +12,7 @@ class SettingsTest extends PHPUnit\Framework\TestCase
     {
         // Attempt to load our test user, if it exists don't create it
         $sql = "SELECT username FROM users WHERE username = '$this->TEST_USERNAME'";
-        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result = DPDatabase::query($sql);
         $row = mysqli_fetch_assoc($result);
         if (!$row) {
             $sql = "
@@ -22,7 +22,7 @@ class SettingsTest extends PHPUnit\Framework\TestCase
                     username = '$this->TEST_USERNAME',
                     email = '$this->TEST_USERNAME@localhost'
             ";
-            $result = mysqli_query(DPDatabase::get_connection(), $sql);
+            $result = DPDatabase::query($sql);
             if (!$result) {
                 throw new Exception("Unable to create test user");
             }
@@ -35,7 +35,7 @@ class SettingsTest extends PHPUnit\Framework\TestCase
             INSERT INTO usersettings
             SET username='%s', setting = '%ssetting', value = 'blah'
         ", $this->TEST_USERNAME, $this->PREFIX);
-        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result = DPDatabase::query($sql);
         if (!$result) {
             throw new Exception("Unable to create test usersetting");
         }
@@ -47,13 +47,13 @@ class SettingsTest extends PHPUnit\Framework\TestCase
             DELETE FROM usersettings
             WHERE username='%s' AND setting like '%s%%'
         ", $this->TEST_USERNAME, $this->PREFIX);
-        mysqli_query(DPDatabase::get_connection(), $sql);
+        DPDatabase::query($sql);
 
         $sql = "
             DELETE FROM users
             WHERE id = '$this->TEST_USERNAME'
         ";
-        $result = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result = DPDatabase::query($sql);
     }
 
     public function testExisting()

--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -53,7 +53,7 @@ class SettingsTest extends PHPUnit\Framework\TestCase
             DELETE FROM users
             WHERE id = '$this->TEST_USERNAME'
         ";
-        $result = DPDatabase::query($sql);
+        DPDatabase::query($sql);
     }
 
     public function testExisting()

--- a/crontab/extend_site_tally_goals.php
+++ b/crontab/extend_site_tally_goals.php
@@ -1,14 +1,13 @@
 <?php
 $relPath = './../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'dpsql.inc');
 include_once($relPath.'misc.inc');
 
 require_localhost_request();
 
-$res = dpsql_query("
+$res = DPDatabase::query("
     SELECT MAX(date) FROM site_tally_goals
-") or die("Aborting");
+");
 [$current_max_date] = mysqli_fetch_row($res);
 
 if (is_null($current_max_date)) {
@@ -18,11 +17,12 @@ if (is_null($current_max_date)) {
     exit;
 }
 
-$res2 = dpsql_query("
+$sql = sprintf("
     SELECT tally_name, goal
     FROM site_tally_goals
-    WHERE date='$current_max_date'
-") or die("Aborting");
+    WHERE date='%s'
+", DPDatabase::escape($current_max_date));
+$res2 = DPDatabase::query($sql);
 
 $values_list = '';
 
@@ -53,8 +53,8 @@ if (empty($values_list)) {
     return;
 }
 
-dpsql_query("
+DPDatabase::query("
     INSERT INTO site_tally_goals
     VALUES
     $values_list
-") or die("Aborting");
+");

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -20,14 +20,15 @@ if ($dry_run) {
 $from = -60 * 60;
 $to = 60 * 60;
 
-$result = mysqli_query(DPDatabase::get_connection(), "
+$sql = sprintf("
     SELECT *
     FROM projects
     WHERE
-        smoothread_deadline >= (UNIX_TIMESTAMP() + $from) 
-        AND smoothread_deadline <= (UNIX_TIMESTAMP() + $to) 
-        AND state = '".PROJ_POST_FIRST_CHECKED_OUT."'
-") or die(DPDatabase::log_error());
+        smoothread_deadline >= (UNIX_TIMESTAMP() + %d)
+        AND smoothread_deadline <= (UNIX_TIMESTAMP() + %d)
+        AND state = '%s'
+", $from, $to, DPDatabase::escape(PROJ_POST_FIRST_CHECKED_OUT));
+$result = DPDatabase::query($sql);
 
 $output = "Checking " . mysqli_num_rows($result) . " projects...\n";
 $any_work_done = false;

--- a/crontab/log_project_states.php
+++ b/crontab/log_project_states.php
@@ -18,8 +18,7 @@ $sql = "
     FROM project_state_stats
     WHERE date = '$date_string'
 ";
-$res = mysqli_query(DPDatabase::get_connection(), $sql)
-    or die(DPDatabase::log_error());
+$res = DPDatabase::query($sql);
 $row = mysqli_fetch_assoc($res);
 if ($row["count"]) {
     echo "Already run once for today ($date_string), exiting.\n";
@@ -49,7 +48,7 @@ $sql = "
     GROUP BY state
     ORDER BY state
 ";
-$result = mysqli_query(DPDatabase::get_connection(), $sql);
+$result = DPDatabase::query($sql);
 
 while ([$state, $num_projects, $num_pages] = mysqli_fetch_row($result)) {
     $num_projects_in_state_[$state] = $num_projects;
@@ -77,7 +76,6 @@ foreach (array_keys($num_projects_in_state_) as $state) {
     if ($testing_this_script) {
         echo "$insert_query\n";
     } else {
-        mysqli_query(DPDatabase::get_connection(), $insert_query)
-            or die(DPDatabase::log_error());
+        DPDatabase::query($insert_query);
     }
 }

--- a/crontab/update_user_counts.php
+++ b/crontab/update_user_counts.php
@@ -11,7 +11,7 @@ require_localhost_request();
 // Each A_<interval> field gives the number of distinct users
 // who were active sometime in the <interval> preceding the row's timestamp.
 
-mysqli_query(DPDatabase::get_connection(), "
+DPDatabase::query("
     INSERT INTO user_active_log
         ( year, month, day, hour, time_stamp,
           L_hour, L_day, L_week, L_4wks,
@@ -35,6 +35,4 @@ mysqli_query(DPDatabase::get_connection(), "
 
     FROM users
     WHERE    t_last_activity > UNIX_TIMESTAMP() - 60 * 60 * 24 * 7 * 4
-") or die(DPDatabase::log_error());
-
-// vim: sw=4 ts=4 expandtab
+");

--- a/feeds/backend.php
+++ b/feeds/backend.php
@@ -75,7 +75,7 @@ if (!file_exists($xmlfile) || filemtime($xmlfile) < $refreshAge) {
         }
 
         $data = '';
-        $result = mysqli_query(DPDatabase::get_connection(), $query);
+        $result = DPDatabase::query($query);
         while ($row = mysqli_fetch_array($result)) {
             $posteddate = date("r", ($row['modifieddate']));
             if (isset($_GET['type'])) {

--- a/pastnews.php
+++ b/pastnews.php
@@ -32,13 +32,14 @@ if ($num == 0) {
         . sprintf(_("Show All %s News"), $news_subject) . "</a>";
 }
 
-$result = mysqli_query(DPDatabase::get_connection(), sprintf("
+$sql = sprintf("
     SELECT * FROM news_items 
     WHERE (news_page_id = '%s' OR news_page_id = 'GLOBAL') AND 
         status = 'recent'
     ORDER BY id DESC
     $limit_clause
-", mysqli_real_escape_string(DPDatabase::get_connection(), $news_page_id)));
+", DPDatabase::escape($news_page_id));
+$result = DPDatabase::query($sql);
 
 if (mysqli_num_rows($result) == 0) {
     echo "<p>" . sprintf(_("No recent news items for %s"), $news_subject) . "</p>";

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -21,15 +21,18 @@ final class DPDatabase
         include('udb_user.php');
         self::$_db_name = $db_name;
 
-        // Ignore warnings from mysqli_connect() so we can handle them
-        // gracefully elsewhere.
-        self::$_connection = @mysqli_connect($db_server, $db_user, $db_password);
+        // Throw exceptions for DB call failures (PHP 8.1 default values)
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-        if (!self::$_connection) {
+        try {
+            self::$_connection = mysqli_connect($db_server, $db_user, $db_password);
+        } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to connect to database");
         }
 
-        if (!mysqli_select_db(self::$_connection, $db_name)) {
+        try {
+            mysqli_select_db(self::$_connection, $db_name);
+        } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to locate database.");
         }
 
@@ -39,7 +42,9 @@ final class DPDatabase
         // We disable it here at the session level rather than in my.cnf
         // to not impact other database users (forum, wiki, etc).
         $sql = "SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));";
-        if (!mysqli_query(self::$_connection, $sql)) {
+        try {
+            mysqli_query(self::$_connection, $sql);
+        } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to set sql_mode");
         }
 
@@ -77,8 +82,9 @@ final class DPDatabase
 
     public static function query($sql, $throw_on_failure = true)
     {
-        $result = mysqli_query(self::$_connection, $sql);
-        if (!$result) {
+        try {
+            $result = mysqli_query(self::$_connection, $sql);
+        } catch (mysqli_sql_exception $e) {
             // include this function's caller in the backtrace
             $error = self::log_error(1);
             if ($throw_on_failure) {
@@ -90,7 +96,7 @@ final class DPDatabase
 
     public static function affected_rows()
     {
-        return  mysqli_affected_rows(self::$_connection);
+        return mysqli_affected_rows(self::$_connection);
     }
 
     public static function log_error($backtrace_level = 0)

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -297,7 +297,7 @@ class LPage
 
     public function get_username_for_round($round)
     {
-        $res = mysqli_query(DPDatabase::get_connection(), "
+        $res = DPDatabase::query("
             SELECT {$round->user_column_name}
             FROM {$this->projectid}
             WHERE image = '{$this->imagefile}'
@@ -427,7 +427,7 @@ class LPage
             // For now, just confirm that the user is entitled to resume
             // this page. (In the DONE case, Page_reopen performs this check.)
 
-            $res = mysqli_query(DPDatabase::get_connection(), "
+            $res = DPDatabase::query("
                 SELECT {$this->round->user_column_name}
                 FROM $this->projectid
                 WHERE image='$this->imagefile'

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -33,11 +33,11 @@ function get_all_current_tallyboards()
 // boards on which there is some tally explicitly recorded.
 {
     $tallyboards = [];
-    $res = mysqli_query(DPDatabase::get_connection(), "
+    $res = DPDatabase::query("
         SELECT DISTINCT tally_name, holder_type
         FROM current_tallies
         ORDER BY holder_type, tally_name
-    ") or die(DPDatabase::log_error());
+    ");
     while ([$tally_name, $holder_type] = mysqli_fetch_row($res)) {
         $tallyboards[] = new TallyBoard($tally_name, $holder_type);
     }
@@ -93,13 +93,13 @@ class TallyBoard
     //    (It could be just a column-name, but don't rely on that.
     //    In particular, don't assume that this will work:
     //
-    //        $res = mysqli_query(DPDatabase::get_connection(), "SELECT ... $expr_for_tally FROM ...");
+    //        $res = DPDatabase::query("SELECT ... $expr_for_tally FROM ...");
     //        $row = mysqli_fetch_assoc($res);
     //        ... $row[$expr_for_tally] ...
     //
     //    Instead, if you want to use mysqli_fetch_assoc, this should work:
     //
-    //        $res = mysqli_query(DPDatabase::get_connection(), "SELECT ... $expr_for_tally AS foo FROM ...");
+    //        $res = DPDatabase::query("SELECT ... $expr_for_tally AS foo FROM ...");
     //        $row = mysqli_fetch_assoc($res);
     //        ... $row['foo'] ...
     {

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -91,9 +91,10 @@ function _update_user_activity_time($update_login_time_too)
         $additional_where = "";
     }
 
-    mysqli_query(DPDatabase::get_connection(), "
+    $sql = sprintf("
         UPDATE users
         SET $settings
-        WHERE username='$pguser' $additional_where
-    ") or die(DPDatabase::log_error());
+        WHERE username='%s' $additional_where
+    ", DPDatabase::escape($pguser));
+    DPDatabase::query($sql);
 }

--- a/pinc/dpsql.inc
+++ b/pinc/dpsql.inc
@@ -24,11 +24,7 @@ function dpsql_dump_themed_query($query, $start_at = 0, $show_rank = DPSQL_NO_RA
 
 function dpsql_query($query)
 {
-    $result = mysqli_query(DPDatabase::get_connection(), $query);
-    if (!$result) {
-        echo DPDatabase::log_error();
-    }
-    return $result;
+    return DPDatabase::query($query);
 }
 
 function dpsql_dump_query_result($result, $start_at = 0, $show_rank = DPSQL_NO_RANK)

--- a/pinc/genres.inc
+++ b/pinc/genres.inc
@@ -96,8 +96,6 @@ function maybe_create_temporary_genre_translation_table()
 {
     $genres = load_genre_translation_array();
 
-    $db_link = DPDatabase::get_connection();
-
     $sql = "
     CREATE TEMPORARY TABLE genre_translations
     (
@@ -108,20 +106,20 @@ function maybe_create_temporary_genre_translation_table()
     ";
 
     try {
-        $result = mysqli_query($db_link, $sql);
-    } catch (mysqli_sql_exception $e) {
-        // in case we throw exceptions in the future
-        $result = false;
-    }
-
-    // if the create table succeeded, populate the table
-    // if it didn't, we assume the table is already created
-    if ($result) {
+        // if the create table succeeded, populate the table
+        DPDatabase::query($sql);
         foreach ($genres as $key => $value) {
-            $key = mysqli_real_escape_string($db_link, $key);
-            $value = mysqli_real_escape_string($db_link, $value);
-            $sql = "INSERT INTO genre_translations SET genre = '$key', trans_genre = '$value'";
-            mysqli_query($db_link, $sql);
+            $sql = sprintf("
+                INSERT INTO genre_translations
+                SET
+                    genre = '%s',
+                    trans_genre = '%s'
+                ",
+                DPDatabase::escape($key),
+                DPDatabase::escape($value));
+            DPDatabase::query($sql);
         }
+    } catch (DBQueryError $error) {
+        // if it didn't, we assume the table is already created
     }
 }

--- a/pinc/post_processing.inc
+++ b/pinc/post_processing.inc
@@ -86,5 +86,5 @@ function _run_pp_threshold_query_result($state, $columns, $user, $ordering_crite
             $user_selector
         $order_by_clause
     ";
-    return mysqli_query(DPDatabase::get_connection(), $sql);
+    return DPDatabase::query($sql);
 }

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -147,7 +147,7 @@ function _test_project_for_large_page_images($projectid)
     $project = new Project($projectid);
     if ($project->pages_table_exists) {
         $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result_res = DPDatabase::query($sql);
 
         $details = "<table class='basic striped'>";
         $details .= "<tr>";
@@ -211,7 +211,7 @@ function _test_project_for_corrupt_pngs($projectid)
         $details = "";
     } elseif ($project->pages_table_exists) {
         $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result_res = DPDatabase::query($sql);
 
         $details = "<table class='basic striped'>";
         $details .= "<tr>";
@@ -278,7 +278,7 @@ function _test_project_for_illo_images($projectid)
     $project = new Project($projectid);
     if ($project->pages_table_exists) {
         $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result_res = DPDatabase::query($sql);
 
         $page_image_names = [];
         while ([$image] = mysqli_fetch_row($result_res)) {
@@ -627,7 +627,7 @@ function _test_project_has_all_page_images($projectid)
 
     if ($project->pages_table_exists) {
         $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = mysqli_query(DPDatabase::get_connection(), $sql);
+        $result_res = DPDatabase::query($sql);
 
         $details = "<p>" . _("The following page images do not exist on the server.") . "</p>";
         $details .= "<ul>";

--- a/pinc/showstartexts.inc
+++ b/pinc/showstartexts.inc
@@ -26,7 +26,7 @@ function showstartexts($etext_limit, $type)
         $description = _("These books have been processed through our site and posted to the Project Gutenberg archive.");
     }
 
-    $total = mysqli_num_rows(mysqli_query(DPDatabase::get_connection(), "SELECT projectid FROM projects WHERE $state"));
+    $total = mysqli_num_rows(DPDatabase::query("SELECT projectid FROM projects WHERE $state"));
 
     echo "<div class='star-text-summary'>";
 

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -138,7 +138,7 @@ function echo_special_legend($projects_where_clause)
 
     $legend_text = _("Legend for Special Day Colors");
 
-    $currspecs_result = mysqli_query(DPDatabase::get_connection(), "
+    $currspecs_result = DPDatabase::query("
             SELECT distinct special_code as spec FROM projects
             WHERE $projects_where_clause
         ");

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -301,7 +301,7 @@ function can_user_get_pages_in_project($username, $project, $round)
                 // Then we reduced it to 6 for English beginner projects.)
                 $max_n_pages_per_project = ($project->language == 'English' ? 6 : 11);
 
-                $result = mysqli_query(DPDatabase::get_connection(), "
+                $result = DPDatabase::query("
                     SELECT COUNT(*) as pagesdone
                     FROM {$project->projectid}
                     WHERE {$round->user_column_name} = '$username'

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -135,7 +135,7 @@ function html_logobar()
 
     if (0) {
         // show number of projects posted to PG
-        $result = mysqli_query(DPDatabase::get_connection(), "
+        $result = DPDatabase::query("
             SELECT COUNT(*) as numproj
             FROM projects
             WHERE $psd->state_selector
@@ -152,7 +152,7 @@ function html_logobar()
         // show number of books posted to PG
         // (takes into account that some books are processed as several projects)
 
-        $result = mysqli_query(DPDatabase::get_connection(), "
+        $result = DPDatabase::query("
             SELECT COUNT(distinct postednum) as numproj
             FROM projects
             WHERE $psd->state_selector
@@ -614,7 +614,7 @@ function show_tally_specific_stats($tally_name)
 
     // Number of users
     echo "<p>\n";
-    $res = mysqli_query(DPDatabase::get_connection(), "SELECT COUNT(*) FROM users");
+    $res = DPDatabase::query("SELECT COUNT(*) FROM users");
     [$num_users] = mysqli_fetch_row($res);
     echo sprintf(_('%s users'), number_format($num_users)), "<br>\n";
 
@@ -795,7 +795,7 @@ function show_birthdays()
         ORDER BY date_created ASC
     ", date("m-d"), $oldest_activity, $timestamp_at_midnight, PRIVACY_ANONYMOUS);
 
-    $result = mysqli_query(DPDatabase::get_connection(), $sql);
+    $result = DPDatabase::query($sql);
 
     if (mysqli_num_rows($result) == 0) {
         return;
@@ -841,7 +841,7 @@ function show_completed_projects($terse = false)
 
         $displaydate = icu_date("MMM y", $begindate);
 
-        $result = mysqli_query(DPDatabase::get_connection(), "
+        $result = DPDatabase::query("
             SELECT COUNT(*) as totalprojects
             FROM projects
             WHERE modifieddate >= $begindate

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -139,8 +139,8 @@ function that_user_is_over_PP_checked_out_limit($username)
         FROM projects
         WHERE checkedoutby LIKE '%s'
             AND state = 'proj_post_first_checked_out'
-    ", mysqli_real_escape_string(DPDatabase::get_connection(), $username));
-    $result = mysqli_query(DPDatabase::get_connection(), $query);
+    ", DPDatabase::escape($username));
+    $result = DPDatabase::query($query);
     $row = mysqli_fetch_row($result);
     $number_out = $row[0];
 

--- a/sitemap.php
+++ b/sitemap.php
@@ -56,7 +56,7 @@ $sql = "
     FROM projects
     ORDER BY $order_by
 ";
-$result = mysqli_query(DPDatabase::get_connection(), $sql);
+$result = DPDatabase::query($sql);
 while ($row = mysqli_fetch_assoc($result)) {
     if ($url_count >= $MAX_URLS) {
         break;

--- a/stats/PP_unknown.php
+++ b/stats/PP_unknown.php
@@ -18,7 +18,7 @@ echo sprintf(_("We don't know for sure who PPd these books; if you do know, or i
 
 //get projects that have been PPd but we don't know by whom
 $psd = get_project_status_descriptor('PPd');
-$result = mysqli_query(DPDatabase::get_connection(), "
+$result = DPDatabase::query("
     SELECT nameofwork, authorsname, username, projectid,
            from_unixtime(modifieddate) as 'LMDate'
     FROM projects

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -38,10 +38,7 @@ function select_from_teams($where_body, $other_clauses = '')
         WHERE $where_body
         $other_clauses
     ";
-    $res = mysqli_query(DPDatabase::get_connection(), $q);
-    if (!$res) {
-        die(DPDatabase::log_error());
-    }
+    $res = DPDatabase::query($q);
     return $res;
 }
 
@@ -206,7 +203,7 @@ function showTeamProfile($curTeam, $preview = false)
 
 function team_get_member_count_rank($team_id)
 {
-    $result = mysqli_query(DPDatabase::get_connection(), "
+    $result = DPDatabase::query("
         SELECT id
         FROM user_teams
         ORDER BY member_count DESC
@@ -305,7 +302,7 @@ function showTeamMbrs($curTeam, $tally_name)
     $req_team_id = get_integer_param($_GET, 'tid', null, 0, null);
 
     $subtitle = null;
-    $latestMbr = mysqli_query(DPDatabase::get_connection(), "SELECT users.username AS Username, users.u_privacy AS Privacy FROM user_teams INNER JOIN users ON user_teams.latestUser = users.u_id WHERE user_teams.id = ".$curTeam['id']." AND user_teams.latestUser <> 0");
+    $latestMbr = DPDatabase::query("SELECT users.username AS Username, users.u_privacy AS Privacy FROM user_teams INNER JOIN users ON user_teams.latestUser = users.u_id WHERE user_teams.id = ".$curTeam['id']." AND user_teams.latestUser <> 0");
     $row = mysqli_fetch_assoc($latestMbr);
     if ($row) {
         if ($row["Privacy"] == PRIVACY_PRIVATE && isset($GLOBALS['pguser'])) {
@@ -573,7 +570,7 @@ function uploadImages($preview, $tid, $type)
             $upload_avatar_dir = "$team_avatars_dir/$avatarID";
             move_uploaded_file($_FILES['teamavatar']['tmp_name'], $upload_avatar_dir);
             if ($preview != 1) {
-                mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET avatar='$avatarID' WHERE id = $tid") or die(DPDatabase::log_error());
+                DPDatabase::query("UPDATE user_teams SET avatar='$avatarID' WHERE id = $tid");
             }
             $teamimages['avatar'] = $avatarID;
         } else {
@@ -592,7 +589,7 @@ function uploadImages($preview, $tid, $type)
             $upload_icon_dir = "$team_icons_dir/$iconID";
             move_uploaded_file($_FILES['teamicon']['tmp_name'], $upload_icon_dir);
             if ($preview != 1) {
-                mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET icon='$iconID' WHERE id = $tid");
+                DPDatabase::query("UPDATE user_teams SET icon='$iconID' WHERE id = $tid");
             }
             $teamimages['icon'] = $iconID;
         } else {
@@ -620,7 +617,7 @@ function deleteImages()
     ];
 
     // Delete unused avatars
-    $result = mysqli_query(DPDatabase::get_connection(), "SELECT id,avatar FROM user_teams");
+    $result = DPDatabase::query("SELECT id,avatar FROM user_teams");
     while ($row = mysqli_fetch_assoc($result)) {
         $id = $row['id'];
         $activeAvatars[$id] = $row['avatar'];
@@ -635,7 +632,7 @@ function deleteImages()
     }
 
     //Delete unused icons
-    $result = mysqli_query(DPDatabase::get_connection(), "SELECT id,icon FROM user_teams");
+    $result = DPDatabase::query("SELECT id,icon FROM user_teams");
     while ($row = mysqli_fetch_assoc($result)) {
         $id = $row['id'];
         $activeIcons[$id] = $row['icon'];

--- a/stats/pm_stats.php
+++ b/stats/pm_stats.php
@@ -18,7 +18,7 @@ dpsql_dump_themed_query("
     SELECT
         count(distinct username) as '"
             // TRANSLATORS: PMs = project managers
-            . mysqli_real_escape_string(DPDatabase::get_connection(), _("Different PMs")) . "'
+            . DPDatabase::escape(_("Different PMs")) . "'
     FROM projects
 ", 0, DPSQL_NO_RANK, DPSQL_NO_RIGHT_ALIGN_INTS);
 
@@ -30,8 +30,8 @@ echo "<h3>" . _("Number of Projects Created") . "</h3>\n";
 $psd = get_project_status_descriptor('created');
 dpsql_dump_themed_query("
     SELECT
-        username as '" . mysqli_real_escape_string(DPDatabase::get_connection(), pgettext("project manager", "PM")) . "',
-        count(*) as '" . mysqli_real_escape_string(DPDatabase::get_connection(), _("Projects Created")) . "'
+        username as '" . DPDatabase::escape(pgettext("project manager", "PM")) . "',
+        count(*) as '" . DPDatabase::escape(_("Projects Created")) . "'
     FROM projects
     WHERE $psd->state_selector
     GROUP BY username
@@ -45,8 +45,8 @@ echo "<h3>" . _("Number of Projects Posted to PG") . "</h3>\n";
 $psd = get_project_status_descriptor('posted');
 dpsql_dump_themed_query("
     SELECT
-        username as '" . mysqli_real_escape_string(DPDatabase::get_connection(), pgettext("project manager", "PM")) . "',
-        count(*) as '" . mysqli_real_escape_string(DPDatabase::get_connection(), _("Projects Posted to PG")) . "'
+        username as '" . DPDatabase::escape(pgettext("project manager", "PM")) . "',
+        count(*) as '" . DPDatabase::escape(_("Projects Posted to PG")) . "'
     FROM projects
     WHERE $psd->state_selector
     GROUP BY username

--- a/stats/ppv_stats.php
+++ b/stats/ppv_stats.php
@@ -17,8 +17,8 @@ echo "<h3>" . _("Number of Projects Posted to PG") . "</h3>\n";
 
 $psd = get_project_status_descriptor('posted');
 dpsql_dump_themed_query("
-    SELECT checkedoutby as '" . mysqli_real_escape_string(DPDatabase::get_connection(), _("PPVer")) . "',
-        count(*) as '" . mysqli_real_escape_string(DPDatabase::get_connection(), _("Projects PPVd")) . "'
+    SELECT checkedoutby as '" . DPDatabase::escape(_("PPVer")) . "',
+        count(*) as '" . DPDatabase::escape(_("Projects PPVd")) . "'
     FROM  `projects`
     WHERE 1  AND checkedoutby != postproofer AND $psd->state_selector
         and checkedoutby != ''

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -83,7 +83,7 @@ $table->set_column_alignments('left', 'right');
 
    //get total users active in the last 7 days
     $begin_time = time() - 604800; // in seconds
-    $users = mysqli_query(DPDatabase::get_connection(), "SELECT count(*) AS numusers FROM users
+    $users = DPDatabase::query("SELECT count(*) AS numusers FROM users
                           WHERE t_last_activity > $begin_time");
     $row = mysqli_fetch_assoc($users);
     $totalusers = $row["numusers"];

--- a/stats/teams/team_topic.php
+++ b/stats/teams/team_topic.php
@@ -13,7 +13,7 @@ $team_id = get_integer_param($_GET, 'team', null, 0, null);
 
 // Get info about team
 
-$team_result = mysqli_query(DPDatabase::get_connection(), "SELECT teamname,team_info, webpage, createdby, owner, topic_id FROM user_teams WHERE id=$team_id");
+$team_result = DPDatabase::query("SELECT teamname,team_info, webpage, createdby, owner, topic_id FROM user_teams WHERE id=$team_id");
 
 $row = mysqli_fetch_array($team_result);
 
@@ -50,7 +50,7 @@ Use this area to have a discussion with your fellow teammates! :-D
                 false);
 
     //Update user_teams with topic_id so it won't be created again
-    $update_team = mysqli_query(DPDatabase::get_connection(), "UPDATE user_teams SET topic_id=$topic_id WHERE id=$team_id");
+    $update_team = DPDatabase::query("UPDATE user_teams SET topic_id=$topic_id WHERE id=$team_id");
 }
 
 // By here, either we had a topic or we've just created one, so redirect to it

--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -36,7 +36,7 @@ $team_id = $curTeam['id'];
 
 //Team info portion of $data
 
-$result = mysqli_query(DPDatabase::get_connection(), "SELECT COUNT(id) AS totalTeams FROM user_teams");
+$result = DPDatabase::query("SELECT COUNT(id) AS totalTeams FROM user_teams");
 $row = mysqli_fetch_assoc($result);
 $totalTeams = $row["totalTeams"];
 

--- a/tools/authors/addbio.php
+++ b/tools/authors/addbio.php
@@ -70,8 +70,6 @@ if (isset($_GET['author_id'])) {
             // failure!
             output_header(_('An error occurred'));
             echo _('It was not possible to save the biography.');
-            echo "<br>";
-            echo DPDatabase::log_error();
         }
         exit;
     } else {

--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -79,7 +79,7 @@ if (isset($_POST) && count($_POST) > 0) {
         if (count($delete_authors) != 0) {
           $clause = '(author_id=' . join(' OR author_id=', $delete_authors) . ')';
           $query = "SELECT author_id, last_modified FROM authors WHERE $clause";
-          $result = mysqli_query(DPDatabase::get_connection(), $query);
+          $result = DPDatabase::query($query);
           $authors_lastmodified = array();
           while ($row = mysqli_fetch_row($result))
             $authors_lastmodified[$row[0]] = $row[1];
@@ -88,7 +88,7 @@ if (isset($_POST) && count($_POST) > 0) {
         if (count($delete_bios) != 0) {
           $clause = '(bio_id=' . join(' OR bio_id=', $delete_bios) . ')';
           $query = "SELECT bio_id, last_modified FROM biographies WHERE $clause";
-          $result = mysqli_query(DPDatabase::get_connection(), $query);
+          $result = DPDatabase::query($query);
           $bios_lastmodified = array();
           while ($row = mysqli_fetch_row($result))
             $bios_lastmodified[$row[0]] = $row[1];

--- a/tools/authors/search.inc
+++ b/tools/authors/search.inc
@@ -115,7 +115,7 @@ function prepare_search()
 function sql_like_encode($str)
 {
     // escape quotes -- note: does not encode % and _ !
-    $str = mysqli_real_escape_string(DPDatabase::get_connection(), $str);
+    $str = DPDatabase::escape($str);
     // % to \%
     // _ to \_
     $str = preg_replace('/%|_/', '\\\$1', $str);

--- a/tools/pending_access_requests.php
+++ b/tools/pending_access_requests.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'dpsql.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'theme.inc');
 
@@ -24,11 +23,11 @@ foreach ($Activity_for_id_ as $activity) {
 }
 
 // Look for unexpected activity_ids
-$res = mysqli_query(DPDatabase::get_connection(), "
+$res = DPDatabase::query("
     SELECT DISTINCT REPLACE(setting,'.access', '')
     FROM usersettings
     WHERE setting LIKE '%.access' AND value='requested'
-") or die(DPDatabase::log_error());
+");
 while ([$activity_id] = mysqli_fetch_row($res)) {
     if (!in_array($activity_id, $activity_ids)) {
         $activity_ids[] = $activity_id;
@@ -37,7 +36,7 @@ while ([$activity_id] = mysqli_fetch_row($res)) {
 
 // ----------------------------------
 
-mysqli_query(DPDatabase::get_connection(), "
+DPDatabase::query("
     CREATE TEMPORARY TABLE access_log_summary
     SELECT 
         activity,
@@ -46,7 +45,7 @@ mysqli_query(DPDatabase::get_connection(), "
         MAX( timestamp * (action='deny_request_for') ) AS t_latest_deny
     FROM access_log
     GROUP BY activity, subject_username
-") or die(DPDatabase::log_error());
+");
 
 foreach ($activity_ids as $activity_id) {
     echo "<h3>";
@@ -55,7 +54,7 @@ foreach ($activity_ids as $activity_id) {
 
     $access_name = "$activity_id.access";
 
-    $res = mysqli_query(DPDatabase::get_connection(), "
+    $res = DPDatabase::query("
         SELECT
             usersettings.username,
             users.u_id,
@@ -71,7 +70,7 @@ foreach ($activity_ids as $activity_id) {
             )
         WHERE setting = '$access_name' AND value='requested'
         ORDER BY username
-    ") or die(DPDatabase::log_error());
+    ");
 
     if (mysqli_num_rows($res) == 0) {
         $word = pgettext("no user", "none");

--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -3,7 +3,6 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'maybe_mail.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'release_queue.inc');
-// include_once($relPath.'dpsql.inc');
 
 function autorelease()
 {

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'dpsql.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'User.inc');

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -116,7 +116,7 @@ function get_table_query_resource($username, $view_mode)
     if ($username) {
         $sql .= sprintf("
             AND username = '%s'
-        ", mysqli_real_escape_string(DPDatabase::get_connection(), $username));
+        ", DPDatabase::escape($username));
     }
 
     if ($view_mode == 'suspect') {
@@ -131,5 +131,5 @@ function get_table_query_resource($username, $view_mode)
 
     $sql .= "ORDER BY username, " .  sql_collater_for_project_state("state");
 
-    return dpsql_query($sql);
+    return DPDatabase::query($sql);
 }

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'dpsql.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'user_is.inc');

--- a/tools/project_manager/post_files.inc
+++ b/tools/project_manager/post_files.inc
@@ -261,15 +261,11 @@ function page_info_query($projectid, $limit_round_id, $which_text)
         }
     }
 
-    $res = mysqli_query(DPDatabase::get_connection(), "
+    $res = DPDatabase::query("
         SELECT $text_column_expr, image $user_fields
         FROM $projectid
         ORDER BY image
     ");
-    if ($res === false) {
-        echo DPDatabase::log_error();
-        return false;
-    }
 
     return $res;
 }

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -278,9 +278,9 @@ function _get_projects_for_pm($pm)
         FROM projects
         WHERE username='%s' AND $where
         ORDER BY $collator, nameofwork
-    ", mysqli_real_escape_string(DPDatabase::get_connection(), $pm));
+    ", DPDatabase::escape($pm));
 
-    $res = mysqli_query(DPDatabase::get_connection(), $query);
+    $res = DPDatabase::query($query);
     while ($ar = mysqli_fetch_array($res)) {
         $returnArray[$ar["projectid"]] = [$ar["nameofwork"], $ar["state"]];
     }

--- a/tools/project_manager/show_project_wordcheck_usage.php
+++ b/tools/project_manager/show_project_wordcheck_usage.php
@@ -77,7 +77,7 @@ $sql = "
     FROM $projectid
     ORDER BY image ASC
 ";
-$res = mysqli_query(DPDatabase::get_connection(), $sql) or die(DPDatabase::log_error());
+$res = DPDatabase::query($sql);
 while ($result = mysqli_fetch_assoc($res)) {
     $page = $result["image"];
     echo "<tr>";

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -5,7 +5,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
-include_once($relPath.'dpsql.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'showavailablebooks.inc');
 include_once($relPath.'theme.inc');
@@ -95,7 +94,7 @@ if ($round->is_a_mentor_round()) {
 if ($pagesproofed > 20) {
     // Link to queues.
     echo "<h2>", _('Release Queues'), "</h2>";
-    $res = dpsql_query("
+    $res = DPDatabase::query("
         SELECT COUNT(*)
         FROM queue_defns
         WHERE round_id='{$round->id}'

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -108,11 +108,12 @@ function do_stuff($projectid, $from_image_, $just_checking)
 
     echo "    projectid: $projectid\n";
 
-    $res = mysqli_query(DPDatabase::get_connection(), "
-            SELECT nameofwork
-            FROM projects
-            WHERE projectid='$projectid'
-        ") or die(DPDatabase::log_error());
+    $sql = sprintf("
+        SELECT nameofwork
+        FROM projects
+        WHERE projectid='%s'
+        ", DPDatabase::escape($projectid));
+    $res = DPDatabase::query($sql);
 
     $n_projects = mysqli_num_rows($res);
     if ($n_projects == 0) {
@@ -127,11 +128,12 @@ function do_stuff($projectid, $from_image_, $just_checking)
 
     // ------------
 
-    $res = mysqli_query(DPDatabase::get_connection(), "
-            SELECT image, fileid
-            FROM $projectid
-            ORDER BY image
-        ") or die(DPDatabase::log_error());
+    validate_projectID($projectid);
+    $res = DPDatabase::query("
+        SELECT image, fileid
+        FROM $projectid
+        ORDER BY image
+    ");
 
     $n_pages = mysqli_num_rows($res);
 

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -42,7 +42,7 @@ if ($action == 'default') {
     echo "</form>";
     echo "<br>";
 } elseif ($action == 'list_all') {
-    $result = mysqli_query(DPDatabase::get_connection(), "
+    $result = DPDatabase::query("
         SELECT *
         FROM non_activated_users
         ORDER BY $order_by

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -42,11 +42,11 @@ echo "projectid: $projectid\n";
 echo "title    : " . html_safe($title) . "\n";
 echo "</pre>\n";
 
-$res = mysqli_query(DPDatabase::get_connection(), "
+$res = DPDatabase::query("
     SELECT fileid, image
     FROM $projectid
     ORDER BY image
-") or die(DPDatabase::log_error());
+");
 
 $current_image_for_fileid_ = [];
 while ([$fileid, $image] = mysqli_fetch_row($res)) {
@@ -349,7 +349,7 @@ switch ($submit_button) {
                 ";
                 echo $query;
                 if ($for_real) {
-                    mysqli_query(DPDatabase::get_connection(), $query) or die(DPDatabase::log_error());
+                    DPDatabase::query($query);
                     $n = DPDatabase::affected_rows();
                     echo "
                         $n rows affected.

--- a/tools/site_admin/shared_postednums.php
+++ b/tools/site_admin/shared_postednums.php
@@ -28,7 +28,7 @@ echo "<p>
 </p>
 ";
 
-$res = dpsql_query("
+$res = DPDatabase::query("
     SELECT postednum, COUNT(*) as c
     FROM projects
     GROUP BY postednum
@@ -43,7 +43,7 @@ while ([$postednum, $count] = mysqli_fetch_row($res)) {
     echo "<br>$postednum:\n";
 
     {
-        $res2 = dpsql_query("
+        $res2 = DPDatabase::query("
             SELECT nameofwork
             FROM projects
             WHERE postednum=$postednum

--- a/tools/site_admin/show_access_log.php
+++ b/tools/site_admin/show_access_log.php
@@ -56,7 +56,7 @@ $where_username = "";
 if ($username) {
     $where_username = sprintf("
         AND subject_username = '%s'
-    ", mysqli_real_escape_string(DPDatabase::get_connection(), $username));
+    ", DPDatabase::escape($username));
 }
 
 $where_action = "";
@@ -70,7 +70,7 @@ $where_activity = "";
 if ($activity) {
     $where_activity = sprintf("
         AND activity = '%s'
-    ", mysqli_real_escape_string(DPDatabase::get_connection(), $activity));
+    ", DPDatabase::escape($activity));
 }
 
 $now = getdate();
@@ -118,7 +118,7 @@ function _get_activity_choices()
         FROM access_log
         ORDER BY activity
     ";
-    $result = mysqli_query(DPDatabase::get_connection(), $sql);
+    $result = DPDatabase::query($sql);
 
     $activities = [''];
     while ($row = mysqli_fetch_row($result)) {

--- a/tools/site_admin/show_common_words_from_project_word_lists.php
+++ b/tools/site_admin/show_common_words_from_project_word_lists.php
@@ -44,7 +44,7 @@ if ($display_list) {
     echo "<td>" . _("Project Languages:") . "</td>";
     echo "<td><select name='language'>";
     // load all project languages
-    $res = mysqli_query(DPDatabase::get_connection(), "
+    $res = DPDatabase::query("
         SELECT language, count(language)
         FROM projects
         GROUP BY language
@@ -147,7 +147,7 @@ function _handle_action($action, $list_type, $language, $cutoff, $lang_match)
             }
 
             // loop through all projects that use $language
-            $res = mysqli_query(DPDatabase::get_connection(), "
+            $res = DPDatabase::query("
                 SELECT projectid
                 FROM projects
                 WHERE $where_clause

--- a/userprefs.php
+++ b/userprefs.php
@@ -306,7 +306,7 @@ function echo_general_tab($user)
         [1 => _("Yes"), 0 => _("No")]
     );
     $theme_options = [];
-    $result = mysqli_query(DPDatabase::get_connection(), "SELECT * FROM themes");
+    $result = DPDatabase::query("SELECT * FROM themes");
     while ($row = mysqli_fetch_array($result)) {
         $option_value = $row['unixname'];
         $option_label = $row['name'];
@@ -397,8 +397,7 @@ function save_general_tab($user)
         SET $update_string
         WHERE u_id = $user->u_id
     ";
-    mysqli_query(DPDatabase::get_connection(), $users_query) or
-        print(DPDatabase::log_error());
+    DPDatabase::query($users_query);
 
     // Opt-out of credits when Content-Providing (deprecated), Image Preparing,
     // Text Preparing, Project-Managing and/or Post-Processing.
@@ -753,8 +752,7 @@ function save_pm_tab($user)
         SET $update_string
         WHERE u_id = $user->u_id
     ";
-    mysqli_query(DPDatabase::get_connection(), $users_query) or
-        print(DPDatabase::log_error());
+    DPDatabase::query($users_query);
 
     // remember if the PM wants to be automatically signed up for email notifications of
     // replies made to their project threads


### PR DESCRIPTION
Finish the long slog of moving `mysqli_query()` calls to`DPDatabase::query()`. This allows us to manage query failures in
a centralized place. Also change `dpsql_query()` to `DPDatabase::query()` where reasonable.

The above allows us to to use `mysqli_report()` to raise an exception on DB error rather than silently failing. Since we use `DPDatabase::query()` everywhere we can catch the exceptions from queries and handle them the same way we did before but we get better error detection with other `mysqli_*` functions. The new error level match the default in PHP 8.1.

These updates are largely straightforward but they touch a lot of code, unfortunately. None of these updates are urgent.

Testable in the [mysqli_improvements](https://www.pgdp.org/~cpeel/c.branch/mysqli_improvements/) sandbox.