### PR TITLE
allow inline math inside display math

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -467,6 +467,12 @@ QUnit.module("Format preview test", function() {
         issueTest(assert, 1, 8, 2, "misMatchTag", 1);
     });
 
+    QUnit.test("inline math inside display math", function (assert) {
+        text = "\\[e=mc^2 \\text{abc \\(x=y\\)}\\]";
+        issArray = analyse(text, mathConfig).issues;
+        noIssueTest(assert);
+    });
+
     QUnit.test("missing maths end tag", function (assert) {
         text = "\\[e=mc^2\\(";
         issArray = analyse(text, mathConfig).issues;


### PR DESCRIPTION
MathJax can compile inline math inside text inside display math but the format preview previously marked it as an error.
Also add a test for it not to cause an error.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/nest_inline