### PR TITLE
Standardize "Return to x" links

### DIFF
--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -39,8 +39,6 @@ function provide_escape_links()
 {
     global $code_url;
 
-    echo "<p>\n";
-    echo _('Go to...'), "\n";
     echo "<ul>\n";
 
     // link to project home
@@ -51,9 +49,7 @@ function provide_escape_links()
             validate_projectID($projectid);
 
             // This link won't work if the error is that the project doesn't exist.
-            $link_url = "$code_url/project.php?id=$projectid";
-            $link_text = _('Project Home');
-            echo "<li><a href='$link_url' target='_top'>$link_text</a></li>\n";
+            echo "<li>" . return_to_project_page_link($projectid) . "</li>\n";
         } catch (InvalidProjectIDException $exception) {
             // don't output anything as the project ID is not valid
         }
@@ -68,20 +64,15 @@ function provide_escape_links()
                 get_parameter_value(['pagestate', 'page_state']));
         }
         if (!is_null($round)) {
-            $link_url = "$code_url/tools/proofers/round.php?round_id={$round->id}";
-            $link_text = $round->name;
-            echo "<li><a href='$link_url' target='_top'>$link_text</a></li>\n";
+            echo "<li>" . return_to_round_page_link($round->id) . "</li>\n";
         }
     }
 
     // link to activity hub
     {
-        $link_url = "$code_url/activity_hub.php";
-        $link_text = _('Activity Hub');
-        echo "<li><a href='$link_url' target='_top'>$link_text</a></li>\n";
+        echo "<li>" . return_to_activity_hub_link() . "</li>\n";
     }
     echo "</ul>\n";
-    echo "</p>\n";
 }
 
 function get_parameter_value($possible_names)

--- a/pinc/links.inc
+++ b/pinc/links.inc
@@ -81,17 +81,36 @@ function private_message_link($proofer_username, $target = "_blank")
 
 // -----------------------------------------------------------------------------
 
-function return_to_project_page_link($projectid, $url_suffix = "")
-// Returns a string containing a snippet of HTML to return to a project page.
-// Optional second argument could be page anchor, e.g "#holds"
-// or additional URL parameter, e.g. "&detail_level=4"
+function project_page_link_url($project_id, $query_param_array = null, $anchor_link = "")
+// Returns HTML-safe URL for the given project page.
+// Optional second argument is array of query parameters (without ?/&), e.g. ["detail_level=4"]
+// Optional third argument is page anchor (without #), e.g "holds"
+// NOTE: query_params and anchor_link should be urlencoded if necessary
 {
     global $code_url;
 
-    $url_suffix = html_safe($url_suffix);
+    $url = "$code_url/project.php?id=$project_id";
+    if (!empty($query_param_array)) {
+        $url .= "&" . implode("&", $query_param_array);
+    }
+    if (!empty($anchor_link)) {
+        $url .= "#" . $anchor_link;
+    }
+    return html_safe($url);
+}
+
+// -----------------------------------------------------------------------------
+
+function return_to_project_page_link($project_id, $query_param_array = null, $anchor_link = "")
+// Returns a string containing an HTML link to return to a project page.
+// Optional second argument is array of query parameters (without ?/&), e.g. ["detail_level=4"]
+// Optional third argument is page anchor (without #), e.g "holds"
+// NOTE: query_params and anchor_link should be urlencoded if necessary
+{
+    $url = project_page_link_url($project_id, $query_param_array, $anchor_link);
     return sprintf(
              _("Return to the <a %s>project page</a>"),
-             "href='$code_url/project.php?id=$projectid$url_suffix' target='_top'"
+             "href='$url' target='_top'"
            );
 }
 

--- a/pinc/links.inc
+++ b/pinc/links.inc
@@ -78,3 +78,46 @@ function private_message_link($proofer_username, $target = "_blank")
 
     return $a;
 }
