### PR TITLE
Highlight non-Latin unicode scripts in WC

### DIFF
--- a/SETUP/tests/UnicodeTest.php
+++ b/SETUP/tests/UnicodeTest.php
@@ -186,4 +186,23 @@ class UnicodeTest extends PHPUnit\Framework\TestCase
         $scripts = utf8_string_scripts($string);
         $this->assertEquals(['Latin', 'Common'], $scripts);
     }
+
+    public function testSplitMultiscriptString()
+    {
+        $string = "abcd";
+        $chunks = split_multiscript_string($string);
+        $this->assertEquals(["abcd"], $chunks);
+
+        $string = "a   ";
+        $chunks = split_multiscript_string($string);
+        $this->assertEquals(["a", "   "], $chunks);
+
+        $string = "aaaЖ";
+        $chunks = split_multiscript_string($string);
+        $this->assertEquals(["aaa", "Ж"], $chunks);
+
+        $string = "aN̅c";
+        $chunks = split_multiscript_string($string);
+        $this->assertEquals(["aN̅c"], $chunks);
+    }
 }

--- a/SETUP/tests/pinc_WordCheckEngineTest.php
+++ b/SETUP/tests/pinc_WordCheckEngineTest.php
@@ -102,14 +102,6 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($bad_words[0], "a1l");
     }
 
-    public function testGetBadWordsWithMultiScripts()
-    {
-        $words = get_distinct_words_in_text($this->TEXT1);
-        $bad_words = get_bad_words_with_multi_scripts($words);
-        $this->assertEquals(count($bad_words), 1);
-        $this->assertEquals($bad_words[0], "Γreat");
-    }
-
     public function testGetBadWordsForTextNoWordLists()
     {
         $languages = ["English"];
@@ -118,11 +110,10 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
             get_bad_words_for_text($this->TEXT1, $languages);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 4);
+        $this->assertEquals(count($bad_words), 3);
         $this->assertEquals($bad_words["Snelling"], WC_WORLD);
         $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
-        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextSiteWordList()
@@ -138,10 +129,9 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 3);
+        $this->assertEquals(count($bad_words), 2);
         $this->assertEquals($bad_words["disembarked"], WC_SITE);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
-        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextProjectWordList()
@@ -157,11 +147,10 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 4);
+        $this->assertEquals(count($bad_words), 3);
         $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["disembarked"], WC_PROJECT);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
-        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextSiteAndProjectWordList()
@@ -178,12 +167,11 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 5);
+        $this->assertEquals(count($bad_words), 4);
         $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["disembarked"], WC_SITE);
         $this->assertEquals($bad_words["opposite"], WC_PROJECT);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
-        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testGetBadWordsForTextAdhocWordList()
@@ -198,10 +186,9 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
             get_bad_words_for_text($this->TEXT1, $languages, $word_lists);
 
         $this->assertEquals(count($messages), 0);
-        $this->assertEquals(count($bad_words), 3);
+        $this->assertEquals(count($bad_words), 2);
         $this->assertEquals($bad_words["b[oe]uf"], WC_WORLD);
         $this->assertEquals($bad_words["a1l"], WC_SITE);
-        $this->assertEquals($bad_words["Γreat"], WC_SITE);
     }
 
     public function testWordListNormalization()
@@ -222,5 +209,31 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
         ];
 
         $this->assertEquals($norm_words, $expected_words);
+    }
+
+    public function testGetWordsWithUncommonScripts()
+    {
+        $words = [
+            "one",
+            "o'neill",
+            "Ṅice",
+            "Диф",
+            "Жblarg",
+            "Δπ",
+        ];
+        [$uncommon_words, $scripts] = get_words_with_uncommon_scripts($words);
+
+        $expected_words = [
+            "Диф",
+            "Жblarg",
+            "Δπ",
+        ];
+        $expected_scripts = [
+            "Cyrillic",
+            "Greek",
+        ];
+
+        $this->assertEquals($expected_words, $uncommon_words);
+        $this->assertEquals($expected_scripts, $scripts);
     }
 }

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -85,6 +85,34 @@ function utf8_character_name($characters)
     return implode(" + ", $title_pieces);
 }
 
