### PR TITLE
Avoid error if proofer dbl-clicks some buttons

### DIFF
--- a/SETUP/tests/jsTests/dp_proofTests.js
+++ b/SETUP/tests/jsTests/dp_proofTests.js
@@ -35,7 +35,7 @@ QUnit.module("dp_proof tests", function(hooks) {
         });
         form.appendChild(submitButton);
         document.body.appendChild(form);
-        assert.false(submitButton.disabled, "button should be disabled");
+        assert.false(submitButton.disabled, "button should be enabled");
         submitButton.click();
         setTimeout(() => {
             // simulate event loop for clicks

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'site_vars.php');  // $charset for javascript_safe()
 include_once($relPath.'misc.inc');  // attr_safe(), javascript_safe()
+include_once($relPath.'misc.inc');  // attr_safe(), javascript_safe()
 
 define('CHANGE_LAYOUT', 'A');
 define('QUIT', 'B');
@@ -113,6 +114,7 @@ function echo_button($button_id, $which_interface)
                 'name' => "button2",
                 $label => attr_safe(_("Save as 'Done' & Proofread Next Page")),
                 'title' => attr_safe(_("Save as 'Done' & Proofread Next Page")),
+                'onClick' => "return submitJustOnce(this);",
                 'src' => "gfx/bt2.png",
                 'class' => "check_button",
             ];
@@ -124,6 +126,7 @@ function echo_button($button_id, $which_interface)
                 'name' => "button5",
                 $label => attr_safe(_("Save as 'Done'")),
                 'title' => attr_safe(_("Save as 'Done'")),
+                'onClick' => "return submitJustOnce(this);",
                 'src' => "gfx/bt13.png",
                 'class' => "check_button",
             ];
@@ -135,6 +138,7 @@ function echo_button($button_id, $which_interface)
                 'name' => "button1",
                 $label => attr_safe(_("Save as 'In Progress'")),
                 'title' => attr_safe(_("Save as 'In Progress'")),
+                'onClick' => "return submitJustOnce(this);",
                 'src' => "gfx/bt3.png",
                 'class' => "check_button",
             ];
@@ -145,6 +149,7 @@ function echo_button($button_id, $which_interface)
                 'name' => "button10",
                 $label => attr_safe(_("WordCheck")),
                 'title' => attr_safe(_("Run WordCheck")),
+                'onClick' => "return submitJustOnce(this);",
                 'src' => "gfx/bt16.png",
             ];
             break;

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -148,7 +148,7 @@ function echo_button($button_id, $which_interface)
                 'name' => "button10",
                 $label => attr_safe(_("WordCheck")),
                 'title' => attr_safe(_("Run WordCheck")),
-                'onClick' => "return submitJustOnce(this);",
+                //                'onClick' => "return submitJustOnce(this);",
                 'src' => "gfx/bt16.png",
             ];
             break;

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath.'site_vars.php');  // $charset for javascript_safe()
 include_once($relPath.'misc.inc');  // attr_safe(), javascript_safe()
-include_once($relPath.'misc.inc');  // attr_safe(), javascript_safe()
 
 define('CHANGE_LAYOUT', 'A');
 define('QUIT', 'B');

--- a/tools/proofers/dp_proof.js
+++ b/tools/proofers/dp_proof.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, no-undef, camelcase */
-/* exported insertCharacter, surroundSelection, changeFontFamily, changeFontSize, showNW, replaceAllText, transformText */
+/* exported insertCharacter, surroundSelection, changeFontFamily, changeFontSize, showNW, replaceAllText, transformText, submitJustOnce */
 // This variable is set by initializeStuff() in dp_scroll.js
 var docRef = null;
 
@@ -230,3 +230,17 @@ function transformText(transformType) {
     txtArea.focus();
 }
 
+// Avoid submitting twice if user double-clicks button
+// Usage: onClick="return submitJustOnce(this);"
+//
+// Uses a data attribute to store when button has been clicked for the first time
+// Returns true on first click to continue submission
+// If attribute is already set (second click), return false to avoid re-submitting
+function submitJustOnce(btn) {
+    if (btn.dataset.alreadysubmitted) {
+        return false;
+    } else {
+        btn.dataset.alreadysubmitted = true;
+        return true;
+    }
+}

