### PR TITLE
Introduce code documentation standards and tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,12 @@ pinc/site_vars.php
 pinc/udb_user.php
 # Ignore compiled message files
 messages.mo
+# Ignore build artifacts
+build
 # Ignore dev tooling byproducts
 node_modules
 vendor
 .phpunit.result.cache
 .php_cs.cache
 .php-cs-fixer.cache
+.phpdoc

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ To get involved with development on this code base, see
 [DP Code Development](https://www.pgdp.net/wiki/DP_Code_Development) in the
 pgdp.net wiki.
 
-See also our [coding standards](SETUP/CODE_STYLE.md).
+See also our [coding standards](SETUP/CODE_STYLE.md) and
+[coding documentation](SETUP/CODE_DOCS.md).
 
 ## License
 

--- a/SETUP/CODE_DOCS.md
+++ b/SETUP/CODE_DOCS.md
@@ -1,0 +1,15 @@
+# Documentation
+
+Code-level docs can be generated using [phpDocumentor](https://www.phpdoc.org/).
+A configuration file is included in the repo.
+
+To generate the docs:
+```bash
+# at repo base
+php path/to/phpDocumentor.phar run
+```
+
+This will generate documentation in `build/docs`.
+
+Work is very slowly underway to update function comments to use DocBlocks
+and until that work is completed the value of the documentation may be dubious.

--- a/SETUP/CODE_STYLE.md
+++ b/SETUP/CODE_STYLE.md
@@ -1,5 +1,7 @@
 # Code Style & Linting
 
+See [CODE_DOCS.md](CODE_DOCS.md) for information on code documentation.
+
 ## PHP
 
 We use [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) for PHP

--- a/SETUP/README.md
+++ b/SETUP/README.md
@@ -15,8 +15,9 @@ Installation and upgrading:
   activities for administrators.
 * [UPGRADE.md](UPGRADE.md) covers upgrading existing DP installs.
 
-For more information about code style and linting:
+For more information about code style, linting, and docs:
 * [CODE_STYLE.md](CODE_STYLE.md)
+* [CODE_DOCS.md](CODE_DOCS.md)
 
 For information on site styling and theming, see:
 * [Styling system](../styles/README.md)

--- a/activity_hub.php
+++ b/activity_hub.php
@@ -140,17 +140,26 @@ activity_descriptions();
 
 // ----------------------------------
 
+/**
+ * Print out the snapshot table.
+ *
+ * The table contains a row for each stage including the user's access for
+ * that stage as well as project and page metrics.
+ *
+ * @param bool $show_filtered_projects
+ *   If TRUE, the table will show numbers based on the user's project filter
+ *   for that stage.
+ *
+ * @param bool $show_filtering_links
+ *   If TRUE, the table will allow the user to toggle between viewing numbers
+ *   for ALL projects and just those for filters.
+ *
+ * @param bool $show_beginner_help
+ *   If TRUE, the table will be prefaced with an informational paragraph.
+ *
+ * @return void
+ */
 function progress_snapshot_table($show_filtered_projects, $show_filtering_links, $show_beginner_help)
-// Prints out a table containing a row for each stage including the user's
-// access for that stage as well as project and page metrics.
-// Arguments:
-//   $show_filtered_projects - if TRUE, the table will show numbers based on
-//                             the user's project filter for that stage
-//   $show_filtering_links   - if TRUE, the table will allow the user to
-//                             toggle between viewing numbers for ALL projects
-//                             and just those for filters.
-//   $show_beginner_help     - if TRUE, the table will be prefaced with an
-//                             informational paragraph
 {
     global $Stage_for_id_;
 
@@ -287,9 +296,23 @@ function progress_snapshot_table($show_filtered_projects, $show_filtering_links,
     echo "<a href='faq/site_progress_snapshot_legend.php' target='_blank'>" . _("Information about this table") . "</a>";
 }
 
+/**
+ * Print out an activity summary row for the progress table.
+ *
+ * @param object $stage Stage to summarize
+ *
+ * @param string[] $desired_states Array of desired states
+ *
+ * @param bool $show_filtered_projects
+ *   If TRUE, the row will include the user's project filter
+ *
+ * @param string $filter_type Type of project filter, usually a stage ID
+ *
+ * @return void
+ *
+ * @see progress_snapshot_table()
+ */
 function summarize_stage($stage, $desired_states, $show_filtered_projects = false, $filter_type = "")
-// Prints out an activity summary table row for a specific stage (be it a
-// Round, Pool, or Stage).
 {
     global $pguser, $n_projects_in_state_, $n_projects_transitioned_to_state_;
 
@@ -474,9 +497,13 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects = fals
 }
 
 
+/**
+ * Prints out a list of activities (Stages, Rounds, and Pools) and their
+ * description.
+ *
+ * @return void
+ */
 function activity_descriptions()
-// Prints out a list of activities (Stages, Rounds, and Pools) and their
-// description.
 {
     global $Stage_for_id_, $code_url;
 


### PR DESCRIPTION
Introduce DocBlock as the preferred function code comment style. This PR includes an example of what this would look like in `activity_hub.php` and docs on how to generate the code-level docs using phpDocumentor. You can see an example of the rendered docs at https://www.pgdp.org/~cpeel/c/build/docs/files/activity-hub.html

As a bonus, many editors (VSCode, Sublime) can parse DocBlocks and provide both syntax color highlighting and function completion.

# Why

This is another case of [yak-shaving](https://en.wiktionary.org/wiki/yak_shaving#/media/File:Yak_shaving.jpg).

`php-cs-fixer` v3 has Strong Opinions on where function comments should be located in functions with multi-line parameters.

For instance, this:
```php
function example_with_multiline_params(
    $param1,
    $param2
)
// Function comment
{
}
```

Becomes this:
```php
function example_with_multiline_params(
    $param1,
    $param2
) {
    // Function comment
}
```

We do this "function comment after the signature and before the open bracket" a lot and moving the function documentation comment into the block is simply incorrect. Before I run `php-cs-fixer` v3 on all of the codebase I need to update all of the functions that follow this pattern. Since I have to touch pretty much every function anyway this seemed like a good time to settle on some code doc standards.

If this PR is approved and we agree on this format going forward I'll merge this in and follow up with another PR that updates function comments to DocBlock format with the least amount of work possible (not adding `@params` descriptions where we don't do so already, etc). That will unblock our upgrade to `php-cs-fixer` v3.