### PR TITLE
Only count PPers posted books in PPV report

### DIFF
--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -78,8 +78,8 @@ $difficulty_level = $project->difficulty;
 $pages = $project->n_pages;
 $subdate = date('jS \o\f F, Y');
 
-// number of books post-processed by this PPer (including this one).
-$psd = get_project_status_descriptor('PPd');
+// number of already-posted books post-processed by this PPer.
+$psd = get_project_status_descriptor('posted');
 $sql = sprintf("
     SELECT COUNT(*) AS num_post_processed
     FROM projects
@@ -415,7 +415,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
             _("Post-Processed by"),
             $project->postproofer
                 . "<br>"
-                . sprintf(_("Number of books post-processed by %1\$s (including this one): %2\$d"),
+                . sprintf(_("Number of posted books post-processed by %1\$s: %2\$d"),
                     $project->postproofer, $number_post_processed)
         )
         . tr_w_two_cells(
@@ -683,7 +683,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM) {
         . "\n"
         . "\nPPV Summary for $project->postproofer"
         . "\n"
-        . "\n    Number of books post-processed by $project->postproofer (including this one): $number_post_processed"
+        . "\n    Number of posted books post-processed by $project->postproofer: $number_post_processed"
         . "\n"
         . "\n"
         . "\nProject Information"


### PR DESCRIPTION
Currently, not only posted books, but also those in PPV Available, or being PPVed are counted and reported in the PPV summary. This has the disadvantages that it can jump up suddenly if a PPer uploads several projects for PPV in a short time, and it can actually go downward if a PPVer returns a project to the PPer for more work. This can be confusing for the PPer/PPVer and maintainers of the PPV records spreadsheet.

Changing to only count posted books will reduce the occurrences of the first disadvantage and remove the second completely.

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/pp-count
