### PR TITLE
Prepare for the R202303 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,6 +7,15 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
+## R202303
+No scripts are required for this upgrade.
+
+* Support PHP 8.x (cpeel, srjfoo)
+* Format Preview updates (70ray)
+* Check for small images on project load and in Project Quick Check (chrismiceli)
+* Revision of PPV form and calculation algorithm (windymilla)
+* Small adjustments to manual project transition edgecases (srjfoo)
+
 ## R202209
 Scripts supporting this upgrade are in `SETUP/upgrade/18`
 

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -121,5 +121,8 @@ Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/18/
 
+### Upgrading from release R202209
+No upgrade scripts are required for this release.
+
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.


### PR DESCRIPTION
Update the changelog and upgrade docs for the upcoming R202303 release. This list tries to encapsulate the notable changes without getting into the weeds (that's what `git log` is for). I welcome thoughts if the wording should be updated or if there are additional things we want to include.

A reminder that you can see all of the commits since the last release with `git log R202209..upstream/master`