### PR TITLE
Add project quick check for small page images

### DIFF
--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -125,6 +125,7 @@ $test_functions = [
     "_test_project_has_all_page_images",
     "_test_project_for_bad_bytes",
     "_test_project_for_corrupt_pngs",
+    "_test_project_for_small_images",
     "_test_project_for_large_page_images",
     "_test_project_for_illo_images",
     "_test_project_for_word_lists",
@@ -256,6 +257,74 @@ function _test_project_for_corrupt_pngs($projectid)
         } else {
             $status = _("Error");
             $summary = _("Some pages images have corrupt PNGs.");
+        }
+    } else {
+        $status = _("Skipped");
+        $summary = _("Page table does not exist.");
+        $details = "";
+    }
+
+    return ["name" => $test_name, "description" => $test_desc, "status" => $status, "summary" => $summary, "details" => $details];
+}
+
+function _test_project_for_small_images($projectid)
+{
+    global $projects_dir;
+    global $projects_url;
+
+    $test_name = _("Small page images");
+    $test_desc = _("This test checks to see if any page image is possibly too small.");
+
+    $project = new Project($projectid);
+
+    if ($project->pages_table_exists) {
+        $sql = "SELECT image FROM $projectid ORDER BY image";
+        $result_res = DPDatabase::query($sql);
+
+        $details = "<table class='basic striped'>";
+        $details .= "<tr>";
+        $details .= "<th>" . _("Image") . "</th>";
+        $details .= "<th>" . _("Status") . "</th>";
+        $details .= "</tr>";
+
+        $error_images = false;
+        while ([$image] = mysqli_fetch_row($result_res)) {
+            // the the file's info
+            $file_info = get_file_info_object($image, "$projects_dir/$projectid", "$projects_url/$projectid");
+
+            // if the file doesn't exist, skip it -- we're not testing for that
+            if (!$file_info->exists) {
+                continue;
+            }
+
+            $status = "";
+            $size = getimagesize($file_info->abs_path);
+            if ($size == false) {
+                $status = _("Unable to determine page image size");
+            } elseif ($size[0] < 1000 || $size[1] < 1000) {
+                $status = sprintf(_("Page image size of %dx%d may be too small"), $size[0], $size[1]);
+            }
+
+            if (!empty($status)) {
+                $details .= "<tr>";
+                $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
+                $details .= "<td>" . $status . "</td>";
+                $details .= "</tr>";
+                $error_images = true;
+            }
+        }
+
+        mysqli_free_result($result_res);
+
+        $details .= "</table>";
+
+        if ($error_images) {
+            $status = _("Error");
+            $summary = _("Some page images may be too small.");
+        } else {
+            $status = _("Success");
+            $summary = _("No small images.");
+            $details = "";
         }
     } else {
         $status = _("Skipped");

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -138,8 +138,6 @@ $test_functions = [
 
 function _test_project_for_large_page_images($projectid)
 {
-    global $projects_dir;
-    global $projects_url;
     global $page_image_size_limit;
 
     $test_name = _("Large Page Image Files");
@@ -147,8 +145,7 @@ function _test_project_for_large_page_images($projectid)
 
     $project = new Project($projectid);
     if ($project->pages_table_exists) {
-        $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = DPDatabase::query($sql);
+        $images = $project->get_page_names_from_db();
 
         $details = "<table class='basic striped'>";
         $details .= "<tr>";
@@ -157,9 +154,9 @@ function _test_project_for_large_page_images($projectid)
         $details .= "</tr>";
 
         $num_large_images = 0;
-        while ([$image] = mysqli_fetch_row($result_res)) {
+        foreach ($images as $image) {
             // the the file's info
-            $file_info = get_file_info_object($image, "$projects_dir/$projectid", "$projects_url/$projectid");
+            $file_info = get_file_info_object($image, $project->dir, $project->url);
 
             // check to see if the file is > size limit
             $error = get_image_size_error($file_info->size);
@@ -172,8 +169,6 @@ function _test_project_for_large_page_images($projectid)
                 $num_large_images++;
             }
         }
-
-        mysqli_free_result($result_res);
 
         $details .= "</table>";
 
@@ -196,9 +191,6 @@ function _test_project_for_large_page_images($projectid)
 
 function _test_project_for_corrupt_pngs($projectid)
 {
-    global $projects_dir;
-    global $projects_url;
-
     $test_name = _("Corrupt page PNGs");
     $test_desc = _("This test checks to see if any page PNGs are corrupt or have internal errors.");
 
@@ -211,8 +203,7 @@ function _test_project_for_corrupt_pngs($projectid)
         $summary = _("pngcheck program not available on this system.");
         $details = "";
     } elseif ($project->pages_table_exists) {
-        $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = DPDatabase::query($sql);
+        $images = $project->get_page_names_from_db();
 
         $details = "<table class='basic striped'>";
         $details .= "<tr>";
@@ -221,9 +212,9 @@ function _test_project_for_corrupt_pngs($projectid)
         $details .= "</tr>";
 
         $error_pngs = 0;
-        while ([$image] = mysqli_fetch_row($result_res)) {
+        foreach ($images as $image) {
             // the the file's info
-            $file_info = get_file_info_object($image, "$projects_dir/$projectid", "$projects_url/$projectid");
+            $file_info = get_file_info_object($image, $project->dir, $project->url);
 
             // if the file doesn't exist, skip it -- we're not testing for that
             if (!$file_info->exists) {
@@ -246,8 +237,6 @@ function _test_project_for_corrupt_pngs($projectid)
             }
         }
 
-        mysqli_free_result($result_res);
-
         $details .= "</table>";
 
         if ($error_pngs == 0) {
@@ -269,17 +258,13 @@ function _test_project_for_corrupt_pngs($projectid)
 
 function _test_project_for_small_images($projectid)
 {
-    global $projects_dir;
-    global $projects_url;
-
     $test_name = _("Small page images");
     $test_desc = _("This test checks to see if any page image is possibly too small.");
 
     $project = new Project($projectid);
 
     if ($project->pages_table_exists) {
-        $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = DPDatabase::query($sql);
+        $images = $project->get_page_names_from_db();
 
         $details = "<table class='basic striped'>";
         $details .= "<tr>";
@@ -288,9 +273,9 @@ function _test_project_for_small_images($projectid)
         $details .= "</tr>";
 
         $error_images = false;
-        while ([$image] = mysqli_fetch_row($result_res)) {
+        foreach ($images as $image) {
             // the the file's info
-            $file_info = get_file_info_object($image, "$projects_dir/$projectid", "$projects_url/$projectid");
+            $file_info = get_file_info_object($image, $project->dir, $project->url);
 
             // if the file doesn't exist, skip it -- we're not testing for that
             if (!$file_info->exists) {
@@ -314,8 +299,6 @@ function _test_project_for_small_images($projectid)
             }
         }
 
-        mysqli_free_result($result_res);
-
         $details .= "</table>";
 
         if ($error_images) {
@@ -337,8 +320,6 @@ function _test_project_for_small_images($projectid)
 
 function _test_project_for_illo_images($projectid)
 {
-    global $projects_dir;
-    global $projects_url;
     global $code_url;
 
     $test_name = _("Illustration Image Files");
@@ -346,16 +327,9 @@ function _test_project_for_illo_images($projectid)
 
     $project = new Project($projectid);
     if ($project->pages_table_exists) {
-        $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = DPDatabase::query($sql);
+        $page_image_names = $project->get_page_names_from_db();
 
-        $page_image_names = [];
-        while ([$image] = mysqli_fetch_row($result_res)) {
-            $page_image_names[] = $image;
-        }
-        mysqli_free_result($result_res);
-
-        chdir("$projects_dir/$projectid");
+        chdir($project->dir);
         $existing_image_names = glob("*.{png,jpg}", GLOB_BRACE);
         // That returns a sorted list of the .png files
         // followed by a sorted list of the .jpg files,
@@ -686,25 +660,21 @@ function _test_project_for_valid_clearance($projectid)
 
 function _test_project_has_all_page_images($projectid)
 {
-    global $projects_dir;
-    global $projects_url;
-
     $test_name = _("Page images exist");
     $test_desc = _("This test validates that all page images exist on the server.");
 
     $project = new Project($projectid);
 
     if ($project->pages_table_exists) {
-        $sql = "SELECT image FROM $projectid ORDER BY image";
-        $result_res = DPDatabase::query($sql);
+        $images = $project->get_page_names_from_db();
 
         $details = "<p>" . _("The following page images do not exist on the server.") . "</p>";
         $details .= "<ul>";
         $error_images = 0;
         $image_count = 0;
-        while ([$image] = mysqli_fetch_row($result_res)) {
+        foreach ($images as $image) {
             // the the file's info
-            $file_info = get_file_info_object($image, "$projects_dir/$projectid", "$projects_url/$projectid");
+            $file_info = get_file_info_object($image, $project->dir, $project->url);
 
             if (!$file_info->exists) {
                 $details .= "<li>$image</li>";
@@ -713,8 +683,6 @@ function _test_project_has_all_page_images($projectid)
             $image_count += 1;
         }
         $details .= "</ul>";
-
-        mysqli_free_result($result_res);
 
         if ($image_count == 0) {
             $status = _("Error");

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -281,7 +281,7 @@ function _test_project_for_small_images($projectid)
                 $details = _("Unable to determine the page image size for some pages.");
                 break;
             } elseif ($size[0] < 1000 || $size[1] < 1000) {
-                $details = _("Some page images have a short width of less than 1000 pixels and may be too small.");
+                $details = _("Some images may be too small: the shortest dimension of some page images is less than 1000 pixels.");
                 break;
             }
         }

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -297,18 +297,18 @@ function _test_project_for_small_images($projectid)
                 continue;
             }
 
-            $status = "";
+            $image_status = "";
             $size = getimagesize($file_info->abs_path);
             if ($size == false) {
-                $status = _("Unable to determine page image size");
+                $image_status = _("Unable to determine page image size");
             } elseif ($size[0] < 1000 || $size[1] < 1000) {
-                $status = sprintf(_("Page image size of %dx%d may be too small"), $size[0], $size[1]);
+                $image_status = sprintf(_("Page image size of %dx%d may be too small"), $size[0], $size[1]);
             }
 
-            if (!empty($status)) {
+            if (!empty($image_status)) {
                 $details .= "<tr>";
                 $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
-                $details .= "<td>" . $status . "</td>";
+                $details .= "<td>" . $image_status . "</td>";
                 $details .= "</tr>";
                 $error_images = true;
             }
@@ -319,7 +319,7 @@ function _test_project_for_small_images($projectid)
         $details .= "</table>";
 
         if ($error_images) {
-            $status = _("Error");
+            $status = _("Warning");
             $summary = _("Some page images may be too small.");
         } else {
             $status = _("Success");

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -259,20 +259,14 @@ function _test_project_for_corrupt_pngs($projectid)
 function _test_project_for_small_images($projectid)
 {
     $test_name = _("Small page images");
-    $test_desc = _("This test checks to see if any page image is possibly too small.");
+    $test_desc = _("This test checks to see if any page images are possibly too small.");
+    $details = "";
 
     $project = new Project($projectid);
 
     if ($project->pages_table_exists) {
         $images = $project->get_page_names_from_db();
 
-        $details = "<table class='basic striped'>";
-        $details .= "<tr>";
-        $details .= "<th>" . _("Image") . "</th>";
-        $details .= "<th>" . _("Status") . "</th>";
-        $details .= "</tr>";
-
-        $error_images = false;
         foreach ($images as $image) {
             // the the file's info
             $file_info = get_file_info_object($image, $project->dir, $project->url);
@@ -282,37 +276,26 @@ function _test_project_for_small_images($projectid)
                 continue;
             }
 
-            $image_status = "";
             $size = getimagesize($file_info->abs_path);
             if ($size == false) {
-                $image_status = _("Unable to determine page image size");
+                $details = _("Unable to determine the page image size for some pages.");
+                break;
             } elseif ($size[0] < 1000 || $size[1] < 1000) {
-                $image_status = sprintf(_("Page image size of %dx%d may be too small"), $size[0], $size[1]);
-            }
-
-            if (!empty($image_status)) {
-                $details .= "<tr>";
-                $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
-                $details .= "<td>" . $image_status . "</td>";
-                $details .= "</tr>";
-                $error_images = true;
+                $details = _("Some page images have a short width of less than 1000 pixels and may be too small.");
+                break;
             }
         }
 
-        $details .= "</table>";
-
-        if ($error_images) {
+        if (!empty($details)) {
             $status = _("Warning");
             $summary = _("Some page images may be too small.");
         } else {
             $status = _("Success");
             $summary = _("No small images.");
-            $details = "";
         }
     } else {
         $status = _("Skipped");
         $summary = _("Page table does not exist.");
-        $details = "";
     }
 
     return ["name" => $test_name, "description" => $test_desc, "status" => $status, "summary" => $summary, "details" => $details];


### PR DESCRIPTION
Per request from @lhamilton1, adding a project quick check for page images being less than 1000px in any dimension.

Sandbox with small images: https://www.pgdp.org/~chrismiceli/c.branch/small-images/tools/project_manager/project_quick_check.php?projectid=projectID45ea6b97d9566#_test_project_for_small_images

![image](https://user-images.githubusercontent.com/1526781/197926594-554b7c59-7dc8-41db-8534-8f0415efe34d.png)
