### PR TITLE
Centralize tab layout logic

### DIFF
--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -661,10 +661,20 @@ function get_search_configure_link()
     return "<a href='?show=config&amp;origin=$origin'>" . _("Configure Result") . "</a>";
 }
 
+function make_url($new_array, $anchor = '')
+{
+    return "?" . http_build_query(array_replace($_GET, $new_array)) . "$anchor";
+}
+
 function make_link($new_array, $text, $anchor = '')
 {
-    $url = "?" . http_build_query(array_replace($_GET, $new_array)) . "$anchor";
+    $url = make_url($new_array, $anchor);
     return "<a href='" . attr_safe($url) . "'>$text</a>";
+}
+
+function get_refine_search_url()
+{
+    return make_url(['show' => 'search_form']);
 }
 
 function get_refine_search_link($label = null)
@@ -672,5 +682,6 @@ function get_refine_search_link($label = null)
     if (!$label) {
         $label = _("Refine Search");
     }
-    return make_link(['show' => 'search_form'], $label);
+    $url = get_refine_search_url();
+    return "<a href='" . attr_safe($url) . "'>$label</a>";
 }

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -1033,3 +1033,48 @@ function get_page_header_image($image)
     // Fall back to nothing
     return "";
 }
+
+// Output a tab bar of various view modes and a selected mode
+// $view_modes is a complex associative array, eg:
+// [
+//     "mode1" => [
+//         "label" => "Tab label",
+//         "url" => "",         # optional URL
+//         "postscript" => "",  # optional postscript for after tab bar
+//     ],
+//     "mode2" => [
+//     ], ...
+function output_tab_bar($view_modes, $selected_mode, $view_variable, $url_addition = "", $display_mode = "full")
+{
+    $div_style = $display_mode == "auto" ? "style='width: auto;'" : "";
+    $clear_style = $display_mode == "auto" ? "style='clear: left;'" : "style='clear: both;'";
+
+    echo "<div class='tabs' $div_style>";
+    echo "<ul>";
+
+    foreach ($view_modes as $setting => $setting_values) {
+        $label = $setting_values["label"];
+        if ($selected_mode == $setting) {
+            echo "<li class='current-tab'><a>" . html_safe($label) . "</a></li>";
+        } else {
+            if (@$setting_values["url"]) {
+                $url = $setting_values["url"];
+            } else {
+                $url = "?{$view_variable}=$setting";
+                if (!startswith($url_addition, "#")) {
+                    $url .= "&amp;";
+                }
+                $url .= $url_addition;
+            }
+            echo "<li><a href='" . attr_safe($url) . "'>" . html_safe($label) . "</a></li>";
+        }
+    }
+
+    echo "</ul>";
+    echo "</div>";
+    echo "<div $clear_style></div>";
+
+    if (isset($view_modes[$selected_mode]["postscript"])) {
+        echo "<p>" . $view_modes[$selected_mode]["postscript"] . "</p>";
+    }
+}

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -1035,15 +1035,23 @@ function get_page_header_image($image)
 }
 
 // Output a tab bar of various view modes and a selected mode
