### PR TITLE
Handle month/day given without Birthday/Otherday code

### DIFF
--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -305,6 +305,11 @@ class ProjectInfoHolder
         if (startswith($this->project->special_code, "Otherday") ||
             startswith($this->project->special_code, "Birthday")) {
             $this->project->special_code .= " {$_POST['bdaymonth']}{$_POST['bdayday']}";
+        } elseif (empty($this->project->special_code) &&
+                  !empty("{$_POST['bdaymonth']}{$_POST['bdayday']}")) {
+            // month/year specified but no special code, so set to Birthday
+            $this->project->special_code = "Birthday {$_POST['bdaymonth']}{$_POST['bdayday']}";
+            $errors[] = _("Special Day code set to 'Birthday'. Check before saving.");
         }
 
         // validate fields managed by the Project class


### PR DESCRIPTION
Requested by task #836

If month/day is given on project edit page, but special code field is left empty, set special code to `Birthday` and output error message for user to check before saving.

Fix is not as slick as it might be, because month/date are not stored in the Project structure or database except when appended to Birthday/Otherday as a special code. This is trying to cope with the case when month/date are set, but special code was left blank. Previously, project would have been saved with no special day code at all, leaving it vulnerable to releasing before the PM realised the mistake.

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/special-date
