### PR TITLE
Better handle missing homepage from composer deps

### DIFF
--- a/credits.php
+++ b/credits.php
@@ -35,7 +35,13 @@ function output_credit_details($credit_details)
     echo "<ul>";
     foreach ($credit_details as $detail) {
         echo "<li>";
-        echo "<b><a href='" . $detail["url"] . "'>" . html_safe($detail["name"]) . "</a></b><br>";
+        echo "<b>";
+        if ($detail["url"]) {
+            echo "<a href='" . $detail["url"] . "'>" . html_safe($detail["name"]) . "</a>";
+        } else {
+            echo html_safe($detail["name"]);
+        }
+        echo "</b><br>";
         if (isset($detail["license_url"])) {
             echo _("License") . ": <a href='" . $detail["license_url"] . "'>" . html_safe($detail["license"]) . "</a>";
         } else {
@@ -77,7 +83,7 @@ function load_composer_credit_details()
     foreach ($packages->packages as $index => $package) {
         $credit_details[$package->name] = [
             "name" => $package->name,
-            "url" => $package->homepage,
+            "url" => $package->homepage ?? null,
             "license" => join(", ", $package->license),
         ];
     }


### PR DESCRIPTION
PHPMailer doesn't set a `homepage` in its composer metadata. Update the code to better handle this edgecase.

Testable in the [fix-missing-homepage-in-credits](https://www.pgdp.org/~cpeel/c.branch/fix-missing-homepage-in-credits/credits.php) sandbox.