### PR TITLE
Do not permit Edit Task to close a task

### DIFF
--- a/SETUP/upgrade/19/20230703_clean_task_statuses.php
+++ b/SETUP/upgrade/19/20230703_clean_task_statuses.php
@@ -1,0 +1,36 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+// The following task status numbers will be set to 1 => "New":
+//   3 => "Duplicate",
+//   4 => "Fixed",
+//   5 => "Invalid",
+//   6 => "Later",
+//   7 => "None",
+//   8 => "Out of Date",
+//   9 => "Postponed",
+//   10 => "Rejected",
+//   11 => "Remind",
+//   12 => "Won't Fix",
+//   13 => "Works for Me",
+//   17 => "Implemented",
+//
+
+echo "Updating rarely used task statuses to 1 = 'New' ...\n";
+$sql = "
+    UPDATE tasks
+        SET task_status = 1
+        WHERE (task_status >= 3 AND task_status <= 13) OR task_status = 17
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/tasks.php
+++ b/tasks.php
@@ -1911,7 +1911,8 @@ function title_string_for_task($pre_task)
 // Input string must be a valid property value
 function get_property_key($value, $array)
 {
-    $key = array_search($value, $array);
-    assert($key !== false);
+    if (($key = array_search($value, $array)) === false) {
+        throw new ValueError("Bad task property value: $value");
+    }
     return $key;
 }

--- a/tasks.php
+++ b/tasks.php
@@ -152,21 +152,9 @@ asort($categories_array);
 $tasks_status_array = [
     1 => "New",
     2 => "Accepted",
-    3 => "Duplicate",
-    4 => "Fixed",
-    5 => "Invalid",
-    6 => "Later",
-    7 => "None",
-    8 => "Out of Date",
-    9 => "Postponed",
-    10 => "Rejected",
-    11 => "Remind",
-    12 => "Won't Fix",
-    13 => "Works for Me",
     14 => "Closed",
     15 => "Reopened",
     16 => "Researching",
-    17 => "Implemented",
     18 => "In Progress",
 ];
 asort($tasks_status_array);
@@ -1173,8 +1161,9 @@ function TaskForm($task)
         $tasks_status_array = [get_property_key("New", $tasks_status_array) => "New"];
     }
 
-    // Don't want to permit setting status to "Closed" when creating/editing a task
+    // Don't want to permit setting status to "Closed" or "Reopened" when creating/editing a task
     unset($tasks_status_array[get_property_key("Closed", $tasks_status_array)]);
+    unset($tasks_status_array[get_property_key("Reopened", $tasks_status_array)]);
 
     $task_summary_enc = attr_safe($task->task_summary);
     $task_details_enc = html_safe($task->task_details);

--- a/tasks.php
+++ b/tasks.php
@@ -1160,6 +1160,9 @@ function TaskForm($task)
         $tasks_status_array = [1 => "New"];
     }
 
+    // Don't want to permit setting status to 'Closed' when creating/editing a task
+    unset($tasks_status_array[14]);
+
     $task_summary_enc = attr_safe($task->task_summary);
     $task_details_enc = html_safe($task->task_details);
 


### PR DESCRIPTION
As per task #1828, tasks aren't closed properly
if their status is just set to Closed via the
Edit (or Create) Task form. It needs to be done
via the button on the main task page.

Therefore, omit Closed from the list of statuses on the Edit page.

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/close-tasks
