### PR TITLE
Remove error_reporting() overrides

### DIFF
--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -10,8 +10,6 @@ include_once($relPath.'misc.inc'); // startswith
 
 use voku\helper\UTF8;
 
-error_reporting(-1);
-
 $_character_data = [
 
     // basic latin

--- a/pinc/project_trans.inc
+++ b/pinc/project_trans.inc
@@ -13,8 +13,6 @@ function project_transition($projectid, $new_state, $who, $extras = [])
 {
     global $testing;
 
-    // error_reporting(E_ALL);
-
     $project = new Project($projectid);
 
     $current_state = $project->state;

--- a/project.php
+++ b/project.php
@@ -26,8 +26,6 @@ include_once($relPath.'special_colors.inc'); // load_special_days
 
 // If the requestor is not logged in, we refer to them as a "guest".
 
-error_reporting(E_ALL);
-
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 // Usually, the user arrives here by clicking on the title of a project

--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -6,6 +6,8 @@ include_once($relPath.'release_queue.inc');
 
 function autorelease()
 {
+    // autorelease is called via cron and output is never shown to end-users
+    // so it's safe to enable full error reporting here
     error_reporting(E_ALL);
 
     echo "<pre>\n";


### PR DESCRIPTION
In general, code should not override error reporting configuration set by the system because this could reveal information to users that they should not see.

TEST has very verbose error reporting (E_ALL) whereas PROD has a the recommended smaller set (E_ALL & ~E_DEPRECATED & ~E_STRICT)