### PR TITLE
Finish abstracting dpsession API

### DIFF
--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -18,11 +18,20 @@
 //     End a session. (The user has logged out.)
 //
 // Page-info...
-// dpsession_page_set($info)
-// dpsession_page_end()
-// dpsession_page_is_set()
-// dpsession_page_get()
+//     dpsession_page_set($info)
+//     dpsession_page_end()
+//     dpsession_page_is_set()
+//     dpsession_page_get()
+//
+// This API is an abstraction around two implementations:
+// * Sessions
+// * Cookies
+//
+// The implementations are controlled by conditionally including one of two
+// PHP files that implement the desired API functions with names that end
+// in an underscore, eg: dpsession_begin_().
 
+global $pguser;
 $pguser = null;
 
 include_once($relPath.'site_vars.php');
@@ -70,6 +79,39 @@ function dpsession_resume()
 
     return $user_is_logged_in;
 }
+
+function dpsession_end()
+{
+    dpsession_end_();
+}
+
+// -----------------------------------------------------------------------------
+
+// The 'debouncer' cookie...
+
+function dpsession_page_set($info)
+{
+    dpsession_page_set_($info);
+}
+
+function dpsession_page_end()
+{
+    dpsession_page_end_();
+}
+
+function dpsession_page_is_set()
+{
+    return dpsession_page_is_set_();
+}
+
+function dpsession_page_get()
+{
+    return dpsession_page_get_();
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// Helper functions that aren't part of the dpsession API.
 
 function _update_user_activity_time($update_login_time_too)
 {

--- a/pinc/dpsession_via_cookies.inc
+++ b/pinc/dpsession_via_cookies.inc
@@ -37,7 +37,7 @@ function dpsession_resume_()
     return true;
 }
 
-function dpsession_end()
+function dpsession_end_()
 {
     user_cookie_disable();
 }
@@ -46,22 +46,22 @@ function dpsession_end()
 
 // The 'debouncer' cookie...
 
-function dpsession_page_set($info)
+function dpsession_page_set_($info)
 {
     local_send_cookie("debouncer", $info);
 }
 
-function dpsession_page_end()
+function dpsession_page_end_()
 {
     local_send_cookie("debouncer", "");
 }
 
-function dpsession_page_is_set()
+function dpsession_page_is_set_()
 {
     return isset($_COOKIE['debouncer']);
 }
 
-function dpsession_page_get()
+function dpsession_page_get_()
 {
     return $_COOKIE['debouncer'];
 }

--- a/pinc/dpsession_via_php_sessions.inc
+++ b/pinc/dpsession_via_php_sessions.inc
@@ -48,7 +48,7 @@ function dpsession_resume_()
     }
 }
 
-function dpsession_end()
+function dpsession_end_()
 {
     session_unset();
     session_destroy();
@@ -58,22 +58,22 @@ function dpsession_end()
 
 // The 'debouncer' variable
 
-function dpsession_page_set($info)
+function dpsession_page_set_($info)
 {
     $_SESSION['debouncer'] = $info;
 }
 
-function dpsession_page_end()
+function dpsession_page_end_()
 {
     $_SESSION['debouncer'] = null;
 }
 
-function dpsession_page_is_set()
+function dpsession_page_is_set_()
 {
     return isset($_SESSION['debouncer']);
 }
 
-function dpsession_page_get()
+function dpsession_page_get_()
 {
     return $_SESSION['debouncer'];
 }


### PR DESCRIPTION
Finish the dpsession API abstraction so `dpsession.inc` contains the full set of functions that need to be implemented. This has no functional changes but it's a pattern I want to use elsewhere and decided it would be best if this "reference implementation" was complete.

Testable in the [finish-session-abstraction](https://www.pgdp.org/~cpeel/c.branch/finish-session-abstraction/) sandbox. 

Testing suggestion:
* Logging in and logging out works as expected
* Getting a page for proofreading (starting to proofread a page) works -- this calls the `dpsession_page_set()` code.

---

Aside: Unfortunately PHP doesn't support a way to "override" or replace a function once it has been defined (like Python and other languages do) which is why this was implemented like this a long time ago. I've not been able to find a better PHP way to do this kind of abstraction.

I had hoped [namespaces](https://www.php.net/manual/en/language.namespaces.php) might work -- define each implementation in its own namespace and then just set which namespace you want the functions called from -- but I can't figure out how to make that work either because the `use` syntax [cannot be inside a block definition](https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.scope), eg:
```php
// namespaces implement the full API so no need for wrappers
if ($use_php_sessions) {
    use DProofreaders\Sessions\PHPSession;
} else {
    use DProofreaders\Sessions\Cookies;
}
```

Instead of using the an implementation pattern of "functions must be named with a trailing `_`" we could use namespaces still eg:
```php
namespace DProofreaders\Sessions\PHPSession;
function dpsession_begin() {
}
```
then
```php
include_once($relPath.'dpsession_via_php_sessions.inc');
include_once($relPath.'dpsession_via_cookies.inc');

if ($use_php_sessions) {
    $session_namespace = "DProofreaders\\Sessions\\PHPSession";
} else {
    $session_namespace = "DProofreaders\\Sessions\\Cookies";
}

function dpsession_begin($userID) {
    $func = "$session_namespace\\dpsession_begin";
    $func($userID);
}
```
But that doesn't seem like it's particularly better.

This isn't particularly important for this sessions code but as I said, I am wanting to use this pattern elsewhere.

Open to ideas on ways to make this "pluggable" in a better way.