### PR TITLE
Basic latin character suite modifications

### DIFF
--- a/pinc/charsuite-basic-latin.inc
+++ b/pinc/charsuite-basic-latin.inc
@@ -12,22 +12,22 @@ $charsuite->codepoints = [
     'U+00a1-U+00ac',
     'U+00ae-U+00ff',
     // codepoints that map to Windows-1252 + extras
-    'U+0128', // [~I] (not in Windows-1252)
-    'U+0129', // [~i] (not in Windows-1252)
-    'U+0152', // OE ligature
-    'U+0153', // oe ligature
-    'U+0160', // [vS]
-    'U+0161', // [vs]
-    'U+0168', // [~U] (not in Windows-1252)
-    'U+0169', // [~u] (not in Windows-1252)
-    'U+017d', // [vZ]
-    'U+017e', // [vz]
-    'U+0178', // [:Y]
-    'U+0192', // latin small letter f with hook florin
-    'U+1ebc', // [~E] (not in Windows-1252)
-    'U+1ebd', // [~e] (not in Windows-1252)
-    'U+2039', // open single guillemet
-    'U+203a', // close single guillemet
+    'U+0128', // Ĩ - I with tilde (not in Windows-1252)
+    'U+0129', // ĩ - i with tilde (not in Windows-1252)
+    'U+0152', // Œ - OE ligature
+    'U+0153', // œ - oe ligature
+    'U+0160', // Š - S with caron
+    'U+0161', // š - s with caron
+    'U+0168', // Ũ - U with tilde (not in Windows-1252)
+    'U+0169', // Ũ - u with tilde (not in Windows-1252)
+    'U+0178', // Ÿ - Y with diaeresis
+    'U+017d', // Ž - Z with caron
+    'U+017e', // ž - z with caron
+    'U+0192', // ƒ - latin small letter f with hook florin
+    'U+1ebc', // Ẽ - E with tilde (not in Windows-1252)
+    'U+1ebd', // ẽ - e with tilde (not in Windows-1252)
+    'U+2039', // ‹ - single left-pointing guillemet
+    'U+203a', // › - single right-pointing guillemet
 ];
 $charsuite->reference_urls = [
     "https://en.wikipedia.org/wiki/Basic_Latin_(Unicode_block)",

--- a/pinc/charsuite-basic-latin.inc
+++ b/pinc/charsuite-basic-latin.inc
@@ -11,15 +11,21 @@ $charsuite->codepoints = [
     // without the soft hyphen
     'U+00a1-U+00ac',
     'U+00ae-U+00ff',
-    // codepoints that map to Windows-1252
+    // codepoints that map to Windows-1252 + extras
+    'U+0128', // [~I] (not in Windows-1252)
+    'U+0129', // [~i] (not in Windows-1252)
     'U+0152', // OE ligature
     'U+0153', // oe ligature
     'U+0160', // [vS]
     'U+0161', // [vs]
+    'U+0168', // [~U] (not in Windows-1252)
+    'U+0169', // [~u] (not in Windows-1252)
     'U+017d', // [vZ]
     'U+017e', // [vz]
     'U+0178', // [:Y]
     'U+0192', // latin small letter f with hook florin
+    'U+1ebc', // [~E] (not in Windows-1252)
+    'U+1ebd', // [~e] (not in Windows-1252)
     'U+2039', // open single guillemet
     'U+203a', // close single guillemet
 ];
@@ -47,14 +53,14 @@ $pickerset->add_subset("ˆ", [
 ], _("Letters with acute, grave, and circumflex"));
 $pickerset->add_subset("~", [
     [
-        'U+00c3', 'U+00d1', 'U+00d5', 'U+00c4', 'U+00cb', 'U+00cf', 'U+00d6',
-        'U+00dc', 'U+0178', 'U+00c5-U+00c7', 'U+00d0', 'U+00d8', 'U+0152',
-        null, 'U+00de',
+        'U+00c3', 'U+1ebc', 'U+0128', 'U+00d1', 'U+00d5', 'U+0168', 'U+00c4',
+        'U+00cb', 'U+00cf', 'U+00d6', 'U+00dc', 'U+0178', 'U+00c5-U+00c7',
+        'U+00d0', 'U+00d8', 'U+0152', null, 'U+00de',
     ],
     [
-        'U+00e3', 'U+00f1', 'U+00f5', 'U+00e4', 'U+00eb', 'U+00ef', 'U+00f6',
-        'U+00fc', 'U+00ff', 'U+00e5-U+00e7', 'U+00f0', 'U+00f8', 'U+0153',
-        'U+00df', 'U+00fe',
+        'U+00e3', 'U+1ebd', 'U+0129', 'U+00f1', 'U+00f5', 'U+0169', 'U+00e4',
+        'U+00eb', 'U+00ef', 'U+00f6', 'U+00fc', 'U+00ff', 'U+00e5-U+00e7',
+        'U+00f0', 'U+00f8', 'U+0153', 'U+00df', 'U+00fe',
     ],
 ], _("Letters with tilde and diaeresis; miscellaneous"));
 $pickerset->add_subset("!", [

--- a/pinc/charsuite-basic-latin.inc
+++ b/pinc/charsuite-basic-latin.inc
@@ -51,6 +51,7 @@ $pickerset->add_subset("ˆ", [
         'U+00f4', 'U+00fb',
     ],
 ], _("Letters with acute, grave, and circumflex"));
+
 $pickerset->add_subset("~", [
     [
         'U+00c3', 'U+1ebc', 'U+0128', 'U+00d1', 'U+00d5', 'U+0168', 'U+00c4',
@@ -63,6 +64,7 @@ $pickerset->add_subset("~", [
         'U+00f0', 'U+00f8', 'U+0153', 'U+00df', 'U+00fe',
     ],
 ], _("Letters with tilde and diaeresis; miscellaneous"));
+
 $pickerset->add_subset("!", [
     [
         'U+0021', 'U+003f', 'U+002e', 'U+002c', 'U+003a', 'U+003b', 'U+0028-U+0029',
@@ -73,25 +75,27 @@ $pickerset->add_subset("!", [
         'U+00bb', 'U+2039', 'U+203a', 'U+007b', 'U+007d', 'U+002f', 'U+002d',
     ],
 ], _("Punctuation"));
+
 $pickerset->add_subset(UTF8::hex_to_chr("U+00b6"), [
     [
-        'U+00b6', 'U+00b7', 'U+00aa', 'U+00ba', 'U+007c', 'U+00a6', 'U+0024',
-        'U+00a2-U+00a5', 'U+0192',
+        'U+00b6', 'U+00b7', 'U+0024', 'U+00a2-U+00a5', 'U+0192',
     ],
     [
-        'U+00a7', 'U+00a9', 'U+00ae', null, 'U+005f', 'U+00b4', 'U+0060',
-        'U+005e', 'U+007e', 'U+00af', 'U+00a8', 'U+00b8',
+        'U+007c', 'U+00a6', 'U+00a7', 'U+00a9', 'U+00ae', 'U+005f',
+        'U+005e', 'U+007e',
     ],
 ], _("Symbols and Currency"));
+
 $pickerset->add_subset("1", [
     [
-        'U+0030-U+0039', 'U+0023', 'U+0025', 'U+00b0',
+        'U+0030-U+0039',
     ],
     [
-        'U+00b9', 'U+00b2-U+00b3', 'U+00bc-U+00be', 'U+002b', 'U+002d', 'U+003d',
+        'U+0023', 'U+0025', 'U+00b0', 'U+002b', 'U+002d', 'U+003d',
         'U+00d7', 'U+00f7', 'U+00b1', 'U+00ac',
     ],
 ], _("Numbers and Math"));
+
 $charsuite->pickerset = $pickerset;
 
 CharSuites::add($charsuite);


### PR DESCRIPTION
The first commit adds `Ẽ`, `ẽ`, `Ĩ`, `ĩ`, `Ũ`, and `ũ` to Basic Latin, and the appropriate picker set, completing the set of vowels with tilde above.

The second commit removes the superscript numbers, fractions, ordinals and standalone diacritical marks from the picker sets. This is a removal from the picker sets, only; the characters will still be valid for Basic Latin.

Compare [the new version in my sandbox](https://www.pgdp.org/~srjfoo/c.branch/basic-latin-mods/tools/charsuites.php?charsuite=basic-latin ) with [the currently deployed version](https://www.pgdp.net/c/tools/charsuites.php?charsuite=basic-latin).