### PR TITLE
Rev browse

### DIFF
--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -540,21 +540,22 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
             .append(proofIntData.strings.projectid, " ", projectInput, projectSelectButton));
     }
 
-    function showProjectInfo(projectData) {
-        if(!simpleHeader) {
-            fixHead.empty();
-            // show project name and button to select another
-            const resetButton = $("<input>", {type: 'button', value: proofIntData.strings.reset});
-            resetButton.click(function () {
-                selectAProject();
-            });
-            const projectRef = new URL(proofIntData.projectFile);
-            projectRef.searchParams.append("id", projectId);
-            fixHead.append($("<p>").append($("<a>", {href: projectRef}).append(projectData.title)), resetButton);
-        }
-        // get pages
+    function getPages() {
         ajax("GET", `v1/projects/${projectId}/pages`)
             .then(displayPages, alert);
+    }
+
+    function showProjectInfo(projectData) {
+        fixHead.empty();
+        // show project name and button to select another
+        const resetButton = $("<input>", {type: 'button', value: proofIntData.strings.reset});
+        resetButton.click(function () {
+            selectAProject();
+        });
+        const projectRef = new URL(proofIntData.projectFile);
+        projectRef.searchParams.append("id", projectId);
+        fixHead.append($("<p>").append($("<a>", {href: projectRef}).append(projectData.title)), resetButton);
+        getPages();
     }
 
     getProjectData = function() {
@@ -566,7 +567,11 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
     };
 
     if(projectId) {
-        getProjectData();
+        if(!simpleHeader) {
+            getProjectData();
+        } else {
+            getPages();
+        }
     } else {
         selectAProject();
     }

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -301,10 +301,7 @@ function makePageControl(pages, selectedImageFileName, changePage) {
     return controls;
 }
 
-function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
-    // showCurrentImageFile will be set to a function so that subsequent pages
-    // can be shown without redrawing the whole page
-    let showCurrentImageFile = null;
+function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowFile = function () {}) {
     // parameters will be null if not defined
     let projectId = params.get("project");
     let displayMode = params.get("mode");
@@ -491,7 +488,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
             return;
         }
 
-        showCurrentImageFile = function(currentImageFileName) {
+        function showCurrentImageFile(currentImageFileName) {
             if(currentImageFileName) {
                 // does filename exist in the project?
                 const currentPage = pages.find( function(page) {
@@ -508,8 +505,11 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
             } else {
                 initialPageSelect();
             }
-        };
+        }
         showCurrentImageFile(params.get("imagefile"));
+        // showCurrentImageFile can be used to show subsequent images
+        // without redrawing the whole page
+        setShowFile(showCurrentImageFile);
     } // end of displayPages
 
     function selectAProject() {
@@ -575,10 +575,4 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false) {
     } else {
         selectAProject();
     }
-
-    // showCurrentImageFile will be null when we first get here
-    // return a function to get its current value
-    return function () {
-        return showCurrentImageFile;
-    };
 }

--- a/tools/project_manager/show_word_context.js
+++ b/tools/project_manager/show_word_context.js
@@ -17,8 +17,6 @@ window.addEventListener("DOMContentLoaded", function() {
         localStorage.setItem(storageKeyLayout, JSON.stringify(layout));
     }
 
-    // this is a function to get a function to show a file
-    let getShowCurrentImageFile = null;
     let switchLink = document.getElementById("h_v_switch");
 
     let mainSplit = splitControl("#show_word_context_container", {
@@ -51,19 +49,23 @@ window.addEventListener("DOMContentLoaded", function() {
     params.set("project", showWordContext.projectid);
     params.set("simpleHeader", "true");
 
+    let ShowImageFile = null;
+    function setShowImageFile(showFile) {
+        ShowImageFile = showFile;
+    }
+
+    function showImage(imageFile) {
+        if (!ShowImageFile) {
+            params.set("imagefile", imageFile);
+            pageBrowse(params, showWordContext.storageKey, function () {}, false, setShowImageFile);
+        } else {
+            ShowImageFile(imageFile);
+        }
+    }
+
     document.querySelectorAll(".page-select").forEach(pageSelect => {
         pageSelect.addEventListener("click", function () {
-            let imageFile = this.dataset.value;
-            let ShowCurrentImageFile;
-            // getShowCurrentImageFile will be null the first time
-            if(getShowCurrentImageFile && (ShowCurrentImageFile = getShowCurrentImageFile())) {
-                // ShowCurrentImageFile could be null if ajax failed or slow
-                ShowCurrentImageFile(imageFile);
-            } else {
-                params.set("imagefile", imageFile);
-                // give a no-action function for replace params
-                getShowCurrentImageFile = pageBrowse(params, showWordContext.storageKey, function () {});
-            }
+            showImage(this.dataset.value);
         });
     });
 });


### PR DESCRIPTION
This simplifies pageBrowse by not getting project information in simple header mode since it is not needed. Also use a callback function to set the showImageFile function after it has been constructed. This simplifies its use in show_word_context().

Sandbox at: https://www.pgdp.org/~rp31/c.branch/rev_browse
Page browse and show word context should continue to work correctly.