--- a/tools/proofers/dp_proof.js
+++ b/tools/proofers/dp_proof.js
@@ -237,10 +237,10 @@ function transformText(transformType) {
 // Returns true on first click to continue submission
 // If attribute is already set (second click), return false to avoid re-submitting
 function submitJustOnce(btn) {
-    if (btn.dataset.alreadysubmitted) {
+    if (btn.dataset.alreadysubmitted === 'true') {
         return false;
     } else {
-        btn.dataset.alreadysubmitted = true;
+        btn.dataset.alreadysubmitted = 'true';
         return true;
     }
 }

--- a/tools/proofers/dp_proof.js
+++ b/tools/proofers/dp_proof.js
@@ -235,7 +235,12 @@ function submitForm(form) {
     setTimeout(() => {
         // disable after form submits (setTimeout) since disabled form values aren't sent and we
         // need the submit button to submit to determine which submit button was clicked
+        // standard interface buttons have type 'submit'
         form.querySelectorAll('input[type=submit]').forEach(inputSubmit => {
+            inputSubmit.disabled = true;
+        });
+        // enhanced interface buttons have type 'image'
+        form.querySelectorAll('input[type=image]').forEach(inputSubmit => {
             inputSubmit.disabled = true;
         });
     }, 0);

--- a/tools/proofers/dp_proof.js
+++ b/tools/proofers/dp_proof.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, no-undef, camelcase */
-/* exported insertCharacter, surroundSelection, changeFontFamily, changeFontSize, showNW, replaceAllText, transformText, submitJustOnce */
+/* exported insertCharacter, surroundSelection, changeFontFamily, changeFontSize, showNW, replaceAllText, transformText, submitJustOnce, submitForm */
 // This variable is set by initializeStuff() in dp_scroll.js
 var docRef = null;
 
@@ -243,4 +243,9 @@ function submitJustOnce(btn) {
         btn.dataset.alreadysubmitted = 'true';
         return true;
     }
+}
+
+function submitForm() {
+    document.querySelector('input').disabled = true;
+    return true;
 }

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -38,6 +38,7 @@ function echo_proof_frame_enh($ppage)
             "$code_url/tools/proofers/process_diacritcal_markup.js",
             "$code_url/scripts/control_bar.js",
             "$code_url/tools/proofers/proof_image.js",
+            "$code_url/tools/proofers/dp_proof.js",
         ],
         "js_data" => get_preview_js_vars() . get_preview_font_data_js() .
         get_control_bar_texts() . "

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -38,7 +38,6 @@ function echo_proof_frame_enh($ppage)
             "$code_url/tools/proofers/process_diacritcal_markup.js",
             "$code_url/scripts/control_bar.js",
             "$code_url/tools/proofers/proof_image.js",
-            "$code_url/tools/proofers/dp_proof.js",
         ],
         "js_data" => get_preview_js_vars() . get_preview_font_data_js() .
         get_control_bar_texts() . "
@@ -65,7 +64,7 @@ function echo_proof_frame_enh($ppage)
     render_validator();
     echo "</div>"; ?>
         <div id='proofdiv'>
-            <form name="editform" id="editform" method="POST" action="processtext.php" onsubmit="return submitForm(this)">
+            <form name="editform" id="editform" method="POST" action="processtext.php" onsubmit="return top.submitForm(this)">
                 <?php $ppage->echo_hidden_fields(); ?>
                 <table id="tbtext">
                     <tr>

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -65,7 +65,7 @@ function echo_proof_frame_enh($ppage)
     render_validator();
     echo "</div>"; ?>
         <div id='proofdiv'>
-            <form name="editform" id="editform" method="POST" action="processtext.php">
+            <form name="editform" id="editform" method="POST" action="processtext.php" onsubmit="return submitForm(this)">
                 <?php $ppage->echo_hidden_fields(); ?>
                 <table id="tbtext">
                     <tr>

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -46,6 +46,7 @@ $header_args = [
         "$code_url/scripts/character_test.js",
         "$code_url/scripts/control_bar.js",
         "$code_url/tools/proofers/proof_image.js",
+        "$code_url/tools/proofers/dp_proof.js",
     ],
     "js_data" => get_page_js($user->profile->i_type == 1 ? 2 : 3) .
         get_control_bar_texts() . "
