### PR TITLE
Fix Author page & XML rendering

### DIFF
--- a/tools/authors/authors.inc
+++ b/tools/authors/authors.inc
@@ -12,11 +12,13 @@ $months = [_('Unknown'),
 // and a link to the xml data will be provided.
 function echo_author($last_name, $other_names, $born, $dead, $author_id)
 {
+    global $code_url;
+
     $name = $last_name . ($other_names != '' ? ", $other_names" : '');
 
     echo "<h2>" . html_safe($name);
     if ($author_id) {
-        echo " <a href='{$GLOBALS['code_url']}/tools/authors/authorxml.php?author_id=$author_id'><img src='{$GLOBALS['code_url']}/graphics/xml.gif' border='0' width='36' height='14' style='vertical-align:middle'></a>\n";
+        echo " <a href='$code_url/tools/authors/authorxml.php?author_id=$author_id'><img src='$code_url/graphics/xml.gif' border='0' width='36' height='14' style='vertical-align:middle'></a>\n";
     }
     echo "</h2>";
 
@@ -30,16 +32,13 @@ function echo_author($last_name, $other_names, $born, $dead, $author_id)
         $sql = sprintf("SELECT bio_id FROM biographies WHERE author_id = %d;", $author_id);
         $result = DPDatabase::query($sql);
         $numrow = mysqli_num_rows($result);
-        $row = mysqli_fetch_assoc($result);
-        $bio_id = $row["bio_id"];
-        if ($numrow == 1) {
-            echo "<tr><th>" . _('Biography') . "</th><td><a href=\"bio.php?bio_id=$bio_id\">" . sprintf(_('Biography %d'), $bio_id) . "</a></td></tr>\n";
-        } elseif ($numrow > 1) {
-            echo "<tr><th rowspan=\"$numrow\" class=\"top-align\">" . _('Biographies') . "</th><td><a href=\"bio.php?bio_id=$bio_id\">" . _('Biography') . " $bio_id</a></td></tr>\n";
+        if ($numrow > 0) {
+            echo "<tr><th class=\"top-align\">" . _('Biographies') . "</th><td>";
             while ($row = mysqli_fetch_assoc($result)) {
                 $bio_id = $row["bio_id"];
-                echo "<tr><td><a href=\"bio.php?bio_id=$bio_id\">" . sprintf(_("Biography %d"), $bio_id) . "</a></td></tr>\n";
+                echo "<a href=\"bio.php?bio_id=$bio_id\">" . sprintf(_("Biography %d"), $bio_id) . "</a><br>\n";
             }
+            echo "</td></tr>\n";
         }
     }
     echo "</table>\n";

--- a/tools/authors/authorxml.php
+++ b/tools/authors/authorxml.php
@@ -1,7 +1,7 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // html_safe()
+include_once($relPath.'misc.inc'); // xmlencode()
 
 require_login();
 
@@ -67,8 +67,8 @@ function create_birth_or_death_data($bd, $sql_row)
               '" month="' . $sql_row[$bd . 'month'] .
                 '" day="' . $sql_row[$bd . 'day'];
     if ($sql_row[$bd . 'comments'] != '') {
-        $res .= '" comments="' . html_safe($sql_row[$bd . 'comments']);
+        $res .= '" comments="' . xmlencode($sql_row[$bd . 'comments']);
     }
-    $res .= "\">\n";
+    $res .= "\" />\n";
     return $res;
 }


### PR DESCRIPTION
If there is no author bio, there is no `$row["bio_id"];` to access and we get a warning of accessing an array offset on a null field, as seen in `php_errors` on PROD. Fix this by simplifying how we output bios on the author page. I did a bit more minor cleanup in `authors.inc` while I was here, none of it functional.

The other functional fix in this PR is making the `authorsxml.php` page render valid XML. Previously we were not closing the `<date>` tag making the document invalid.

Testable in the [fix-author-rendering](https://www.pgdp.org/~cpeel/c.branch/fix-author-rendering/) sandbox.