### PR TITLE
Allow mentors, etc to view diffs in BB format

### DIFF
--- a/pinc/BBDiffFormatter.inc
+++ b/pinc/BBDiffFormatter.inc
@@ -1,0 +1,151 @@
+<?php
+// This file allows formatting of diffs using BB code, inherited from
+// MediaWiki difference formatter base class
+//
+// See 3rdparty/mediawiki/README.md for which MediaWiki version this maps to.
+include_once($relPath."misc.inc"); // html_safe()
+include_once($relPath."3rdparty/mediawiki/DiffFormatter.php");
+
+class BBDiffFormatter extends DiffFormatter
+{
+    protected $diffurl;
+    protected $leadingContextLines = 1;   // Code assumes 1 leading context line - displayed for add/delete only
+    protected $trailingContextLines = 0;  // Code assumes 0 trailing context lines
+
+    public function __construct($diffurl)
+    {
+        $this->diffurl = $diffurl;
+    }
+
+    // Outputs an edit block
+    // Leading context line is output before add/delete changes
+    // Assumes zero trailing context lines
+    protected function block($xbeg, $xlen, $ybeg, $ylen, &$edits)
+    {
+        // We don't display leading context line for change edits, so need to
+        // increment the starting line number for change edits with context
+        $has_context = false;
+        $has_change = false;
+        foreach ($edits as $edit) {
+            if ($edit->type == 'copy') {
+                $has_context = true;
+            } elseif ($edit->type == 'change') {
+                $has_change = true;
+            }
+        }
+        if ($has_context and $has_change) {
+            $xbeg++;
+        }
+
+        $this->startBlock($this->blockHeader($xbeg, $xlen, $ybeg, $ylen));
+
+        $leading_context = null;
+        foreach ($edits as $edit) {
+            if ($edit->type == 'copy') {
+                $leading_context = $edit->orig;
+            } elseif ($edit->type == 'add') {
+                $this->added($edit->closing, $leading_context);
+            } elseif ($edit->type == 'delete') {
+                $this->deleted($edit->orig, $leading_context);
+            } elseif ($edit->type == 'change') {
+                $this->changed($edit->orig, $edit->closing);
+            } else {
+                throw new MWException("Unknown edit type: {$edit->type}");
+            }
+        }
+        $this->endBlock();
+    }
+
+    // Called at the start of a block of connected edits.
+    protected function startBlock($header)
+    {
+        $linenum = preg_replace('/^(\d+).*/', 'Line $1', $header);
+        $difflabel = $this->make_safe(preg_replace('/.*image=(.+\.png).*/', '$1', $this->diffurl));
+        $safeurl = $this->make_safe($this->diffurl);
+        $this->writeOutput("\n----- [b]$linenum, page [url=$safeurl]${difflabel}[/url][/b] -----\n");
+    }
+
+    // Writes all (optionally prefixed) lines to the output buffer, separated by newlines
+    // and enclosed in BBCode [code] markup
+    protected function lines($lines, $prefix = '')
+    {
+        $this->writeOutput("[code]\n");
+        foreach ($lines as $line) {
+            $this->writeOutput($this->make_safe("$prefix$line\n"));
+        }
+        $this->writeOutput("[/code]\n");
+    }
+
+    // Output lines that were added by the diff
+    protected function added($lines, $leading_context = null)
+    {
+        $this->added_deleted('added', $lines, $leading_context);
+    }
+
+    // Output lines that were deleted by the diff
+    protected function deleted($lines, $leading_context = null)
+    {
+        $this->added_deleted('deleted', $lines, $leading_context);
+    }
+
+    // Output lines that were added/deleted by the diff
+    private function added_deleted($adddel_string, $lines, $leading_context)
+    {
+        if (empty($leading_context)) {  // Must be first line of the page if no context
+            $this->writeOutput("At the top of the page, ");
+        } elseif ($this->count_all_blank_lines($leading_context) > 0) {
+            $this->writeOutput("After the blank line, ");   // Context line is a blank line
+        } else {
+            $this->writeOutput("After this line:\n");
+            $this->lines($leading_context);
+        }
+
+        // If all added/deleted lines are blank, tell user about them, rather than literal output
+        $blank_lines = $this->count_all_blank_lines($lines);
+        if ($blank_lines > 1) {
+            $this->writeOutput("$blank_lines blank lines need to be $adddel_string.\n");
+        } elseif ($blank_lines === 1) {
+            $this->writeOutput("$blank_lines blank line needs to be $adddel_string.\n");
+        } else {
+            $this->writeOutput("the following needs to be $adddel_string:\n");
+            $this->lines($lines);
+        }
+    }
+
+    // Count blank lines in given array if they are all blank
+    //
+    private function count_all_blank_lines($lines)
+    {
+        foreach ($lines as &$line) {
+            if (!empty($line)) {
+                return 0;
+            }
+        }
+        return count($lines);
+    }
+
+    // Output lines that were changed by the diff
+    protected function changed($orig, $closing)
+    {
+        $this->lines($orig);
+        $this->writeOutput("is proofread as\n");
+        $this->lines($closing);
+    }
+
+    // Make string safe for this type of output
+    // No changes needed for BBCode output
+    protected function make_safe($string)
+    {
+        return $string;
+    }
+}
+
+// Makes BBCode diffs suitable for displaying within HTML
+class BBDiffFormatterHTML extends BBDiffFormatter
+{
+    // Make string safe for HTML output
+    protected function make_safe($string)
+    {
+        return html_safe($string);
+    }
+}

