### PR TITLE
Reset mysqli error logging for phpBB calls

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -22,6 +22,8 @@ final class DPDatabase
         self::$_db_name = $db_name;
 
         // Throw exceptions for DB call failures (PHP 8.1 default values)
+        // See forum_interface.inc for some special-cases when dealing with
+        // phpBB for login / logout.
         mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
         try {

--- a/pinc/forum_interface.inc
+++ b/pinc/forum_interface.inc
@@ -185,6 +185,9 @@ function login_forum_user($username, $password)
 
         include($phpbb_root_path . 'common.' . $phpEx);
 
+        // set mysqli logging to pre-PHP 8.1 defaults
+        mysqli_report(MYSQLI_REPORT_OFF);
+
         $user->session_begin();
         $auth->acl($user->data);
 
@@ -223,6 +226,9 @@ function login_forum_user($username, $password)
                 break;
         }
 
+        // reset mysqli logging
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
         return [$success, $reason];
     }
 }
@@ -259,9 +265,15 @@ function logout_forum_user()
 
         include($phpbb_root_path . 'common.' . $phpEx);
 
+        // set mysqli logging to pre-PHP 8.1 defaults
+        mysqli_report(MYSQLI_REPORT_OFF);
+
         // Re-initialize phpBB session object in $user so we can kill it
         $user->session_begin();
         $user->session_kill();
+
+        // reset mysqli logging
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
     }
 }
 


### PR DESCRIPTION
phpBB 3.x doesn't explicitly support PHP 8.1, nor do they set an explicit mysqli reporting value, so reset the value right before we do any inline calls to phpBB functions. This prevents the case where a DB call in phpBB code for login/logout errors and results in an uncaught DB error.

After phpBB supports PHP 8.1 we can either change MYSQLI_REPORT_OFF in `forum_interface.inc` to the value they use, or if they don't set a value, we can revert this commit entirely and use the PHP 8.1 defaults.

login and logout are the only place where we use inline phpBB code, so as long as login / logout both still work this commit is good to go after code inspection. Testable in the [play-nice-with-phpbb-db-errors](https://www.pgdp.org/~cpeel/c.branch/play-nice-with-phpbb-db-errors/) sandbox.