### PR TITLE
Make a function to split text into blocks

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -257,10 +257,28 @@ QUnit.module("Format preview test", function() {
         issueTest(assert, 0, 8, 1, "spaceBeforeEnd", 1);
     });
 
-    QUnit.test("entirely bold heading", function (assert) {
+    QUnit.test("entirely bold heading with two lines", function (assert) {
+        text = "ab\n\n\n\n\n<b>c\nd</b>\n\nef";
+        issArray = analyse(text, configuration).issues;
+        issueTest(assert, 0, 7, 3, "noBold", 1);
+    });
+
+    QUnit.test("entirely bold sub-heading", function (assert) {
+        text = "ab\n\n\n\n\nc\nd\n\n<b>c\nd</b>\n\nef";
+        issArray = analyse(text, configuration).issues;
+        issueTest(assert, 0, 12, 3, "noBoldSub", 1);
+    });
+
+    QUnit.test("entirely bold section heading", function (assert) {
         text = "ab\n\n\n<b>cd</b>\n\nef";
         issArray = analyse(text, configuration).issues;
-        issueTest(assert, 0, 5, 3, "noBold", 1);
+        issueTest(assert, 0, 5, 3, "noBoldSec", 1);
+    });
+
+    QUnit.test("entirely bold section heading at end", function (assert) {
+        text = "ab\n\n\n<b>THE END</b>";
+        issArray = analyse(text, configuration).issues;
+        issueTest(assert, 0, 5, 3, "noBoldSec", 1);
     });
 
     QUnit.test("small cap text with no capitals", function (assert) {

--- a/styles/preview.css
+++ b/styles/preview.css
@@ -107,13 +107,6 @@
     font-weight: bold;
     text-align: center;
 }
-.para {
-    text-indent: 1em;
-    margin-bottom: 0.4em;
-}
-.mid_para {
-    margin-bottom: 0.4em;
-}
 
 /* thought break */
 .tb {
@@ -124,21 +117,4 @@
     margin-right: 15%;
     border-style: inset;
     border-width: 1px;
-}
-
-/* block quote */
-.bq {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-    margin-left: 1em;
-    margin-right: 1em;
-}
-
-/* no wrap */
-.nw {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-    margin-left: 1em;
-    margin-right: 1em;
-    white-space: pre-wrap;
 }

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -43,6 +43,8 @@ function get_preview_messages()
         "sideNoteBlank" => _("A blank line should precede and follow Sidenote"),
         "emptyTag" => _("Empty tag"),
         "multipleAnchors" => _("Multiple anchors for same footnote"),
+        "noBoldSub" => _("Sub-heading should not be entirely bold"),
+        "noBoldSec" => _("Section heading should not be entirely bold"),
     ];
 }
 


### PR DESCRIPTION
This fixes  task 2038 https://www.pgdp.net/c/tasks.php?action=show&task_id=2038 and simplifies and improves re-wrap.

Classify blocks based on number of preceding blank lines. Use the function for checking all-bold headings and for re-wrap. Allow Headings and sub-headings to have more than one line. 2 blank lines introduce a section. If the block following the 2 blank lines consists of only one line treat it as a section heading (not all bold); else treat like a paragraph. Add different error codes for not all bold in heading, sub-heading or section heading, add tests for them. Revise re-wrap code and remove unused preview styles.