### PR TITLE
Disallow @s in new usernames

### DIFF
--- a/SETUP/tests/UserTest.php
+++ b/SETUP/tests/UserTest.php
@@ -124,4 +124,43 @@ class UserTest extends PHPUnit\Framework\TestCase
         $user = new User();
         $user->save();
     }
+
+
+    // Username validation tests
+
+    public function testValidRegUsername()
+    {
+        $error = check_username("oneONE1- .", true);
+        $this->assertEquals("", $error);
+    }
+
+    public function testValidNonRegUsername()
+    {
+        $error = check_username("oneONE1- .@_");
+        $this->assertEquals("", $error);
+    }
+
+    public function testInvalidUsernameTrailingSpace()
+    {
+        $error = check_username("one two ");
+        $this->assertStringContainsString("leading or trailing whitespace", $error);
+    }
+
+    public function testInvalidUsernameAdjacentSpace()
+    {
+        $error = check_username("one  two");
+        $this->assertStringContainsString("contains adjacent space characters", $error);
+    }
+
+    public function testInvalidRegUsernameUnderscore()
+    {
+        $error = check_username("one_two", true);
+        $this->assertStringContainsString("contains invalid characters", $error);
+    }
+
+    public function testInvalidRegUsernameAt()
+    {
+        $error = check_username("one@two", true);
+        $this->assertStringContainsString("contains invalid characters", $error);
+    }
 }

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -117,7 +117,7 @@ echo sprintf(_("Thank you for your interest in %s. To create an account, please 
 
 echo "<h2>" . _("Registration Hints") . "</h2>";
 echo "<ul>";
-echo "<li>" . _("Your User Name will be visible to other volunteers and cannot be changed. Please choose it carefully. We suggest that you <strong>do not use your e-mail address as a User Name</strong> since e-mail addresses can change, and you may not want to make that address viewable.") . "</li>";
+echo "<li>" . _("Your User Name will be visible to other volunteers and <strong>cannot be changed</strong>. Please choose it carefully.") . "</li>";
 echo "<li>" . sprintf(_("Please ensure that the e-mail address you provide is correct. %s will e-mail a confirmation link for you to follow in order to activate your account."), $site_name) . "</li>";
 echo "<li>" . sprintf(_("<strong>Before</strong> you submit this form, please add <i>%s</i> to your e-mail contacts list to avoid the activation e-mail being treated as spam."), $general_help_email_addr) . "</li>";
 echo "</ul>";

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -405,7 +405,7 @@ class User
 
 global $valid_username_chars_statement_for_reg_form;
 global $valid_username_chars_statement_for_elsewhere;
-$valid_username_chars_statement_for_reg_form = _("(Valid characters are: a-z A-Z 0-9 @ - . space)");
+$valid_username_chars_statement_for_reg_form = _("(Valid characters are: a-z A-Z 0-9 - . space)");
 $valid_username_chars_statement_for_elsewhere = _("(Valid characters are: a-z A-Z 0-9 @ - . _ space)");
 
 function check_username($username, $registering = false)
@@ -427,11 +427,12 @@ function check_username($username, $registering = false)
         return $error;
     }
 
-    // For new registrations, we disallow underscore (because it confuses the wiki software).
+    // For new registrations, we disallow underscore (because it confuses the wiki software)
+    // and @s to prevent people from using their emails as usernames.
     // Elsewhere, we still have to allow underscore in usernames, for pre-existing users.
     if ($registering) {
         global $valid_username_chars_statement_for_reg_form;
-        $bad_char_regex = "/[^-a-zA-Z0-9@. ]/";
+        $bad_char_regex = "/[^-a-zA-Z0-9. ]/";
         $valid_username_chars_statement = $valid_username_chars_statement_for_reg_form;
     } else {
         global $valid_username_chars_statement_for_elsewhere;


### PR DESCRIPTION
By squirrel request: to further discourage people using emails for their usernames, disallow `@`s in new registrations.

Testable in https://www.pgdp.org/~cpeel/c.branch/disallow-ats-in-new-usernames/