+
+// -----------------------------------------------------------------------------
+
+function return_to_project_page_link($projectid, $url_suffix = "")
+// Returns a string containing a snippet of HTML to return to a project page.
+// Optional second argument could be page anchor, e.g "#holds"
+// or additional URL parameter, e.g. "&detail_level=4"
+{
+    global $code_url;
+
+    $url_suffix = html_safe($url_suffix);
+    return sprintf(
+             _("Return to the <a %s>project page</a>"),
+             "href='$code_url/project.php?id=$projectid$url_suffix' target='_top'"
+           );
+}
+
+// -----------------------------------------------------------------------------
+
+function return_to_round_page_link($round_id)
+// Returns a string containing a snippet of HTML to return to a round page.
+{
+    global $code_url;
+
+    return sprintf(
+             _("Return to <a %s>round %s</a>"),
+             "href='$code_url/tools/proofers/round.php?round_id=$round_id' target='_top'",
+             $round_id
+           );
+}
+
+// -----------------------------------------------------------------------------
+
+function return_to_activity_hub_link()
+// Returns a string containing a snippet of HTML to return to the Activity Hub.
+{
+    global $code_url;
+
+    return sprintf(
+             _("Return to the <a %s>Activity Hub</a>"),
+             "href='$code_url/activity_hub.php' target='_top'"
+           );
+}

--- a/pinc/links.inc
+++ b/pinc/links.inc
@@ -81,7 +81,7 @@ function private_message_link($proofer_username, $target = "_blank")
 
 // -----------------------------------------------------------------------------
 
-function project_page_link_url($project_id, $query_param_array = null, $anchor_link = "")
+function project_page_link_url($projectid, $query_param_array = null, $anchor_link = "")
 // Returns HTML-safe URL for the given project page.
 // Optional second argument is array of query parameters (without ?/&), e.g. ["detail_level=4"]
 // Optional third argument is page anchor (without #), e.g "holds"
