### PR TITLE
Rename user.id to user.reg_token

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -801,7 +801,7 @@ CREATE TABLE `user_teams_membership` (
 #
 
 CREATE TABLE `users` (
-  `id` varchar(50) NOT NULL default '',
+  `reg_token` varchar(50) NOT NULL default '',
   `real_name` varchar(100) NOT NULL default '',
   `username` varchar(25) NOT NULL default '',
   `email` varchar(100) NOT NULL default '',

--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -10,25 +10,7 @@ class SettingsTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        // Attempt to load our test user, if it exists don't create it
-        $sql = "SELECT username FROM users WHERE username = '$this->TEST_USERNAME'";
-        $result = DPDatabase::query($sql);
-        $row = mysqli_fetch_assoc($result);
-        if (!$row) {
-            $sql = "
-                INSERT INTO users
-                SET id = '$this->TEST_USERNAME',
-                    real_name = '$this->TEST_USERNAME',
-                    username = '$this->TEST_USERNAME',
-                    email = '$this->TEST_USERNAME@localhost'
-            ";
-            $result = DPDatabase::query($sql);
-            if (!$result) {
-                throw new Exception("Unable to create test user");
-            }
-        } else {
-            mysqli_free_result($result);
-        }
+        create_test_user($this->TEST_USERNAME);
 
         // Now create the usersettings record
         $sql = sprintf("
@@ -49,11 +31,7 @@ class SettingsTest extends PHPUnit\Framework\TestCase
         ", $this->TEST_USERNAME, $this->PREFIX);
         DPDatabase::query($sql);
 
-        $sql = "
-            DELETE FROM users
-            WHERE id = '$this->TEST_USERNAME'
-        ";
-        DPDatabase::query($sql);
+        delete_test_user($this->TEST_USERNAME);
     }
 
     public function testExisting()

--- a/SETUP/tests/phpunit_test_helpers.inc
+++ b/SETUP/tests/phpunit_test_helpers.inc
@@ -6,7 +6,7 @@ function create_test_user($username, $age = 0)
     // Attempt to load our test user, replace if it exists
     $sql = sprintf("
         REPLACE INTO users
-        SET id = '%1\$s',
+        SET reg_token = '%1\$s',
             real_name = '%1\$s',
             username = '%1\$s',
             email = '%1\$s@localhost',
@@ -45,7 +45,7 @@ function delete_test_user($username)
     // remove the test user
     $sql = sprintf("
         DELETE FROM users
-        WHERE id = '%s'
+        WHERE username = '%s'
     ", DPDatabase::escape($username));
     $result = DPDatabase::query($sql);
     if (!$result) {

--- a/SETUP/upgrade/20/20230920_update_user_table.php
+++ b/SETUP/upgrade/20/20230920_update_user_table.php
@@ -1,0 +1,18 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Renaming users.id to users.reg_token\n";
+$sql = "
+    ALTER TABLE users RENAME COLUMN id TO reg_token
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -18,14 +18,14 @@ class User
 
     // List of fields that when set for a user should never change
     private $immutable_fields = [
-        "id",
+        "reg_token",
         "username",
         "u_id",
     ];
 
     // Fields are assumed to be integers unless included here
     private $string_fields = [
-        "id",
+        "reg_token",
         "real_name",
         "username",
         "email",
@@ -319,12 +319,12 @@ class User
         return $user;
     }
 
-    // Load a User record by registration token (ie: the 'id' column)
-    // e.g. $user = User::load_from_registration_token($id);
-    public static function load_from_registration_token($id)
+    // Load a User record by registration token
+    // e.g. $user = User::load_from_registration_token($reg_token);
+    public static function load_from_registration_token($reg_token)
     {
         $user = new User();
-        $user->load('id', $id);
+        $user->load('reg_token', $reg_token);
         return $user;
     }
 

--- a/pinc/new_user_mails.inc
+++ b/pinc/new_user_mails.inc
@@ -12,7 +12,7 @@ include_once($relPath.'forum_interface.inc');
 // This is because this function may be called by a site admin to send
 // a mail to a completely different user (e.g. a Polish user shouldn't
 // get a Spanish mail because one of the site admins is Spanish).
-function send_activate_mail($email, $real_name, $ID, $username, $u_intlang)
+function send_activate_mail($email, $real_name, $reg_token, $username, $u_intlang)
 {
     global $code_url, $site_name;
 
@@ -27,7 +27,7 @@ function send_activate_mail($email, $real_name, $ID, $username, $u_intlang)
 
         To complete your registration, please visit this URL:
 
-        $code_url/accounts/activate.php?id=$ID
+        $code_url/accounts/activate.php?reg_token=$reg_token
 
         We require this confirmation step to prevent someone from registering
         an account in your name without your knowledge. If you do not follow


### PR DESCRIPTION
The `id` column of the `users` table is horribly misnamed as it is only ever used as the account registration token and not an ID.

Like with many things, I encountered / stumbled over this while trying to do something else and decided I'd just take time to fix it for future-me and others. The DB changes have been already applied to TEST so account registration is testable in the following sandbox, but will fail on TEST outside of the sandbox.

https://www.pgdp.org/~cpeel/c.branch/rename-reg-token-column/

