### PR TITLE
Make search/replaced Regex multiline

### DIFF
--- a/tools/proofers/srchrep.js
+++ b/tools/proofers/srchrep.js
@@ -27,7 +27,7 @@ var srchrep = (function() {
             replacetext = replacetext.replace(/\$/g, '$$$$');
         }
         opener.parent.docRef.editform.text_data.value = opener.parent.docRef.editform.text_data.value.replace(
-            new RegExp(search,'gu'),
+            new RegExp(search,'gum'),
             replacetext);
         setUndoButtonDisabled(false);
     }


### PR DESCRIPTION
Make `^` and `$` match the first and last of each line within a page during search/replace, not just the first and last of the string. [Task 2044](https://www.pgdp.net/c/tasks.php?action=show&task_id=2044)

Testable in https://www.pgdp.org/~cpeel/c.branch/use-multiline-regex/

