### PR TITLE
Set UTF-8 CharSet for PHPMailer emails

### DIFF
--- a/pinc/send_mail.inc
+++ b/pinc/send_mail.inc
@@ -55,6 +55,7 @@ function send_mail($to, $subject, $message, $from = null, $reply_to = null)
     $mail = new PHPMailer(true);
     try {
         // Server settings
+        $mail->CharSet = 'UTF-8';
         $mail->isSMTP();
         foreach ($phpmailer_smtp_config as $key => $value) {
             $mail->$key = $value;


### PR DESCRIPTION
CharSet needs to be set to UTF-8 so that PHPMailer can encode the header lines correctly

As per [forum comments](https://www.pgdp.net/phpBB3/viewtopic.php?p=1310484#p1310484) and Slack discussion, email headers are not being encoded correctly. Most likely reason seems to be that PHPMailer uses `CharSet=ISO-8859-1` by default. Comment in [this PHPMailer issue](https://github.com/PHPMailer/PHPMailer/issues/133) implies that PHPMailer will encode the header correctly using B or Q encoding, but obviously it won't be able to do that if we are handing it UTF-8 header string but leaving it thinking the CharSet is ISO-8859-1

Testing: I don't know if the FakeEmail server would show the issue. If so, we can temporarily hack the code on TEST so it sends the email as well as displaying it on screen - comment in `send_mail.inc` line 50 explains how.
Sandbox at: https://www.pgdp.org/~windymilla/c.branch/email-encoding
