### PR TITLE
Add Mastodon social media link

### DIFF
--- a/default.php
+++ b/default.php
@@ -33,6 +33,7 @@ if (!$testing) {
                   "sameAs": [
                     "https://www.pgdp.net/c",
                     "https://blog.pgdp.net/",
+                    "https://universeodon.com/@DProofreaders",
                     "https://twitter.com/DProofreaders",
                     "https://www.linkedin.com/groups/832347/",
                     "https://www.facebook.com/distributed.proofreaders/"

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -959,13 +959,13 @@ function show_donation_stuff()
         _("Thank you for supporting <b>DP</b>! You can also support the site by making a donation to the non-profit <a href='%s'>Distributed Proofreaders Foundation</a>."),
         $DPF_home_url
     );
-    echo "<br>";
+    echo "</p>\n";
+
     echo "<div class='center-align' style='padding-top: 3px;'>";
     echo "<button type='button' onclick='window.open(\"$DPF_donor_url\");' class='button bold' style='font-size: 1em; box-shadow: 2px 2px;'>";
     echo _("Donate");
     echo "</button>";
     echo "</div>";
-    echo "</p>\n";
 
     echo "</div>\n";
     echo "<hr class='divider'>\n";

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -981,6 +981,11 @@ function show_social_media_links()
             "class" => "fab fa-wordpress fa-2x",
             "url" => "https://blog.pgdp.net",
         ],
+        "Mastodon" => [
+            "class" => "fab fa-mastodon fa-2x",
+            "url" => "https://universeodon.com/@DProofreaders",
+            "rel" => "me",
+        ],
         "Twitter" => [
             "class" => "fab fa-twitter fa-2x",
             "url" => "https://twitter.com/DProofreaders",
@@ -1000,7 +1005,8 @@ function show_social_media_links()
     foreach ($social_links as $name => $data) {
         $class = $data["class"];
         $url = $data["url"];
-        $links[] = "<a style='text-decoration: none;' href='$url' aria-label='$name'>" .
+        $rel = $data["rel"] ?? "";
+        $links[] = "<a style='text-decoration: none;' href='$url' rel='$rel' aria-label='$name'>" .
             "<i aria-hidden='true' class='$class' title='$name'></i>" .
             "</a>";
     }


### PR DESCRIPTION
Adds a link to the new DP presence on Mastodon. Also fixes a minor HTML validation issue in the donations blurb.

Testable in the [add-mastodon-social-media](https://www.pgdp.org/~cpeel/c.branch/add-mastodon-social-media/) sandbox.