### PR TITLE
Better validate & escape inputs to processtext.php

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -81,7 +81,8 @@ function _get_bad_words_for_project_text($which_result_values, $text, $projectid
 {
     $messages = [];
 
-    // Get the list of languages that we'll use.
+    // Get the list of languages that we'll use. This also ensures that
+    // $aux_language is a valid language and if not discards it.
     $languages = array_values(get_project_languages($projectid, $aux_language));
 
     // And the langcode3s for those languages

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -91,10 +91,10 @@ if (isset($_POST['rerunauxlanguage'])) {
 $user = User::load_current();
 if ($user->profile->i_type == 1) {
     if (isset($_POST['fntFace'])) {
-        $fntFace = $_POST['fntFace'];
+        $fntFace = get_integer_param($_POST, 'fntFace', 0, 0, null);
     }
     if (isset($_POST['fntSize'])) {
-        $fntSize = $_POST['fntSize'];
+        $fntSize = get_integer_param($_POST, 'fntSize', 0, 0, null);
     }
 
     if ($user->profile->i_layout == 1) {
@@ -207,7 +207,7 @@ try {
             include_once('spellcheck_text.inc');
             [$correct_text, $corrections] = spellcheck_apply_corrections();
             $accepted_words = explode(' ', $_POST["accepted_words"]);
-            $_SESSION["is_header_visible"] = $_POST["is_header_visible"];
+            $_SESSION["is_header_visible"] = get_integer_param($_POST, 'is_header_visible', 0, 0, 1);
 
             // the user is submitting corrections, so pull any temporary corrections
             // they made long the way for saving in WordCheck (they've already been
@@ -221,7 +221,7 @@ try {
             // functions for returning the round ID and the page number
             // without the mess below
             save_wordcheck_event(
-                $_POST["projectid"], $ppage->lpage->round->id, $page, $pguser, $accepted_words, $corrections);
+                $projectid, $ppage->lpage->round->id, $page, $pguser, $accepted_words, $corrections);
 
             $ppage->saveAsInProgress($correct_text, $pguser);
             leave_spellcheck_mode($ppage);
@@ -232,14 +232,14 @@ try {
             include_once('spellcheck_text.inc');
             $correct_text = spellcheck_quit();
             $accepted_words = explode(' ', $_POST["accepted_words"]);
-            $_SESSION["is_header_visible"] = $_POST["is_header_visible"];
+            $_SESSION["is_header_visible"] = get_integer_param($_POST, 'is_header_visible', 0, 0, 1);
 
             // the user wants to quit, so clear out the temporary variable
             // storing the corrections
             unset($_SESSION[$wcTempCorrections]);
 
             save_wordcheck_event(
-                $_POST["projectid"], $ppage->lpage->round->id, $page, $pguser, $accepted_words, []);
+                $projectid, $ppage->lpage->round->id, $page, $pguser, $accepted_words, []);
 
             $ppage->saveAsInProgress($correct_text, $pguser);
             leave_spellcheck_mode($ppage);
@@ -254,7 +254,7 @@ try {
             include_once('spellcheck_text.inc');
             $correct_text = spellcheck_quit();
             $accepted_words = explode(' ', $_POST["accepted_words"]);
-            $_SESSION["is_header_visible"] = $_POST["is_header_visible"];
+            $_SESSION["is_header_visible"] = get_integer_param($_POST, 'is_header_visible', 0, 0, 1);
 
             // 1. Quit the wordcheck interface:
             // Discard the session state holding current wordcheck corrections
@@ -269,7 +269,7 @@ try {
             unset($_SESSION[$wcTempCorrections]);
 
             save_wordcheck_event(
-                $_POST["projectid"], $ppage->lpage->round->id, $page, $pguser, $accepted_words, []);
+                $projectid, $ppage->lpage->round->id, $page, $pguser, $accepted_words, []);
 
             // 2. Save the current page as done
             $ppage->attempt_to_save_as_done($correct_text);
@@ -295,7 +295,7 @@ try {
             include_once('spellcheck_text.inc');
             $aux_language = $_POST["aux_language"];
             $accepted_words = explode(' ', $_POST["accepted_words"]);
-            $_SESSION["is_header_visible"] = $_POST["is_header_visible"];
+            $_SESSION["is_header_visible"] = get_integer_param($_POST, 'is_header_visible', 0, 0, 1);
             [$text_data, $corrections] = spellcheck_apply_corrections();
 
             // save the already-made corrections in a temporary session variable
@@ -305,7 +305,7 @@ try {
             }
             $_SESSION[$wcTempCorrections] = $corrections;
 
-            $is_changed = $_POST['is_changed'];
+            $is_changed = get_integer_param($_POST, 'is_changed', 0, 0, 1);
             include('spellcheck.inc');
             break;
 

--- a/tools/proofers/spellcheck.inc
+++ b/tools/proofers/spellcheck.inc
@@ -9,7 +9,12 @@ include_once('spellcheck_text.inc');
 include_once('PPage.inc');
 include_once('image_block_enh.inc');
 
-// text_data should be set before we get here -- should take place in processtext.php
+// The following variables should be set before we get here (via processtext.php)
+// * $ppage
+// * $text_data
+// * $is_changed
+// * $accepted_words
+// * $aux_language
 
 $revert_text = $_POST['revert_text'] ?? $text_data;
 
@@ -78,10 +83,10 @@ if ($user->profile->i_type == 1) {
     $revert_text = str_replace(["\r", "\n\n", "\n"], ["\n", "[lf]", "[lf]"], $revert_text);
 
     echo "<input type='hidden' name='revert_text' value='" . attr_safe($revert_text) . "'>\n";
-    echo "<input type='hidden' id='is_changed' name='is_changed' value='$is_changed'>\n";
+    echo "<input type='hidden' id='is_changed' name='is_changed' value='" . attr_safe($is_changed) . "'>\n";
     echo "<input type='hidden' id='accepted_words' name=\"accepted_words\" value='"
         . attr_safe(implode(' ', $accepted_words)) . "'>\n";
-    echo "<input type='hidden' id='is_header_visible' name=\"is_header_visible\" value='$is_header_visible'>\n";
+    echo "<input type='hidden' id='is_header_visible' name=\"is_header_visible\" value='" . attr_safe($is_header_visible) . "'>\n";
 
     // run the text through the spellcheck - returns the form contents and a list of languages the page was checked against
     [$page_contents, $languages, $messages, $highlights] =


### PR DESCRIPTION
Do a more accurate job of validating POST inputs to `processtext.php` and escaping outputs of user inputs during WordCheck.

Note that the interaction between these two files is a bit opaque. `processtext.php` processes the user input from the proofreading interface and then `include()s` `spellcheck.inc` when initiating WordCheck. This is not ideal as it masks whose the origin of variables and whose job it is to validate them. This is, alas, not resolved in this PR.

Available in the [https://www.pgdp.org/~cpeel/c.branch/better-pi-input-validation/](better-pi-input-validation) sandbox.