@@ -206,6 +207,7 @@ if ($user->profile->i_type == 1) {
             id="spsaveandnext"
             value="<?php echo attr_safe(_("Save as 'Done' & Proofread Next Page")); ?>"
             title="<?php echo attr_safe(_("Save page as done and proofread the next available page")); ?>"
+            onClick="return submitJustOnce(this);",
 <?php
     if ($is_changed) {
         echo "            disabled\n";

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -207,7 +207,7 @@ if ($user->profile->i_type == 1) {
             id="spsaveandnext"
             value="<?php echo attr_safe(_("Save as 'Done' & Proofread Next Page")); ?>"
             title="<?php echo attr_safe(_("Save page as done and proofread the next available page")); ?>"
-            onClick="return submitJustOnce(this);",
+            onClick="return submitJustOnce(this);"
 <?php
     if ($is_changed) {
         echo "            disabled\n";

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -46,7 +46,6 @@ $header_args = [
         "$code_url/scripts/character_test.js",
         "$code_url/scripts/control_bar.js",
         "$code_url/tools/proofers/proof_image.js",
-        "$code_url/tools/proofers/dp_proof.js",
     ],
     "js_data" => get_page_js($user->profile->i_type == 1 ? 2 : 3) .
         get_control_bar_texts() . "
@@ -72,7 +71,7 @@ if ($user->profile->i_type == 1) {
     echo '<div>';
 }
 ?>
-<form name="spcorrects" action="processtext.php" method="POST" onsubmit="return submitForm(this)">
+<form name="spcorrects" action="processtext.php" method="POST" onsubmit="return top.submitForm(this)">
 <?php
     // change all EOL characters to [lf]
     $revert_text = str_replace(["\r", "\n\n", "\n"], ["\n", "[lf]", "[lf]"], $revert_text);

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -23,7 +23,6 @@ function echo_text_frame_std($ppage)
             "$code_url/scripts/text_validator.js",
             "$code_url/tools/proofers/proof_validate.js",
             "$code_url/tools/proofers/process_diacritcal_markup.js",
-            "$code_url/tools/proofers/dp_proof.js",
         ],
         "js_data" => get_preview_js_vars() . get_preview_font_data_js() . "
         function ldAll() {
@@ -37,7 +36,7 @@ function echo_text_frame_std($ppage)
         "body_attributes" => "id='standard_interface_text' onload='ldAll()'",
     ];
     slim_header(_("Text Frame"), $header_args); ?>
-    <form name="editform" id="editform" method="post" action="processtext.php" target="proofframe" onsubmit="return submitForm(this)">
+    <form name="editform" id="editform" method="post" action="processtext.php" target="proofframe" onsubmit="return top.submitForm(this)">
     <div style = 'height: 100vh'>
     <?php
     output_preview_div();

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -23,6 +23,7 @@ function echo_text_frame_std($ppage)
             "$code_url/scripts/text_validator.js",
             "$code_url/tools/proofers/proof_validate.js",
             "$code_url/tools/proofers/process_diacritcal_markup.js",
+            "$code_url/tools/proofers/dp_proof.js",
         ],
         "js_data" => get_preview_js_vars() . get_preview_font_data_js() . "
         function ldAll() {

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -37,7 +37,7 @@ function echo_text_frame_std($ppage)
         "body_attributes" => "id='standard_interface_text' onload='ldAll()'",
     ];
     slim_header(_("Text Frame"), $header_args); ?>
-    <form name="editform" id="editform" method="post" action="processtext.php" target="proofframe">
+    <form name="editform" id="editform" method="post" action="processtext.php" target="proofframe" 'onsubmit'="return submitForm()">
     <div style = 'height: 100vh'>
     <?php
     output_preview_div();


### PR DESCRIPTION
Buttons in the proofing interface that change the page's status can cause an error if double-clicked. Since first click changes the status, second click gives an error. Error only appears to occur on some systems.

Solution is to stop the second click from attempting to re-submit by returning false from onClick handler. On first click, set a user-defined data attribute to true, so second click knows it's the second click.

Affects WordCheck, Save as Done and Proofread Next Page (from proofing and WordCheck interfaces), Save as In Progress and Save as Done.

Testable at https://www.pgdp.org/~windymilla/c/