### PR TITLE
fix demo splitter jump

### DIFF
--- a/SETUP/tests/manual_web/split_test/switchable_split.js
+++ b/SETUP/tests/manual_web/split_test/switchable_split.js
@@ -1,5 +1,5 @@
 /* global $ splitControl */
-$(function () {
+window.addEventListener("load", () => {
 
     function appendControlButton(controlDiv, theSplit, splitVert) {
         let vSwitchButton = $("<input>", {type: 'button', value: 'Switch to Vertical Split'});

--- a/SETUP/tests/manual_web/split_test/vertical_horizontal_split.js
+++ b/SETUP/tests/manual_web/split_test/vertical_horizontal_split.js
@@ -1,5 +1,5 @@
-/* global $ splitControl */
-$(function () {
+/* global splitControl */
+window.addEventListener("load", () => {
     let mainSplit = splitControl("#top-container", {dragBarColor: "green"});
     splitControl("#sub-container", {splitVertical: false, reDraw: mainSplit.reSize, dragBarSize: 10, dragBarColor: "blue"});
     mainSplit.reLayout();


### PR DESCRIPTION
run code after page competely loaded rather than when DOM loaded which jquey $() does.

The split demonstations [https://www.pgdp.org/~rp31/c/SETUP/tests/manual_web/split_test/vertical_horizontal_split_flex.php](url) and [https://www.pgdp.org/~rp31/c/SETUP/tests/manual_web/split_test/switchable_split.php](url) showed a jump on the horizontal scroll bar when first loaded. Apparently because the splitter code measured the height of the pane before the flex layout had completed.

