### PR TITLE
Validate page state on leaving proofreading UI

### DIFF
--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -5,6 +5,7 @@ include_once($relPath.'slim_header.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'misc.inc'); // array_get()
 include_once($relPath.'abort.inc');
+include_once($relPath.'Project.inc'); // $PROJECT_STATES_IN_ORDER
 include_once('PPage.inc');
 include_once('proof_frame.inc');
 include_once('text_frame_std.inc');
@@ -20,7 +21,7 @@ $_POST:
 */
 
 $projectid = get_projectID_param($_POST, 'projectid');
-$proj_state = $_POST['proj_state'];
+$proj_state = get_enumerated_param($_POST, 'proj_state', null, $PROJECT_STATES_IN_ORDER);
 $imagefile = get_page_image_param($_POST, 'imagefile');
 $text_data = array_get($_POST, 'text_data', '');
 


### PR DESCRIPTION
Prevent XSS injection into "Save as Done" and "Return Page to Round" via the page state. We don't use the page state within the page, but we pass it into the return link.

Testable in [validate-proj-state](https://www.pgdp.org/~cpeel/c.branch/validate-proj-state/) sandbox.

This was found via the Detectify monthly run.