### PR TITLE
Skip ProjectTest::test_can_be_proofed_available

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -403,6 +403,8 @@ class ProjectTest extends ProjectUtils
 
     public function test_can_be_proofed_available()
     {
+        $this->markTestSkipped('Not valid in pgdp-production where P1 requires approval first.');
+
         global $pguser;
 
         $pguser = $this->TEST_USERNAME;


### PR DESCRIPTION
[Note, this PR is against `pgdp-production` and not `master`.]

In `pgdp-production`, users must first pass a quiz and request access before they can proofreading in P1 making this test fail so skip it.

This was discussed in #pgdpdev and the PR passes if the test in the phpunit GHA all pass.