### PR TITLE
Disable requested_books.php

### DIFF
--- a/stats/requested_books.php
+++ b/stats/requested_books.php
@@ -16,6 +16,9 @@ output_header($title);
 echo "<h1>$title</h1>\n";
 echo "<p>" . _("You can sign up for notifications in the Event Subscriptions section of the Project Comments page when proofreading.") . "</p>";
 
+echo "<p class='warning'>This page has been temporarily disabled due to its high load on the system. We're working to fix this.</p>";
+exit;
+
 echo "<h2>" . _("Most Requested Books Being Proofread") . "</h2>\n";
 
 create_temporary_project_event_subscription_summary_table();


### PR DESCRIPTION
Temporarily disable the `requested_books.php`. It creates a temporary table based on the `user_project_info` table, but due to the size of that table on PROD (3.7m rows) it takes 4 minutes to create. That table also drives the My Project table and is updated every time a user goes to a project page. Disabling it in `pgdp-production` branch until we get the table fixed.

Testable in the [disable-most-req-books](https://www.pgdp.org/~cpeel/c.branch/disable-most-req-books/stats/requested_books.php) sandbox.