### PR TITLE
Handle edgecase in PM view upgrade script

### DIFF
--- a/SETUP/upgrade/20/20230920_move_pmdefault_to_usersettings.php
+++ b/SETUP/upgrade/20/20230920_move_pmdefault_to_usersettings.php
@@ -13,9 +13,16 @@ $pm_view_options = [
 ];
 
 $pms = Settings::get_users_with_setting("manager", "yes");
+sort($pms);
 
 foreach ($pms as $pm) {
-    $user = new User($pm);
+    echo "Setting PM view for $pm\n";
+    try {
+        $user = new User($pm);
+    } catch (NonexistentUserException $exception) {
+        echo "    Error: " . $exception->getMessage() . "\n";
+        continue;
+    }
     $user_settings = new Settings($pm);
     $user_settings->set_value("pm_view", $pm_view_options[$user->i_pmdefault]);
 }


### PR DESCRIPTION
When running this upgrade script on PROD in today's deployment we ran into the case where a username was in the `user_settings` table but not in the `users` table. This shouldn't happen, but we don't have foreign keys in place to prevent it* and we shouldn't break the upgrade script if it happens.

\* MyISAM tables -- which we used originally -- didn't support foreign keys. InnoDB tables do and we should consider using them where we can although that's going to be a bit of a bear to implement since we need to handle cases like this in the process.