+// Split a string into chunks on Unicode script boundaries
+// Inherited characters are included in the chunk with the base character
+function split_multiscript_string($string)
+{
+    $chunks = [];
+    $chunk = null;
+    $chunk_script = null;
+
+    foreach (UTF8::str_split($string) as $char) {
+        $script = utf8_char_script($char);
+        if ($chunk === null) {
+            $chunk = $char;
+            $chunk_script = $script;
+        } elseif ($script == $chunk_script || $script == "Inherited") {
+            $chunk .= $char;
+        } else {
+            $chunks[] = $chunk;
+            $chunk_script = $script;
+            $chunk = $char;
+        }
+    }
+    if ($chunk) {
+        $chunks[] = $chunk;
+    }
+
+    return $chunks;
+}
+
 function split_graphemes($string)
 {
     $next = 0;

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -24,9 +24,13 @@ $word_pattern = "!$char_pattern+(?:'$char_pattern+)*!uS";
 // analyzing the pattern in order to speed up the time taken for matching,
 // but the effect seems pretty close to negligible.)
 
-// string of punctuation characters
-// this is only used for punctuation highlighting
+
+// The following two variables control text highlighting in the interface.
+// String of punctuation characters
 $puncCharacters = '.,;:?!*/()#@%+=[]{}<>\"$|_¬¢£¥©®§°±¶·´¸º×¦¡¿-»«¯÷¹²³¼½¾¤';
+
+// Unicode scripts that are "common" and shouldn't be highlighted
+$common_unicode_scripts = ["Latin", "Common", "Inherited"];
 
 // -----------------------------------------------------------------------------
 
@@ -161,9 +165,6 @@ function get_bad_words_for_text($text, $languages, $word_lists = [])
 
         $acc->add_bad_words(
             get_bad_words_via_pattern($input_words_w_freq, $languages), WC_SITE);
-
-        $acc->add_bad_words(
-            get_bad_words_with_multi_scripts($input_words_w_freq), WC_SITE);
     }
 
     // The project
@@ -422,29 +423,6 @@ function get_bad_words_via_pattern($input_words_w_freq, $languages)
     // placeholder for future patterns
 
     return $badWords;
-}
-
-// Return a list of "bad" words where characters within a word are not all
-// of the same Unicode script type. For instance, this detects words that
-// contain a mix of Latin and Cyrillic characters.
-// Arguments:
-//   input_words_w_freq - an array whose keys are the distinct words of the input text
-//
-// Returns:
-//       -- an array of bad words
-//
-function get_bad_words_with_multi_scripts($input_words_w_freq)
-{
-    $bad_words = [];
-
-    foreach ($input_words_w_freq as $word => $freq) {
-        $scripts = utf8_string_scripts($word);
-        if (count(array_diff($scripts, ["Common", "Inherited"])) > 1) {
-            $bad_words[] = $word;
-        }
-    }
-
-    return $bad_words;
 }
 
 // -----------------------------------------------------------------------------
@@ -1122,13 +1100,46 @@ function rtrim_walk(&$item)
     $item = rtrim($item);
 }
 
