### PR TITLE
More basic usages

### DIFF
--- a/SETUP/tests/manual_web/split_test/switchable_split.js
+++ b/SETUP/tests/manual_web/split_test/switchable_split.js
@@ -35,7 +35,7 @@ $(function () {
     function appendIndicator(controlDiv, theSplit) {
         let indicator = $("<input>", {readonly: 'true'});
         $(controlDiv).append(indicator);
-        theSplit.dragEnd.add(function (percent) {
+        theSplit.dragEnd.push(function (percent) {
             indicator.val(percent);
         });
     }

--- a/SETUP/tests/manual_web/split_test/switchable_split.js
+++ b/SETUP/tests/manual_web/split_test/switchable_split.js
@@ -35,7 +35,7 @@ $(function () {
     function appendIndicator(controlDiv, theSplit) {
         let indicator = $("<input>", {readonly: 'true'});
         $(controlDiv).append(indicator);
-        theSplit.dragEnd.push(function (percent) {
+        theSplit.onDragEnd.add(function (percent) {
             indicator.val(percent);
         });
     }

--- a/SETUP/tests/manual_web/split_test/vertical_horizontal_split.js
+++ b/SETUP/tests/manual_web/split_test/vertical_horizontal_split.js
@@ -1,6 +1,6 @@
 /* global $ splitControl */
 $(function () {
     let mainSplit = splitControl("#top-container", {dragBarColor: "green"});
-    splitControl("#sub-container", {splitVertical: false, reDraw: mainSplit.reSize, dragBarSize: 10, dragBarColor: "blue"});
+    splitControl("#sub-container", {splitVertical: false, reDraw: mainSplit.onResize, dragBarSize: 10, dragBarColor: "blue"});
     mainSplit.reLayout();
 });

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -26,11 +26,12 @@ var makeImageControl = function(content) {
     }
 
     function mouseup() {
-        $(document).unbind("mousemove mouseup");
+        document.removeEventListener("mousemove", mousemove);
+        document.removeEventListener("mouseup", mouseup);
         image.style.cursor = imageCursor;
     }
 
-    $(image).mousedown( function(event) {
+    image.addEventListener("mousedown", function(event) {
         event.preventDefault();
 
         // so image can be moved with arrow keys
@@ -38,8 +39,8 @@ var makeImageControl = function(content) {
         image.style.cursor = "grabbing";
         scrollDiffX = event.pageX + content.scrollLeft();
         scrollDiffY = event.pageY + content.scrollTop();
-        $(document).on("mousemove", mousemove)
-            .on("mouseup", mouseup);
+        document.addEventListener("mousemove", mousemove);
+        document.addEventListener("mouseup", mouseup);
     });
 
     let imageKey;
@@ -173,7 +174,7 @@ var makeImageControl = function(content) {
         setup: function(storageKey) {
             imageKey = storageKey + "-image";
             let imageData = JSON.parse(localStorage.getItem(imageKey));
-            if(!$.isPlainObject(imageData)) {
+            if (!imageData || typeof imageData.zoom !== 'number') {
                 imageData = {zoom: defaultPercent};
             }
             percent = imageData.zoom;
@@ -339,7 +340,9 @@ function makeControlDiv(container, content, controls, onChange) {
             break;
         }
         if(onChange) {
-            onChange.fire();
+            onChange.forEach(function (onChangeCallback) {
+                onChangeCallback();
+            });
         }
     }
 
@@ -427,7 +430,7 @@ function makeControlDiv(container, content, controls, onChange) {
         setupControls: function (storageKey) {
             barKey = storageKey + "-bar";
             let barData = JSON.parse(localStorage.getItem(barKey));
-            if(!$.isPlainObject(barData)) {
+            if (!barData || typeof barData.location !== 'string') {
                 barData = {location: "NM"};
             }
             // location is two letters:

--- a/scripts/filter_project.js
+++ b/scripts/filter_project.js
@@ -7,18 +7,24 @@ window.addEventListener('DOMContentLoaded', function() {
     var diffOpt = document.querySelectorAll(".diff-opt");
 
     function showMatcher() {
-        langMatch.style.display = 0 === langSelector.selectedIndex ? "none" : "block";
+        if (langMatch) {
+            langMatch.style.display = 0 === langSelector.selectedIndex ? "none" : "block";
+        }
     }
 
-    langSelector.addEventListener("change", function () {
-        showMatcher();
-    });
-
-    diffAll.addEventListener("change", function () {
-        diffOpt.forEach(diffOption => {
-            diffOption.checked = false;
+    if (langSelector) {
+        langSelector.addEventListener("change", function () {
+            showMatcher();
         });
-    });
+    }
+
+    if (diffAll) {
+        diffAll.addEventListener("change", function () {
+            diffOpt.forEach(diffOption => {
+                diffOption.checked = false;
+            });
+        });
+    }
 
     diffOpt.forEach(diffOption => {
         diffOption.addEventListener("change", function() {

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -25,7 +25,7 @@ var maketextControl = function(textArea) {
         fontFaceSelector.add(new Option(fontFaces[index], index));
     });
 
-    $(fontFaceSelector).change(function () {
+    fontFaceSelector.addEventListener("change", function () {
         const fontFaceIndex = this.value;
         setFontFace(fontFaceIndex);
         textData.fontFaceIndex = fontFaceIndex;
@@ -42,7 +42,7 @@ var maketextControl = function(textArea) {
         fontSizeSelector.add(new Option(displayFontSize, fontSize));
     });
 
-    $(fontSizeSelector).change(function () {
+    fontSizeSelector.addEventListener("change", function () {
         const fontSize = fontSizeSelector.value;
         setFontSize(fontSize);
         textData.fontSize = fontSize;
@@ -69,7 +69,10 @@ var maketextControl = function(textArea) {
         setup: function(storageKey) {
             textKey = storageKey + "-text";
             textData = JSON.parse(localStorage.getItem(textKey));
-            if(!$.isPlainObject(textData)) {
+            if(!textData ||
+                typeof textData.textWrap !== "string" ||
+                typeof textData.fontFaceIndex !== "number" ||
+                typeof textData.fontSize !== "string") {
                 textData = {
                     textWrap: "N",
                     fontFaceIndex: 0,
@@ -109,7 +112,7 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
         content.append(topTextDiv, bottomTextDiv);
 
         subSplitter = splitControl(content, {splitVertical: false, reDraw: reLayout});
-        subSplitter.dragEnd.add(function (percent) {
+        subSplitter.dragEnd.push(function (percent) {
             textSplitData.splitPercent = percent;
             localStorage.setItem(splitterKey, JSON.stringify(textSplitData));
         });
@@ -122,7 +125,7 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
             if(splitter) {
                 splitterKey = textWidgetKey + "-split";
                 textSplitData = JSON.parse(localStorage.getItem(splitterKey));
-                if(!$.isPlainObject(textSplitData)) {
+                if(!textSplitData || typeof textSplitData.splitPercent !== 'number') {
                     textSplitData = {splitPercent: 100};
                 }
                 subSplitter.setSplitPercent(textSplitData.splitPercent);
@@ -145,7 +148,7 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
 var viewSplitter = function(container, storageKey) {
     const storageKeyLayout = storageKey + "-layout";
     let layout = JSON.parse(localStorage.getItem(storageKeyLayout));
-    if(!$.isPlainObject(layout)) {
+    if(!layout || layout.splitDirection !== "horizontal" || layout.splitDirection !== "vertical") {
         layout = {splitDirection: "horizontal"};
     }
     const splitVertical = (layout.splitDirection === "vertical");
@@ -159,12 +162,12 @@ var viewSplitter = function(container, storageKey) {
     const hSwitchButton = $("<button>", {type: 'button', class: 'img-button control', title: proofIntData.strings.switchHoriz}).append(hSplitImage);
 
     let splitKey;
-    const setSplitDirCallback = $.Callbacks();
-    setSplitDirCallback.add(function(storageKey) {
+    const setSplitDirCallback = [];
+    setSplitDirCallback.push(function(storageKey) {
         // get the split percent for vertical or horizontal
         splitKey = storageKey + "-split";
         let directionData = JSON.parse(localStorage.getItem(splitKey));
-        if(!$.isPlainObject(directionData)) {
+        if(!directionData || typeof directionData.splitPercent !== 'number') {
             directionData = {splitPercent: 50};
         }
         mainSplit.setSplitPercent(directionData.splitPercent);
@@ -181,7 +184,9 @@ var viewSplitter = function(container, storageKey) {
     }
 
     function fireSetSplitDir() {
-        setSplitDirCallback.fire(storageKey + "-" + layout.splitDirection);
+        setSplitDirCallback.forEach(function (setSplitDirCallbackFunction) {
+            setSplitDirCallbackFunction(storageKey + "-" + layout.splitDirection);
+        })
     }
 
     function changeSplit(splitVert) {
@@ -202,7 +207,7 @@ var viewSplitter = function(container, storageKey) {
 
     setSplitControls(splitVertical);
 
-    mainSplit.dragEnd.add(function (percent) {
+    mainSplit.dragEnd.push(function (percent) {
         localStorage.setItem(splitKey, JSON.stringify({splitPercent: percent}));
     });
 
@@ -229,7 +234,7 @@ function makePageControl(pages, selectedImageFileName, changePage) {
             pageSelector.add(new Option(page.image, index, false, false));
         });
 
-        $(pageSelector).change( function() {
+        pageSelector.addEventListener("change", function() {
             changePage(pages[pageSelector.value]);
         });
 
@@ -263,7 +268,7 @@ function makePageControl(pages, selectedImageFileName, changePage) {
         changePage(pages[pageSelector.value]);
     }
 
-    $(pageSelector).change(pageChange);
+    pageSelector.addEventListener("change", pageChange);
 
     prevButton.click(function () {
         pageSelector.selectedIndex -= 1;
@@ -275,9 +280,9 @@ function makePageControl(pages, selectedImageFileName, changePage) {
         pageChange();
     });
 
-    $(document).keydown(function(event) {
+    document.addEventListener("keydown", function(event) {
         if(event.altKey === true) {
-            if(event.which === 38) {
+            if(event.key === "Up" || event.key === "ArrowUp") {
                 // up arrow
                 // prevent another simultaneous action if a control has focus
                 event.preventDefault();
@@ -285,7 +290,7 @@ function makePageControl(pages, selectedImageFileName, changePage) {
                     pageSelector.selectedIndex -= 1;
                     pageChange();
                 }
-            } else if(event.which === 40) {
+            } else if(event.key === "Down" || event.key === "ArrowDown") {
                 // down arrow
                 event.preventDefault();
                 if(nextEnabled()) {
@@ -441,7 +446,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                             } else {
                                 textWidget = makeTextWidget(textDiv);
                             }
-                            theSplitter.setSplitDirCallback.add(imageWidget.setup, textWidget.setup);
+                            theSplitter.setSplitDirCallback.push(imageWidget.setup, textWidget.setup);
                             fixHead.append(imageButton, textButton, pageControls, roundControls, theSplitter.buttons);
                             theSplitter.fireSetSplitDir();
                             break;

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -169,7 +169,7 @@ var viewSplitter = function(container, storageKey) {
         // get the split percent for vertical or horizontal
         splitKey = storageKey + "-split";
         let directionData = JSON.parse(localStorage.getItem(splitKey));
-        if(!directionData || 
+        if(!directionData ||
            (typeof directionData.splitPercent !== 'number' &&
             typeof directionData.splitPercent !== 'string')) {
             directionData = {splitPercent: 50};

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -71,7 +71,8 @@ var maketextControl = function(textArea) {
             textData = JSON.parse(localStorage.getItem(textKey));
             if(!textData ||
                 typeof textData.textWrap !== "string" ||
-                typeof textData.fontFaceIndex !== "number" ||
+                (typeof textData.fontFaceIndex !== "number" &&
+                typeof textData.fontFaceIndex !== "string") ||
                 typeof textData.fontSize !== "string") {
                 textData = {
                     textWrap: "N",

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -151,7 +151,7 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
 var viewSplitter = function(container, storageKey) {
     const storageKeyLayout = storageKey + "-layout";
     let layout = JSON.parse(localStorage.getItem(storageKeyLayout));
-    if(!layout || layout.splitDirection !== "horizontal" || layout.splitDirection !== "vertical") {
+    if(!layout || (layout.splitDirection !== "horizontal" && layout.splitDirection !== "vertical")) {
         layout = {splitDirection: "horizontal"};
     }
     const splitVertical = (layout.splitDirection === "vertical");

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -186,7 +186,7 @@ var viewSplitter = function(container, storageKey) {
     function fireSetSplitDir() {
         setSplitDirCallback.forEach(function (setSplitDirCallbackFunction) {
             setSplitDirCallbackFunction(storageKey + "-" + layout.splitDirection);
-        })
+        });
     }
 
     function changeSplit(splitVert) {

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -112,7 +112,7 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
         content.append(topTextDiv, bottomTextDiv);
 
         subSplitter = splitControl(content, {splitVertical: false, reDraw: reLayout});
-        subSplitter.dragEnd.push(function (percent) {
+        subSplitter.onDragEnd.add(function (percent) {
             textSplitData.splitPercent = percent;
             localStorage.setItem(splitterKey, JSON.stringify(textSplitData));
         });
@@ -125,7 +125,9 @@ function makeTextWidget(container, splitter = false, reLayout = null) {
             if(splitter) {
                 splitterKey = textWidgetKey + "-split";
                 textSplitData = JSON.parse(localStorage.getItem(splitterKey));
-                if(!textSplitData || typeof textSplitData.splitPercent !== 'number') {
+                if(!textSplitData ||
+                   (typeof textSplitData.splitPercent !== 'number' &&
+                    typeof textSplitData.splitPercent !== 'string')) {
                     textSplitData = {splitPercent: 100};
                 }
                 subSplitter.setSplitPercent(textSplitData.splitPercent);
@@ -167,7 +169,9 @@ var viewSplitter = function(container, storageKey) {
         // get the split percent for vertical or horizontal
         splitKey = storageKey + "-split";
         let directionData = JSON.parse(localStorage.getItem(splitKey));
-        if(!directionData || typeof directionData.splitPercent !== 'number') {
+        if(!directionData || 
+           (typeof directionData.splitPercent !== 'number' &&
+            typeof directionData.splitPercent !== 'string')) {
             directionData = {splitPercent: 50};
         }
         mainSplit.setSplitPercent(directionData.splitPercent);
@@ -207,7 +211,7 @@ var viewSplitter = function(container, storageKey) {
 
     setSplitControls(splitVertical);
 
-    mainSplit.dragEnd.push(function (percent) {
+    mainSplit.onDragEnd.add(function (percent) {
         localStorage.setItem(splitKey, JSON.stringify({splitPercent: percent}));
     });
 
@@ -442,7 +446,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                             const theSplitter = viewSplitter(stretchDiv, storageKey);
                             if(mentorMode) {
                                 // make a text widget with splitter
-                                textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.reSize);
+                                textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.onResize);
                             } else {
                                 textWidget = makeTextWidget(textDiv);
                             }

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -12,7 +12,7 @@
  *   splitPercent: (50), percentage of contaner occupied by pane1,
  *   reDraw - callback which should be fired when the container size changes.
  *       by default this is fired by window resize
- *       for a subsidiary splitter use reSize returned by the parent splitter
+ *       for a subsidiary splitter use onResize returned by the parent splitter
  *   dragBarSize: (6), the width/height of the splitterbar in pixels,
  *   dragBarColor: ("darkgray"),
  * }
@@ -21,16 +21,16 @@
  * setSplit(splitVertical): a function to change the splitDirection
  * reLayout(): a function to re-draw the panes, this should be called after
  *     drawing any divs surrounding the container.
- * reSize: this callback is fired after relayout has been called
+ * onResize: this callback is fired after relayout has been called
  *     and after moving the dragbar. It can be used as the reDraw parameter for
  *     subsidiary splitControls.
- * dragEnd: this callback is fired at the end of a drag resize with
+ * onDragEnd: this callback is fired at the end of a drag resize with
  *     a percentage parameter. It enables the split percentage to be stored so
  *     that when splitControl is used again the split ratio can be persisted.
  */
 var splitControl = function(container, config) {
 
-    let windowResize = [];
+    let windowResize = new Set();
     window.addEventListener("resize", function () {
         windowResize.forEach(function (windowResizeCallback) {
             windowResizeCallback();
@@ -60,8 +60,8 @@ var splitControl = function(container, config) {
     let height;
     let width;
 
-    let reSize = [];
-    let dragEnd = [];
+    let onResize = new Set();
+    let onDragEnd = new Set();
 
     function moveSplit() {
         if (splitPos < minPos) {
@@ -71,7 +71,7 @@ var splitControl = function(container, config) {
             splitPos = maxPos;
         }
         pane1.css({flex: `0 0 ${splitPos - base}px`});
-        reSize.forEach(function (reSizeCallback) {
+        onResize.forEach(function (reSizeCallback) {
             reSizeCallback();
         });
     }
@@ -123,7 +123,7 @@ var splitControl = function(container, config) {
         pane1.css("pointerEvents", "auto");
         if(range > 0) {
             splitRatio = (splitPos - base) / range;
-            dragEnd.forEach(function (dragEndCallback) {
+            onDragEnd.forEach(function (dragEndCallback) {
                 dragEndCallback((splitRatio * 100).toFixed(0));
             });
         }
@@ -162,7 +162,7 @@ var splitControl = function(container, config) {
 
     dragBar.on("mousedown", dragMouseDown);
     dragBar.on("touchstart", dragTouchStart);
-    theConfig.reDraw.push(reLayout);
+    theConfig.reDraw.add(reLayout);
 
     return {
         setSplit: function (splitVertical) {
@@ -174,7 +174,7 @@ var splitControl = function(container, config) {
             reLayout();
         },
         reLayout: reLayout,
-        reSize: reSize,
-        dragEnd: dragEnd,
+        onResize: onResize,
+        onDragEnd: onDragEnd,
     };
 };

--- a/tools/project_manager/show_word_context.js
+++ b/tools/project_manager/show_word_context.js
@@ -39,7 +39,7 @@ window.addEventListener("DOMContentLoaded", function() {
         saveLayout();
     });
 
-    mainSplit.dragEnd.add(function (percent) {
+    mainSplit.dragEnd.push(function (percent) {
         layout.splitPercent = percent;
         saveLayout();
     });

--- a/tools/project_manager/show_word_context.js
+++ b/tools/project_manager/show_word_context.js
@@ -39,7 +39,7 @@ window.addEventListener("DOMContentLoaded", function() {
         saveLayout();
     });
 
-    mainSplit.dragEnd.push(function (percent) {
+    mainSplit.onDragEnd.add(function (percent) {
         layout.splitPercent = percent;
         saveLayout();
     });

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -182,14 +182,14 @@ window.addEventListener("DOMContentLoaded", () => {
         document.getElementById(viewMode).checked = true;
         // check if MathJax already loaded. Will break if load more than once
         if(previewStyles.allowMathPreview && (typeof(MathJax) === 'undefined')) {
-            const maxjaxScriptElement = document.createElement('script');
-            maxjaxScriptElement.type = "text/javascript";
-            maxjaxScriptElement.src = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js";
+            const mathJaxScriptElement = document.createElement('script');
+            mathJaxScriptElement.type = "text/javascript";
+            mathJaxScriptElement.src = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js";
             const scriptLoadPromise = new Promise(function(resolve) {
-                maxjaxScriptElement.onload = function () {
+                mathJaxScriptElement.onload = function () {
                     resolve();
                 };
-                document.body.appendChild(maxjaxScriptElement);
+                document.body.appendChild(mathJaxScriptElement);
             });
 
             return scriptLoadPromise;

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -183,14 +183,14 @@ window.addEventListener("DOMContentLoaded", () => {
         // check if MathJax already loaded. Will break if load more than once
         if(previewStyles.allowMathPreview && (typeof(MathJax) === 'undefined')) {
             const maxjaxScriptElement = document.createElement('script');
-            maxjaxScriptElement.type= "text/javascript";
+            maxjaxScriptElement.type = "text/javascript";
             maxjaxScriptElement.src = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js";
             const scriptLoadPromise = new Promise(function(resolve) {
                 maxjaxScriptElement.onload = function () {
                     resolve();
-                }
+                };
                 document.body.appendChild(maxjaxScriptElement);
-            })
+            });
 
             return scriptLoadPromise;
         }


### PR DESCRIPTION
The main goal here is to remove jQuery for more usages that don't involve creating and modifying a bunch of DOM elements. This mostly consist of
1. Using normal event listeners
2. Removing $.Callbacks in favor of arrays of methods
3. Removing $.isPlainObject

I also took the opportunity to fix a deprecation warning on event.which.

Again, this is low priority with some risks, so no pressure to merge or review.

Branch for testing
https://www.pgdp.org/~chrismiceli/c.branch/jquery/