### PR TITLE
Properly include Project.inc

### DIFF
--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -5,6 +5,7 @@ include_once($relPath."theme.inc");
 include_once($relPath."unicode.inc");
 include_once($relPath."CharSuites.inc");
 include_once($relPath."prefs_options.inc");
+include_once($relPath."Project.inc"); // get_projectID_param()
 include_once($relPath."misc.inc"); // array_get()
 
 require_login();

--- a/tools/site_admin/projects_with_odd_values.php
+++ b/tools/site_admin/projects_with_odd_values.php
@@ -4,6 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'iso_lang_list.inc');
 include_once($relPath.'genres.inc'); // load_genre_translation_array()
+include_once($relPath.'Project.inc'); // get_project_difficulties()
 include_once($relPath.'user_is.inc');
 
 require_login();


### PR DESCRIPTION
These two files need functions in `Project.inc`. They work on TEST and PROD because something in `pgdp-production` is including that somewhere in the chain. Both of these changes are in the PHP8 branch, but pulling them out into this PR to unblock some other dev work for @srjfoo.