### PR TITLE
Streamline project listing filter interface

### DIFF
--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -151,23 +151,27 @@ class DifficultyElement extends ProjectFilterElement
 {
     public function echo_active_html_control()
     {
-        echo "<p><b>$this->label:</b> ";
-        echo "<label for='diff-all'>" . pgettext("all difficulties", "All") . "</label><input type='checkbox' name='difficulty[]' id='diff-all' value=''";
+        echo "<div class='flex_row'>";
+        echo "<div class='entry'><b>$this->label:</b></div>";
+        echo "<div class='entry'><input type='checkbox' name='difficulty[]' id='diff-all' value=''";
         $difficulty = array_get($this->data, "difficulty", []);
         if (!count($difficulty)) {
             echo " checked";
         }
-        echo ">\n";
+        echo "> <label for='diff-all'>" . pgettext("all difficulties", "All") . "</label>\n";
+        echo "</div>\n";
         foreach (get_project_difficulties() as $value => $option) {
             $escaped_option = html_safe($option);
-            echo "&nbsp;<label for='$value'>$escaped_option</label><input type='checkbox' name='difficulty[]' class='diff-opt' id='$value' value='$value'";
+            echo "<div class='entry'>";
+            echo "<input type='checkbox' name='difficulty[]' class='diff-opt' id='$value' value='$value'";
             if (is_array($difficulty) && in_array($value, $difficulty)) {
                 echo " checked";
                 $this->selected_options[] = $option;
             }
-            echo ">\n";
+            echo "> <label for='$value'>$escaped_option</label>\n";
+            echo "</div>";
         }
-        echo "</p>\n";
+        echo "</div>\n";
     }
 }
 
