### PR TITLE
Fix ImageMagick package conflicts

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install composer dependencies
         run: composer install
       - name: Install aspell dependencies for WordCheck tests
-        run: sudo apt install aspell aspell-en
+        run: sudo apt --fix-broken install aspell aspell-en
       - name: Run phpunit tests
         run: cd SETUP/tests && ../../vendor/bin/phpunit
   jsunit:


### PR DESCRIPTION
Yesterday our static checks Github Action started failing when the aspell install started throwing odd package errors: https://github.com/DistributedProofreaders/dproofreaders/actions/runs/4554126764/jobs/8031574260?pr=875

This adds the suggested `apt` arg to fix it although I don't know why it started breaking. I'm also not 100% sure that this will fix it consistently because it doesn't seem to be failing consistently, but a run with this change did succeed.