### PR TITLE
Quiet zip output when downloading project images

### DIFF
--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -42,6 +42,7 @@ if (!is_null($zip_type)) {
         escapeshellarg($list_name),
         "|",
         "zip",
+        "-q", // quiet so output doesn't go to Apache error logs
         "-@",
         "-",
     ]);


### PR DESCRIPTION
When the `zip` command runs it outputs the list of files it's adding as it goes. When we use this in `images_index.php` to stream a zip file back to the user the output ends up in the Apache error logs. Prevent this with the `-q` argument.

I don't love the fact that we do a call-out like this, but I don't see a way to use the internal PHP zip tools to do this without creating the file, tossing it back to the user, and then deleting it -- and this appears to have worked since circa 2004.

Testable in the [quite-zip-creation](https://www.pgdp.org/~cpeel/c.branch/quite-zip-creation/) sandbox.