### PR TITLE
Escape sql wildcards for Project Search

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -82,6 +82,11 @@ final class DPDatabase
         return mysqli_real_escape_string(self::$_connection, $value);
     }
 
+    public static function escape_like_wildcards($value)
+    {
+        return addcslashes($value, "%_[]^-");
+    }
+
     public static function query($sql, $throw_on_failure = true, $log_on_failure = true)
     {
         try {

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -116,7 +116,7 @@ class ProjectSearchWidget
             if ($comparator == '=') {
                 $contribution = "$column_name = '$value'";
             } elseif ($comparator == 'LIKE') {
-                $value = normalize_whitespace($value);
+                $value = DPDatabase::escape_like_wildcards(normalize_whitespace($value));
                 $contribution = "$column_name LIKE '%$value%'";
             }
         }
@@ -138,6 +138,7 @@ class ProjectSearchWidget
             $values_list = surround_and_join($values, "'", "'", ",");
             $contribution = "$column_name$inv IN ($values_list)";
         } elseif ($comparator == 'LIKE') {
+            $values = array_map("DPDatabase::escape_like_wildcards", $values);
             $likes_str = surround_and_join($values, "$column_name LIKE '%", "%'", ' OR ');
             $contribution = "$inv($likes_str)";
         }

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -24,7 +24,7 @@ if ($uname) {
         $where_clause = sprintf("WHERE username = '%s'", DPDatabase::escape($uname));
     } else {
         $where_clause = sprintf("WHERE username LIKE '%%%s%%'",
-            addcslashes(DPDatabase::escape($uname), "%_"));
+            DPDatabase::escape_like_wildcards(DPDatabase::escape($uname)));
     }
 
     // Not using sprintf() here because of the wildcard where_clause above.

--- a/stats/teams/tlist.php
+++ b/stats/teams/tlist.php
@@ -21,7 +21,7 @@ if ($tname) {
         $where_body = sprintf("teamname = '%s'", DPDatabase::escape($tname));
     } else {
         $where_body = sprintf("teamname LIKE '%%%s%%'",
-            addcslashes(DPDatabase::escape($tname), "%_"));
+            DPDatabase::escape_like_wildcards(DPDatabase::escape($tname)));
     }
 
     $tResult = select_from_teams($where_body, "ORDER BY $order $direction LIMIT $tstart,20");


### PR DESCRIPTION
As per task #2018, underscore was treated as a wildcard character, e.g. in PPer field in Project Search.

Searching for a username on the Stats page already escaped percent and underscore. Escape the sql
wildcard characters when a LIKE comparison is being done in Project Search