### PR TITLE
Change daily page limit for P1 and P2 to 60

### DIFF
--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -42,7 +42,7 @@ new Round(
     _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
     'proofreading_guidelines.php',
     $pi_tools_for_P,
-    90, // daily_page_limit
+    60, // daily_page_limit
     [],
     [
         0 => _('Novice'),
@@ -83,7 +83,7 @@ new Round(
     _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
     'proofreading_guidelines.php',
     $pi_tools_for_P,
-    120, // daily_page_limit
+    60, // daily_page_limit
     ['P1'],
     [
         0 => _('Precise Proofreader'),


### PR DESCRIPTION
The daily page limit on PROD has already been hotfixed for P1 and P2 to be 60 pages per day. The purpose of this PR is to get the changes into the site-specific code. Sandbox [here](https://www.pgdp.org/~srjfoo/c.branch/update-dpl-to-60) if you really want to proof 60 pages per day to test it 😁 .

For reference, discussion topic [here](https://www.pgdp.net/phpBB3/viewtopic.php?f=1&t=80170).