### PR TITLE
Fix PP Limit

### DIFF
--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -126,7 +126,7 @@ function user_has_project_loads_disabled()
 function that_user_is_over_PP_checked_out_limit($username)
 {
     $userSettings = & Settings::get_settings($username);
-    $limit = $userSettings->get_value("PP_checked_out_limit", 'none');
+    $limit = $userSettings->get_value("pp_limit_value", 'none');
     if (! is_numeric($limit)) {
         return false;
     }


### PR DESCRIPTION
Obviously not something that's used often, or it would have been fixed long ago. `manage_site_access_privileges.php` and `user_is.inc` were not using the same setting name. Sandbox at [fix-pp-limit](https://www.pgdp.org/~srjfoo/c.branch/fix-pp-limit/).