### PR TITLE
Use different pattern for callback functions

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -1,7 +1,7 @@
 /*global $ texts */
 /* exported makeImageWidget */
 
-function makeControlDiv(container, content, controls, onChange = null) {
+function makeControlDiv(container, content, controls) {
     let barKey;
     let compassPoint;
     let begMidEnd;
@@ -173,15 +173,14 @@ function makeControlDiv(container, content, controls, onChange = null) {
         menu.hide();
     });
 
+    let onChange = new Set();
     function newPoint(newP) {
         compassPoint = newP;
         saveLocation();
         setCompassPoint();
-        if(onChange) {
-            onChange.forEach(function (onChangeCallback) {
-                onChangeCallback();
-            });
-        }
+        onChange.forEach(function (onChangeCallback) {
+            onChangeCallback();
+        });
         menu.hide();
     }
 
@@ -252,6 +251,7 @@ function makeControlDiv(container, content, controls, onChange = null) {
             setCompassPoint();
             setBegMidEnd();
         },
+        onChange: onChange,
     };
 }
 

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -1,7 +1,7 @@
 /*global $ proofIntData ajax splitControl makeImageWidget makeControlDiv */
 /* exported pageBrowse */
 
-function makeTextWidget(container, splitter = false, onResize = null) {
+function makeTextWidget(container, splitter = false) {
     const textArea = document.createElement("textarea");
     textArea.classList.add("text-pane");
     textArea.readOnly = !splitter;
@@ -69,7 +69,7 @@ function makeTextWidget(container, splitter = false, onResize = null) {
 
     const content = $("<div>");
     const controls = [fontFaceSelector, fontSizeSelector, wrapControl];
-    const controlDiv = makeControlDiv(container, content, controls, onResize);
+    const controlDiv = makeControlDiv(container, content, controls);
     let subSplitter;
     let splitterKey;
     let textSplitData;
@@ -79,9 +79,7 @@ function makeTextWidget(container, splitter = false, onResize = null) {
         content.append(topTextDiv, bottomTextDiv);
 
         subSplitter = splitControl(content, {splitVertical: false});
-        if(onResize) {
-            onResize.add(subSplitter.reLayout);
-        }
+        controlDiv.onChange.add(subSplitter.reLayout);
 
         subSplitter.onDragEnd.add(function (percent) {
             textSplitData.splitPercent = percent;
@@ -138,7 +136,13 @@ function makeTextWidget(container, splitter = false, onResize = null) {
             textArea.value = text;
             textArea.scrollTop = 0;
             textArea.scrollLeft = 0;
-        }
+        },
+
+        reLayout: function () {
+            if(splitter) {
+                subSplitter.reLayout();
+            }
+        },
     };
 }
 
@@ -445,7 +449,8 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                             const theSplitter = viewSplitter(stretchDiv, storageKey);
                             if(mentorMode) {
                                 // make a text widget with splitter
-                                textWidget = makeTextWidget(textDiv, true, theSplitter.mainSplit.onResize);
+                                textWidget = makeTextWidget(textDiv, true);
+                                theSplitter.mainSplit.onResize.add(textWidget.reLayout);
                             } else {
                                 textWidget = makeTextWidget(textDiv);
                             }


### PR DESCRIPTION
Use a more uniform pattern for callback functions. Following the model of `window.addEventListener("resize", function)`, let the function (call it A) which initiates the event return a `Set` of functions (possibly initially empty) and let it call each of them when the event occurs. The code which calls function A can add any functions to the set which it wishes to be called when the event occurs. The events are typically something which causes a window to change its size.
This should make it easier to add new cases where an action has to be taken when the event occurs.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/event_callback

This should not change any functionality. The changed code is used in the page browser and the image_widget in the proofreading interface.