@@ -89,7 +89,7 @@ function project_page_link_url($project_id, $query_param_array = null, $anchor_l
 {
     global $code_url;
 
-    $url = "$code_url/project.php?id=$project_id";
+    $url = "$code_url/project.php?id=$projectid";
     if (!empty($query_param_array)) {
         $url .= "&" . implode("&", $query_param_array);
     }
@@ -101,13 +101,13 @@ function project_page_link_url($project_id, $query_param_array = null, $anchor_l
 
 // -----------------------------------------------------------------------------
 
-function return_to_project_page_link($project_id, $query_param_array = null, $anchor_link = "")
+function return_to_project_page_link($projectid, $query_param_array = null, $anchor_link = "")
 // Returns a string containing an HTML link to return to a project page.
 // Optional second argument is array of query parameters (without ?/&), e.g. ["detail_level=4"]
 // Optional third argument is page anchor (without #), e.g "holds"
 // NOTE: query_params and anchor_link should be urlencoded if necessary
 {
-    $url = project_page_link_url($project_id, $query_param_array, $anchor_link);
+    $url = project_page_link_url($projectid, $query_param_array, $anchor_link);
     return sprintf(
              _("Return to the <a %s>project page</a>"),
              "href='$url' target='_top'"

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -1,7 +1,7 @@
 <?php
 include_once('RoundDescriptor.inc'); // get_Round_for_round_number()
 include_once('wordcheck_engine.inc'); // get_file_info_object()
-include_once('links.inc'); // new_window_link()
+include_once('links.inc');
 include_once('slim_header.inc'); // slim_header()
 include_once($relPath.'../tools/project_manager/post_files.inc'); // page_info_query page_info_fetch
 include_once('bad_bytes.inc');
@@ -38,7 +38,7 @@ function gate_on_pqc($projectid)
         echo "</p>";
 
         echo "<p>";
-        echo sprintf(_("Return to the <a %s>project page</a>"), "href='$code_url/project.php?id=$projectid'");
+        echo return_to_project_page_link($projectid);
         echo "</p>";
 
         echo "<h2>" . _("Project Quick Check Summary") . "</h2>";

--- a/tools/extend_sr.php
+++ b/tools/extend_sr.php
@@ -6,6 +6,7 @@ include_once($relPath.'Project.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'smoothread.inc'); // handle_smooth_reading_change()
 include_once($relPath.'metarefresh.inc');
+include_once($relPath.'links.inc');
 
 class ActionException extends Exception
 {
@@ -19,7 +20,8 @@ $days = get_integer_param($_REQUEST, 'days', 0, 0, 56);
 
 $title = _("Extend the Smooth Reading deadline");
 $new_state = PROJ_POST_FIRST_CHECKED_OUT;
-$back_url = "$code_url/project.php?id=$projectid&amp;expected_state=$new_state#smooth_start";
+$suffix = "&amp;expected_state=$new_state#smooth_start";
+$back_url = "$code_url/project.php?id=$projectid$suffix";
 
 try {
     // validate the user has the ability to do this action
@@ -46,5 +48,5 @@ try {
     echo "<h1>$title</h1>";
     echo "<h2>", sprintf("Project: %s", html_safe($project->nameofwork)), "</h2>";
     echo "<p class='error'>", $e->getMessage(), "</p>\n";
-    echo "<a href='$back_url'>", _("Return to the Project Page"), "</a>";
+    echo return_to_project_page_link($projectid, "$suffix");
 }

--- a/tools/extend_sr.php
+++ b/tools/extend_sr.php
@@ -20,8 +20,9 @@ $days = get_integer_param($_REQUEST, 'days', 0, 0, 56);
 
 $title = _("Extend the Smooth Reading deadline");
 $new_state = PROJ_POST_FIRST_CHECKED_OUT;
-$suffix = "&amp;expected_state=$new_state#smooth_start";
-$back_url = "$code_url/project.php?id=$projectid$suffix";
+$query_param = ["expected_state=$new_state"];
+$anchor_link = "smooth_start";
+$back_url = project_page_link_url($projectid, $query_param, $anchor_link);
 
 try {
     // validate the user has the ability to do this action
@@ -48,5 +49,5 @@ try {
     echo "<h1>$title</h1>";
     echo "<h2>", sprintf("Project: %s", html_safe($project->nameofwork)), "</h2>";
     echo "<p class='error'>", $e->getMessage(), "</p>\n";
-    echo return_to_project_page_link($projectid, "$suffix");
+    echo return_to_project_page_link($projectid, $query_param, $anchor_link);
 }

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -10,6 +10,7 @@ include_once($relPath.'project_states.inc'); // get_project_status_descriptor()
 include_once($relPath.'misc.inc');  // array_get() startswith() attr_safe()
 include_once($relPath.'faq.inc');
 include_once($relPath.'pg.inc');
+include_once($relPath.'links.inc');
 
 header_remove("Expires");
 header_remove("Cache-Control");
@@ -877,7 +878,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM) {
     $subject = "PPV Summary - $project->postproofer ($_POST[pp_evaluation])";
     $message = $reportcard;
     send_mail($to, $subject, $message, "$pguser <$ppver->email>");
-    printf(_("Return to <a href='%s'>the Project Page</a>"), "../../project.php?id=$projectid");
+    echo return_to_project_page_link($projectid);
     exit();
 } else {
     assert(false);

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -174,7 +174,7 @@ if (!@$_POST['confirmed']) {
 }
 
 echo "<hr>\n";
-echo return_to_project_page_link($projectid, "&detail_level=4") . "\n";
+echo return_to_project_page_link($projectid, ["detail_level=4"]) . "\n";
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -633,7 +633,8 @@ class Loader
         echo "<br>\n";
         echo _("Please review the information, and use the link at the bottom of the page to proceed with the load.");
         echo "<br>\n";
-        echo _("If there's a problem, return to the  <a href='$code_url/project.php?id=$projectid&detail_level=4'>Project Page</a> without loading the files.");
+        $project_url = project_page_link_url($projectid, ["detail_level=4"]);
+        echo _("If there's a problem, return to the  <a href='$project_url'>project page</a> without loading the files.");
         echo "</p>\n";
 
         // --------------

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -634,7 +634,7 @@ class Loader
         echo _("Please review the information, and use the link at the bottom of the page to proceed with the load.");
         echo "<br>\n";
         $project_url = project_page_link_url($projectid, ["detail_level=4"]);
-        echo _("If there's a problem, return to the  <a href='$project_url'>project page</a> without loading the files.");
+        echo sprintf(_("If there's a problem, return to the <a %s>project page</a> without loading the files."), "href='$project_url'");
         echo "</p>\n";
 
         // --------------

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -7,6 +7,7 @@ include_once($relPath.'project_edit.inc');
 include_once($relPath.'DPage.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath.'links.inc');
 include_once($relPath.'prefs_options.inc');
 include_once($relPath.'image_check.inc');
 
@@ -71,7 +72,7 @@ if ($rel_source == '') {
         echo sprintf(_("Source directory '%s' is not acceptable."), html_safe($rel_source));
         echo "</p>";
         echo "<hr>\n";
-        echo "Return to <a href='$code_url/project.php?id=$projectid'>Project Page</a>.\n";
+        echo return_to_project_page_link($projectid) . "\n";
         return;
     }
 }
@@ -123,7 +124,7 @@ if (!$r) {
     echo sprintf(_("Directory '%s' does not exist, or is inaccessible."), html_safe($source_project_dir));
     echo "</p>";
     echo "<hr>\n";
-    echo "Return to <a href='$code_url/project.php?id=$projectid'>Project Page</a>.\n";
+    echo return_to_project_page_link($projectid) . "\n";
     return;
 }
 
@@ -173,7 +174,7 @@ if (!@$_POST['confirmed']) {
 }
 
 echo "<hr>\n";
-echo "Return to <a href='$code_url/project.php?id=$projectid&detail_level=4'>Project Page</a>.\n";
+echo return_to_project_page_link($projectid, "&detail_level=4") . "\n";
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -129,10 +129,7 @@ do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_column_nam
               $L_text_column_name, $R_text_column_name, $only_nonempty_diffs, $bb_diffs);
 echo $navigation_text;
 
-$url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";
-$label = _("Go to Project Page");
-
-echo "\n<p><a href='$url'>$label</a>\n";
+echo "\n<p>" . return_to_project_page_link($projectid, "&expected_state=$state") . "\n";
 
 if ($L_format || $R_format) {
     // show option to change compare method
@@ -182,7 +179,7 @@ echo $diffEngine->getDiff($L_label, $R_label);
 // at the top of the page it's buttons, then project page
 // we reverse the order here for symmetry :)
 if ($L_text != $R_text) {
-    echo "\n<p><a href='$url'>$label</a></p>\n";
+    echo "\n<p>" . return_to_project_page_link($projectid, "&expected_state=$state") . "\n";
     echo $navigation_text;
 }
 

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -129,7 +129,7 @@ do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_column_nam
               $L_text_column_name, $R_text_column_name, $only_nonempty_diffs, $bb_diffs);
 echo $navigation_text;
 
-echo "\n<p>" . return_to_project_page_link($projectid, "&expected_state=$state") . "\n";
+echo "\n<p>" . return_to_project_page_link($projectid, ["expected_state=$state"]) . "\n";
 
 if ($L_format || $R_format) {
     // show option to change compare method
@@ -179,7 +179,7 @@ echo $diffEngine->getDiff($L_label, $R_label);
 // at the top of the page it's buttons, then project page
 // we reverse the order here for symmetry :)
 if ($L_text != $R_text) {
-    echo "\n<p>" . return_to_project_page_link($projectid, "&expected_state=$state") . "\n";
+    echo "\n<p>" . return_to_project_page_link($projectid, ["expected_state=$state"]) . "\n";
     echo $navigation_text;
 }
 

--- a/tools/project_manager/edit_pages.php
+++ b/tools/project_manager/edit_pages.php
@@ -63,7 +63,7 @@ if (@$_REQUEST['confirmed'] == 'yes') {
         echo "<br>\n";
         echo "<br>\n";
     }
-    echo "<a href='$code_url/project.php?id=$projectid&amp;detail_level=4'>", _("Project Page"), "</a><br>\n";
+    echo return_to_project_page_link($projectid, "&detail_level=4") . "<br>\n";
 } else {
     // Obtain confirmation
 

--- a/tools/project_manager/edit_pages.php
+++ b/tools/project_manager/edit_pages.php
@@ -63,7 +63,7 @@ if (@$_REQUEST['confirmed'] == 'yes') {
         echo "<br>\n";
         echo "<br>\n";
     }
-    echo return_to_project_page_link($projectid, "&detail_level=4") . "<br>\n";
+    echo return_to_project_page_link($projectid, ["detail_level=4"]) . "<br>\n";
 } else {
     // Obtain confirmation
 

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -3,6 +3,7 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath.'links.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath."PageUnformatter.inc"); // PageUnformatter()
 
@@ -46,10 +47,7 @@ class Comparator
         echo "<h2>" . html_safe($sub_title) . "</h2>\n";
 
         $state = $this->project->state;
-        $project_url = "$code_url/project.php?id=$this->projectid&amp;expected_state=$state";
-
-        $label = _("Return to Project Page");
-        echo "<p><a href='$project_url'>$label</a></p>\n";
+        echo "<p>" . return_to_project_page_link($this->projectid, "&expected_state=$state") . "</p>\n";
 
         if (!$this->project->check_pages_table_exists($warn_message)) {
             echo "<p class='warning'>$warn_message</p>\n";

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -47,7 +47,7 @@ class Comparator
         echo "<h2>" . html_safe($sub_title) . "</h2>\n";
 
         $state = $this->project->state;
-        echo "<p>" . return_to_project_page_link($this->projectid, "&expected_state=$state") . "</p>\n";
+        echo "<p>" . return_to_project_page_link($this->projectid, ["expected_state=$state"]) . "</p>\n";
 
         if (!$this->project->check_pages_table_exists($warn_message)) {
             echo "<p class='warning'>$warn_message</p>\n";

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -54,10 +54,7 @@ output_header("$page_details_str: $title", NO_STATSBAR);
 echo "<h1>" . html_safe($title) . "</h1>\n";
 echo "<h2>$page_details_str</h2>\n";
 
-$url = "$code_url/project.php?id=$projectid&amp;expected_state=$state";
-$label = _("Return to Project Page");
-
-echo "<p><a href='$url'>$label</a></p>\n";
+echo "<p>" . return_to_project_page_link($projectid, "&expected_state=$state") . "</p>\n";
 
 if ($project->check_pages_table_exists($warn_message)) {
     echo_detail_legend();

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -54,7 +54,7 @@ output_header("$page_details_str: $title", NO_STATSBAR);
 echo "<h1>" . html_safe($title) . "</h1>\n";
 echo "<h2>$page_details_str</h2>\n";
 
-echo "<p>" . return_to_project_page_link($projectid, "&expected_state=$state") . "</p>\n";
+echo "<p>" . return_to_project_page_link($projectid, ["expected_state=$state"]) . "</p>\n";
 
 if ($project->check_pages_table_exists($warn_message)) {
     echo_detail_legend();

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -6,7 +6,7 @@ include_once($relPath.'page_tally.inc');
 include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 include_once($relPath.'LPage.inc');
 include_once($relPath.'misc.inc'); // html_safe()
-include_once($relPath.'links.inc'); // private_message_link()
+include_once($relPath.'links.inc');
 include_once($relPath.'forum_interface.inc'); // get_forum_user_id()
 include_once($relPath.'misc.inc'); // get_enumerated_param()
 
@@ -311,23 +311,13 @@ class PPage
 
         echo "<ul>\n"
             .   "<li>"
-            .     sprintf(
-                    _("Return to the <a %s>project page</a>"),
-                    "href='$code_url/project.php?id=$projectid' target='_top'"
-                  )
+            .     return_to_project_page_link($projectid)
             .   "</li>\n"
             .   "<li>"
-            .     sprintf(
-                    _("Return to <a %s>round %s</a>"),
-                    "href='round.php?round_id={$round->id}' target='_top'",
-                    $round->id
-                  )
+            .     return_to_round_page_link($round->id)
             .   "</li>\n"
             .   "<li>"
-            .     sprintf(
-                    _("Return to the <a %s>Activity Hub</a>."),
-                    "href='$code_url/activity_hub.php' target='_top'"
-                  )
+            .     return_to_activity_hub_link()
             .   "</li>\n"
             . "</ul>\n"
             ;

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -5,6 +5,7 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 include_once($relPath.'project_states.inc'); // PROJ_NEW, PROJ_P1_UNAVAILABLE
+include_once($relPath.'links.inc');
 
 require_login();
 
@@ -55,7 +56,7 @@ if (!is_null($zip_type)) {
     echo "
         <h1>" . html_safe($project->nameofwork) . "</h1>
         <p>$projectid</p>
-        <p><a href='$code_url/project.php?id=$projectid'>", _('Return to Project Page'), "</a></p>
+        <p>" . return_to_project_page_link($projectid) . "</p>
         <h2>$image_index_str</h2>
     ";
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -355,11 +355,13 @@ function leave_proofing_interface($title)
 
     slim_header($title);
 
-    $url = "$code_url/project.php?id=$projectid&expected_state=$proj_state";
-
-    $text = _("You will be returned to the <a href='%s' target='_top'>Project Page</a> in one second.");
-    echo sprintf($text, $url);
+    // HTML requires HTML-safe version, whereas script doesn't want escaped ampersands
+    $query_param = "expected_state=$proj_state";
+    $safe_url = project_page_link_url($projectid, [$query_param]);
+    $raw_url = "$code_url/project.php?id=$projectid&$query_param";
+    $text = _("You will be returned to the <a href='%s' target='_top'>project page</a> in one second.");
+    echo sprintf($text, $safe_url);
     echo "<script><!--\n";
-    echo "setTimeout(\"top.location.href='$url';\", 1000);\n";
+    echo "setTimeout(\"top.location.href='$raw_url';\", 1000);\n";
     echo "// --></script>\n";
 }

--- a/tools/proofers/proof_frame.php
+++ b/tools/proofers/proof_frame.php
@@ -7,6 +7,7 @@ include_once($relPath.'abort.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'Project.inc'); // get_projectID_param()
 include_once($relPath.'slim_header.inc');
+include_once($relPath.'links.inc');
 include_once('PPage.inc');
 include_once('proof_frame.inc');
 
@@ -98,8 +99,7 @@ if (isset($_GET['page_state'])) {
         // the project page.
         $project = new Project($projectid);
         if ($project->can_be_managed_by_user($pguser)) {
-            $body = $err . "<br> " . sprintf(_("Return to the <a %s>project page</a>."),
-                "href='$code_url/project.php?id=$projectid' target='_top'");
+            $body = $err . "<br> " . return_to_project_page_link($projectid);
         } else {
             $body = $err . "<br> " . sprintf(_("Return to the <a %s>project listing page</a>."),
                 "href='round.php?round_id={$round->id}' target='_top'");

--- a/tools/request_access.php
+++ b/tools/request_access.php
@@ -4,6 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'send_mail.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'slim_header.inc');
+include_once($relPath.'links.inc');
 include_once($relPath.'User.inc');
 
 require_login();
@@ -92,9 +93,4 @@ if ($uao->can_access) {
 }
 echo "</p>\n";
 
-echo "<p>";
-printf(
-    _("Back to <a href='%s'>Activity Hub</a>"),
-    "$code_url/activity_hub.php"
-);
-echo "</p>\n";
+echo "<p>" . return_to_activity_hub_link() . "</p>\n";

--- a/tools/set_project_event_subs.php
+++ b/tools/set_project_event_subs.php
@@ -4,6 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'user_project_info.inc');
 include_once($relPath.'Project.inc');  // get_projectID_param()
+include_once($relPath.'links.inc');
 
 require_login();
 
@@ -50,4 +51,4 @@ function _html_ul($header, $items)
     echo "</ul>\n";
 }
 
-echo "<p>" . sprintf(_("Return to the <a %s>project page</a>"), "href='$code_url/project.php?id=$projectid#event_subscriptions'") . "</p>";
+echo "<p>" . return_to_project_page_link($projectid, "#event_subscriptions") . "</p>";

--- a/tools/set_project_event_subs.php
+++ b/tools/set_project_event_subs.php
@@ -51,4 +51,4 @@ function _html_ul($header, $items)
     echo "</ul>\n";
 }
 
-echo "<p>" . return_to_project_page_link($projectid, "#event_subscriptions") . "</p>";
+echo "<p>" . return_to_project_page_link($projectid, null, "event_subscriptions") . "</p>";

--- a/tools/set_project_holds.php
+++ b/tools/set_project_holds.php
@@ -90,4 +90,4 @@ foreach ($headers as $w => $header) {
     }
 }
 
-echo "<p>" . return_to_project_page_link($projectid, "#holds") . "</p>";
+echo "<p>" . return_to_project_page_link($projectid, null, "holds") . "</p>";

--- a/tools/set_project_holds.php
+++ b/tools/set_project_holds.php
@@ -6,6 +6,7 @@ $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'Project.inc'); // get_projectID_param()
+include_once($relPath.'links.inc');
 
 require_login();
 
@@ -89,4 +90,4 @@ foreach ($headers as $w => $header) {
     }
 }
 
-echo "<p>" . sprintf(_("Return to the <a %s>project page</a>"), "href='$code_url/project.php?id=$projectid#holds'") . "</p>";
+echo "<p>" . return_to_project_page_link($projectid, "#holds") . "</p>";

--- a/tools/site_admin/project_jump.php
+++ b/tools/site_admin/project_jump.php
@@ -4,6 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath.'links.inc');
 include_once($relPath.'Project.inc');
 
 require_login();
@@ -39,7 +40,7 @@ switch ($action) {
 
     case 'dojump':
         do_stuff($projectid, $new_state, false);
-        echo "\n\n<a href='$code_url/project.php?id={$projectid}'>" . _("Project Home") . "</a>\n";
+        echo "\n\n" . return_to_project_page_link($projectid) . "\n";
         break;
 }
 

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -70,8 +70,8 @@ if ($stage == 'post_1') {
     $project_is_in_valid_state = PROJ_POST_FIRST_CHECKED_OUT == $project->state;
     $user_is_able_to_perform_action = $project->PPer_is_current_user || user_is_a_sitemanager();
     $new_state = PROJ_POST_FIRST_CHECKED_OUT;
-    $back_url = "$code_url/project.php?id=$projectid&amp;expected_state=$new_state";
-    $back_blurb = _("Project Page");
+    $back_url = project_page_link_url($projectid, ["expected_state=$new_state"]);
+    $back_blurb = _("project page");
     $comment_title = _("Comments:");
 } elseif ($stage == 'return_1') {
     $title = _("Return project to the post-processing pool");
@@ -92,8 +92,8 @@ if ($stage == 'post_1') {
     $project_is_in_valid_state = PROJ_POST_SECOND_CHECKED_OUT == $project->state;
     $user_is_able_to_perform_action = $project->PPVer_is_current_user || user_is_a_sitemanager();
     $new_state = PROJ_POST_SECOND_CHECKED_OUT;
-    $back_url = "$code_url/project.php?id=$projectid&amp;expected_state=$new_state";
-    $back_blurb = _("Project Page");
+    $back_url = project_page_link_url($projectid, ["expected_state=$new_state"]);
+    $back_blurb = _("project page");
     $comment_title = _("Comments:");
 } elseif ($stage == 'return_2') {
     $title = _("Return project to the post-processing verification pool");
@@ -114,8 +114,8 @@ if ($stage == 'post_1') {
     $project_is_in_valid_state = PROJ_POST_FIRST_CHECKED_OUT == $project->state;
     $user_is_able_to_perform_action = $project->PPer_is_current_user || user_is_a_sitemanager();
     $new_state = PROJ_POST_FIRST_CHECKED_OUT;
-    $back_url = "$code_url/project.php?id=$projectid&amp;expected_state=$new_state#smooth_start";
-    $back_blurb = _("Project Page");
+    $back_url = project_page_link_url($projectid, ["expected_state=$new_state"], "smooth_start");
+    $back_blurb = _("project page");
     $comment_title = _("Leave instructions for smooth readers:");
 } elseif ($stage == 'smooth_done') {
     $title = _("Upload a Smooth Read report");
@@ -130,8 +130,8 @@ if ($stage == 'post_1') {
     }
     $user_is_able_to_perform_action = true;
     $new_state = PROJ_POST_FIRST_CHECKED_OUT;
-    $back_url = "$code_url/project.php?id=$projectid&amp;expected_state=$new_state";
-    $back_blurb = _("Project Page");
+    $back_url = project_page_link_url($projectid, ["expected_state=$new_state"]);
+    $back_blurb = _("project page");
     $comment_title = null;
 } elseif (!$stage) {
     // this may be due to a timeout when uploading big files.
@@ -154,7 +154,6 @@ $returning_to_pool = ('return_1' == $stage || 'return_2' == $stage);
 $return_anchor = "<a href='$back_url'>$back_blurb</a>";
 // TRANSLATORS: %s is an already-translated page name, eg: Project Page
 $return_message = "<p>". sprintf(_("Return to the %s"), $return_anchor). "</p>";
-$return_to_project_link = return_to_project_page_link($projectid). "\n";
 
 if (!isset($action)) {
     // Present the upload page.
@@ -199,7 +198,7 @@ if (!isset($action)) {
             echo "<p class='error'>$message</p>";
         }
     }
-    echo $return_to_project_link;
+    echo return_to_project_page_link($projectid) . "\n";
 } else {
     // Handle a submission from the upload page.
 
@@ -282,7 +281,7 @@ if (!isset($action)) {
         echo $return_message;
     } catch (FileUploadException $e) {
         echo "<p class='error'>", $e->getMessage(), "</p>\n";
-        echo $return_to_project_link;
+        echo return_to_project_page_link($projectid) . "\n";
     }
 }
 

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -11,6 +11,7 @@ include_once($relPath.'forum_interface.inc');
 include_once($relPath.'misc.inc'); // html_safe(), extract_zip_to(), return_bytes(), remove_common_basedir_from_zip()
 include_once($relPath.'smoothread.inc'); // handle_smooth_reading_change()
 include_once($relPath.'upload_file.inc'); // show_upload_form(), detect_too_large(), validate_uploaded_file, zip_check()
+include_once($relPath.'links.inc');
 
 detect_too_large();
 require_login();
@@ -153,7 +154,7 @@ $returning_to_pool = ('return_1' == $stage || 'return_2' == $stage);
 $return_anchor = "<a href='$back_url'>$back_blurb</a>";
 // TRANSLATORS: %s is an already-translated page name, eg: Project Page
 $return_message = "<p>". sprintf(_("Return to the %s"), $return_anchor). "</p>";
-$return_to_project_link = "<a href='$code_url/project.php?id=$projectid'>" . _("Return to the Project Page") . "</a>\n";
+$return_to_project_link = return_to_project_page_link($projectid). "\n";
 
 if (!isset($action)) {
     // Present the upload page.


### PR DESCRIPTION
As per task #1871, linked phrases such as
"Return to the project page" were inconsistently worded, puncutated and marked up for translation.

Standardize return to project, round and Activity Hub.

Note that further standardization of capitalization of "project page" could be done in future, where it does not appear just as a simple "Return to" link.

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/return-links
