### PR TITLE
Return correct type for POFileIterator

### DIFF
--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -187,7 +187,7 @@ class POFileIterator implements Iterator
         $this->next();
     }
 
-    public function current(): mixed
+    public function current(): string
     {
         return $this->current_block;
     }


### PR DESCRIPTION
"mixed" was introduced as a valid type in PHP 8.0 and is only a pseudo-type in 7.4. Fix the return type to work with 7.4.

This fixes an error in the translation center which we missed during the PHP 8.x updates.

Testable in the [fix-translation-center](https://www.pgdp.org/~cpeel/c.branch/fix-translation-center/) sandbox. Hotfixed on PROD8.