### PR TITLE
set image size when switching horizontal/vertical

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -89,12 +89,12 @@ var makeImageControl = function(content) {
             percent = maxPercent;
         }
         percentInput.val(Math.round(percent));
+        setImageStyle();
     }
 
     function setDrawSave() {
         setZoom();
         localStorage.setItem(imageKey, JSON.stringify({zoom: percent}));
-        setImageStyle();
     }
 
     percentInput.change(function() {


### PR DESCRIPTION
When using the page browser in image+text mode, if the image zoom is changed in one split mode, then change to other split mode the image itself remained at the same size. The number in the zoom control switched correctly but the image itself did not.
This fixes it so the image changes size correctly at once.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/image_switch
