### PR TITLE
Update MediaWiki extensions to support MW 1.39

### DIFF
--- a/SETUP/MediaWiki_extensions/README.md
+++ b/SETUP/MediaWiki_extensions/README.md
@@ -1,6 +1,6 @@
 # MediaWiki Extensions
 These MediaWiki extensions enable the use of Magic Tags to show project
-information on a wiki page.
+information on a wiki page. These extensions support MediaWiki 1.32 and later.
 
 ## Requirements
 These assume that the MediaWiki tables and the DP tables are running in the
@@ -13,9 +13,10 @@ To use them:
 1. Copy the files to your MediaWiki `extensions/` directory
 2. Edit the files and update `$relPath` to point to your DP `c/pinc/` directory
 3. Add the following lines to your MediaWiki `LocalSettings.php` file:
-
+```php
     require_once('extensions/dpExtensions.php');
     require_once('extensions/hospitalExtensions.php');
+```
 
 ## Magic Tags provided
 The following magic tags are provided:

--- a/SETUP/MediaWiki_extensions/dpExtensions.php
+++ b/SETUP/MediaWiki_extensions/dpExtensions.php
@@ -34,8 +34,8 @@ $wgExtensionFunctions[] = "wfProjectInfo";
 
 function wfPgFormats()
 {
-    global $wgParser;
-    $wgParser->setHook("pg_formats", "getPgFormats");
+    $parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
+    $parser->setHook("pg_formats", "getPgFormats");
 }
 
 function getPgFormats($input, $argv)
@@ -85,8 +85,8 @@ function getPgFormats($input, $argv)
 
 function wfProjectInfo()
 {
-    global $wgParser;
-    $wgParser->setHook("projectinfo", "showProjectInfo");
+    $parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
+    $parser->setHook("projectinfo", "showProjectInfo");
 }
 
 function showProjectInfo($input, $argv, $parser)

--- a/SETUP/MediaWiki_extensions/hospitalExtensions.php
+++ b/SETUP/MediaWiki_extensions/hospitalExtensions.php
@@ -33,8 +33,8 @@ $wgExtensionFunctions[] = "wfHospitalInfo";
 
 function wfHospitalInfo()
 {
-    global $wgParser;
-    $wgParser->setHook("hospital_info", "listHospitalProjects");
+    $parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
+    $parser->setHook("hospital_info", "listHospitalProjects");
 }
 
 function listHospitalProjects($input, $argv)


### PR DESCRIPTION
Update the DP MediaWiki extensions to support MediaWiki 1.32 and later, including 1.39 which is the latest LTS.

The `$wgParser` global is reportedly [just deprecated](https://www.mediawiki.org/wiki/Manual:$wgParser), but it actually refused to work after I upgraded MW to 1.39 on test, so move to the format that works with 1.32 and later.

Proof that they now work at https://www.pgdp.org/wiki/User:Cpeel/MediaWiki_Extensions