### PR TITLE
Make main page completed numbers consistent

### DIFF
--- a/list_etexts.php
+++ b/list_etexts.php
@@ -16,6 +16,7 @@ if ($x == "g") {
     $type = "gold";
     $title = _("Completed Gold E-Texts");
     $state = SQL_CONDITION_GOLD;
+    $group_clause = "GROUP BY postednum";
     $info = [
         _("Below is the list of Gold e-texts that have been produced on this site. Gold e-texts are books that have passed through all phases of proofreading, formatting, and post-processing. They have been submitted to Project Gutenberg and are now available for your enjoyment and download."),
         _("These e-texts are the product of hundreds of hours of labor donated by all of our volunteers. The list is sorted with the most recently submitted e-texts at the top. You can sort them based upon your own preferences by clicking below. Enjoy!!"),
@@ -25,6 +26,7 @@ if ($x == "g") {
     $type = "silver";
     $title = _("In Progress Silver E-Texts");
     $state = SQL_CONDITION_SILVER;
+    $group_clause = "";
     $info = [
         _("Below is the list of Silver e-texts that have almost completed processing on our site. Silver e-texts are books that have passed through all phases of proofreading and formatting and are now in the post-processing phase. Post-processing is the final assembly stage in which one volunteer performs a series of checks for consistency and correctness before the e-book is submitted to Project Gutenberg for your enjoyment and download."),
         _("These e-texts are the product of hundreds of hours of labor donated by our volunteers, and are in one of our post-processing states. The list is sorted by date, with the most recent to have changed state sorted to the top. You can re-sort them based on your own preferences. Enjoy!!"),
@@ -34,6 +36,7 @@ if ($x == "g") {
     $type = "bronze";
     $title = _("Now Proofreading Bronze E-Texts");
     $state = SQL_CONDITION_BRONZE;
+    $group_clause = "";
     $info = [
         _("Below is the list of Bronze e-texts that are currently available for proofreading on this site. Bronze e-texts are those that our volunteers are now proofreading or formatting. After going through three proofreading and two formatting rounds, the e-text then goes to an experienced volunteer for final assembly (post-processing), after which the e-text is submitted to Project Gutenberg for your enjoyment and download."),
         _("Some of these e-texts are just beginning their journeys, others are almost done, and many variations in between. If you would like to help, log in and choose an activity from the navigation bar to see the lists of projects you are eligible to work in."),
@@ -83,4 +86,4 @@ $sortlist = [
     "ORDER BY modifieddate desc",
 ];
 
-list_projects($state, $sortlist[$sort], "list_etexts.php?x=$x&amp;sort=$sort&amp;", $per_page, $offset);
+list_projects($state, $sortlist[$sort], $group_clause, "list_etexts.php?x=$x&amp;sort=$sort&amp;", $per_page, $offset);

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -102,7 +102,7 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
         $MAXPAGES = 5;
         $curpage = floor($offset / $per_page);
         $firstpage = max(0, $curpage - $MAXPAGES);
-        $lastpage = min($curpage + $MAXPAGES, $num_found_rows / $per_page);
+        $lastpage = min($curpage + $MAXPAGES, ($num_found_rows - 1) / $per_page);
         for ($i = $firstpage; $i <= $lastpage; $i++) {
             $url = $url_base . "per_page=$per_page&amp;offset=" . ($i * $per_page);
             if ($i == $curpage) {
@@ -113,7 +113,7 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
         }
 
         // Display 'next' link if we're not on the last page
-        if ($offset + $per_page < $num_found_rows) {
+        if ($offset + $per_page + 1 < $num_found_rows) {
             $t = _('Next');
             $next_offset = min($num_found_rows - 1, $offset + $per_page);
             $url = $url_base . "per_page=$per_page&amp;offset=$next_offset";

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -40,17 +40,7 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
 {
     global $code_url;
 
-    // first get the number of projects
-    $sql = "
-        SELECT COUNT(*)
-        FROM projects
-            LEFT OUTER JOIN pg_books
-            ON projects.postednum=pg_books.etext_number
-        WHERE $where_condition
-    ";
-    $result = DPDatabase::query($sql);
-    [$num_found_rows] = mysqli_fetch_row($result);
-
+    $num_found_rows = total_completed_projects();
     if ($num_found_rows == 0) {
         echo _("There are currently no projects in this category.");
         return;
@@ -72,6 +62,7 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
             LEFT OUTER JOIN pg_books
             ON projects.postednum=pg_books.etext_number
         WHERE $where_condition
+        GROUP by postednum
         $order_clause
         LIMIT $per_page OFFSET $offset
     ";

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -33,20 +33,14 @@ function list_projects_tersely($where_condition, $order_clause, $limit_clause)
     echo "</ul>\n";
 }
 
-function list_projects($where_condition, $order_clause, $url_base, $per_page = 20, $offset = 0)
+function list_projects($where_condition, $order_clause, $group_clause, $url_base, $per_page = 20, $offset = 0)
 // List the specified projects,
 // giving brief information about each.
 // url_base is the URL with the beginning of a query string, eg "foo.php?x=10&amp;" or "foo.php?"
 {
     global $code_url;
 
-    $num_found_rows = total_completed_projects();
-    if ($num_found_rows == 0) {
-        echo _("There are currently no projects in this category.");
-        return;
-    }
-
-    // now load the paged results
+    // first get the number of projects
     $sql = "
         SELECT
             projectid,
@@ -62,7 +56,16 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
             LEFT OUTER JOIN pg_books
             ON projects.postednum=pg_books.etext_number
         WHERE $where_condition
-        GROUP by postednum
+        $group_clause
+    ";
+    $num_found_rows = mysqli_num_rows(DPDatabase::query($sql));
+    if ($num_found_rows == 0) {
+        echo _("There are currently no projects in this category.");
+        return;
+    }
+
+    // now load the paged results by ordering, limiting and offsetting
+    $sql .= "
         $order_clause
         LIMIT $per_page OFFSET $offset
     ";
@@ -162,4 +165,17 @@ function list_projects($where_condition, $order_clause, $url_base, $per_page = 2
         echo "</li>";
     }
     echo "</ol>";
+}
+
+function total_completed_projects()
+// return number of books posted to PG
+// (takes into account that some books are processed as several projects)
+{
+    $psd = get_project_status_descriptor('posted');
+    $sql = "
+        SELECT COUNT(distinct postednum)
+        FROM projects
+        WHERE $psd->state_selector
+    ";
+    return mysqli_fetch_row(DPDatabase::query($sql))[0];
 }

--- a/pinc/showstartexts.inc
+++ b/pinc/showstartexts.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'project_states.inc');
+include_once($relPath.'theme.inc');
 
 function showstartexts($etext_limit, $type)
 {
@@ -9,24 +10,25 @@ function showstartexts($etext_limit, $type)
     if ($type == "bronze") {
         $aria_label_attr = attr_safe(_("Bronze Star"));
         $state = SQL_CONDITION_BRONZE;
+        $total = mysqli_num_rows(DPDatabase::query("SELECT projectid FROM projects WHERE $state"));
         $content = "proofing";
         $category = _("%s in Proofreading");
         $description = _("These books are currently being processed through our site; sign in and start helping!");
     } elseif ($type == "silver") {
         $aria_label_attr = attr_safe(_("Silver Star"));
         $state = SQL_CONDITION_SILVER;
+        $total = mysqli_num_rows(DPDatabase::query("SELECT projectid FROM projects WHERE $state"));
         $content = "postprocessing";
         $category = _("%s In Progress");
         $description = _("These books are undergoing their final checks before being assembled into a completed e-book.");
     } elseif ($type == "gold") {
         $aria_label_attr = attr_safe(_("Gold Star"));
         $state = SQL_CONDITION_GOLD;
+        $total = total_completed_projects();
         $content = "posted";
         $category = _("%s in Completed");
         $description = _("These books have been processed through our site and posted to the Project Gutenberg archive.");
     }
-
-    $total = mysqli_num_rows(DPDatabase::query("SELECT projectid FROM projects WHERE $state"));
 
     echo "<div class='star-text-summary'>";
 

--- a/pinc/showstartexts.inc
+++ b/pinc/showstartexts.inc
@@ -1,7 +1,7 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'project_states.inc');
-include_once($relPath.'theme.inc');
+include_once($relPath.'list_projects.inc');
 
 function showstartexts($etext_limit, $type)
 {
@@ -10,14 +10,14 @@ function showstartexts($etext_limit, $type)
     if ($type == "bronze") {
         $aria_label_attr = attr_safe(_("Bronze Star"));
         $state = SQL_CONDITION_BRONZE;
-        $total = mysqli_num_rows(DPDatabase::query("SELECT projectid FROM projects WHERE $state"));
+        $total = mysqli_fetch_row(DPDatabase::query("SELECT count(*) FROM projects WHERE $state"))[0];
         $content = "proofing";
         $category = _("%s in Proofreading");
         $description = _("These books are currently being processed through our site; sign in and start helping!");
     } elseif ($type == "silver") {
         $aria_label_attr = attr_safe(_("Silver Star"));
         $state = SQL_CONDITION_SILVER;
-        $total = mysqli_num_rows(DPDatabase::query("SELECT projectid FROM projects WHERE $state"));
+        $total = mysqli_fetch_row(DPDatabase::query("SELECT count(*) FROM projects WHERE $state"))[0];
         $content = "postprocessing";
         $category = _("%s In Progress");
         $description = _("These books are undergoing their final checks before being assembled into a completed e-book.");

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -851,22 +851,6 @@ function show_completed_projects($terse = false)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function total_completed_projects()
-// return number of books posted to PG
-// (takes into account that some books are processed as several projects)
-{
-    $psd = get_project_status_descriptor('posted');
-    $result = DPDatabase::query("
-        SELECT COUNT(distinct postednum) as numproj
-        FROM projects
-        WHERE $psd->state_selector
-    ");
-    $row = mysqli_fetch_assoc($result);
-    return $row["numproj"];
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
 function show_key_help_links()
 {
     $faq_central_url = get_faq_url("faq_central.php");

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -131,42 +131,16 @@ function html_logobar()
 
     echo "<div id='titles-preserved'><p>\n";
 
-    $psd = get_project_status_descriptor('posted');
-
-    if (0) {
-        // show number of projects posted to PG
-        $result = DPDatabase::query("
-            SELECT COUNT(*) as numproj
-            FROM projects
-            WHERE $psd->state_selector
-        ");
-        $row = mysqli_fetch_assoc($result);
-        echo "<span id='x-preserved'>";
-        echo sprintf(
-            _('%s projects completed!'),
-            number_format($row["numproj"]));
-        echo "</span>\n";
-    }
-
-    if (1) {
-        // show number of books posted to PG
-        // (takes into account that some books are processed as several projects)
-
-        $result = DPDatabase::query("
-            SELECT COUNT(distinct postednum) as numproj
-            FROM projects
-            WHERE $psd->state_selector
-        ");
-        $row = mysqli_fetch_assoc($result);
-        echo "<span id='x-preserved'>";
-        echo sprintf(
-            _('%s titles preserved for the world!'),
-            number_format($row["numproj"]));
-        echo "</span>\n";
-        echo "<span id='month-preserved-summary'>";
-        show_completed_projects(true);
-        echo "</span>";
-    }
+    // show number of books posted to PG
+    // (takes into account that some books are processed as several projects)
+    echo "<span id='x-preserved'>";
+    echo sprintf(
+        _('%s titles preserved for the world!'),
+        number_format(total_completed_projects()));
+    echo "</span>\n";
+    echo "<span id='month-preserved-summary'>";
+    show_completed_projects(true);
+    echo "</span>";
 
     echo "</p></div>\n";
     echo "</div>\n";
@@ -873,6 +847,22 @@ function show_completed_projects($terse = false)
     } else {
         echo "</table>\n";
     }
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+function total_completed_projects()
+// return number of books posted to PG
+// (takes into account that some books are processed as several projects)
+{
+    $psd = get_project_status_descriptor('posted');
+    $result = DPDatabase::query("
+        SELECT COUNT(distinct postednum) as numproj
+        FROM projects
+        WHERE $psd->state_selector
+    ");
+    $row = mysqli_fetch_assoc($result);
+    return $row["numproj"];
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
As reported in [Task 1883](https://www.pgdp.net/c/tasks.php?action=show&task_id=1883), the number of "titles preserved for the world" does not match the number of Gold texts.

Use a common function that only counts distinct PG ebook numbers for both cases, and use "group by" when listing the Gold texts on the `list_etexts` page.

Also, fix bug in number of pages used to display the Gold texts: if the number of texts per page was an exact divisor of the total number of texts, it miscalculated the number of pages needed by one, the last of which was blank. Testing note: on TEST, there are currently 15 projects, but if shown 5 per page, tries to use 4 pages. With these changes, there are only 14 projects, which can be shown 7 per page on 2 pages.

Questions:
1. Using "group by" means that it is random (or rather "indeterminate")  which of the projects that share the PG etext number will be shown - is this OK?
2. Is "group by" bad performance-wise? 

Sandbox at: https://www.pgdp.org/~windymilla/c.branch/completed-numbers
