### PR TITLE
Check if team_id exists before creating topic

### DIFF
--- a/stats/teams/team_topic.php
+++ b/stats/teams/team_topic.php
@@ -24,7 +24,7 @@ $row = mysqli_fetch_array($team_result);
 // If no row was returned, there is no team matching that ID,
 // this can only happen due to URL hacking so just throw an error.
 if (!$row) {
-    throw new ValueError("No team with ID $team_id");
+    throw new InvalidArgumentException("No team with ID $team_id");
 }
 
 $topic_id = $row['topic_id'];

--- a/stats/teams/team_topic.php
+++ b/stats/teams/team_topic.php
@@ -13,9 +13,19 @@ $team_id = get_integer_param($_GET, 'team', null, 0, null);
 
 // Get info about team
 
-$team_result = DPDatabase::query("SELECT teamname,team_info, webpage, createdby, owner, topic_id FROM user_teams WHERE id=$team_id");
+$sql = sprintf("
+    SELECT teamname, team_info, webpage, createdby, owner, topic_id
+    FROM user_teams
+    WHERE id=%d", $team_id);
+$team_result = DPDatabase::query($sql);
 
 $row = mysqli_fetch_array($team_result);
+
+// If no row was returned, there is no team matching that ID,
+// this can only happen due to URL hacking so just throw an error.
+if (!$row) {
+    throw new ValueError("No team with ID $team_id");
+}
 
 $topic_id = $row['topic_id'];
 


### PR DESCRIPTION
If someone manipulates the team discussion link on the Teams page to use a numeric, but invalid, team ID the script blindly plunges forward. Instead, if we can't find a team ID just error out. This page is only accessible from the teams page.

Available in https://www.pgdp.org/~cpeel/c.branch/better-checks-team-discussion/