### PR TITLE
Rework forum code to be specific to phpBB3

### DIFF
--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -111,16 +111,16 @@ _DYN_URL=$base_url/d
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-# phpBB forum configuration
+# Forum configuration
 # -------------------------
 
-# The DP code requires phpBB for authentication. phpBB versions 3.0, 3.1,
-# 3.2, and 3.3 are currently supported.
+# The DP code uses a forum for authentication and facilitating communication
+# about projects. The following types are supported:
+#   phpbb3 -- phpBB versions 3.0, 3.1, 3.2, and 3.3
+_FORUM_TYPE=phpbb3
 
-_PHPBB_VERSION=3
-# Valid values: 3 (for phpBB 3.x)
-
-_PHPBB_TABLE_PREFIX=phpbb
+# phpBB3 forum configuration options
+#
 # Upon installation, phpBB tables are prefixed with a specific string.
 # The DP code needs to know what this prefix is in order to access the
 # tables directly.
@@ -129,10 +129,12 @@ _PHPBB_TABLE_PREFIX=phpbb
 # the database name and the prefix here. For example, if the phpBB
 # were using the 'phpbb3db' database and a prefix of 'phpbb', set this
 # value to phpbb3db.phpbb
-
-_FORUMS_DIR=$base_dir/phpBB3
-_FORUMS_URL=$base_url/phpBB3
+_PHPBB_TABLE_PREFIX=phpbb
+#
 # Locations of the phpBB code via filesystem path and URL.
+# These should not contain a trailing /
+_PHPBB_DIR=$base_dir/phpBB3
+_PHPBB_URL=$base_url/phpBB3
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/SETUP/tests/ci_configuration.sh
+++ b/SETUP/tests/ci_configuration.sh
@@ -14,10 +14,10 @@ _CODE_URL='http://localhost'
 _DYN_DIR=$HOME
 _DYN_URL='http://localhost'
 
-_PHPBB_VERSION=3
+_FORUM_TYPE=phpbb3
 _PHPBB_TABLE_PREFIX=phpbb3.phpbb
-_FORUMS_DIR=$HOME/phpBB3
-_FORUMS_URL='http://localhost/phpBB3'
+_PHPBB_DIR=$HOME/phpBB3
+_PHPBB_URL='http://localhost/phpBB3'
 
 _DEFAULT_CHAR_SUITES='[ "basic-latin" ]'
 

--- a/pinc/forum_interface.inc
+++ b/pinc/forum_interface.inc
@@ -14,6 +14,8 @@ include_once($relPath."misc.inc"); // array_get()
 // support was removed to handle the possible future case where other
 // version conditionals are needed.
 
+define('PHPBB_VERSION', '3');
+
 /*
 Important notes about using phpBB code within DP
 ------------------------------------------------
@@ -44,7 +46,8 @@ assert(PHPBB_VERSION == 3, "Only phpBB version 3 is supported");
 */
 function phpbb_table($table)
 {
-    return PHPBB_TABLE_PREFIX . "_" . $table;
+    global $forums_phpbb_table_prefix;
+    return $forums_phpbb_table_prefix . "_" . $table;
 }
 
 function phpbb_lang($locale = false)
