### PR TITLE
Permit ampersands in team names

### DIFF
--- a/stats/teams/new_team.php
+++ b/stats/teams/new_team.php
@@ -12,9 +12,9 @@ $user = User::load_current();
 
 $theme_extra_args = ["js_data" => get_newHelpWin_javascript("$code_url/pophelp.php?category=teams&name=edit_")];
 
-$teamname = stripAllString(trim(array_get($_POST, "teamname", "")));
+$teamname = trim(array_get($_POST, "teamname", ""));
 $text_data = stripAllString(array_get($_POST, "text_data", ""));
-$teamwebpage = stripAllString(array_get($_POST, "teamwebpage", ""));
+$teamwebpage = array_get($_POST, "teamwebpage", "");
 $tavatar = array_get($_POST, "tavatar", "");
 $ticon = array_get($_POST, "ticon", "");
 


### PR DESCRIPTION
Team names and webpage were passed through `stripAllString` which is intended to convert bb markup in team info to HTML markup, e.g. for italic. This conversion is not needed for team name and webpage.

Since `stripAllString` calls `html_safe`, ampersands were getting encoded, then encoded again via `attr_safe` in `ShowEdit`.

Addresses task #2041

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/team-name