-// $view_modes is a complex associative array, eg:
-// [
-//     "mode1" => [
-//         "label" => "Tab label",
-//         "url" => "",         # optional URL
-//         "postscript" => "",  # optional postscript for after tab bar
-//     ],
-//     "mode2" => [
-//     ], ...
+// $view_modes - a complex associative array, eg:
+//     [
+//         "mode1" => [
+//             "label" => "Tab label",
+//             "url" => "",         # optional URL
+//             "postscript" => "",  # optional postscript for after tab bar
+//         ],
+//         "mode2" => [
+//         ], ...
+//     ]
+// $selected_mode - which view mode (a key in $view_modes) is currently selected
+// $view_variable - the URL parameter to use when selecting a new mode,
+//     most commonly "show" but it can be anything
+// $url_addition - an optional string that will be appended to the URL. This can
+//     be other page parameters and/or a page anchor
+// $display_mode - one of "full" or "auto" - full will cause the bar to span the
+//     entire page while auto will only use as much horizontal space as needed.
 function output_tab_bar($view_modes, $selected_mode, $view_variable, $url_addition = "", $display_mode = "full")
 {
     $div_style = $display_mode == "auto" ? "style='width: auto;'" : "";

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -19,11 +19,11 @@ if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
 $view_modes = [
     "suspect" => [
         "label" => _("Projects with suspect clearances"),
-        "description" => _("Showing projects with suspect clearances that have not been posted or deleted."),
+        "postscript" => _("Showing projects with suspect clearances that have not been posted or deleted."),
     ],
     "all" => [
         "label" => _("All projects"),
-        "description" => _("Showing all of your projects that have not been posted or deleted."),
+        "postscript" => _("Showing all of your projects that have not been posted or deleted."),
     ],
 ];
 
@@ -50,9 +50,8 @@ if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
 
 echo "<h1>$title</h1>";
 
-show_page_menu($view_modes, $view_mode, $username);
-
-echo "<p>" . $view_modes[$view_mode]["description"] . "</p>";
+$url_additions = ($pguser != $username) ? "username=$username&amp;" : "";
+output_tab_bar($view_modes, $view_mode, "show", $url_additions);
 
 echo "<table class='themed theme_striped' style='width: auto;'>";
 echo "<tr>";
@@ -77,32 +76,6 @@ while ($row = mysqli_fetch_assoc($res)) {
 echo "</table>";
 
 //---------------------------------------------------------------------------
-
-function show_page_menu($all_view_modes, $view_mode, $username)
-{
-    global $pguser;
-
-    $qs_username = "";
-    if ($pguser != $username) {
-        $qs_username = "username=$username&amp;";
-    }
-
-    echo "<div class='tabs'>";
-    echo "<ul>";
-
-    foreach ($all_view_modes as $setting => $setting_values) {
-        $label = $setting_values["label"];
-        if ($view_mode == $setting) {
-            echo "<li class='current-tab'><a>$label</a></li>";
-        } else {
-            echo "<li><a href='?${qs_username}show=$setting'>$label</a></li>";
-        }
-    }
-
-    echo "</ul>";
-    echo "</div>";
-    echo "<div style='clear: both;'></div>";
-}
 
 function get_table_query_resource($username, $view_mode)
 {

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -107,27 +107,21 @@ $search_results->render($condition);
 function echo_shortcut_links($show_view)
 {
     $views = [
-        // TRANSLATORS: Abbreviation for Project Manager
-        "user_active" => _("Your Active PM Projects"),
-        // TRANSLATORS: Abbreviation for Project Manager
-        "user_all" => _("All Your PM Projects"),
-        "search" => _("Search"),
+        "user_active" => [
+            // TRANSLATORS: Abbreviation for Project Manager
+            "label" => _("Your Active PM Projects"),
+        ],
+        "user_all" => [
+            // TRANSLATORS: Abbreviation for Project Manager
+            "label" => _("All Your PM Projects"),
+        ],
+        "search" => [
+            "label" => _("Search"),
+            "url" => get_refine_search_url(),
+        ],
     ];
 
-    echo "<div class='tabs' style='width: auto;'>";
-    echo "<ul>";
-    foreach ($views as $view => $label) {
-        if ($show_view == $view) {
-            echo "<li class='current-tab'><a>$label</a></li>";
-        } elseif ($view == "search") {
-            echo "<li>" . get_refine_search_link($label) . "</li>";
-        } else {
-            echo "<li><a href='?show=$view'>$label</a></li>";
-        }
-    }
-    echo "</ul>";
-    echo "</div>";
-    echo "<div style='clear: left;'></div>";
+    output_tab_bar($views, $show_view, "show", "", "auto");
 
     $links = [];
     if ($show_view == "search") {

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -498,24 +498,10 @@ function show_page_menu($all_view_modes, $round_view, $username, $key)
 
     $qs_username = "";
     if ($pguser != $username) {
-        $qs_username = "username=$username&amp;";
+        $qs_username = "username=$username";
     }
 
-    echo "<div class='tabs'>";
-    echo "<ul>";
-
-    foreach ($all_view_modes as $setting => $setting_values) {
-        $label = $setting_values["label"];
-        if ($round_view == $setting) {
-            echo "<li class='current-tab'><a>$label</a></li>";
-        } else {
-            echo "<li><a href='?{$qs_username}{$key}=$setting#$key'>$label</a></li>";
-        }
-    }
-
-    echo "</ul>";
-    echo "</div>";
-    echo "<div style='clear: both;'></div>";
+    output_tab_bar($all_view_modes, $round_view, $key, "$qs_username#$key");
 }
 
 function sql_order_spec($colspecs, $order_col, $order_dir)

--- a/userprefs.php
+++ b/userprefs.php
@@ -38,11 +38,17 @@ if (empty($origin)) {
 // Define the available tabs.
 // The indexes of the array are used elsewhere in this script.
 $tabs = [
-    0 => _('General'),
-    1 => _('Proofreading'),
+    0 => [
+        "label" => _('General'),
+    ],
+    1 => [
+        "label" => _('Proofreading'),
+    ],
 ];
 if (user_is_PM()) {
-    $tabs[2] = _('Project managing');
+    $tabs[2] = [
+        "label" => _('Project managing'),
+    ];
 }
 
 $selected_tab = get_integer_param($_REQUEST, "tab", 0, 0, max(array_keys($tabs)));
@@ -185,7 +191,7 @@ set_csrf_token();
 output_header($header, NO_STATSBAR, $theme_extra_args);
 echo "<h1>$header</h1>";
 
-echo_tabs($tabs, $selected_tab);
+output_tab_bar($tabs, $selected_tab, "tab", "origin=" . urlencode($origin));
 
 echo "<p>" . _("Click the ? for help on that specific preference.") . "</p>";
 
@@ -220,26 +226,6 @@ echo "\n\n<script><!--\nwindow.onload = function() { $window_onload_event };\n--
 // End main code. Functions below.
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// Produce tabs (display as an unordered list of links to non-CSS browsers)
-function echo_tabs($tab_names, $selected_tab)
-{
-    global $origin;
-
-    echo "<div class='tabs'>";
-    echo "<ul>";
-    foreach (array_keys($tab_names) as $index) {
-        if ($index == $selected_tab) {
-            echo "<li class='current-tab'>";
-        } else {
-            echo "<li>";
-        }
-        $url = "?tab=$index&amp;origin=" . urlencode($origin);
-        echo "<a href='$url'>{$tab_names[$index]}</a>";
-    }
-    echo "</ul>";
-    echo "</div>";
-    echo "<div style='clear: left;'></div>";
-}
 
 function echo_general_tab($user)
 {


### PR DESCRIPTION
Some of our pages use "tabbed" views of data and we've copy/pasted that code so we have 4 copies of it. I want to use it in a new place and this centralizes it into one and re-uses it everywhere.

There should be no change in functionality on any of the pages.

Testable in the [centralize-tab-output](https://www.pgdp.org/~cpeel/c.branch/centralize-tab-output/) sandbox.