@@ -241,10 +245,7 @@ function process_and_display_project_filter_form($username, $filter_type, $filte
 
     $difficulty_element->echo_html_control();
 
-    echo "<input type='submit' name='reset' value='", attr_safe(_("Remove Filter")), "'>";
-    echo "&nbsp;<input type='submit' name='apply' value='", attr_safe(_("Apply Selections")), "'>";
-    echo "</fieldset>";
-    echo "</form>\n";
+    echo "<input type='submit' name='apply' value='", attr_safe(_("Apply Selections")), "'>";
 
     // construct the summary display
     $display_lines = [];
@@ -256,17 +257,16 @@ function process_and_display_project_filter_form($username, $filter_type, $filte
     // save a single line version to use in activity hub
     save_display($username, $filter_type, implode(" | ", $display_lines));
 
-    echo "<p>", _("Current filter:"), " <b>";
-
-    // show multi-line version on this page
+    // and show it here in the same form
     if (!empty($display_lines)) {
-        foreach ($display_lines as $line) {
-            echo "<br>$line";
-        }
-    } else {
-        echo _("No filter, all books shown.");
+        echo "<fieldset style='margin-top: 1em'><legend>" . _("Current filter:") . "</legend>\n";
+        echo html_safe(implode(" | ", $display_lines));
+        echo "<br><input type='submit' name='reset' value='", attr_safe(_("Remove Filter")), "'>";
+        echo "</fieldset>\n";
     }
-    echo "</b></p>\n";
+
+    echo "</fieldset>";
+    echo "</form>\n";
 }
 
 // ----- classes & functions for getting sql and display data

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -37,7 +37,7 @@ class ProjectFilterElement
     protected function echo_active_html_control()
     {
         echo "<td>";
-        echo "<b>$this->label:</b><br>";
+        echo "<b> " . html_safe("$this->label:") . "</b><br>";
         $this->echo_selector();
         echo "</td>\n";
     }
@@ -128,7 +128,7 @@ class LanguageElement extends ProjectFilterElement
     protected function echo_active_html_control()
     {
         echo "<td>";
-        echo "<b>$this->label:</b><br>";
+        echo "<b>" . html_safe("$this->label:") . "</b><br>";
         $this->echo_selector();
         echo "<br>";
 
@@ -152,13 +152,13 @@ class DifficultyElement extends ProjectFilterElement
     public function echo_active_html_control()
     {
         echo "<div class='flex_row'>";
-        echo "<div class='entry'><b>$this->label:</b></div>";
+        echo "<div class='entry'><b>" . html_safe("$this->label:") . "</b></div>";
         echo "<div class='entry'><input type='checkbox' name='difficulty[]' id='diff-all' value=''";
         $difficulty = array_get($this->data, "difficulty", []);
         if (!count($difficulty)) {
             echo " checked";
         }
-        echo "> <label for='diff-all'>" . pgettext("all difficulties", "All") . "</label>\n";
+        echo "> <label for='diff-all'>" . html_safe(pgettext("all difficulties", "All")) . "</label>\n";
         echo "</div>\n";
         foreach (get_project_difficulties() as $value => $option) {
             $escaped_option = html_safe($option);

--- a/scripts/filter_project.js
+++ b/scripts/filter_project.js
@@ -7,7 +7,7 @@ $(function () {
     var diffOpt = $(".diff-opt");
 
     function showMatcher() {
-        langMatch.css("visibility", (0 === langSelector.prop("selectedIndex") ? "hidden" : "visible"));
+        langMatch.css("display", (0 === langSelector.prop("selectedIndex") ? "none" : "block"));
     }
 
     langSelector.change(function () {

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -708,6 +708,19 @@ table.filter {
 }
 
 /* ------------------------------------------------------------------------ */
+/* Flex row & entity -- useful when needing a dynamic list of things */
+
+div.flex_row {
+    display: flex;
+    flex-flow: row wrap;
+    margin: 0.25em;
+    div.entry {
+        padding: 0 0.25em;
+    }
+}
+
+
+/* ------------------------------------------------------------------------ */
 /* Random Rules */
 /* Because the guidelines are in the wiki, we have to jump through
    some hoops to get any tables used there to be displayed properly

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -1739,6 +1739,16 @@ table.filter td select {
   width: 100%;
 }
 /* ------------------------------------------------------------------------ */
+/* Flex row & entity -- useful when needing a dynamic list of things */
+div.flex_row {
+  display: flex;
+  flex-flow: row wrap;
+  margin: 0.25em;
+}
+div.flex_row div.entry {
+  padding: 0 0.25em;
+}
+/* ------------------------------------------------------------------------ */
 /* Random Rules */
 /* Because the guidelines are in the wiki, we have to jump through
    some hoops to get any tables used there to be displayed properly

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1739,6 +1739,16 @@ table.filter td select {
   width: 100%;
 }
 /* ------------------------------------------------------------------------ */
+/* Flex row & entity -- useful when needing a dynamic list of things */
+div.flex_row {
+  display: flex;
+  flex-flow: row wrap;
+  margin: 0.25em;
+}
+div.flex_row div.entry {
+  padding: 0 0.25em;
+}
+/* ------------------------------------------------------------------------ */
 /* Random Rules */
 /* Because the guidelines are in the wiki, we have to jump through
    some hoops to get any tables used there to be displayed properly

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1739,6 +1739,16 @@ table.filter td select {
   width: 100%;
 }
 /* ------------------------------------------------------------------------ */
+/* Flex row & entity -- useful when needing a dynamic list of things */
+div.flex_row {
+  display: flex;
+  flex-flow: row wrap;
+  margin: 0.25em;
+}
+div.flex_row div.entry {
+  padding: 0 0.25em;
+}
+/* ------------------------------------------------------------------------ */
 /* Random Rules */
 /* Because the guidelines are in the wiki, we have to jump through
    some hoops to get any tables used there to be displayed properly

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1739,6 +1739,16 @@ table.filter td select {
   width: 100%;
 }
 /* ------------------------------------------------------------------------ */
+/* Flex row & entity -- useful when needing a dynamic list of things */
+div.flex_row {
+  display: flex;
+  flex-flow: row wrap;
+  margin: 0.25em;
+}
+div.flex_row div.entry {
+  padding: 0 0.25em;
+}
+/* ------------------------------------------------------------------------ */
 /* Random Rules */
 /* Because the guidelines are in the wiki, we have to jump through
    some hoops to get any tables used there to be displayed properly


### PR DESCRIPTION
While working on some unrelated potential updates to the round pages I saw a chance to improve the way we present project filter information. This update moves the current filter into the filter table along side the button to reset it. If there is no filter the filter isn't shown.

Compare:
* [original P1 page](https://www.pgdp.org/c/tools/proofers/round.php?round_id=P1#filter_form)
* [update P1 page](https://www.pgdp.org/~cpeel/c.branch/update-filter-box/tools/proofers/round.php?round_id=P1#filter_form)

Note that the filter form does not show up unless you've [proofread 20 pages](https://github.com/DistributedProofreaders/dproofreaders/blob/master/tools/proofers/round.php#L121), so if you don't see a filter selection box, go proofread 20 pages.