### PR TITLE
Set a size for images in buttons

### DIFF
--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -152,9 +152,10 @@ var viewSplitter = function(container, storageKey) {
 
     const mainSplit = splitControl(container, {splitVertical: splitVertical});
 
-    const vSplitImage = $("<img>", {src: proofIntData.buttonImages.imgVSplit});
+    const imageButtonSize = 26;
+    const vSplitImage = $("<img>", {src: proofIntData.buttonImages.imgVSplit, height: imageButtonSize, width: imageButtonSize});
     const vSwitchButton = $("<button>", {type: 'button', class: 'img-button control', title: proofIntData.strings.switchVert}).append(vSplitImage);
-    const hSplitImage = $("<img>", {src: proofIntData.buttonImages.imgHSplit});
+    const hSplitImage = $("<img>", {src: proofIntData.buttonImages.imgHSplit, height: imageButtonSize, width: imageButtonSize});
     const hSwitchButton = $("<button>", {type: 'button', class: 'img-button control', title: proofIntData.strings.switchHoriz}).append(hSplitImage);
 
     let splitKey;
@@ -444,8 +445,8 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
                                 textWidget = makeTextWidget(textDiv);
                             }
                             theSplitter.setSplitDirCallback.add(imageWidget.setup, textWidget.setup);
-                            theSplitter.fireSetSplitDir();
                             fixHead.append(imageButton, textButton, pageControls, roundControls, theSplitter.buttons);
+                            theSplitter.fireSetSplitDir();
                             break;
                         }
                         }


### PR DESCRIPTION
and re-order 2 lines.

This fixes a bug with the horizontal split bar in the page browser. If you display image+text with a horizontal split and adjust the window width so that the split button just wraps into the next line thus: 
![Hsplit](https://user-images.githubusercontent.com/31585092/224989851-ba73ddc4-7eb5-4aa4-8550-0cdc2613f14e.png)
Then refresh the page and move the splitter bar. It would jump a small distance away from the mouse pointer.
This happened because the size of the viewing pane was measured before the image in the splitter button was loaded. This PR sets the size of the image so the layout is correct before the image is loaded.
Also the control buttons are now added before the splitter is set up.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/split_jump
