### PR TITLE
Enable bypassing error log on DB query failure

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -82,13 +82,17 @@ final class DPDatabase
         return mysqli_real_escape_string(self::$_connection, $value);
     }
 
-    public static function query($sql, $throw_on_failure = true)
+    public static function query($sql, $throw_on_failure = true, $log_on_failure = true)
     {
         try {
             $result = mysqli_query(self::$_connection, $sql);
         } catch (mysqli_sql_exception $e) {
-            // include this function's caller in the backtrace
-            $error = self::log_error(1);
+            if ($log_on_failure) {
+                // include this function's caller in the backtrace
+                $error = self::log_error(1);
+            } else {
+                $error = _("An error occurred during a database query.");
+            }
             if ($throw_on_failure) {
                 throw new DBQueryError($error);
             }

--- a/pinc/genres.inc
+++ b/pinc/genres.inc
@@ -107,7 +107,7 @@ function maybe_create_temporary_genre_translation_table()
 
     try {
         // if the create table succeeded, populate the table
-        DPDatabase::query($sql);
+        DPDatabase::query($sql, true, false);
         foreach ($genres as $key => $value) {
             $sql = sprintf("
                 INSERT INTO genre_translations


### PR DESCRIPTION
There are rare times when we know a query might fail and we don't want to log an error to the error log. Create a temporary table is one of them because we can't otherwise determine if the temporary table exists as it isn't populated in the schema and we don't want to give elevated privs to run sys.table_exists().

This is testable in the [fix-temp-table-logging-message](https://www.pgdp.org/~cpeel/c.branch/fix-temp-table-logging-message/) sandbox. Success is loading the round pages without generating errors in `php_errors`.