@@ -106,7 +109,6 @@ function create_forum_user($username, $password, $email, $password_is_digested =
 // Note: Use a strict comparison operator (=== or !==) against TRUE
 // to evaluate the pass/fail status of this function.
 {
-    global $forums_dir;
     if (PHPBB_VERSION == 3) {
         // Use the phpBB3 API to create the user, but do so via phpbb3.inc
         // as to not mix the DP and phpBB3 codespace.
@@ -151,9 +153,9 @@ function login_forum_user($username, $password)
 //         'too_many_attempts'
 //         'unknown'
 {
-    global $forums_dir;
+    global $forums_phpbb_dir;
 
-    if (!is_dir($forums_dir)) {
+    if (!is_dir($forums_phpbb_dir)) {
         return false;
     }
 
@@ -168,7 +170,7 @@ function login_forum_user($username, $password)
 
     if (PHPBB_VERSION == 3) {
         global $phpbb_root_path, $phpEx;
-        $phpbb_root_path = $forums_dir."/";
+        $phpbb_root_path = $forums_phpbb_dir."/";
         $phpEx = "php";
 
         // these globals are pulled from
@@ -181,7 +183,7 @@ function login_forum_user($username, $password)
         global $phpbb_container, $phpbb_dispatcher, $table_prefix;
 
         define('IN_PHPBB', true);
-        define('ROOT_PATH', $forums_dir);
+        define('ROOT_PATH', $forums_phpbb_dir);
 
         include($phpbb_root_path . 'common.' . $phpEx);
 
@@ -236,10 +238,10 @@ function login_forum_user($username, $password)
 function logout_forum_user()
 // Log out the currently-authenticated user from the forum.
 {
-    global $forums_dir;
+    global $forums_phpbb_dir;
     global $pguser;
 
-    if (!is_dir($forums_dir)) {
+    if (!is_dir($forums_phpbb_dir)) {
         return;
     }
 
@@ -248,7 +250,7 @@ function logout_forum_user()
 
     if (PHPBB_VERSION == 3) {
         global $phpbb_root_path, $phpEx;
-        $phpbb_root_path = $forums_dir."/";
+        $phpbb_root_path = $forums_phpbb_dir."/";
         $phpEx = "php";
 
         // these globals are pulled from
@@ -261,7 +263,7 @@ function logout_forum_user()
         global $phpbb_container, $phpbb_dispatcher, $table_prefix;
 
         define('IN_PHPBB', true);
-        define('ROOT_PATH', $forums_dir);
+        define('ROOT_PATH', $forums_phpbb_dir);
 
         include($phpbb_root_path . 'common.' . $phpEx);
 
@@ -279,10 +281,8 @@ function logout_forum_user()
 
 function get_reset_password_url()
 {
-    global $forums_url;
-
     if (PHPBB_VERSION == 3) {
-        return "$forums_url/ucp.php?mode=sendpassword";
+        return get_url_for_forum() . "/ucp.php?mode=sendpassword";
     }
 }
 
@@ -442,60 +442,49 @@ function get_forum_email_address($username)
 function get_url_for_forum()
 // Return a URL to the base of the forum
 {
-    global $forums_url;
-    return $forums_url;
+    global $forums_phpbb_url;
+    return $forums_phpbb_url;
 }
 
 function get_url_for_forum_user_login()
 // Return a URL that a user can use to manually log in to the forums.
 {
-    global $forums_url;
-    return "$forums_url/ucp.php?mode=login";
+    return get_url_for_forum() . "/ucp.php?mode=login";
 }
 
 function get_url_to_compose_message_to_user($username)
 // Given a forum username, return a URL that can be used to
 // access a form to send the user a message.
 {
-    global $forums_url;
-
     $userid = get_forum_user_id($username);
 
     if (PHPBB_VERSION == 3) {
-        return "$forums_url/ucp.php?i=pm&mode=compose&u=$userid";
+        return get_url_for_forum() . "/ucp.php?i=pm&mode=compose&u=$userid";
     }
 }
 
 function get_url_to_view_forum($forum_id)
 // Given a forum id, return a URL that can be used to view the forum.
 {
-    global $forums_url;
-
-    return "$forums_url/viewforum.php?f=$forum_id";
+    return get_url_for_forum() . "/viewforum.php?f=$forum_id";
 }
 
 function get_url_to_view_topic($topic_id)
 // Given a topic id, return a URL that can be used to view the topic.
 {
-    global $forums_url;
-
-    return "$forums_url/viewtopic.php?t=$topic_id";
+    return get_url_for_forum() . "/viewtopic.php?t=$topic_id";
 }
 
 function get_url_to_view_post($post_id)
 // Given a post id, return a URL that can be used to view the post.
 {
-    global $forums_url;
-
-    return "$forums_url/viewtopic.php?p=$post_id#$post_id";
+    return get_url_for_forum() . "/viewtopic.php?p=$post_id#$post_id";
 }
 
 function get_url_for_user_avatar($username)
 // Given a forum username, return a URL that can be used to load the user's
 // avatar. If no avatar is defined, this function returns NULL.
 {
-    global $forums_url;
-
     $user_details = get_forum_user_details($username);
 
     if (empty($user_details["avatar"])) {
@@ -505,7 +494,7 @@ function get_url_for_user_avatar($username)
     if (PHPBB_VERSION == 3) {
         switch ($user_details["avatar_type"]) {
             case "avatar.driver.upload":
-                $url = "$forums_url/download/file.php?avatar=" . $user_details["avatar"];
+                $url = get_url_for_forum() . "/download/file.php?avatar=" . $user_details["avatar"];
                 break;
             case "avatar.driver.remote":
                 $url = $user_details["avatar"];
@@ -525,30 +514,24 @@ function get_url_for_user_avatar($username)
 function get_url_to_edit_profile()
 // Return a URL that can be used to edit the current user's profile.
 {
-    global $forums_url;
-
     if (PHPBB_VERSION == 3) {
-        return "$forums_url/ucp.php";
+        return get_url_for_forum() . "/ucp.php";
     }
 }
 
 function get_url_to_view_profile($user_id)
 // Return a URL that can be used to view a given user's profile.
 {
-    global $forums_url;
-
     if (PHPBB_VERSION == 3) {
-        return "$forums_url/memberlist.php?mode=viewprofile&u=$user_id";
+        return get_url_for_forum() . "/memberlist.php?mode=viewprofile&u=$user_id";
     }
 }
 
 function get_url_for_inbox()
 // Return the URL for accessing the current user's inbox.
 {
-    global $forums_url;
-
     if (PHPBB_VERSION == 3) {
-        return "$forums_url/ucp.php?i=pm&folder=inbox";
+        return get_url_for_forum() . "/ucp.php?i=pm&folder=inbox";
     }
 }
 
@@ -639,7 +622,7 @@ function get_topic_details($topic_id)
 //     forum_id         - the id of the forum the topic is in
 //     creator_username - the username of the topic creator
 {
-    global $forums_dir;
+    global $forums_phpbb_dir;
 
     $phpbb_topics = phpbb_table("topics");
     $phpbb_forums = phpbb_table("forums");
@@ -648,7 +631,7 @@ function get_topic_details($topic_id)
     // The database column used to get the total number of posts in a topic
     // changed between 3.0 and 3.1. We try to determine this automatically
     // by checking for a directory that only exists in 3.1 and later.
-    if (PHPBB_VERSION == 3 && is_dir("$forums_dir/phpbb")) {
+    if (PHPBB_VERSION == 3 && is_dir("$forums_phpbb_dir/phpbb")) {
         // 3.1 and later
         // topic_posts_approved includes the initial post in addition
         // to the replies so we need to subtract 1 to get the number of
@@ -739,9 +722,9 @@ function call_phpbb_function($func_name, $args)
         echo "call_phpbb_function( $func_name, ", print_r($args, true), ")<br>\n";
     }
 
-    global $forums_dir;
-    if (!is_dir($forums_dir)) {
-        echo "Warning: unable to call '$func_name' because \$forums_dir ($forums_dir) does not exist.\n";
+    global $forums_phpbb_dir;
+    if (!is_dir($forums_phpbb_dir)) {
+        echo "Warning: unable to call '$func_name' because \$forums_phpbb_dir ($forums_phpbb_dir) does not exist.\n";
         return;
     }
 

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -24,12 +24,12 @@ $this_is_top_level_cli_invocation = (
 if ($this_is_top_level_cli_invocation) {
     // We assume it was invoked from the pinc/ directory.
     $relPath = './';
-    include_once($relPath.'site_vars.php'); // $forums_dir, $charset
+    include_once($relPath.'site_vars.php'); // $forums_phpbb_dir, $charset
 }
 
 // PHPBB includes (from the standard installation)
 define('IN_PHPBB', true);
-$phpbb_root_path = $forums_dir.'/';
+$phpbb_root_path = $forums_phpbb_dir.'/';
 $phpEx = 'php';
 include_once($phpbb_root_path . 'common.'.$phpEx);
 include_once($phpbb_root_path . 'includes/functions_posting.'.$phpEx);
@@ -60,12 +60,12 @@ function phpbb3_create_user(
     $email,
     $lang
 ) {
-    $phpbb_table_prefix = PHPBB_TABLE_PREFIX;
+    global $forums_phpbb_table_prefix;
 
     // get the group_id for the REGISTERED user group
     global $db;
     $sql = "SELECT group_id
-            FROM {$phpbb_table_prefix}_groups
+            FROM {$forums_phpbb_table_prefix}_groups
             WHERE group_name = 'REGISTERED'
     ";
     $result = $db->sql_query($sql);
@@ -96,8 +96,6 @@ function phpbb3_create_topic(
     $poster_is_real,
     $make_poster_watch_topic
 ) {
-    $phpbb_table_prefix = PHPBB_TABLE_PREFIX;
-
     $post_result = _insert_post(
         $forum_id,
         0, // causes a new topic to be created
@@ -135,13 +133,13 @@ function phpbb3_add_post(
     $poster_name,
     $poster_is_real
 ) {
-    $phpbb_table_prefix = PHPBB_TABLE_PREFIX;
+    global $forums_phpbb_table_prefix;
 
     // Which forum is the topic in?
     global $db;
     $sql = "
         SELECT forum_id
-        FROM {$phpbb_table_prefix}_topics
+        FROM {$forums_phpbb_table_prefix}_topics
         WHERE topic_id = $topic_id
     ";
     $result = $db->sql_query($sql);
@@ -178,12 +176,11 @@ function _insert_post(
 // -- we override $user_ip;
 // -- we disable smilies
 {
-    global $charset;
+    global $charset, $forums_phpbb_table_prefix;
 
     // see: https://phpbbmodders.net/articles/3.0/create_post/
     global $db, $user, $auth;
 
-    $phpbb_table_prefix = PHPBB_TABLE_PREFIX;
 
     if ($poster_is_real) {
         $username = $poster_name;
@@ -193,7 +190,7 @@ function _insert_post(
     }
     $sql = "
         SELECT *
-        FROM {$phpbb_table_prefix}_users
+        FROM {$forums_phpbb_table_prefix}_users
         WHERE username='$username'
     ";
     $result = $db->sql_query($sql);

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -188,11 +188,11 @@ function _insert_post(
     } else {
         $username = "Anonymous";
     }
-    $sql = "
+    $sql = sprintf("
         SELECT *
         FROM {$forums_phpbb_table_prefix}_users
-        WHERE username='$username'
-    ";
+        WHERE username='%s'
+    ", $db->sql_escape($username));
     $result = $db->sql_query($sql);
     $row = $db->sql_fetchrow($result);
     if (!$row) {

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -45,10 +45,10 @@ $wikihiero_url = '<<WIKIHIERO_URL>>';
 
 $archive_projects_dir = '<<ARCHIVE_PROJECTS_DIR>>';
 
-defined('PHPBB_VERSION') or define('PHPBB_VERSION', '<<PHPBB_VERSION>>');
-defined('PHPBB_TABLE_PREFIX') or define('PHPBB_TABLE_PREFIX', '<<PHPBB_TABLE_PREFIX>>');
-$forums_dir = '<<FORUMS_DIR>>';
-$forums_url = '<<FORUMS_URL>>';
+$forum_type = '<<FORUM_TYPE>>';
+$forums_phpbb_table_prefix = '<<PHPBB_TABLE_PREFIX>>';
+$forums_phpbb_dir = '<<PHPBB_DIR>>';
+$forums_phpbb_url = '<<PHPBB_URL>>';
 
 
 $general_forum_idx                = '<<FORUMS_GENERAL_IDX>>';


### PR DESCRIPTION
This is a stepping stone to supporting more forum types than just phpBB, specifically to have a "dev only" forum shim to allow local development without installing phpBB. A follow-up PR will rename `pinc/forum_interface.inc` and it is much easier to review the changes made to that file before doing so.

The PR should have no functional changes in it.

This is in https://www.pgdp.org/~cpeel/c.branch/forum-abstraction/