+// Filter words to only those of a specific script + Inherited
 function filter_words_to_script($words, $script)
 {
     $script_words = [];
     foreach ($words as $word) {
-        if (in_array($script, utf8_string_scripts($word))) {
+        if (array_diff(utf8_string_scripts($word), [$script, "Inherited"]) === []) {
             $script_words[] = $word;
         }
     }
     return $script_words;
+}
+
+// Return a list of words where characters within a word contain "uncommon"
+// Unicode scripts.
+// Arguments:
+//   words - an array of words
+//
+// Returns:
+//       -- the array: [words[], found_scripts[]]
+//
+function get_words_with_uncommon_scripts($words)
+{
+    global $common_unicode_scripts;
+
+    $found_words = [];
+    $found_scripts = [];
+
+    foreach ($words as $word) {
+        $scripts = array_diff(utf8_string_scripts($word), $common_unicode_scripts);
+        if (count($scripts) > 0) {
+            $found_words[] = $word;
+            foreach ($scripts as $script) {
+                $found_scripts[$script] = 1;
+            }
+        }
+    }
+
+    // alpha sort the scripts so they are consistent within the set detected
+    $found_scripts = array_keys($found_scripts);
+    sort($found_scripts);
+
+    return [$found_words, $found_scripts];
 }

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -84,7 +84,7 @@ if ($user->profile->i_type == 1) {
     echo "<input type='hidden' id='is_header_visible' name=\"is_header_visible\" value='$is_header_visible'>\n";
 
     // run the text through the spellcheck - returns the form contents and a list of languages the page was checked against
-    [$page_contents, $languages, $messages] =
+    [$page_contents, $languages, $messages, $highlights] =
         spellcheck_text($text_data, $ppage->projectid(), $ppage->imagefile(), $aux_language, $accepted_words);
 
     // start the div containing the link to show/hide the WordCheck header
@@ -165,6 +165,17 @@ if ($user->profile->i_type == 1) {
         "<img src=\"$code_url/graphics/Book-Plus-Small.gif\" border=\"0\">"
     );
     echo "</p>";
+
+    // text highlight legend
+    if ($highlights) {
+        echo "<p>";
+        echo _("The following highlights have been used:") . "<br>";
+        foreach ($highlights as $hl_class => $message) {
+            echo "<span class='$hl_class'>$message</span><br>";
+        }
+        echo "</p>";
+    }
+
     echo "</div>";
     // here ends the div for the WordCheck header
 

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -51,6 +51,13 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
 
     [$uncommonScriptWords, $uncommonScripts] =
         get_words_with_uncommon_scripts(array_keys(get_distinct_words_in_text($orig_text)));
+
+    // If Greek is present in $uncommonScripts, we always want it to be first
+    // so it always has the same color across pages and projects. We do this
+    // only for Greek as it is the most common non-Latin script at pgdp.net.
+    if (in_array("Greek", $uncommonScripts)) {
+        $uncommonScripts = array_merge(["Greek"], array_diff($uncommonScripts, ["Greek"]));
+    }
     $uncommonScriptMap = array_flip($uncommonScripts);
 
     // Prepare the style block which requires some dynamic content from

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -66,9 +66,10 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
                    "  pre { line-height: 2.7; }".
                    "  .proofingfont { font-family: $font_family; $font_size }" .
                    "  .hl-punc { background-color: yellow; color: black; }" .
-                   "  .hl-script-0 { background-color: lightgreen; color: black; }" .
-                   "  .hl-script-1 { background-color: aqua; color: black; }" .
-                   "  .hl-script-2 { background-color: mistyrose; color: black; }" .
+                   "  .hl-script-0 { background-color: CadetBlue; color: black; }" .
+                   "  .hl-script-1 { background-color: lightpink; color: black; }" .
+                   "  .hl-script-2 { background-color: lightgreen; color: black; }" .
+                   "  .hl-script-3 { background-color: mediumpurple; color: black; }" .
                    "  img.aw { border: 0; margin-left: 5px; }" .
                    "  span.aw { background-color: white; color: black; }" .
                    "</style>";

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -53,23 +53,27 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
         get_words_with_uncommon_scripts(array_keys(get_distinct_words_in_text($orig_text)));
     $uncommonScriptMap = array_flip($uncommonScripts);
 
-    // ok, at this point we have a finalized list of bad words.
-    // start preparing the page
+    // Prepare the style block which requires some dynamic content from
+    // the user's preferences and the page itself.
     [$font_style, $font_size, $font_family] = get_user_proofreading_font();
     if ($font_size != '') {
         $font_size = "font-size: $font_size";
     } else {
         $font_size = "font-size: unset";
     }
-    // define the styles used for the interface (highlight for the punctuation, AW button, etc)
+
+    $highlight_colors = ["lightpink", "lightgreen", "CadetBlue", "mediumpurple"];
+    $highlight_styles = "  .hl-punc { background-color: yellow; color: black; }\n";
+    for ($index = 0; $index < count($uncommonScripts); $index++) {
+        $color_index = min($index, count($highlight_colors) - 1);
+        $color = $highlight_colors[$color_index];
+        $highlight_styles .= "  .hl-script-{$index} { background-color: $color; color: black; }\n";
+    }
+
     $returnString .= "<style>" .
                    "  pre { line-height: 2.7; }".
                    "  .proofingfont { font-family: $font_family; $font_size }" .
-                   "  .hl-punc { background-color: yellow; color: black; }" .
-                   "  .hl-script-0 { background-color: CadetBlue; color: black; }" .
-                   "  .hl-script-1 { background-color: lightpink; color: black; }" .
-                   "  .hl-script-2 { background-color: lightgreen; color: black; }" .
-                   "  .hl-script-3 { background-color: mediumpurple; color: black; }" .
+                   $highlight_styles .
                    "  img.aw { border: 0; margin-left: 5px; }" .
                    "  span.aw { background-color: white; color: black; }" .
                    "</style>";

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -24,7 +24,6 @@ use voku\helper\UTF8;
 function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $accepted_words)
 {
     global $puncCharacters;
-    global $code_url;
 
     // variable holding final string
     $returnString = "";
@@ -50,6 +49,10 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
     [$badWordHash, $languages, $messages] =
         get_bad_word_levels_for_project_text($orig_text, $projectid, $aux_language, $accepted_words);
 
+    [$uncommonScriptWords, $uncommonScripts] =
+        get_words_with_uncommon_scripts(array_keys(get_distinct_words_in_text($orig_text)));
+    $uncommonScriptMap = array_flip($uncommonScripts);
+
     // ok, at this point we have a finalized list of bad words.
     // start preparing the page
     [$font_style, $font_size, $font_family] = get_user_proofreading_font();
@@ -62,7 +65,10 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
     $returnString .= "<style>" .
                    "  pre { line-height: 2.7; }".
                    "  .proofingfont { font-family: $font_family; $font_size }" .
-                   "  .hl { background-color: yellow; color: black; }" .
+                   "  .hl-punc { background-color: yellow; color: black; }" .
+                   "  .hl-script-0 { background-color: lightgreen; color: black; }" .
+                   "  .hl-script-1 { background-color: aqua; color: black; }" .
+                   "  .hl-script-2 { background-color: mistyrose; color: black; }" .
                    "  img.aw { border: 0; margin-left: 5px; }" .
                    "  span.aw { background-color: white; color: black; }" .
                    "</style>";
@@ -70,9 +76,6 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
 
     $puncArray = UTF8::str_split($puncCharacters);
 
-    // initialize the wordCount and the numBadWords
-    $numBadWords = 0;
-    $wordCount = [];
     $badWords = array_keys($badWordHash);
     // we need to force PHP to treat bad words that are numbers
     // as strings (and compare them as such), otherwise things like
@@ -106,7 +109,10 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
 
         // find the index for each word before we futz with the line
         foreach (get_all_words_in_text($origLine, true) as $lineIndex => $word) {
-            if ($word != "" && (in_array($word, $badWords) || in_array($word, $accepted_words))) {
+            if ($word != "" && (
+                in_array($word, $badWords) || in_array($word, $accepted_words) ||
+                in_array($word, $uncommonScriptWords)
+            )) {
                 // erase any punctuation-markers covered by this word
                 for ($li = $lineIndex; $li < $lineIndex + UTF8::strlen($word); $li++) {
                     unset($indexArray[$li]);
@@ -116,7 +122,8 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
             }
         }
 
-        // now do the search/replace
+        // now do the search/replace from right-to-left so our line index
+        // remains valid while the length of the string grows
         krsort($indexArray);
         foreach ($indexArray as $lineIndex => $word) {
             if ($word == "") {
@@ -125,54 +132,26 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
 
             $wordLen = UTF8::strlen($word);
 
-            // see if we are punctuation
-            if (in_array($word, $puncArray)) {
-                $newLine = UTF8::substr_replace($newLine, _wrapPunc($word), $lineIndex, $wordLen);
-            } elseif (in_array($word, $accepted_words)) {
-                // see if we're an AW word
-                $newLine = UTF8::substr_replace($newLine, _wrapAW($word), $lineIndex, $wordLen);
-            } else {
-                // not punctuation, handle word
+            $replaceString = null;
 
-                // sanitize the words for the AW javascript
-                $jsSanitizedWord = bin2hex($word);
-                @$wordCount[$word]++;
-                $wordID = "{$jsSanitizedWord}_{$wordCount[$word]}";
-                $numBadWords++;
-                $wordSafe = attr_safe($word);
+            // Process the words in the most to least important if the word
+            // at the index is found in multiple arrays
+            if (in_array($word, $accepted_words)) {
+                // an accepted word (AW)
+                $replaceString = _wrapAW($word);
+            } elseif (in_array($word, $badWords)) {
+                // a bad word
+                [$replaceString, $numBadWords] = _wrapBadWord($word, $origLineNum, $lineIndex, $wordLen, @$badWordHash[$word]);
+            } elseif (in_array($word, $puncArray)) {
+                // punctuation
+                $replaceString = _wrapPunc($word);
+            } elseif (in_array($word, $uncommonScriptWords)) {
+                // word with one or more characters in an "uncommon" script
+                $replaceString = _wrapScriptWord($word, $uncommonScriptMap);
+            }
 
-                // set the size of the edit box
-                // note: in some browsers the edit box is not wide enough
-                // for longer words, hence the scaling mechanism
-                $textBoxLen = $wordLen + max(1 + round($wordLen / 5), 2);
-
-                // reset the string that will hold the edit box
-                $replaceString = "";
-
-                // if the AW button is wanted, add the initial span
-                if (@$badWordHash[$word] == WC_WORLD) {
-                    $replaceString .= "<span id='$wordID'>";
-                    $onChange = " onBlur=\"markBox('$wordID');\"";
-                    $onChange .= " oninput=\"disableAW('$wordID');\"";
-                } else {
-                    $onChange = " onBlur=\"markBox('$wordID');\"";
-                    $onChange .= " oninput=\"evaluateWordChange('$wordID');\"";
-                }
-
-                // create the edit box
-                $replaceString .=
-                    "<input type='hidden' name='posit{$numBadWords}' value='$origLineNum|$lineIndex|$wordLen'>" .
-                    "<input type='text' id='input_$wordID' name='sp$numBadWords' size='$textBoxLen' value='$wordSafe' class='proofingfont'$onChange>";
-
-                // if the AW button is wanted, add the closing span and the button
-                if (@$badWordHash[$word] == WC_WORLD) {
-                    $replaceString .=
-                        "<a href='#' id='a_$wordID' onClick=\"return acceptWord('$jsSanitizedWord','$wordCount[$word]');\">" .
-                        "<img id='button_$wordID' src='$code_url/graphics/Book-Plus-Small.gif' title='" . attr_safe(_("Unflag All &amp; Suggest Word")) . "' class='aw'></a>" .
-                        "</span>";
-                }
-
-                $newLine = UTF8::substr_replace($newLine, $replaceString, $lineIndex, UTF8::strlen($word));
+            if ($replaceString !== null) {
+                $newLine = UTF8::substr_replace($newLine, $replaceString, $lineIndex, $wordLen);
             }
         }
 
@@ -183,19 +162,100 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
     $returnString .= "</pre>";
     $returnString .= "<input id='sptotal' type='hidden' name='sptotal' value='$numBadWords'>";
 
-    return [$returnString, $languages, $messages];
+    $highlightsUsed = [];
+    $highlightsUsed["hl-punc"] = _("punctuation");
+    foreach ($uncommonScriptMap as $script => $index) {
+        $highlightClass = "hl-script-$index";
+        $highlightsUsed[$highlightClass] = _wrapHighlight(sprintf(_("Unicode script: %s"), $script), $highlightClass);
+    }
+
+    return [$returnString, $languages, $messages, $highlightsUsed];
+}
+
+// adds HTML code to highlight text
+function _wrapHighlight($word, $highlightClass)
+{
+    return "<span class='$highlightClass'>$word</span>";
 }
 
 // adds HTML code to punctuation to highlight it
 function _wrapPunc($word)
 {
-    return "<span class='hl'>$word</span>";
+    return _wrapHighlight($word, "hl-punc");
+}
+
+// adds HTML code to highlight words in multiple scripts
+function _wrapScriptWord($word, $scriptMap)
+{
+    global $common_unicode_scripts;
+
+    $returnString = "";
+    foreach (split_multiscript_string($word) as $chunk) {
+        $chunkScript = utf8_char_script(UTF8::str_split($chunk)[0]);
+        if (in_array($chunkScript, $common_unicode_scripts)) {
+            $returnString .= $chunk;
+        } else {
+            $highlightClass = "hl-script-" . $scriptMap[$chunkScript];
+            $returnString .= _wrapHighlight($chunk, $highlightClass);
+        }
+    }
+    return $returnString;
 }
 
 // adds HTML code to an accepted word to highlight it
 function _wrapAW($word)
 {
     return "<span class='aw'>$word</span>";
+}
+
+// adds HTML code to manage a bad word
+function _wrapBadWord($word, $origLineNum, $lineIndex, $wordLen, $badWordType)
+{
+    global $code_url;
+
+    static $wordCount = [];
+    static $numBadWords = 0;
+
+    $numBadWords++;
+
+    // sanitize the words for the AW javascript
+    $jsSanitizedWord = bin2hex($word);
+    @$wordCount[$word]++;
+    $wordID = "{$jsSanitizedWord}_{$wordCount[$word]}";
+    $wordSafe = attr_safe($word);
+
+    // set the size of the edit box
+    // note: in some browsers the edit box is not wide enough
+    // for longer words, hence the scaling mechanism
+    $textBoxLen = $wordLen + max(1 + round($wordLen / 5), 2);
+
+    // reset the string that will hold the edit box
+    $replaceString = "";
+
+    // if the AW button is wanted, add the initial span
+    if ($badWordType == WC_WORLD) {
+        $replaceString .= "<span id='$wordID'>";
+        $onChange = " onBlur=\"markBox('$wordID');\"";
+        $onChange .= " oninput=\"disableAW('$wordID');\"";
+    } else {
+        $onChange = " onBlur=\"markBox('$wordID');\"";
+        $onChange .= " oninput=\"evaluateWordChange('$wordID');\"";
+    }
+
+    // create the edit box
+    $replaceString .=
+        "<input type='hidden' name='posit{$numBadWords}' value='$origLineNum|$lineIndex|$wordLen'>" .
+        "<input type='text' id='input_$wordID' name='sp$numBadWords' size='$textBoxLen' value='$wordSafe' class='proofingfont'$onChange>";
+
+    // if the AW button is wanted, add the closing span and the button
+    if ($badWordType == WC_WORLD) {
+        $replaceString .=
+            "<a href='#' id='a_$wordID' onClick=\"return acceptWord('$jsSanitizedWord','$wordCount[$word]');\">" .
+            "<img id='button_$wordID' src='$code_url/graphics/Book-Plus-Small.gif' title='" . attr_safe(_("Unflag All &amp; Suggest Word")) . "' class='aw'></a>" .
+            "</span>";
+    }
+
+    return [$replaceString, $numBadWords];
 }
 
 // --------------------------------------------


### PR DESCRIPTION
To improve proofreaders ability to differentiate look-alike characters, highlight non-Latin characters in WordCheck like we do for punctuation. This removes the current behavior where words containing multiple Unicode scripts are flagged as bad in lieu of highlighting the characters instead.

Testable in the [highlight-non-latin-scripts](https://www.pgdp.org/~cpeel/c.branch/highlight-non-latin-scripts/) sandbox -- in particular the [UTF-8 Practice: Dogs of all nations](https://www.pgdp.org/~cpeel/c.branch/highlight-non-latin-scripts/project.php?id=projectID5e20bc6bd5786&expected_state=P1.proj_avail) project which has some additional character suites and custom characters.