### PR TITLE
Update DB schema tooling

### DIFF
--- a/SETUP/check_db_schema.template
+++ b/SETUP/check_db_schema.template
@@ -62,6 +62,7 @@ echo "
 
     # String values
     _DEFAULT_CHAR_SUITES='[ \"basic-latin\" ]'
+    _PHPMAILER_SMTP_CONFIG='[]'
 
     # For update_phpbb_posts_text.php
     _FORUMS_PROJECT_WAITING_IDX=99

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -1,3 +1,5 @@
+# Disable foreign key checks to until all tables are created
+SET FOREIGN_KEY_CHECKS=0;
 
 #
 # Table structure for table `access_log`
@@ -775,6 +777,23 @@ CREATE TABLE `user_teams` (
 # --------------------------------------------------------
 
 #
+# Table structure for table `user_teams_membership`
+#
+# Creation:
+# Last update:
+#
+
+CREATE TABLE `user_teams_membership` (
+  `u_id` int(11) unsigned NOT NULL,
+  `t_id` int(11) unsigned NOT NULL,
+  PRIMARY KEY (`u_id`,`t_id`),
+  KEY (`t_id`),
+  FOREIGN KEY (`u_id`) REFERENCES `users` (`u_id`),
+  FOREIGN KEY (`t_id`) REFERENCES `user_teams` (`id`)
+);
+# --------------------------------------------------------
+
+#
 # Table structure for table `users`
 #
 # Creation:
@@ -810,23 +829,6 @@ CREATE TABLE `users` (
   KEY `t_last_activity` (`t_last_activity`),
   KEY `api_key_username` (`api_key`,`username`),
   KEY `email` (`email`)
-);
-# --------------------------------------------------------
-
-#
-# Table structure for table `user_teams_membership`
-#
-# Creation:
-# Last update:
-#
-
-CREATE TABLE `user_teams_membership` (
-  `u_id` int(11) unsigned NOT NULL,
-  `t_id` int(11) unsigned NOT NULL,
-  PRIMARY KEY (`u_id`,`t_id`),
-  KEY (`t_id`),
-  FOREIGN KEY (`u_id`) REFERENCES `users` (`u_id`),
-  FOREIGN KEY (`t_id`) REFERENCES `user_teams` (`id`)
 );
 # --------------------------------------------------------
 
@@ -867,4 +869,7 @@ CREATE TABLE `wordcheck_events` (
   KEY `pc_compound` (`projectid`,`timestamp`,`image`)
 );
 # --------------------------------------------------------
+
+# Re-enable foreign key checks
+SET FOREIGN_KEY_CHECKS=1;
 

--- a/SETUP/dump_db_schema.template
+++ b/SETUP/dump_db_schema.template
@@ -96,6 +96,12 @@ get_table_names()
 tables=`get_table_names`
 
 if true; then
+    # The order tables are dumped is not consistent and it's possible to have
+    # tables with foreign keys before the foreign key tables are created.
+    # To make sure the dump is loadable, we have to temporarily disable
+    # foreign key checks for this session.
+    echo "SET FOREIGN_KEY_CHECKS=0;"
+
     mysqldump --user=$db_user --password="$db_password" \
         --no-data --quote-names --add-drop-table=FALSE --force \
         $db_name $tables |
@@ -119,5 +125,7 @@ if true; then
     # Skip MySQL command sequences as they may be version-specific
     # (and generate a lot of noise in the diffs).
     grep -v '/*!'
+
+    # Re-enable foreign key checks
+    echo "SET FOREIGN_KEY_CHECKS=1;"
 fi
-# vim: sw=4 ts=4 expandtab ai

--- a/SETUP/install_db.php
+++ b/SETUP/install_db.php
@@ -18,6 +18,7 @@ if (!DPDatabase::get_connection()) {
 
 DPDatabase::query("CREATE DATABASE IF NOT EXISTS $db_name");
 DPDatabase::query("USE $db_name");
+DPDatabase::query("SET FOREIGN_KEY_CHECKS=0");
 
 // Declare all variables
 $db_schema = "db_schema.sql";
@@ -49,5 +50,7 @@ while ($lines = array_shift($array)) {
     echo "Running stanza: " . substr(trim($lines), 0, 50) . " ...\n";
     DPDatabase::query($lines);
 }
+
+DPDatabase::query("SET FOREIGN_KEY_CHECKS=1");
 
 echo "Tables have been created.\n";


### PR DESCRIPTION
The `dump_db_schema` script is used in concert with `check_db_schema` during a code release to ensure that the prior release + new upgrade scripts = what's currently in the DB. The order mysqldump outputs tables is inconsistent and there's no guarantee that the tables will be output in an order that allows them to be created due to foreign key constraints.

@chrismiceli addressed this for the `users` table in a54b13b266317a477c0e15f78f4b590719811a30 for initial creation, but we still have that problem during the pre-release check. This PR rolls back Chris' commit and uses the `FOREIGN_KEY_CHECKS` variable to control how the checks are managed. This is another belt-and-suspenders approach where we make the changes in `db_schema.sql` (in case someone wants to just load it directly as it _is_ valid SQL), `install_db.php` which is how users are directed to load the schema, and in `dump_db_schema.template` so that it outputs SQL that can actually be loaded.

This is all non-live code and I have tested it all locally as part of my pre-release work. I'm looking for "does this pass the sniff test" review.