### PR TITLE
Only update user_project_info.t_latest_home_visit for PP/PPVers

### DIFF
--- a/SETUP/upgrade/19/20230601_prune_user_project_info.php
+++ b/SETUP/upgrade/19/20230601_prune_user_project_info.php
@@ -1,0 +1,79 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+include_once($relPath.'Project.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+// We've changed the t_latest_home_visit field to only track PP/PPV visits.
+// Delete rows from the user_project_info table that ONLY have a value for this
+// field and only if the row is for a non-PP/PPVer of the project. This
+// deletes entries that were only added by users who opened the project page
+// but didn't otherwise interact with the project (proofing a page, subscribing
+// to events, etc).
+
+echo "Pruning entries in user_project_info\n";
+$sql = "
+    SELECT projectid
+    FROM projects
+    ORDER BY projectid
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+while ([$projectid] = mysqli_fetch_row($result)) {
+    $project = new Project($projectid);
+    $sql = sprintf("
+        SELECT username
+        FROM user_project_info
+        WHERE projectid = '%s'
+            AND t_latest_page_event = 0
+            AND iste_round_available = 0
+            AND iste_round_complete = 0
+            AND iste_pp_enter = 0
+            AND iste_sr_available = 0
+            AND iste_sr_complete = 0
+            AND iste_ppv_enter = 0
+            AND iste_posted = 0
+            AND iste_sr_reported = 0
+        ORDER BY username
+    ", DPDatabase::escape($projectid));
+
+    $upi_result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+    $upi_users_to_delete = [];
+    $upi_users_to_retain = [];
+    while ([$username] = mysqli_fetch_row($upi_result)) {
+        if ($username != $project->PPer and $username != $project->PPVer) {
+            $upi_users_to_delete[] = $username;
+        } else {
+            $upi_users_to_retain[] = $username;
+        }
+    }
+    $upi_rows_delete = count($upi_users_to_delete);
+    $upi_rows_retain = count($upi_users_to_retain);
+
+    // skip the table if there are no rows to delete
+    if ($upi_rows_delete == 0) {
+        continue;
+    }
+
+    // delete the row -- because ($projectid, $username) is the primary key
+    // we can delete it just based on those two fields alone
+    $sql = sprintf("
+        DELETE FROM user_project_info
+        WHERE projectid = '%s'
+            AND username in (%s)
+    ", DPDatabase::escape($projectid),
+    surround_and_join(array_map("DPDatabase::escape", $upi_users_to_delete), "'", "'", ","));
+
+    mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+    echo "$projectid: rows with non-zero t_latest_home_visit to delete = $upi_rows_delete; to retain = $upi_rows_retain\n";
+}
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -42,7 +42,11 @@ function send_pp_reminders($PPer, $projects, $which_message)
         $authorsname = $project["authorsname"];
         $projectid = $project["projectid"];
         $modifieddate = icu_date_template("short", $project["modifieddate"], $user);
-        $lastvisitdate = icu_date_template("short", $project["lastvisitdate"], $user);
+        if ($project["lastvisitdate"] == null) {
+            $lastvisitdate = _("Never");
+        } else {
+            $lastvisitdate = icu_date_template("short", $project["lastvisitdate"], $user);
+        }
 
         // TRANSLATORS: %1$s is a project title, %2$s is the author, %3%s is the projectid
         $work_details = sprintf(_('%1$s by %2$s (%3$s)'), $nameofwork, $authorsname, $projectid);

--- a/pinc/post_processing.inc
+++ b/pinc/post_processing.inc
@@ -75,6 +75,8 @@ function _run_pp_threshold_query_result($state, $columns, $user, $ordering_crite
     // user_project_info.t_latest_home_visit may not always be a good
     // timestamp to use to determine the cutoff. Use the more recent value
     // of t_latest_home_visit and modifieddate.
+    // To handle the (very rare) case where the user has never visited the
+    // project page, we need the IFNULL() function to map the visit time to 0.
     $sql = "
         SELECT
             $column_selector
@@ -82,7 +84,7 @@ function _run_pp_threshold_query_result($state, $columns, $user, $ordering_crite
             projects.projectid = user_project_info.projectid AND
             projects.checkedoutby = user_project_info.username
         WHERE state = '$state' AND
-            GREATEST(user_project_info.t_latest_home_visit, modifieddate) <= $cutoff_timestamp
+            GREATEST(IFNULL(user_project_info.t_latest_home_visit, 0), modifieddate) <= $cutoff_timestamp
             $user_selector
         $order_by_clause
     ";

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -562,8 +562,15 @@ function show_project_listing(
                     $num_done = 0;
                 }
                 $cell = $num_done;
-            } elseif ($col_id == "days_avail" || $col_id == "days_left" || $col_id == "days_since_visit") {
+            } elseif ($col_id == "days_avail" || $col_id == "days_left") {
                 $cell = sprintf("%.1f", $book[$col_id]);
+            } elseif ($col_id == "days_since_visit") {
+                // days_since_visit could be null if the page was never visited
+                if ($book[$col_id] == null) {
+                    $cell = _("Never");
+                } else {
+                    $cell = sprintf("%.1f", $book[$col_id]);
+                }
             } else {
                 $cell = html_safe($book[$col_id]);
             }

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -10,8 +10,9 @@ subscriptions in addition to two timestamp fields that the site uses in
 various places:
 
 * t_latest_home_visit - timestamp of the last page visit (see project.php).
-                        As of 2023-06 we only update this for PP/PPVers as
-                        this is only used for PP/PPV notifications
+                        As of 2023-06 we only update this for users who have
+                        otherwise interacted with the project, except for
+                        PP/PPVers as it is used for PP/PPV notifications
                         (see post_processing.inc).
 * t_latest_page_event - timestamp of the last page saved in the project
                         (see DPage.inc). Originally this recorded the last
@@ -20,21 +21,32 @@ various places:
                         database updated to reflect that.
 */
 
-function upi_set_t_latest_home_visit($username, $projectid, $timestamp)
+function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_row = false)
 {
-    $sql = sprintf("
-        INSERT INTO user_project_info
-        SET
-            username            = '%s',
-            projectid           = '%s',
-            t_latest_home_visit = %d
-        ON DUPLICATE KEY UPDATE
-            t_latest_home_visit = %d",
-        DPDatabase::escape($username),
-        DPDatabase::escape($projectid),
-        $timestamp,
-        $timestamp
-    );
+    if ($ensure_row) {
+        $sql = sprintf("
+            INSERT INTO user_project_info
+            SET
+                username            = '%s',
+                projectid           = '%s',
+                t_latest_home_visit = %d
+            ON DUPLICATE KEY UPDATE
+                t_latest_home_visit = %d",
+            DPDatabase::escape($username),
+            DPDatabase::escape($projectid),
+            $timestamp,
+            $timestamp
+        );
+    } else {
+        $sql = sprintf("
+            UPDATE user_project_info
+            SET t_latest_home_visit = %d
+            WHERE username = '%s' AND projectid = '%s'",
+            $timestamp,
+            DPDatabase::escape($username),
+            DPDatabase::escape($projectid)
+        );
+    }
     DPDatabase::query($sql);
 }
 

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -9,7 +9,10 @@ to the (username, projectid) tuple. This includes things like project
 subscriptions in addition to two timestamp fields that the site uses in
 various places:
 
-* t_latest_home_visit - timestamp of the last page visit (see project.php)
+* t_latest_home_visit - timestamp of the last page visit (see project.php).
+                        As of 2023-06 we only update this for PP/PPVers as
+                        this is only used for PP/PPV notifications
+                        (see post_processing.inc).
 * t_latest_page_event - timestamp of the last page saved in the project
                         (see DPage.inc). Originally this recorded the last
                         proofer-initiated page event and was later changed

--- a/project.php
+++ b/project.php
@@ -95,10 +95,13 @@ if (!$user_is_logged_in) {
     return;
 }
 
-// We only want to update the latest home visit if the user is a PPer or PPVer
-// for this project.
-if ($user_is_logged_in && ($project->PPer_is_current_user or $project->PPVer_is_current_user)) {
-    upi_set_t_latest_home_visit($pguser, $project->projectid, time());
+if ($user_is_logged_in) {
+    upi_set_t_latest_home_visit(
+        $pguser,
+        $project->projectid,
+        time(),
+        $project->PPer_is_current_user or $project->PPVer_is_current_user
+    );
 }
 
 if ($detail_level == 1) {

--- a/project.php
+++ b/project.php
@@ -95,7 +95,9 @@ if (!$user_is_logged_in) {
     return;
 }
 
-if ($user_is_logged_in) {
+// We only want to update the latest home visit if the user is a PPer or PPVer
+// for this project.
+if ($user_is_logged_in && ($project->PPer_is_current_user or $project->PPVer_is_current_user)) {
     upi_set_t_latest_home_visit($pguser, $project->projectid, time());
 }
 


### PR DESCRIPTION
The `user_project_info` tracks the last time a user visits a project page, proofs a project page, or subscribes to a project event. The table definition looks like:
```
+----------------------+--------------+------+-----+---------+-------+
| Field                | Type         | Null | Key | Default | Extra |
+----------------------+--------------+------+-----+---------+-------+
| username             | varchar(25)  | NO   | PRI | NULL    |       |
| projectid            | varchar(22)  | NO   | PRI | NULL    |       |
| t_latest_home_visit  | int unsigned | NO   |     | 0       |       |
| t_latest_page_event  | int unsigned | NO   |     | 0       |       |
| iste_round_available | tinyint(1)   | NO   |     | 0       |       |
| iste_round_complete  | tinyint(1)   | NO   |     | 0       |       |
| iste_pp_enter        | tinyint(1)   | NO   |     | 0       |       |
| iste_sr_available    | tinyint(1)   | NO   |     | 0       |       |
| iste_sr_complete     | tinyint(1)   | NO   |     | 0       |       |
| iste_ppv_enter       | tinyint(1)   | NO   |     | 0       |       |
| iste_posted          | tinyint(1)   | NO   |     | 0       |       |
| iste_sr_reported     | tinyint(1)   | NO   |     | 0       |       |
+----------------------+--------------+------+-----+---------+-------+
```
At pgdp.net the `user_project_info` table is the 3rd largest table and has 4 million rows in it. Almost half of the rows are from users who have visited a project page but have never proofed a page or subscribed to an event.

The only place in the code that uses `user_project_info.t_latest_home_visit` is the PP/PPV notification code in `pinc/post_processing.inc`. Change it so that this field is only updated for current PP/PPVers of a project and add an upgrade script that will delete any rows that don't satisfy this new requirement. This will delete about half the rows in that table.

This is a "quick" fix for what should be a larger architectural change of moving the "is the PP/PPV still paying attention to this project" date in the `projects` table rather than the `user_project_info` table, and using a more active mechanism than just visiting the page, but this change will immediately stop this table from growing so quickly and should decrease the periodic lock timeouts we see on it.

The code is live in the [only-update-visit-for-pper](https://www.pgdp.org/~cpeel/c.branch/only-update-visit-for-pper/) sandbox.

I've tested the update script on 3 projects on TEST and it worked as-expected:
```
projectID44dcf8bc3a74f: rows with non-zero t_latest_home_visit to delete = 11; to retain = 0
projectID44dcfc8b0b855: rows with non-zero t_latest_home_visit to delete = 16; to retain = 0
projectID536a29867c0c4: rows with non-zero t_latest_home_visit to delete = 7; to retain = 1
```
For the last one, `libby` is the PPer (and PPVer) of `projectID536a29867c0c4` and their record was retained along with two other rows with people who had proofed a page in the project.

