### PR TITLE
Use the full JS path to get date modified arg

### DIFF
--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -62,7 +62,7 @@ $initialFreq = getInitialCutoff($freqCutoff, $cutoffOptions);
 $header_args = [
     "js_files" => [
         "$code_url/scripts/splitControl.js",
-        "./show_all_good_word_suggestions.js",
+        "$code_url/tools/project_manager/show_all_good_word_suggestions.js",
     ],
     "js_data" => get_cutoff_script($cutoffOptions, $instances),
 

--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -39,7 +39,7 @@ $header_args = [
         "$code_url/scripts/splitControl.js",
         "$code_url/scripts/control_bar.js",
         "$code_url/scripts/page_browse.js",
-        "./show_word_context.js",
+        "$code_url/tools/project_manager/show_word_context.js",
     ],
     "js_data" => get_proofreading_interface_data_js() .
         get_control_bar_texts() . "

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -38,7 +38,7 @@ $header_args = [
         "$code_url/scripts/splitControl.js",
         "$code_url/scripts/control_bar.js",
         "$code_url/scripts/page_browse.js",
-        "./show_word_context.js",
+        "$code_url/tools/project_manager/show_word_context.js",
     ],
     "js_data" => get_proofreading_interface_data_js() .
         get_control_bar_texts() . "


### PR DESCRIPTION
Use the full JS path so that the date modified arg is appended. This forces browsers to recognize when JS files have changed.

Testable in https://www.pgdp.org/~cpeel/c.branch/use-full-js-path/