### PR TITLE
Rev Google Font URLs

### DIFF
--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v26/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v26/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v26/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -146,7 +146,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(https://fonts.gstatic.com/s/ebgaramond/v26/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
+  src: url(https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUAw.ttf) format('truetype');
 }
 /* ======================================================================== */
 /* Page Interface Structures */


### PR DESCRIPTION
It's that time for another Google font URL update. Last one was in Apr 2022 which isn't so bad.

Sandbox at https://www.pgdp.org/~cpeel/c.branch/rev-google-font-urls/