### PR TITLE
Change some project transitions

### DIFF
--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -434,7 +434,7 @@ function get_transition($from_state, $to_state)
 new ProjectTransition(
     PROJ_NEW,
     PROJ_P1_UNAVAILABLE,
-    'manager',
+    'unrestricted_manager',
     [
         'project_restriction' => null,
         'action_name' => '[default]',

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -681,26 +681,6 @@ for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
         ];
 
         foreach ($from_states as $from_state) {
-            if ($rn > 1) {
-                // Transition to go back 1 round.
-
-                $prev_round = get_Round_for_round_number($rn - 1);
-
-                new ProjectTransition(
-                    $from_state,
-                    $prev_round->project_waiting_state,
-                    'site_manager',
-                    [
-                        'project_restriction' => null,
-                        'action_name' => sprintf(_('Send back to %s'), $prev_round->id),
-                        'confirmation_question' => '[default]',
-                        'detour' => null,
-                        'settings_template' => "", // don't set modifieddate
-                        'collateral_actions' => null,
-                    ]
-                );
-            }
-
             if ($rn < MAX_NUM_PAGE_EDITING_ROUNDS) {
                 $next_round = get_Round_for_round_number($rn + 1);
 

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -58,8 +58,8 @@ function check_user_can_load_projects($exit_if_not)
     global $site_manager_email_addr;
     if (user_has_project_loads_disabled()) {
         echo "
-              <div class='display-flex'><div class='callout'>"
-            ._("You are not currently permitted to create new projects, or move projects out of the unavailable state.")
+              <div class='display-flex' style='margin-bottom:0.5em'><div class='callout'>"
+            ._("You are not currently permitted to create new projects, or move projects out of the new project or unavailable states.")
             ."<br>\n"
             .sprintf(_("If you believe you are receiving this message in error, please contact a <a href='%s'>site manager</a>."),
                      "mailto:$site_manager_email_addr"

--- a/project.php
+++ b/project.php
@@ -1911,7 +1911,8 @@ function do_change_state()
     }
 
     // print out a message if PM has project loads disabled,
-    // as they can't move a project out of the unavailable state
+    // as they can't move a project out of the new project
+    // or unavailable state
     if ($project->can_be_managed_by_current_user) {
         check_user_can_load_projects(false);
     }


### PR DESCRIPTION
The first commit removes the button that squirrels could use to move a project back into the previous round (the effect of which was to change the project state to unavailable for the previous round and the page states to the previous round's `page_avail` state. This was easy to confuse with doing a round repeat (which is done via separate script). The original reason for the button appears to have been to make it easier, after the move from 2 to 3 proofreading rounds, to shove a P3 project that had no P2 back into an empty P2 round.

The second commit removes the ability for disabled project managers to move a project out of the new project state. From the new project state, it is easier for them to fix problems with a project themselves instead of having to request a squirrel to do so.

Testable in [https://www.pgdp.org/~srjfoo/c.branch/change-pm-transitions/](https://www.pgdp.org/~srjfoo/c.branch/change-pm-transitions/).