### PR TITLE
add include links.inc to abort.inc file

### DIFF
--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -2,6 +2,7 @@
 include_once($relPath.'site_vars.php');
 include_once($relPath.'slim_header.inc'); // html_safe()
 include_once($relPath.'misc.inc'); // html_safe()
+include_once($relPath.'links.inc');
 
 function abort($error_message)
 {


### PR DESCRIPTION
If abort() is called from inside proof.php then the links are not shown but instead a message about a missing function `return_to_project_page_link` is shown.
The problems that cause this are `no expected state in url` or any of the issues that cause `can_be_proofed_by_current_user()` to fail.
It is probably not possible to see the problem this fixes without doing something naughty like changing your identity while proofreading a page or manipulating the url. For example start proofreading a page from a good project in round 1 on the test server and change the procectid in the url to that of the project that is not utf8 Nothing & co {not UTF-8} (projectID459698b8b63ac).

Sandbox at: https://www.pgdp.org/~rp31/c.branch/abort_link
