### PR TITLE
Move PM view preferences to user_settings table

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -814,7 +814,6 @@ CREATE TABLE `users` (
   `http_referrer` varchar(256) NOT NULL DEFAULT '',
   `u_neigh` tinyint(4) NOT NULL default '0',
   `u_align` tinyint(1) NOT NULL default '0',
-  `i_prefs` tinyint(1) default '0',
   `i_theme` varchar(100) NOT NULL default 'project_gutenberg',
   `u_id` int(10) unsigned NOT NULL auto_increment,
   `u_profile` int(10) unsigned NOT NULL default '0',

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -816,7 +816,6 @@ CREATE TABLE `users` (
   `u_align` tinyint(1) NOT NULL default '0',
   `i_prefs` tinyint(1) default '0',
   `i_theme` varchar(100) NOT NULL default 'project_gutenberg',
-  `i_pmdefault` smallint(1) NOT NULL default '0',
   `u_id` int(10) unsigned NOT NULL auto_increment,
   `u_profile` int(10) unsigned NOT NULL default '0',
   `u_intlang` varchar(25) default '',

--- a/SETUP/upgrade/20/20230920_drop_i_prefs_column.php
+++ b/SETUP/upgrade/20/20230920_drop_i_prefs_column.php
@@ -1,0 +1,19 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Dropping users.i_prefs column\n";
+$sql = "
+    ALTER TABLE users
+    DROP COLUMN i_prefs
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/SETUP/upgrade/20/20230920_move_pmdefault_to_usersettings.php
+++ b/SETUP/upgrade/20/20230920_move_pmdefault_to_usersettings.php
@@ -1,0 +1,33 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+$pm_view_options = [
+    0 => "user_all",
+    1 => "user_active",
+    2 => "blank",
+];
+
+$pms = Settings::get_users_with_setting("manager", "yes");
+
+foreach ($pms as $pm) {
+    $user = new User($pm);
+    $user_settings = new Settings($pm);
+    $user_settings->set_value("pm_view", $pm_view_options[$user->i_pmdefault]);
+}
+
+echo "Dropping users.i_pmdefault column\n";
+$sql = "
+    ALTER TABLE users
+    DROP COLUMN i_pmdefault
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -16,16 +16,8 @@ include_once('projectmgr.inc'); // echo_manager_links();
 require_login();
 
 $user = User::load_current();
-switch ($user->i_pmdefault) {
-    case 0:
-        $default_view = "user_all";
-        break;
-    case 1:
-        $default_view = "user_active";
-        break;
-    default:
-        $default_view = "blank";
-}
+$user_settings = Settings::get_Settings($user->username);
+$default_view = $user_settings->get_value("pm_view", "user_all");
 
 try {
     $show_view = get_enumerated_param($_GET, 'show', $default_view,

--- a/userprefs.php
+++ b/userprefs.php
@@ -382,7 +382,6 @@ function save_general_tab($user)
     $input_numeric_fields = ["u_align", "u_neigh", "u_privacy"];
 
     $update_string = _create_mysql_update_string($_POST, $input_string_fields, $input_numeric_fields);
-    $update_string .= ", i_prefs=1";
 
     $users_query = "
         UPDATE users

--- a/userprefs.php
+++ b/userprefs.php
@@ -691,15 +691,19 @@ function echo_pm_tab($user)
 {
     global $userSettings;
 
-    $i_pm = [_("All Projects"), _("Active Projects"), _("Basic Page")];
+    $pm_view_options = [
+        "user_all" => _("All Projects"),
+        "user_active" => _("Active Projects"),
+        "blank" => _("Basic Page"),
+    ];
 
     echo "<tr>\n";
     show_preference(
         // TRANSLATORS: PM = project manager
-        _('Default PM Page'), 'i_pmdefault', 'pmdefault',
-        $user->i_pmdefault,
+        _('Default PM Page'), 'pm_view', 'pmdefault',
+        $userSettings->get_value('pm_view', "user_all"),
         'dropdown',
-        $i_pm
+        $pm_view_options
     );
     echo "</tr>\n";
 
@@ -732,19 +736,9 @@ function save_pm_tab($user)
 {
     global $userSettings;
 
-    // set users values
-    $input_string_fields = [];
-    //  i_pmdefault is "Default PM Page"
-    $input_numeric_fields = ["i_pmdefault"];
+    // persist the default view for the PM's page
 
-    $update_string = _create_mysql_update_string($_POST, $input_string_fields, $input_numeric_fields);
-
-    $users_query = "
-        UPDATE users
-        SET $update_string
-        WHERE u_id = $user->u_id
-    ";
-    DPDatabase::query($users_query);
+    $userSettings->set_value('pm_view', $_POST["pm_view"]);
 
     // remember if the PM wants to be automatically signed up for email notifications of
     // replies made to their project threads


### PR DESCRIPTION
The `users.i_pmdefault` setting is only applicable to PMs so move the setting to the `user_settings` table rather than in the table for all users. This follows the pattern we user for other PM-specific settings and further simplifies the user table to be applicable to all users.

Also remove the unused and unreferenced `users.i_perfs` column. The only thing I think this is currently tracking is if the user has saved their preferences at any point and that doesn't seem useful.

Testable in the https://www.pgdp.org/~cpeel/c.branch/move-pm-pref-to-usersettings/ sandbox.

_Note that the new setting has been populated on the TEST system but the column has not yet been dropped from the `users` table. After this PR is approved I'll confirm than the update script works in-full rather than just the data population half._