### PR TITLE
Send event notifications in receivers language

### DIFF
--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -244,6 +244,15 @@ function show_projects_for_pool($pool, $checkedout_or_available)
         $pool->foo_field_name => ['Person', $pool->foo_Header],
     ];
 
+    // PPV pool allows filter by PP not PM
+    $filter_custom_display_fields = [];
+    if ($pool->id == 'PPV') {
+        $filter_custom_display_fields = [
+            "checkedoutby" => true,
+            "username" => false,
+        ];
+    }
+
     $ch_or_av = substr($checkedout_or_available, 0, 2);
     $ext_sort_param_name = "order_{$checkedout_or_available}";
     $ext_sort_setting_name = "{$pool->id}_{$ch_or_av}_order";
@@ -300,7 +309,7 @@ function show_projects_for_pool($pool, $checkedout_or_available)
         $available_filtertype_stem = "{$pool->id}_av";
 
         $initial_project_selector = "state = '{$pool->project_available_state}'";
-        process_and_display_project_filter_form($pguser, $available_filtertype_stem, $pool->name, $_POST, $initial_project_selector);
+        process_and_display_project_filter_form($pguser, $available_filtertype_stem, $pool->name, $_POST, $initial_project_selector, $filter_custom_display_fields);
         $projects_filter = get_project_filter_sql($pguser, $available_filtertype_stem);
 
         $optional_select_clause = "";

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -54,20 +54,25 @@ function upi_set_t_latest_page_event($username, $projectid, $timestamp)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-$subscribable_project_events = [
-    'round_available' => _("Project becomes available in a round"),
-    'round_complete' => _("Project finishes a round"),
-    'pp_enter' => _("Project enters Post-Processing stage"),
-    'sr_available' => _("Project becomes available for Smooth Reading"),
-    'sr_reported' => _("User has uploaded a Smooth Reading report"),
-    'sr_complete' => _("Project finishes Smooth Reading"),
-    'ppv_enter' => _("Project enters Post-Processing Verification stage"),
-    'posted' => _("Project posted to Project Gutenberg"),
-];
+
+function get_subscribable_project_events()
+{
+    $subscribable_project_events = [
+        'round_available' => _("Project becomes available in a round"),
+        'round_complete' => _("Project finishes a round"),
+        'pp_enter' => _("Project enters Post-Processing stage"),
+        'sr_available' => _("Project becomes available for Smooth Reading"),
+        'sr_reported' => _("User has uploaded a Smooth Reading report"),
+        'sr_complete' => _("Project finishes Smooth Reading"),
+        'ppv_enter' => _("Project enters Post-Processing Verification stage"),
+        'posted' => _("Project posted to Project Gutenberg"),
+    ];
+    return $subscribable_project_events;
+}
 
 function get_label_for_event($event)
 {
-    global $subscribable_project_events;
+    $subscribable_project_events = get_subscribable_project_events();
     $label = @$subscribable_project_events[$event];
     if (is_null($label)) {
         die("Unknown event: '$event'");
@@ -152,65 +157,8 @@ function can_user_subscribe_to_project_event($username, $projectid, $event)
 
 function notify_project_event_subscribers($project, $event, $extras = [])
 {
-    $event_label = get_label_for_event($event);
-
     $projectid = $project->projectid;
     $title = $project->nameofwork;
-
-    $msg_subject = "$event_label: \"$title\"";
-
-    $msg_body = $project->email_introduction();
-
-    switch ($event) {
-        case 'posted':
-            $pg_url = get_pg_catalog_url_for_etext($project->postednum);
-            $msg_body .=
-                _("This project has been sent to Project Gutenberg and will soon be available for reading.")
-                . " "
-                . _("Usually, the files will be ready by the time you receive this mail; sometimes there may be a delay of a day or so.")
-                . " "
-                . sprintf(_("You can download the files via PG's online catalog at <%s>."), $pg_url)
-                . "\n";
-            break;
-
-        case 'round_available':
-            $msg_body .=
-                sprintf(_("This project has become available for work in %s."), $extras['round']->id);
-            break;
-
-        case 'round_complete':
-            $msg_body .=
-                sprintf(_("This project has completed work in %s."), $extras['round']->id);
-            break;
-
-        case 'pp_enter':
-            $msg_body .=
-                _("This project has entered post-processing.");
-            break;
-
-        case 'sr_available':
-            $msg_body .=
-                _("This project has become available for Smooth Reading.");
-            break;
-
-        case 'sr_reported':
-            $msg_body .=
-                _("A new Smooth Reading report has been uploaded.");
-            break;
-
-        case 'sr_complete':
-            $msg_body .=
-                _("This project has finished Smooth Reading.");
-            break;
-
-        case 'ppv_enter':
-            $msg_body .=
-                _("This project has entered post-processing verification.");
-            break;
-
-        default:
-            assert(0);
-    }
 
     $sql1 = sprintf("
         SELECT username
@@ -221,7 +169,64 @@ function notify_project_event_subscribers($project, $event, $extras = [])
     );
     $res1 = DPDatabase::query($sql1);
     $n_subscribers = mysqli_num_rows($res1);
+
+    // Loop contains everything that needs localizing,
+    // so it can be localized for each recipient
     while ([$username] = mysqli_fetch_row($res1)) {
+        configure_gettext_for_user($username);
+        $event_label = get_label_for_event($event);
+        $msg_subject = "$event_label: \"$title\"";
+        $msg_body = $project->email_introduction();
+        switch ($event) {
+            case 'posted':
+                $pg_url = get_pg_catalog_url_for_etext($project->postednum);
+                $msg_body .=
+                    _("This project has been sent to Project Gutenberg and will soon be available for reading.")
+                    . " "
+                    . _("Usually, the files will be ready by the time you receive this mail; sometimes there may be a delay of a day or so.")
+                    . " "
+                    . sprintf(_("You can download the files via PG's online catalog at <%s>."), $pg_url)
+                    . "\n";
+                break;
+
+            case 'round_available':
+                $msg_body .=
+                    sprintf(_("This project has become available for work in %s."), $extras['round']->id);
+                break;
+
+            case 'round_complete':
+                $msg_body .=
+                    sprintf(_("This project has completed work in %s."), $extras['round']->id);
+                break;
+
+            case 'pp_enter':
+                $msg_body .=
+                    _("This project has entered post-processing.");
+                break;
+
+            case 'sr_available':
+                $msg_body .=
+                    _("This project has become available for Smooth Reading.");
+                break;
+
+            case 'sr_reported':
+                $msg_body .=
+                    _("A new Smooth Reading report has been uploaded.");
+                break;
+
+            case 'sr_complete':
+                $msg_body .=
+                    _("This project has finished Smooth Reading.");
+                break;
+
+            case 'ppv_enter':
+                $msg_body .=
+                    _("This project has entered post-processing verification.");
+                break;
+
+            default:
+                assert(0);
+        }
         $email = get_forum_email_address($username);
         maybe_mail(
             $email,
@@ -229,6 +234,7 @@ function notify_project_event_subscribers($project, $event, $extras = [])
             sprintf(_("Hello %s,"), $username) . "\n" . $msg_body
         );
     }
+    configure_gettext_for_user();
 
     if ($event == 'posted') {
         // Take the number of users subscribed to the event
@@ -247,10 +253,10 @@ function notify_project_event_subscribers($project, $event, $extras = [])
 // -----------------------------------------------------------------------------
 
 function get_n_users_subscribed_to_events_for_project($projectid)
-// Return an array: keys are the same as $subscribable_project_events,
+// Return an array: keys are the same as array returned by get_subscribable_project_events(),
 // each value is the number of subscriptions to that event for the given project.
 {
-    global $subscribable_project_events;
+    $subscribable_project_events = get_subscribable_project_events();
     $items = [];
     foreach ($subscribable_project_events as $event => $label) {
         $items[] = "SUM(iste_$event) AS $event";

--- a/project.php
+++ b/project.php
@@ -966,7 +966,7 @@ function do_waiting_queues()
 
 function do_event_subscriptions()
 {
-    global $project, $code_url, $subscribable_project_events, $pguser;
+    global $project, $code_url, $pguser;
 
     $projectid = $project->projectid;
 
@@ -998,6 +998,7 @@ function do_event_subscriptions()
     echo "<th>", _("Subscribed?"), "</th>";
     echo "<th>", _("Users Subscribed"), "</th>";
     echo "</tr>\n";
+    $subscribable_project_events = get_subscribable_project_events();
     foreach ($subscribable_project_events as $event => $label) {
         if (!can_user_subscribe_to_project_event($pguser, $projectid, $event)) {
             continue;

--- a/tools/set_project_event_subs.php
+++ b/tools/set_project_event_subs.php
@@ -11,6 +11,7 @@ $projectid = get_projectID_param($_POST, 'projectid');
 
 $subs = [];
 $unsubs = [];
+$subscribable_project_events = get_subscribable_project_events();
 foreach ($subscribable_project_events as $event => $label) {
     if (!can_user_subscribe_to_project_event($pguser, $projectid, $event)) {
         continue;

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -622,7 +622,7 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
         // for each subscribable event
         //   for each user subscribed to "from" project
         //      subscribe user to "to" project
-        global $subscribable_project_events;
+        $subscribable_project_events = get_subscribable_project_events();
         $count = 0;
         foreach ($subscribable_project_events as $event => $label) {
             $query = sprintf("


### PR DESCRIPTION
Put string generating code inside recipient loop, so it's translated into the correct language for each recipient
Use function instead of global for event labels so they are translated at call time.

Fixes #582 

Testing sandbox: https://www.pgdp.org/~windymilla/c.branch/lang-email/
Note that the popup of email contents on TEST is not seen for event notifications (possibly due to the redirection) so the sandbox has a small hack to write the contents of the email to a file in `/tmp`. Name of file contains email address and timestamp to aid testing.
