### PR TITLE
Prepare for the R202209 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,6 +7,19 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
+## R202209
+Scripts supporting this upgrade are in `SETUP/upgrade/18`
+
+* Several DP API updates (cpeel)
+  * Create & edit projects
+  * Add & remove project holds
+  * Properly return numeric values as strings for string fields
+* New `Math symbols` character suite (bunny-crunch, okrick, srjfoo, windymilla)
+* Format Preview updates (70ray)
+* Upgrade node dependencies (chrismiceli)
+* Upgrade composer dependencies, including portable-utf8 (cpeel)
+* Removed the incomplete Metadata & Correction features (cpeel)
+
 ## R202202
 Scripts supporting this upgrade are in `SETUP/upgrade/17`
 

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -101,17 +101,25 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/15/
 * c/SETUP/upgrade/16/
 * c/SETUP/upgrade/17/
+* c/SETUP/upgrade/18/
 
 ### Upgrading from release R202102
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/16/
 * c/SETUP/upgrade/17/
+* c/SETUP/upgrade/18/
 
 ### Upgrading from release R202109
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/17/
+* c/SETUP/upgrade/18/
+
+### Upgrading from release R202202
+Run the scripts in the following directories in order
+
+* c/SETUP/upgrade/18/
 
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.


### PR DESCRIPTION
Prepare for our usual September release. This won't be merged until just before we're ready to cut the release.

The full list of commits can be seen with:
```bash
git log R202202..master
```