### PR TITLE
Append newline to email footers

### DIFF
--- a/pinc/send_mail.inc
+++ b/pinc/send_mail.inc
@@ -120,11 +120,12 @@ function get_standard_email_footers()
         $site_url,
         "",
         $automated_message,
+        "",
     ]);
     $html_footer = implode("\n", [
         "<hr style='width:12em; margin-left:0; margin-top:2em;'>",
         "<a href='$site_url'>$site_name</a><br>",
-        "<small>$automated_message</small>",
+        "<small>$automated_message</small><br>",
     ]);
     return [$text_footer, $html_footer];
 }


### PR DESCRIPTION
Previously, no final newline was included in the text emails. When HTML emails were added, no final `<br>` was added. This only appears to cause an issue where the email is send to a mailing list, e.g. PPV mailing list. It appears that a mailing list footer is appended, which probably includes a newline followed by a line of underscores then some info about the mailing list. This worked OK with text messages since the newline put the underscores onto the line below, but with the HTML version, a newline does nothing, and a `<br>` is needed.

In fact, it seems reasonable that all our emails, text and HTML, should have a terminating newline/`<br>`.