--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -25,12 +25,20 @@ include_once($relPath."3rdparty/mediawiki/DairikiDiff.php");
 include_once($relPath."3rdparty/mediawiki/WordLevelDiff.php");
 include_once($relPath."3rdparty/mediawiki/DiffEngine.php");
 include_once($relPath."3rdparty/mediawiki/DiffFormatter.php");
-include_once($relPath."3rdparty/mediawiki/TableDiffFormatter.php");
 
-class DifferenceEngineWrapper
+abstract class DifferenceEngineWrapper
 {
     private $oldText;
     private $newText;
+    private $formatter;
+
+    protected function __construct(DiffFormatter $formatter = null)
+    {
+        if ($formatter === null) {
+            $formatter = new DiffFormatter();
+        }
+        $this->formatter = $formatter;
+    }
 
     public function setText($oldText, $newText)
     {
@@ -38,7 +46,7 @@ class DifferenceEngineWrapper
         $this->newText = $newText;
     }
 
-    public function showDiff($oldTitle, $newTitle)
+    public function getDiff($oldTitle, $newTitle)
     {
         $otext = $this->oldText;
         $ntext = $this->newText;
@@ -48,7 +56,7 @@ class DifferenceEngineWrapper
         $difftext = $this->localiseLineNumbers($difftext);
 
         // from DifferenceEngine::getDiff()
-        echo $this->addHeader($difftext, $oldTitle, $newTitle);
+        return $this->addHeader($difftext, $oldTitle, $newTitle);
     }
 
     private function generateTextDiffBody($otext, $ntext)
@@ -65,54 +73,15 @@ class DifferenceEngineWrapper
         $ota = explode("\n", $wgContLang->segmentForDiff($otext));
         $nta = explode("\n", $wgContLang->segmentForDiff($ntext));
         $diffs = new Diff($ota, $nta);
-        $formatter = new TableDiffFormatter();
-        $difftext = $wgContLang->unsegmentForDiff($formatter->format($diffs));
+        $difftext = $wgContLang->unsegmentForDiff($this->formatter->format($diffs));
 
         return $difftext;
     }
 
-    private function addHeader($diff, $otitle, $ntitle, $multi = '', $notice = '')
+    // Default implementation adds nothing
+    protected function addHeader($diff, $otitle, $ntitle, $multi = '', $notice = '')
     {
-        // lifted from DifferenceEngine::addHeader()
-        // but without any of the $userLang bits
-
-        $tableClass = 'diff';
-        $header = "<table class='$tableClass'>";
-
-        if (!$diff && !$otitle) {
-            $header .= "
-            <tr class='diff-title'>
-            <td class='diff-ntitle'>{$ntitle}</td>
-            </tr>";
-            $multiColspan = 1;
-        } else {
-            if ($diff) { // Safari/Chrome show broken output if cols not used
-                $header .= "
-                <col class='diff-marker' />
-                <col class='diff-content' />
-                <col class='diff-marker' />
-                <col class='diff-content' />";
-                $colspan = 2;
-                $multiColspan = 4;
-            } else {
-                $colspan = 1;
-                $multiColspan = 2;
-            }
-            $header .= "
-            <tr class='diff-title'>
-            <td colspan='$colspan' class='diff-otitle'>{$otitle}</td>
-            <td colspan='$colspan' class='diff-ntitle'>{$ntitle}</td>
-            </tr>";
-        }
-
-        if ($multi != '') {
-            $header .= "<tr><td colspan='{$multiColspan}' class='diff-multi'>{$multi}</td></tr>";
-        }
-        if ($notice != '') {
-            $header .= "<tr><td colspan='{$multiColspan}' class='diff-notice'>{$notice}</td></tr>";
-        }
-
-        return $header . $diff . "</table>";
+        return $diff;
     }
 
     private function localiseLineNumbers($text)
