### PR TITLE
Increase newcomer reserve for P1 to 14 days for English

### DIFF
--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -410,8 +410,8 @@ function get_reserve_length($project, $round)
             return 0;
         }
 
-        // Otherwise, reserve for 7 days.
-        return 7;
+        // Otherwise, reserve as requested by GM.
+        return 14;
     }
 
     // Anything not covered above


### PR DESCRIPTION
At the GM's request, the newcomer reserve has been extended from 7 to 14 days for English projects.

Testable in [this project in the sandbox](https://www.pgdp.org/~srjfoo/c.branch/change-newcomer-reserve-english/project.php?id=projectID45b672b501229). The sandbox has been doctored so that you'll need to use an unprivileged account that has more than 2 days on site and more than 5 pages proofed to verify it (instead of the normal 21 days and 500 pages 😁).