### PR TITLE
Update the CHANGELOG for the upcoming R202309 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,11 +7,25 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
-## R......
+## R202309
+Scripts supporting this upgrade are in `SETUP/upgrade/19`
 
 **This is the last release to include support for the original DP session
 management with cookies. Future releases will only support PHP sessions
 (the default since before 2004).**
+
+* Emails are now sent with PHPMailer enabling HTML emails (windymilla)
+  * Configure with `_PHPMAILER_SMTP_CONFIG` in `configuration.sh`
+* Updates to the forum abstraction code (cpeel)
+  * _The following variables in `configuration.sh` have changed._
+    * `_FORUMS_DIR` is now `_PHPBB_DIR`
+    * `_FORUMS_URL` is now `_PHPBB_URL`
+* API responses now include error numbers (70ray)
+* Some accented vowels added to Basic Latin character suite (srjfoo)
+* Event notifications are now sent in receiver's language (windymilla)
+* Numerous improvements for PP and PPV (windymilla)
+* Reduce jQuery dependency (chrismiceli)
+* Numerous bugfixes and improvements (windymilla, 70ray)
 
 ## R202303
 No scripts are required for this upgrade.

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -102,6 +102,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/16/
 * c/SETUP/upgrade/17/
 * c/SETUP/upgrade/18/
+* c/SETUP/upgrade/19/
 
 ### Upgrading from release R202102
 Run the scripts in the following directories in order
@@ -109,20 +110,25 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/16/
 * c/SETUP/upgrade/17/
 * c/SETUP/upgrade/18/
+* c/SETUP/upgrade/19/
 
 ### Upgrading from release R202109
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/17/
 * c/SETUP/upgrade/18/
+* c/SETUP/upgrade/19/
 
 ### Upgrading from release R202202
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/18/
+* c/SETUP/upgrade/19/
 
-### Upgrading from release R202209
-No upgrade scripts are required for this release.
+### Upgrading from release R202209 or R202303
+Run the scripts in the following directories in order
+
+* c/SETUP/upgrade/19/
 
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -6,11 +6,7 @@ release.
 
 ## Back up your data
 Before doing an upgrade, back up your data. The most important data
-is the one in your database. You can dump that data from within the
-existing installation with:
-```bash
-c/SETUP/dump_db_schema > somewhere/pre_upgrade_db_schema
-```
+is the one in your database.
 
 You should also back up your `projects/` directory.
 


### PR DESCRIPTION
Update the `CHANGELOG.md` file for the upcoming R202309 release happening next month. I'll hold off getting this in until just before the release but wanted to get the doc updates out for review.

A reminder that we only call out the "highlights" in the changelog and rely on the git history for the details. That said, I'm open to suggestions on if this hits the right balance or if things should be added or removed!