@@ -167,32 +136,4 @@ if (!function_exists("wfDebug")) {
     {
         // don't log any debug messages
     }
-}
-
-// Override default css for DP customizations
-function get_DifferenceEngine_css_data()
-{
-    [, $font_size, $font_family] = get_user_proofreading_font();
-    if ($font_size != '') {
-        $font_size = "font-size: $font_size;";
-    }
-
-    return "
-.diff-otitle,
-.diff-ntitle {
-    font-weight: bold;
-}
-.diff-marker,
-.diff-addedline,
-.diff-deletedline,
-.diff-context {
-    font-family: $font_family;
-    $font_size
-}
-/* Adjust padding to prevent descenders from being chopped off. Task 1936 */
-.diff-deletedline .diffchange,
-.diff-addedline .diffchange {
-    padding: 0.1em 0;
-}
-";
 }

--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -18,7 +18,6 @@
 //
 // See 3rdparty/mediawiki/README.md for which MediaWiki version this maps to.
 include_once($relPath."misc.inc"); // html_safe() in following includes
-include_once($relPath."prefs_options.inc"); // get_user_proofreading_font()
 include_once($relPath."3rdparty/mediawiki/ComplexityException.php");
 include_once($relPath."3rdparty/mediawiki/WordAccumulator.php");
 include_once($relPath."3rdparty/mediawiki/DairikiDiff.php");

--- a/pinc/DifferenceEngineWrapperBB.inc
+++ b/pinc/DifferenceEngineWrapperBB.inc
@@ -1,0 +1,34 @@
+<?php
+// This file inherits from DifferenceEngineWrapper to facilitate
+// formatting diffs using BB code.
+include_once($relPath."DifferenceEngineWrapper.inc");
+include_once($relPath."BBDiffFormatter.inc");
+
+// Format diffs using BB code, without HTML markup
+class DifferenceEngineWrapperBB extends DifferenceEngineWrapper
+{
+    public function __construct($diffurl)
+    {
+        parent::__construct(new BBDiffFormatter($diffurl));
+    }
+}
+
+// Format diffs using BB code, displayed within HTML markup
+class DifferenceEngineWrapperBBHTML extends DifferenceEngineWrapper
+{
+    public function __construct($diffurl)
+    {
+        parent::__construct(new BBDiffFormatterHTML($diffurl));
+    }
+
+    protected function addHeader($diff, $otitle, $ntitle, $multi = '', $notice = '')
+    {
+        $header = "";
+        if (!$diff && !$otitle) {
+            $header .= $ntitle;
+        } else {
+            $header .= "\n$otitle<br>\n$ntitle";
+        }
+        return "$header\n<pre>$diff</pre>\n";
+    }
+}

--- a/pinc/DifferenceEngineWrapperTable.inc
+++ b/pinc/DifferenceEngineWrapperTable.inc
@@ -1,6 +1,7 @@
 <?php
 // This file inherits from DifferenceEngineWrapper to facilitate
 // formatting diffs in an HTML table.
+include_once($relPath."prefs_options.inc"); // get_user_proofreading_font()
 include_once($relPath."DifferenceEngineWrapper.inc");
 include_once($relPath."3rdparty/mediawiki/TableDiffFormatter.php");
 

