### PR TITLE
No block blank

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -510,6 +510,18 @@ QUnit.module("Format preview test", function() {
         assert.strictEqual(procText, "xy]zaef");
     });
 
+    QUnit.test("Check blank line after block quote start", function (assert) {
+        let text = "/#\n\nabcd\n#/";
+        issArray = analyse(text, configuration).issues;
+        issueTest(assert, 0, 0, 2, "BQStart", 1);
+    });
+
+    QUnit.test("Check blank line before block quote end", function (assert) {
+        let text = "/#\nabcd\n\n#/";
+        issArray = analyse(text, configuration).issues;
+        issueTest(assert, 0, 9, 2, "BQEnd", 1);
+    });
+
     function getMessage(messageCode) {
         return messageCode;
     }

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -19,6 +19,8 @@ function get_preview_messages()
         "charAfter" => _("No characters should follow %s"),
         "OolPrev" => _("Out-of-line start tag should not be preceded by normal text"),
         "OolNext" => _("Out-of-line end tag should not be followed by normal text"),
+        "BQStart" => _("Block quote start tag should not be followed by a blank line"),
+        "BQEnd" => _("Block quote end tag should not be preceded by a blank line"),
         "blankLines124" => _("Only 1, 2 or 4 blank lines should be used"),
         "puncAfterStart" => _("Punctuation after start tag"),
         "spaceAfterStart" => _("Space after start tag"),

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -152,6 +152,8 @@ window.addEventListener('DOMContentLoaded', function() {
             charAfter: 1,
             OolPrev: 1,
             OolNext: 1,
+            BQStart: 1,
+            BQEnd: 1,
             blankLines124: 1,
             puncAfterStart: 0,
             spaceAfterStart: 1,
@@ -526,6 +528,18 @@ window.addEventListener('DOMContentLoaded', function() {
             }
         }
 
+        function blankInBQ() {
+            let result;
+            let re = /\/#\n\n/g;
+            while ((result = re.exec(txt)) !== null) {
+                reportIssue(result.index, 2, "BQStart");
+            }
+            re = /\n\n#\//g;
+            while ((result = re.exec(txt)) !== null) {
+                reportIssue(result.index + 2, 2, "BQEnd");
+            }
+        }
+
         function checkBlankNumber() { // only 1, 2 or 4 blank lines should appear
             var result;
             var end;
@@ -837,6 +851,7 @@ window.addEventListener('DOMContentLoaded', function() {
                 blockSplit(txt, testBoldBlock);
             }
             parseOol();
+            blankInBQ();
             checkFootnotes();
             checkBlankLines();
             if(config.allowMathPreview) {


### PR DESCRIPTION
While considering re-making the re-wrap function, it appeared that blank lines after the block-quote start tag and before the block-quote end tag would have some peculiar effects. Rather trying to work around these, it seemed better to ensure that such blank lines are not present.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/no_block_blank
