### PR TITLE
Set focus on proofing interface S/R Search field

### DIFF
--- a/tools/proofers/srchrep.php
+++ b/tools/proofers/srchrep.php
@@ -17,7 +17,7 @@ slim_header(_("Search/Replace"), [
 <tr><td class="right-align">
 <?php echo _("Search"); ?>:
 </td><td>
-<input type="text" name="search" id='search'>
+<input type="text" name="search" id='search' autofocus>
 </td></tr>
 <tr><td class="right-align">
 <?php echo _("Replace"); ?>:


### PR DESCRIPTION
When the Search/Replace tool is popped in the proofing interface, ensure the keyboard focus is in its Search field. This enables the proofer to begin typing the Search term immediately without an additional click.