--- a/pinc/DifferenceEngineWrapperTable.inc
+++ b/pinc/DifferenceEngineWrapperTable.inc
@@ -1,0 +1,85 @@
+<?php
+// This file inherits from DifferenceEngineWrapper to facilitate
+// formatting diffs in an HTML table.
+include_once($relPath."DifferenceEngineWrapper.inc");
+include_once($relPath."3rdparty/mediawiki/TableDiffFormatter.php");
+
+class DifferenceEngineWrapperTable extends DifferenceEngineWrapper
+{
+    public function __construct()
+    {
+        parent::__construct(new TableDiffFormatter());
+    }
+
+    protected function addHeader($diff, $otitle, $ntitle, $multi = '', $notice = '')
+    {
+        // lifted from DifferenceEngine::addHeader()
+        // but without any of the $userLang bits
+
+        $tableClass = 'diff';
+        $header = "<table class='$tableClass'>";
+
+        if (!$diff && !$otitle) {
+            $header .= "
+            <tr class='diff-title'>
+            <td class='diff-ntitle'>{$ntitle}</td>
+            </tr>";
+            $multiColspan = 1;
+        } else {
+            if ($diff) { // Safari/Chrome show broken output if cols not used
+                $header .= "
+                <col class='diff-marker' />
+                <col class='diff-content' />
+                <col class='diff-marker' />
+                <col class='diff-content' />";
+                $colspan = 2;
+                $multiColspan = 4;
+            } else {
+                $colspan = 1;
+                $multiColspan = 2;
+            }
+            $header .= "
+            <tr class='diff-title'>
+            <td colspan='$colspan' class='diff-otitle'>{$otitle}</td>
+            <td colspan='$colspan' class='diff-ntitle'>{$ntitle}</td>
+            </tr>";
+        }
+
+        if ($multi != '') {
+            $header .= "<tr><td colspan='{$multiColspan}' class='diff-multi'>{$multi}</td></tr>";
+        }
+        if ($notice != '') {
+            $header .= "<tr><td colspan='{$multiColspan}' class='diff-notice'>{$notice}</td></tr>";
+        }
+
+        return $header . $diff . "</table>";
+    }
+}
+
+// Override default css for DP customizations
+function get_DifferenceEngine_css_data()
+{
+    [, $font_size, $font_family] = get_user_proofreading_font();
+    if ($font_size != '') {
+        $font_size = "font-size: $font_size;";
+    }
+
+    return "
+.diff-otitle,
+.diff-ntitle {
+    font-weight: bold;
+}
+.diff-marker,
+.diff-addedline,
+.diff-deletedline,
+.diff-context {
+    font-family: $font_family;
+    $font_size
+}
+/* Adjust padding to prevent descenders from being chopped off. Task 1936 */
+.diff-deletedline .diffchange,
+.diff-addedline .diffchange {
+    padding: 0.1em 0;
+}
+";
+}

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -175,11 +175,8 @@ echo "</p>\n";
 $diffurl = "$code_url/tools/project_manager/diff.php?project=$projectid&image=$image&L_round_num=$L_round_num&R_round_num=$R_round_num";
 
 $diffEngine = $bb_diffs ? new DifferenceEngineWrapperBBHTML($diffurl) : new DifferenceEngineWrapperTable();
-
 $diffEngine->setText($L_text, $R_text);
-$difftext = $diffEngine->getDiff($L_label, $R_label);
-
-echo $difftext;
+echo $diffEngine->getDiff($L_label, $R_label);
 
 // don't print out the navigation bit again if there is no difference
 // at the top of the page it's buttons, then project page

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -6,7 +6,8 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'links.inc');
 include_once($relPath.'misc.inc'); // get_integer_param(), attr_safe()
-include_once($relPath."DifferenceEngineWrapper.inc");
+include_once($relPath."DifferenceEngineWrapperTable.inc");
+include_once($relPath."DifferenceEngineWrapperBB.inc");
 include_once($relPath."PageUnformatter.inc"); // PageUnformatter()
 
 require_login();
@@ -17,6 +18,8 @@ $L_round_num = get_integer_param($_GET, 'L_round_num', null, 0, MAX_NUM_PAGE_EDI
 $R_round_num = get_integer_param($_GET, 'R_round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
 $format = get_enumerated_param($_GET, "format", null, ["keep", "remove"], true);
 $only_nonempty_diffs = @$_GET['only_nonempty_diffs'] === 'on';
+$bb_diffs = (@$_GET['bb_diffs'] === 'on' and user_can_mentor_in_any_round());
+
 
 $project = new Project($projectid);
 $state = $project->state;
@@ -110,14 +113,20 @@ $image_url = "$code_url/tools/page_browser.php?project=$projectid&amp;imagefile=
 $image_link = sprintf($link_text, new_window_link($image_url, $image));
 $extra_args = [
     "css_data" => get_DifferenceEngine_css_data(),
+    "js_data" => "
+        function copyToClip(textstring) {
+            navigator.clipboard.writeText(textstring).catch(function () {alert('Unable to copy!');});
+        }
+    ",
 ];
+
 output_header("$title: $project_title", NO_STATSBAR, $extra_args);
 
 echo "<h1>" . html_safe($project_title) . "</h1>\n";
 echo "<h2>$image_link</h2>\n";
 
 do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_column_name, $L_user, $format,
-              $L_text_column_name, $R_text_column_name, $only_nonempty_diffs);
+              $L_text_column_name, $R_text_column_name, $only_nonempty_diffs, $bb_diffs);
 echo $navigation_text;
 
 $url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";
