### PR TITLE
Add links from PM Word List pages

### DIFF
--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -265,10 +265,18 @@ function prep_numeric_keys_for_multisort(&$assocArray)
 
 function echo_page_header($title, $projectid)
 {
+    global $code_url;
+
     echo "<h1>$title</h1>";
 
     $project_text = sprintf(_("Project: %s"), html_safe(get_project_name($projectid)));
     echo "<h2>$project_text</h2>\n";
+    echo "<p>"
+      . "<a href='$code_url/tools/project_manager/edit_project_word_lists.php?projectid=$projectid'>"
+      . _("Edit project word lists")
+      . "</a> | "
+      . return_to_project_page_link($projectid)
+      . "</p>\n";
 }
 
 function get_project_name($projectid)


### PR DESCRIPTION
As requested in Task #1953, add links to project page and Edit project word lists page. Task requested links on Candidates for Good Words List from Proofreaders, but other similar pages also benefit from links, so added in common header.

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/good-bad-links

Testing notes: Affected pages should be

- Ad hoc word details
- Good word candidates from Word Check
- Good word candidates from proofers
- Bad word candidates from site list
- Bad word candidates from diffs
