### PR TITLE
Rev browse

### DIFF
--- a/SETUP/tests/manual_web/split_test/switchable_split.js
+++ b/SETUP/tests/manual_web/split_test/switchable_split.js
@@ -17,6 +17,7 @@ $(function () {
 
         function changeSplit(splitVertical) {
             theSplit.setSplit(splitVertical);
+            theSplit.reLayout();
             setSplitControls(splitVertical);
         }
 

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -190,7 +190,7 @@ var makeImageControl = function(content) {
     };
 };
 
-function makeControlDiv(container, content, controls, onChange) {
+function makeControlDiv(container, content, controls, onChange = null) {
     let barKey;
     let compassPoint;
     let begMidEnd;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -339,11 +339,6 @@ function makeControlDiv(container, content, controls, onChange) {
             fillNavBox(["", northButton, "", westButton, hideButton, eastButton, leftButton, centerButton, rightButton]);
             break;
         }
-        if(onChange) {
-            onChange.forEach(function (onChangeCallback) {
-                onChangeCallback();
-            });
-        }
     }
 
     function setBegMidEnd() {
@@ -371,6 +366,11 @@ function makeControlDiv(container, content, controls, onChange) {
         compassPoint = newP;
         saveLocation();
         setCompassPoint();
+        if(onChange) {
+            onChange.forEach(function (onChangeCallback) {
+                onChangeCallback();
+            });
+        }
         menu.hide();
     }
 

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -197,6 +197,7 @@ var viewSplitter = function(container, storageKey) {
         setSplitDirCallback.forEach(function (setSplitDirCallbackFunction) {
             setSplitDirCallbackFunction(storageKey + "-" + layout.splitDirection);
         });
+        mainSplit.reLayout();
     }
 
     function changeSplit(splitVert) {

--- a/scripts/splitControl.js
+++ b/scripts/splitControl.js
@@ -154,11 +154,9 @@ var splitControl = function(container, {splitVertical = true, splitPercent = 50,
     return {
         setSplit: function (vertical) {
             splitVertical = vertical;
-            reLayout();
         },
         setSplitPercent: function (percent) {
             splitRatio = percent / 100;
-            reLayout();
         },
         reLayout: reLayout,
         onResize: onResize,

--- a/tools/project_manager/show_word_context.js
+++ b/tools/project_manager/show_word_context.js
@@ -35,6 +35,7 @@ window.addEventListener("DOMContentLoaded", function() {
     switchLink.addEventListener("click", function () {
         splitVertical = !splitVertical;
         mainSplit.setSplit(splitVertical);
+        mainSplit.reLayout();
         setSplitLink();
         layout.splitDirection = splitVertical ? "vertical" : "horizontal";
         saveLayout();


### PR DESCRIPTION
This avoids unnecessary multiple calls to splitControl.reLayout.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/rev_browse

This should not make any visible changes to functionality. The split control is used in the page browser and in show word context.