@@ -127,6 +136,7 @@ echo "\n<p><a href='$url'>$label</a>\n";
 
 if ($L_format || $R_format) {
     // show option to change compare method
+    $format_save = array_get($_GET, "format", $format);
     if ($format == "remove") {
         $format_label = _("Compare with formatting");
         $_GET["format"] = "keep";
@@ -135,17 +145,41 @@ if ($L_format || $R_format) {
         $_GET["format"] = "remove";
     }
     $format_url = "?" . attr_safe(http_build_query($_GET));
+    $format_label = html_safe($format_label);
     echo "| <a href='$format_url'>$format_label</a>\n";
+    // Restore $_GET in case needed below
+    $_GET["format"] = $format_save;
+}
+
+if (user_can_mentor_in_any_round()) {
+    // show option to change diff style
+    $bb_diffs_save = array_get($_GET, "bb_diffs", "off");
+    if ($bb_diffs) {
+        $bb_diffs_label = _("Show table-style diff");
+        $_GET["bb_diffs"] = "off";
+    } else {
+        $bb_diffs_label = _("Show BBCode-style diff");
+        $_GET["bb_diffs"] = "on";
+    }
+    $bb_diffs_url = "?" . attr_safe(http_build_query($_GET));
+    $bb_diffs_label = html_safe($bb_diffs_label);
+    echo "| <a href='$bb_diffs_url'>$bb_diffs_label</a>\n";
+    // Restore $_GET in case needed below
+    $_GET["bb_diffs"] = $bb_diffs_save;
 }
 
 echo "</p>\n";
 
 // ---------------------------------------------------------
 
-$diffEngine = new DifferenceEngineWrapper();
+$diffurl = "$code_url/tools/project_manager/diff.php?project=$projectid&image=$image&L_round_num=$L_round_num&R_round_num=$R_round_num";
+
+$diffEngine = $bb_diffs ? new DifferenceEngineWrapperBBHTML($diffurl) : new DifferenceEngineWrapperTable();
 
 $diffEngine->setText($L_text, $R_text);
-$diffEngine->showDiff($L_label, $R_label);
+$difftext = $diffEngine->getDiff($L_label, $R_label);
+
+echo $difftext;
 
 // don't print out the navigation bit again if there is no difference
 // at the top of the page it's buttons, then project page
@@ -158,7 +192,7 @@ if ($L_text != $R_text) {
 // build up the text for the navigation bit, so we can repeat it
 // again at the bottom of the page
 function do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_column_name, $L_user, $format,
-                       $L_text_column_name, $R_text_column_name, $only_nonempty_diffs)
+                       $L_text_column_name, $R_text_column_name, $only_nonempty_diffs, $bb_diffs)
 {
     global $navigation_text;
     $jump_to_js = "this.form.image.value=this.form.jumpto[this.form.jumpto.selectedIndex].value; this.form.submit();";
@@ -169,6 +203,9 @@ function do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_c
     $navigation_text .= "\n<input type='hidden' name='L_round_num' value='$L_round_num'>";
     $navigation_text .= "\n<input type='hidden' name='R_round_num' value='$R_round_num'>";
     $navigation_text .= "\n<input type='hidden' name='format' value='$format'>";
+    if ($bb_diffs) {
+        $navigation_text .= "\n<input type='hidden' name='bb_diffs' value='on'>";
+    }
     $navigation_text .= "\n" . _("Jump to") . ": <select name='jumpto' onChange='$jump_to_js'>\n";
 
     validate_projectID($projectid);


### PR DESCRIPTION
In order to aid feedback to mentees and similar situations provide an option on the diffs page to view the diffs as BB-code formatted text instead of the usual table view

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/bbdiff

This addresses [Task #1875](https://www.pgdp.net/c/tasks.php?action=show&task_id=1875)
