### PR TITLE
Update function comments to DocBlock form

### DIFF
--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -211,8 +211,11 @@ include($relPath.'/../faq/privacy.php');
 //---------------------------------------------------------------------------
 
 
-// Validate the user input fields
-// Returns an empty string upon success and an error message upon failure
+/**
+ * Validate the user input fields for the page.
+ *
+ * Returns an empty string upon success and an error message upon failure.
+ */
 function _validate_fields($real_name, $username, $userpass, $userpass2, $email, $email2, $email_updates, $referrer, $referrer_details)
 {
     global $testing, $general_help_email_addr;

--- a/accounts/login.php
+++ b/accounts/login.php
@@ -113,11 +113,18 @@ metarefresh(0, $url, "", "");
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// When a login failure occurs, redirect the user to login_failure.php to see
-// the error message and some tips to correct it.
-//
-// $error_code is a short URL-friendly key into an array defined in
-// login_failure.php that contains a translated, user-friendly error message.
+/**
+ * Redirect user to login_failure.php.
+ *
+ * When a login failure occurs, redirect the user to login_failure.php to see
+ * the error message and some tips to correct it.
+ *
+ * @param string $error_code
+ *   A short URL-friendly key into an array defined in login_failure.php that
+ *   contains a translated, user-friendly error message.
+ * @param string $destination
+ *   A URL where the user should be redirected back to upon a successful login.
+ */
 function login_failure($error_code, $destination)
 {
     global $code_url;

--- a/api/exceptions.inc
+++ b/api/exceptions.inc
@@ -1,7 +1,10 @@
 <?php
 
-// Base exception that all API exceptions should derive from
-// These exception codes range from 1 to 99
+/**
+ * Base exception that all API exceptions should derive from.
+ *
+ * These exception codes range from 1 to 99
+ */
 class ApiException extends Exception
 {
     public function __construct($message = "API exception", $code = 1)

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -129,8 +129,10 @@ function api_v1_projects($method, $data, $query_params)
 //---------------------------------------------------------------------------
 // projects/:projectid
 
-// Return a list of updatable project fields mapped from the API names
-// to the Project object names.
+/**
+ * Return a list of updatable project fields mapped from the API names
+ * to the Project object names.
+ */
 function get_updatable_project_fields()
 {
     return [
@@ -625,11 +627,14 @@ function api_v1_projects_holdstates($method, $data, $query_params)
 //---------------------------------------------------------------------------
 // Utility functions
 
-// Check to see if the user requested an enabled filter. This returns one of
-// three possible states:
-//   null - no enabled flag was set
-//   true - enabled flag was set to "true" or an empty string (for ?enabled)
-//   false - enabled flag was set to "false"
+/**
+ * Check to see if the user requested an enabled filter.
+ *
+ * This returns one of three possible states:
+ * - null - no enabled flag was set
+ * - true - enabled flag was set to "true" or an empty string (for ?enabled)
+ * - false - enabled flag was set to "false"
+ */
 function _get_enabled_filter($query_params)
 {
     if (!isset($query_params["enabled"])) {

--- a/credits.php
+++ b/credits.php
@@ -92,9 +92,14 @@ function load_composer_credit_details()
     return $credit_details;
 }
 
-// Ignore exceptions when iterating over the directory, such as permission
-// errors from SETUP/
-// from antennen at https://www.php.net/manual/en/class.recursivedirectoryiterator.php
+/**
+ * A permissive recursive directory iterator
+ *
+ * Ignore exceptions when iterating over the directory, such as permission
+ * errors from `SETUP/`.
+ *
+ * From antennen at https://www.php.net/manual/en/class.recursivedirectoryiterator.php
+ */
 class PermissiveRecursiveDirectoryIterator extends RecursiveDirectoryIterator
 {
     public function getChildren()
@@ -107,7 +112,11 @@ class PermissiveRecursiveDirectoryIterator extends RecursiveDirectoryIterator
     }
 }
 
-// https://stackoverflow.com/questions/173400/how-to-check-if-php-array-is-associative-or-sequential
+/**
+ * Detect if an array is associative or sequential
+ *
+ * From https://stackoverflow.com/questions/173400/how-to-check-if-php-array-is-associative-or-sequential
+ */
 function isAssoc(array $arr)
 {
     if ([] === $arr) {

--- a/faq/privacy.php
+++ b/faq/privacy.php
@@ -120,21 +120,27 @@ function insert_site_name($sentence)
     return sprintf($sentence, $site_name);
 }
 
+/**
+ * Output a paragraph of sentences.
+ *
+ * Each sentence will have the first sprintf argument replaced with $site_name.
+ */
 function output_paragraph($sentences)
-// Output a paragraph of sentences. Each sentence will have the first sprintf
-// argument replaced with $site_name.
 {
     echo "<p>";
     echo implode(" ", array_map("insert_site_name", $sentences));
     echo "</p>";
 }
 
+/**
+ * Output a section of the privacy statement, including the section header
+ * and one or more paragraphs.
+ *
+ * The number of arguments this function accepts is variable, and is of the
+ * format ($header, $paragraph1, $paragraph2, ...) where each paragraph is
+ * an array of strings (ie: sentences).
+ */
 function output_section()
-// Output a section of the privacy statement, including the section header
-// and one or more paragraphs.
-// The number of arguments this function accepts is variable, and is of the
-// format ($header, $paragraph1, $paragraph2, ...) where each paragraph is
-// an array of strings (ie: sentences).
 {
     $arguments = func_get_args();
     $header = array_shift($arguments);

--- a/list_etexts.php
+++ b/list_etexts.php
@@ -4,8 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'list_projects.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param(), get_integer_param(),
-                                   // surround_and_join()
+include_once($relPath.'misc.inc'); // get_enumerated_param(), get_integer_param(), surround_and_join()
 
 $x = get_enumerated_param($_GET, 'x', 'g', ['g', 's', 'b']);
 $sort = get_integer_param($_GET, 'sort', 0, 0, 5);

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -23,33 +23,47 @@ $Activity_for_id_ = [];
 
 class Activity
 {
+    /**
+     * Activity constructor
+     *
+     * @param string $id
+     *   A very short mnemonic identifier for the activity.
+     *   (Should probably conform to the rules for a PHP variable name.)
+     * @param string $name
+     *   A gettext-translated name for the activity.
+     * @param array $access_minima
+     *   A (possibly empty) array of minimum requirements that a user must satisfy
+     *   in order to be allowed to participate in this activity
+     *   (barring special permission).
+     * @param string $after_satisfying_minima
+     *   After satisfying the above minima (if any), does the user have to do
+     *   anything else to work in this activity?
+     *   ```
+     *   'IMMEDIATE'  Nope, they get immediate access.
+     *   'REQ-AUTO'   They must ask for access, but it is auto-granted.
+     *   'REQ-HUMAN'  They must ask for access, and it must be human-granted.
+     *   'NOREQ'      They don't request access (or at least, we don't supply
+     *                a link by which to request access). Instead, they just
+     *                wait until they are approved.
+     *   ```
+     * @param string $evaluation_criteria
+     *   A brief description of what the evaluation criteria are.
+     * @param string $access_change_callback
+     *   A callback function that will be called when a user's access for this
+     *   round has changed. The function will be passed a User object representing
+     *   the user with the access change in addition to the access change itself, eg:
+     *   ```
+     *   p1_access_change_callback($user, $change)
+     *   ```
+     *   where $change is one of `[ "grant", "revoke", "request", "deny_request_for" ]`
+     */
     public function __construct(
         $id,
-            // A very short mnemonic identifier for the activity.
-            // (Should probably conform to the rules for a PHP variable name.)
         $name,
-            // A gettext-translated name for the activity.
         $access_minima,
-            // A (possibly empty) array of minimum requirements that a user must satisfy
-            // in order to be allowed to participate in this activity
-            // (barring special permission).
         $after_satisfying_minima,
-            // After satisfying the above minima (if any), does the user have to do
-            // anything else to work in this activity?
-            //     'IMMEDIATE'  Nope, they get immediate access.
-            //     'REQ-AUTO'   They must ask for access, but it is auto-granted.
-            //     'REQ-HUMAN'  They must ask for access, and it must be human-granted.
-            //     'NOREQ'      They don't request access (or at least, we don't supply
-            //                  a link by which to request access). Instead, they just
-            //                  wait until they are approved.
         $evaluation_criteria,
-            // A brief description of what the evaluation criteria are.
         $access_change_callback
-            // A callback function that will be called when a user's access for this
-            // round has changed. The function will be passed a User object representing
-            // the user with the access change in addition to the access change itself
-            //     eg: p1_access_change_callback($user, $change)
-            // where $change is one of [ "grant", "revoke", "request", "deny_request_for" ]
     ) {
         $this->id = $id;
         $this->name = $name;
@@ -86,26 +100,30 @@ class Activity
         $Activity_for_id_[$id] = & $this;
     }
 
+    /**
+     * Return a User Access object
+     *
+     * Return an object with the following properties:
+     * - can_access:
+     *         a boolean: TRUE iff the user can access this activity.
+     * - minima_table:
+     *         an array of arrays (4-tuples):
+     *         ( $criterion_str, $minimum, $user_score, $satisfied )
+     * - all_minima_satisfied:
+     *         boolean
+     * - request_status:
+     *         enumerated type: sat-unneeded, sat-granted, sat-available, sat-requested,
+     *                          sat-wait, sat-denied
+     *                          unsat-granted, unsat-requested, unsat-ungranted,
+     *                          unsat-denied
+     * - evaluation_criteria:
+     *         message to display about evaluation
+     *
+     * UNIMPLEMENTED:
+     * If $n_pages_completed is non-null, use it as the number of pages
+     * that the user has completed. Otherwise, consult the database.
+     */
     public function user_access($username, $n_pages_completed = null)
-    // Return an object with the following properties:
-    // -- can_access:
-    //         a boolean: TRUE iff the user can access this activity.
-    // -- minima_table:
-    //         an array of arrays (4-tuples):
-    //         ( $criterion_str, $minimum, $user_score, $satisfied )
-    // -- all_minima_satisfied:
-    //         boolean
-    // -- request_status:
-    //         enumerated type: sat-unneeded, sat-granted, sat-available, sat-requested,
-    //                          sat-wait, sat-denied
-    //                          unsat-granted, unsat-requested, unsat-ungranted,
-    //                          unsat-denied
-    // -- evaluation_criteria:
-    //         message to display about evaluation
-    //
-    // UNIMPLEMENTED:
-    // If $n_pages_completed is non-null, use it as the number of pages
-    // that the user has completed. Otherwise, consult the database.
     {
         if (is_null($username)) {
             $uao = new StdClass(); // user access object

--- a/pinc/BBDiffFormatter.inc
+++ b/pinc/BBDiffFormatter.inc
@@ -17,9 +17,12 @@ class BBDiffFormatter extends DiffFormatter
         $this->diffurl = $diffurl;
     }
 
-    // Outputs an edit block
-    // Leading context line is output before add/delete changes
-    // Assumes zero trailing context lines
+    /**
+     * Outputs an edit block
+     *
+     * Leading context line is output before add/delete changes
+     * Assumes zero trailing context lines
+     */
     protected function block($xbeg, $xlen, $ybeg, $ylen, &$edits)
     {
         // We don't display leading context line for change edits, so need to
@@ -56,7 +59,9 @@ class BBDiffFormatter extends DiffFormatter
         $this->endBlock();
     }
 
-    // Called at the start of a block of connected edits.
+    /**
+     * Called at the start of a block of connected edits.
+     */
     protected function startBlock($header)
     {
         $linenum = preg_replace('/^(\d+).*/', 'Line $1', $header);
@@ -65,8 +70,10 @@ class BBDiffFormatter extends DiffFormatter
         $this->writeOutput("\n----- [b]$linenum, page [url=$safeurl]${difflabel}[/url][/b] -----\n");
     }
 
-    // Writes all (optionally prefixed) lines to the output buffer, separated by newlines
-    // and enclosed in BBCode [code] markup
+    /**
+     * Writes all (optionally prefixed) lines to the output buffer, separated by newlines
+     * and enclosed in BBCode [code] markup
+     */
     protected function lines($lines, $prefix = '')
     {
         $this->writeOutput("[code]\n");
@@ -76,19 +83,25 @@ class BBDiffFormatter extends DiffFormatter
         $this->writeOutput("[/code]\n");
     }
 
-    // Output lines that were added by the diff
+    /**
+     * Output lines that were added by the diff
+     */
     protected function added($lines, $leading_context = null)
     {
         $this->added_deleted('added', $lines, $leading_context);
     }
 
-    // Output lines that were deleted by the diff
+    /**
+     * Output lines that were deleted by the diff
+     */
     protected function deleted($lines, $leading_context = null)
     {
         $this->added_deleted('deleted', $lines, $leading_context);
     }
 
-    // Output lines that were added/deleted by the diff
+    /**
+     * Output lines that were added/deleted by the diff
+     */
     private function added_deleted($adddel_string, $lines, $leading_context)
     {
         if (empty($leading_context)) {  // Must be first line of the page if no context
@@ -112,8 +125,9 @@ class BBDiffFormatter extends DiffFormatter
         }
     }
 
-    // Count blank lines in given array if they are all blank
-    //
+    /**
+     * Count blank lines in given array if they are all blank
+     */
     private function count_all_blank_lines($lines)
     {
         foreach ($lines as &$line) {
@@ -124,7 +138,9 @@ class BBDiffFormatter extends DiffFormatter
         return count($lines);
     }
 
-    // Output lines that were changed by the diff
+    /**
+     * Output lines that were changed by the diff
+     */
     protected function changed($orig, $closing)
     {
         $this->lines($orig);
@@ -132,18 +148,25 @@ class BBDiffFormatter extends DiffFormatter
         $this->lines($closing);
     }
 
-    // Make string safe for this type of output
-    // No changes needed for BBCode output
+    /**
+     * Make string safe for this type of output
+     *
+     * No changes needed for BBCode output
+     */
     protected function make_safe($string)
     {
         return $string;
     }
 }
 
-// Makes BBCode diffs suitable for displaying within HTML
+/**
+ * Makes BBCode diffs suitable for displaying within HTML
+ */
 class BBDiffFormatterHTML extends BBDiffFormatter
 {
-    // Make string safe for HTML output
+    /**
+     * Make string safe for HTML output
+     */
     protected function make_safe($string)
     {
         return html_safe($string);

--- a/pinc/BrowseUtility.inc
+++ b/pinc/BrowseUtility.inc
@@ -76,26 +76,34 @@ class BrowseUtility
         }
     }
 
-    // returns the number of rows to display (typically count)
+    /**
+     * Return the number of rows to display (typically count)
+     */
     public function getRowCountToList()
     {
         return $this->_displayed_count;
     }
 
-    // returns true if there can (should) be a "previous" link, false otherwise
+    /**
+     * Return true if there can (should) be a "previous" link, false otherwise
+     */
     public function isPreviousBrowseAvailable()
     {
         return ($this->_start > 0);
     }
 
-    // returns true if there can (should) be a "next" link, false otherwise
+    /**
+     * Return true if there can (should) be a "next" link, false otherwise
+     */
     public function isNextBrowseAvailable()
     {
         return ($this->_last_index < $this->_total_row_count - 1);
     }
 
-    // returns query strings such as "start=40&count=20"
-    // to use with a "previous" link
+    /**
+     * Return query strings such as "start=40&count=20"
+     * to use with a "previous" link
+     */
     public function getPreviousBrowseQueryString()
     {
         $new_start = $this->_start - $this->_count;
@@ -105,16 +113,22 @@ class BrowseUtility
         return "start=$new_start&count=" . $this->_count;
     }
 
-    // returns query strings such as "start=40&count=20"
-    // to use with a "next" link
+    /**
+     * Return query strings such as "start=40&count=20"
+     * to use with a "next" link
+     */
     public function getNextBrowseQueryString()
     {
         $new_start = $this->_start + $this->_count;
         return "start=$new_start&count=" . $this->_count;
     }
 
-    // "Displaying entries 6-10 of 24."
-    // indices are reported one high, e.g. 1-10 instead of 0-9
+    /**
+     * Return pagination details string
+     *
+     * For Example: "Displaying entries 6-10 of 24.".
+     * Indices are reported one high, e.g. 1-10 instead of 0-9
+     */
     public function getDisplayingString()
     {
         if ($this->_total_row_count == 0) {
@@ -128,14 +142,17 @@ class BrowseUtility
         }
     }
 
-    // writes a drop-down for selecting the count-parameter
-    // arguments: any number of integers that will be used
-    // as options for count. Zero means infinity.
-    // No arguments means a default list will be used.
-    // The page is simply reloaded with the new count,
-    // all other arguments being the same and the method (POST/GET)
-    // being the same.
-    // Supports POST and GET.
+    /**
+     * Writes a drop-down for selecting the count-parameter
+     *
+     * Arguments: any number of integers that will be used
+     * as options for count. Zero means infinity.
+     * No arguments means a default list will be used.
+     * The page is simply reloaded with the new count,
+     * all other arguments being the same and the method (POST/GET)
+     * being the same.
+     * Supports POST and GET.
+     */
     public function echoCountSelectionList()
     {
         if (func_num_args() == 0) {

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -186,8 +186,16 @@ class CharSuites
         DPDatabase::query($sql);
     }
 
-    // Check to see if $charsuite is a real CharSuite object or a charsuite name
-    // and if the latter, return the former.
+    /**
+     * Resolve $charsuite to a CharSuite object
+     *
+     * Check to see if `$charsuite` is a real CharSuite object or a charsuite
+     * name and if the latter, return a CharSuite object of that name.
+     *
+     * @param string|object $charsuite Character suite name or object
+     *
+     * @return object
+     */
     public static function resolve($charsuite)
     {
         if ($charsuite instanceof CharSuite) {

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -144,9 +144,13 @@ function project_add_page(
     _project_adjust_n_available_pages($projectid, +1);
 }
 
+/**
+ * Load a page from a file.
+ *
+ * This function should always be used to load page contents from a file to
+ * ensure consistency.
+ */
 function load_page_from_file($file_path, $projectid)
-// Load a page from a file. This function should always be used to load
-// page contents from a file to ensure consistency.
 {
     $text = file_get_contents($file_path);
     if ($text === false) {
@@ -166,11 +170,14 @@ function load_page_from_file($file_path, $projectid)
     return _normalize_page_text($text, $projectid);
 }
 
+/**
+ * Return an SQL expression that will yield the contents of the given file
+ * as a string or NULL if the file can't be read.
+ *
+ * @param string $file_path Absolute file path
+ * @param string $projectid Project ID
+ */
 function file_content_expr($file_path, $projectid)
-// Return an SQL expression that will yield:
-// -- the contents of the given file as a string
-// -- or NULL if the file can't be read.
-// $file_path must be absolute.
 {
     $txt = load_page_from_file($file_path, $projectid);
     if ($txt === null) {
@@ -211,8 +218,12 @@ function Page_delete($projectid, $image, $user)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Replace a page image
+ *
+ * For example, replace 001.png with 001.jpg.
+ */
 function Page_replaceImage($projectid, $image, $new_image, $user)
-// e.g., replace 001.png with 001.jpg
 {
     $setter = set_col_str("image", $new_image);
     _Page_UPDATE($projectid, $image, $setter);
@@ -528,13 +539,20 @@ function _Page_UPDATE($projectid, $image, $settings)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Normalize a page-text before we store it in the db.
+ *
+ * This does several transformations to ensure we have a UTF-8 string with
+ * codepoints allowed for the project. When updating this function, also
+ * update `get_normalize_page_text_changes()` used to report page text changes
+ * to users elsewhere.
+ *
+ * @param string $page_text UTF-8 string of page text.
+ * @param string $projectid Project ID
+ *
+ * @see get_normalize_page_text_changes()
+ */
 function _normalize_page_text($page_text, $projectid)
-// Normalize a page-text before we store it in the db. This does several
-// transformations to ensure we have a UTF-8 string with codepoints
-// allowed for the project. This function assumes that $page_text is
-// valid UTF-8.
-// When updating this function, also update get_normalize_page_text_changes()
-// used to report page text changes to users elsewhere.
 {
     // Filter characters to just the Latin-1 set
     $project = new Project($projectid);
@@ -581,10 +599,15 @@ function _normalize_page_text($page_text, $projectid)
     return preg_replace($patterns, $repls, $page_text);
 }
 
+/**
+ * Return a list of "notable" changes that a page text will undergo for
+ * user consumption.
+ *
+ * This should be updated when `_normalize_page_text()` is updated.
+ *
+ * @see _normalize_page_text()
+ */
 function get_normalize_page_text_changes($text, $projectid)
-// Return a list of "notable" changes that a page text will undergo for
-// user consumption. This should be updated when _normalize_page_text()
-// is updated.
 {
     $project = new Project($projectid);
 
@@ -663,9 +686,14 @@ function get_normalize_page_text_changes($text, $projectid)
     return $changes;
 }
 
+/**
+ * Return a list of text page changes should $filename be loaded into a project.
+ *
+ * This should be updated if `load_page_from_file()` is updated.
+ *
+ * @see load_page_from_file()
+ */
 function get_load_page_from_file_changes($filename, $projectid)
-// Return a list of text page changes should $filename be loaded into a project.
-// This should be updated if load_page_from_file() is updated.
 {
     $changes = [];
 
@@ -784,8 +812,10 @@ function _project_adjust_n_available_pages($projectid, $adjustment)
     DPDatabase::query($sql);
 }
 
+/**
+ * Calculate the project's n_pages and n_available_pages from scratch.
+ */
 function project_recalculate_page_counts($projectid)
-// Calculate the project's n_pages and n_available_pages from scratch.
 {
     validate_projectID($projectid);
     $sql = "

--- a/pinc/DifferenceEngineWrapperBB.inc
+++ b/pinc/DifferenceEngineWrapperBB.inc
@@ -4,7 +4,9 @@
 include_once($relPath."DifferenceEngineWrapper.inc");
 include_once($relPath."BBDiffFormatter.inc");
 
-// Format diffs using BB code, without HTML markup
+/**
+ * Format diffs using BB code, without HTML markup
+ */
 class DifferenceEngineWrapperBB extends DifferenceEngineWrapper
 {
     public function __construct($diffurl)
@@ -13,7 +15,9 @@ class DifferenceEngineWrapperBB extends DifferenceEngineWrapper
     }
 }
 
-// Format diffs using BB code, displayed within HTML markup
+/**
+ * Format diffs using BB code, displayed within HTML markup
+ */
 class DifferenceEngineWrapperBBHTML extends DifferenceEngineWrapper
 {
     public function __construct($diffurl)

--- a/pinc/DifferenceEngineWrapperTable.inc
+++ b/pinc/DifferenceEngineWrapperTable.inc
@@ -57,7 +57,9 @@ class DifferenceEngineWrapperTable extends DifferenceEngineWrapper
     }
 }
 
-// Override default css for DP customizations
+/**
+ * Override default css for DP customizations
+ */
 function get_DifferenceEngine_css_data()
 {
     [, $font_size, $font_family] = get_user_proofreading_font();

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -13,10 +13,14 @@ include_once($relPath.'daily_page_limit.inc'); // get_dpl_count_for_user_in_roun
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Returns the best page entry for the user given the specified preceding
+ * project restriction.
+ *
+ * If successful, it returns [ $imagename, $state ],
+ * on failure it returns NULL;
+ */
 function get_available_page_array($project, $round, $pguser, $preceding_proofer_restriction)
-// Returns the best page entry for the user given the specified preceding
-// project restriction. If successful, it returns [ $imagename, $state ],
-// on failure it returns NULL;
 {
     // Normally, pages are served in order of "page number"
     // (i.e., by the 'image' field)
@@ -121,9 +125,11 @@ function get_available_page_array($project, $round, $pguser, $preceding_proofer_
     return [$npage['image'], $npage['state']];
 }
 
+/**
+ * Returns an LPage, unless no page is available,
+ * in which case returns NULL and sets $err.
+ */
 function get_available_page($projectid, $proj_state, $pguser, &$err)
-// Returns an LPage, unless no page is available,
-// in which case returns NULL and sets $err.
 {
     // can throw NonexistentProjectException
     $project = new Project($projectid);
@@ -150,9 +156,11 @@ function get_available_page($projectid, $proj_state, $pguser, &$err)
     return $lpage;
 }
 
+/**
+ * Returns an array [image, state] unless no page is available,
+ * in which case throw an exception.
+ */
 function get_available_proof_page_array($project, $round, $pguser)
-// Returns an array [image, state] unless no page is available,
-// in which case throw an exception.
 {
     global $preceding_proofer_restriction;
 
@@ -179,14 +187,16 @@ function get_available_proof_page_array($project, $round, $pguser)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Returns an LPage, unless the parameters do not correctly identify a page,
+ * in which case it throws an exception.
+ */
 function get_indicated_LPage(
     $projectid,
     $proj_state,
     $imagefile,
     $page_state,
     $reverting_to_orig)
-// Returns an LPage, unless the parameters do not correctly identify a page,
-// in which case it throws an exception.
 {
     // Make sure project is still in same state.
     // can throw NonexistentProjectException
@@ -245,12 +255,15 @@ function project_continuity_test($project, $orig_state, $no_more_pages)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Logical page
+ *
+ * The "L" stands for "Logic", as in the 3 tiers of Data, Logic, and Presentation.
+ * For pages, the Data layer is `pinc/DPage.inc`,
+ * and the Presentation layer is most of `tools/proofers/*`.
+ * However, we're not very strict about the divisions yet.
+ */
 class LPage
-// The "L" stands for "Logic",
-// as in the 3 tiers of Data, Logic, and Presentation.
-// (For pages, the Data layer is pinc/DPage.inc,
-// and the Presentation layer is most of tools/proofers/*.
-// However, we're not very strict about the divisions yet.)
 {
     public function __construct($projectid, $imagefile, $page_state, $reverting_to_orig)
     {
@@ -328,14 +341,18 @@ class LPage
         $this->reverting_to_orig = 0;
     }
 
+    /**
+     * Attempt to save a page as done
+     *
+     * Return an array containing two values:
+     * - a boolean indicating whether the page was saved,
+     * - a boolean indicating whether user has reached the round's daily page limit.
+     *
+     * Note that `[FALSE, FALSE]` is currently impossible:
+     * - if this function says that the page was not saved,
+     * - it can only be because the user already reached the daily page limit.
+     */
     public function attemptSaveAsDone($text_data, $pguser)
-    // Return an array containing two values:
-    // a boolean indicating whether the page was saved,
-    // and a boolean indicating whether user has reached the round's daily page limit.
-    //
-    // (Note that (FALSE, FALSE) is currently impossible:
-    // if this function says that the page was not saved,
-    // it can only be because the user already reached the DPL.)
     {
         if ($this->round->has_a_daily_page_limit()) {
             $pre_save_dpl_count = get_dpl_count_for_user_in_round($pguser, $this->round);
@@ -376,8 +393,10 @@ class LPage
         $this->reverting_to_orig = 0;
     }
 
+    /**
+     * Return TRUE if this report causes project to be marked bad.
+     */
     public function markAsBad($user, $reason)
-    // Return TRUE if this report causes project to be marked bad.
     {
         global $code_url, $PAGE_BADNESS_REASONS;
 

--- a/pinc/NonactivatedUser.inc
+++ b/pinc/NonactivatedUser.inc
@@ -194,8 +194,15 @@ class NonactivatedUser
 
     // static functions
 
-    // Load a NonactivatedUser record by ID
-    // e.g. $user = NonactivatedUser::load_from_id($id);
+    /**
+     * Load a NonactivatedUser record by ID
+     *
+     * Example: `$user = NonactivatedUser::load_from_id($id);`
+     *
+     * @param string $id
+     *
+     * @return object NonactivatedUser
+     */
     public static function load_from_id($id)
     {
         $user = new NonactivatedUser();
@@ -203,10 +210,18 @@ class NonactivatedUser
         return $user;
     }
 
-    // Load a NonactivatedUser record by email address
-    // e.g. $user = NonactivatedUser::load_from_email($email);
-    // The email address is not guaranteed to be unique and this function
-    // may raise NonuniqueNonactivatedUserException
+    /**
+     * Load a NonactivatedUser record by email address
+     *
+     * Example: `$user = NonactivatedUser::load_from_email($email);`
+     *
+     * @param string $email
+     *
+     * @throws NonuniqueNonactivatedUserException
+     *   The email address is not guaranteed to be unique.
+     *
+     * @return object NonactivatedUser
+     */
     public static function load_from_email($email)
     {
         $user = new NonactivatedUser();

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -43,8 +43,11 @@ class POFile
         return $this->num_messages_translated;
     }
 
-    // Count the total number of strings and the number of translated strings.
-    // Returns: array($count, $translated);
+    /**
+     * Count the total number of strings and the number of translated strings.
+     *
+     * @return array `[$count, $translated]`
+     */
     private function count_translated_strings()
     {
         $iterator = new POFileIterator($this->po_filename);
@@ -75,9 +78,12 @@ class POFile
         $this->num_messages_translated = $translated;
     }
 
-    // Given a msgid/msgstr block from a PO file, determine if the block
-    // is translated. This is slightly complicated because of multiline
-    // strings, hence the gymnastics.
+    /**
+     * Given a msgid/msgstr block from a PO file, determine if the block
+     * is translated.
+     *
+     * This is slightly complicated because of multiline strings, hence the gymnastics.
+     */
     private function is_block_translated($block)
     {
         [$msgid, $msgstr] = @explode("msgstr", $block);
@@ -90,8 +96,10 @@ class POFile
         return true;
     }
 
-    // Get the full Content-Type from the comment block at the beginning of a PO
-    // file (without any trailing newline) or NULL on error.
+    /**
+     * Get the full Content-Type from the comment block at the beginning of a PO
+     * file (without any trailing newline) or NULL on error.
+     */
     private function get_content_type()
     {
         $fh = fopen($this->po_filename, "rt");

--- a/pinc/PageUnformatter.inc
+++ b/pinc/PageUnformatter.inc
@@ -1,6 +1,8 @@
 <?php
 
-// functions to remove formatting in order to compare P to F (or F to F) rounds
+/**
+ * Functions to remove formatting in order to compare P to F (or F to F) rounds
+ */
 class PageUnformatter
 {
     private function find_close($text, $offset)

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -9,42 +9,48 @@ $Pool_for_id_ = [];
 $Pool_for_state_ = [];
 
 class Pool extends Stage
-// A container for various constants relating to a particular pool.
 {
+    /**
+     * Pool constructor
+     *
+     * A container for various constants relating to a particular pool.
+     *
+     * @param string $project_checkedout_state
+     * @param string $project_available_state
+     * @param $foo_Header
+     * @param $foo_field_name
+     *   The relevant person to display in pool listings, both
+     *   as shown to the user and as a field in the projects table
+     *   (e.g. "postprocessor" when listing books available for PPV).
+     *   Used by `pinc/showavailablebooks.inc`
+     * @param $blather
+     *   An array of strings to echo on the pool's home page.
+     */
     public function __construct(
-        $pool_id,
-        $pool_name,
+        $id,
+        $name,
         $access_minima,
         $after_satisfying_minima,
         $evaluation_criteria,
         $access_change_callback,
         $description,
         $document,
-
         $project_checkedout_state,
         $project_available_state,
-            // Eventually, these will be generated based on $pool_id
-
         $foo_Header,
         $foo_field_name,
-            // The relevant person to display in pool listings, both
-            // as shown to the user and as a field in the projects table
-            // (e.g. "postprocessor" when listing books available for PPV).
-            // Used by pinc/showavailablebooks.inc
-
         $blather
-            // An array of strings to echo on the pool's home page.
     ) {
         parent::__construct(
-            $pool_id,
-            $pool_name,
+            $id,
+            $name,
             $access_minima,
             $after_satisfying_minima,
             $evaluation_criteria,
             $access_change_callback,
             $description,
             $document,
-            "tools/pool.php?pool_id=$pool_id"
+            "tools/pool.php?pool_id=$id"
         );
 
         $this->project_checkedout_state = $project_checkedout_state;

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -17,9 +17,13 @@ class UTF8ConversionException extends Exception
 {
 }
 
+/**
+ * Base exception that all Project exceptions should derive from.
+ *
+ * These exception codes range from 100 to 199
+ */
 class ProjectException extends Exception
 {
-    // all project errors extend from here and in range 100-199
     public function __construct($message, $code = 100)
     {
         parent::__construct($message, $code);
@@ -152,10 +156,14 @@ class Project
     // -------------------------------------------------------------------------
     // Load & Validate
 
+    /**
+     * Return a list of default fields with their values.
+     *
+     * Note that the value types given here are enforced in validate() except
+     * for nulls.
+     */
     private function _get_field_defaults()
     {
-        // Return a list of default fields with their values. Note that the
-        // value types given here are enforced in validate() except for nulls.
         return [
             "projectid" => null,
             "nameofwork" => "",
@@ -184,10 +192,13 @@ class Project
         ];
     }
 
+    /**
+     * Initialize Project with core fields and default values.
+     *
+     * These alone aren't sufficient to validate() and persist the project.
+     */
     private function _init_fields_to_defaults()
     {
-        // Initialize Project with core fields and default values.
-        // These alone aren't sufficient to validate() and persist the project.
         foreach ($this->_get_field_defaults() as $key => $value) {
             $this->$key = $value;
         }
@@ -654,8 +665,10 @@ class Project
 
     // -------------------------------------------------------------------------
 
-    // Return an associative array of project fields with localized labels
-    // for use in the UI.
+    /**
+     * Return an associative array of project fields with localized labels
+     * for use in the UI.
+     */
     public static function get_field_labels()
     {
         return [
@@ -987,9 +1000,12 @@ class Project
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Validate this project can be proofed by the current user
+     *
+     * Where "proofed" means "worked on in a round, right now".
+     */
     public function validate_can_be_proofed_by_current_user()
-    // (where "proofed" means "worked on in a round, right now".)
-    // Can throw Exceptions
     {
         global $pguser;
 
@@ -1129,12 +1145,15 @@ class Project
         return array_intersect($db_names, $disk_names);
     }
 
-    // Given a project image, return the file size in bytes. If the image
-    // doesn't exist on disk, return NULL.
-    // TODO: This function would be better in a ProjectPage object, but we
-    // don't have one of those.
+    /**
+     * Given a project image, return the file size in bytes.
+     *
+     * If the image doesn't exist on disk, return NULL.
+     */
     public function get_image_file_size($image)
     {
+        // TODO: This function would be better in a ProjectPage object, but we
+        // don't have one of those.
         $image_path = realpath("{$this->dir}/$image");
         if (file_exists($image_path)) {
             return filesize($image_path);
@@ -1158,9 +1177,13 @@ class Project
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return the current credit line for a project
+     *
+     * The string will not be localized, since it should be ready
+     * to be included with the finished project.
+     */
     private function _create_credit_line()
-    // The string will not be localized, since it should be ready
-    // to be included with the finished project.
     {
         global $site_url;
 
@@ -1290,9 +1313,11 @@ class Project
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return a string that can be included in the body of an email message,
+     * introducing this project as the focus of the message.
+     */
     public function email_introduction()
-    // Return a string that can be included in the body of an email message,
-    // introducing this project as the focus of the message.
     {
         global $site_name, $code_url;
 
@@ -1347,8 +1372,10 @@ class Project
         return $states;
     }
 
+    /**
+     * Return an array containing the states for which this project has holds.
+     */
     public function get_hold_states()
-    // Return an array containing the states for which this project has holds.
     {
         $hold_states = [];
         $sql = sprintf("
@@ -1476,7 +1503,9 @@ class Project
 
     // -------------------------------------------------------------------------
 
-    // Given a MARCRecord, write a dc XML document for this project
+    /**
+     * Given a MARCRecord, write a dc XML document for this project
+     */
     public function create_dc_xml_oai($marc_record)
     {
         global $charset, $site_name, $code_url;
@@ -1534,7 +1563,9 @@ class Project
     // upon project creation. The updated_* columns hold updated YAZ records
     // based on edits to the project record.
 
-    // Populate the original_* columns for this project's MARC record
+    /**
+     * Populate the original_* columns for this project's MARC record
+     */
     public function init_marc_record($marc_record)
     {
         $original_marc_array = $marc_record->get_yaz_array();
@@ -1549,7 +1580,9 @@ class Project
         );
     }
 
-    // Update the updated_* columns for this project's MARC record
+    /**
+     * Update the updated_* columns for this project's MARC record
+     */
     public function save_marc_record($marc_record)
     {
         $updated_marc_array = $marc_record->get_yaz_array();
@@ -1567,7 +1600,9 @@ class Project
         $this->create_dc_xml_oai($marc_record);
     }
 
-    // Load the updated MARC record for this project
+    /**
+     * Load the updated MARC record for this project
+     */
     public function load_marc_record()
     {
         $updated_record = new MARCRecord();
@@ -1591,7 +1626,9 @@ class Project
         return $updated_record;
     }
 
-    // Update the project's MARC record from the current Project values
+    /**
+     * Update the project's MARC record from the current Project values
+     */
     public function update_marc_record()
     {
         $marc_record = $this->load_marc_record();
@@ -1617,7 +1654,9 @@ class Project
         $this->save_marc_record($marc_record);
     }
 
-    // check if project has entered a formatting round
+    /**
+     * Check if project has entered a formatting round
+     */
     public function has_entered_formatting_round()
     {
         global $PROJECT_STATES_IN_ORDER;
@@ -1631,7 +1670,9 @@ class Project
         return false;
     }
 
-    // get time for last page proofread in round
+    /**
+     * Get time for last page proofread in round
+     */
     public function get_last_proofread_time($round)
     {
         validate_projectID($this->projectid);
@@ -1661,7 +1702,13 @@ class Project
         return true;
     }
 
-    // Used for checking whether a book is currently in the Smooth Reading Pool
+    /**
+     * Returns if the project is available for smoothreading
+     *
+     * Used for checking whether a book is currently in the Smooth Reading Pool.
+     *
+     * @return bool
+     */
     public function is_available_for_smoothreading()
     {
         return $this->state == PROJ_POST_FIRST_CHECKED_OUT &&
@@ -1713,10 +1760,12 @@ function project_has_a_hold_in_state($projectid, $state)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Return the username of the user to whom the project will be
+ * automatically checked out for PPing when it reaches the PP stage,
+ * or NULL if the project will merely go into the available-for-PP state.
+ */
 function project_get_auto_PPer($projectid)
-// Return the username of the user to whom the project will be
-// automatically checked out for PPing when it reaches the PP stage,
-// or NULL if the project will merely go into the available-for-PP state.
 {
     $project = new Project($projectid);
     $checkedoutby = $project->checkedoutby;
@@ -1755,7 +1804,12 @@ function project_get_auto_PPer($projectid)
 // The following two functions don't particularly belong here, as they aren't
 // project-specific. However, nobody else uses them yet.
 
-// $activity should be one of 'cp', 'pm', 'pp', 'ip' and 'tp'.
+/**
+ * Does the user want anonymity for a given activity.
+ *
+ * @param string $login_name Username
+ * @param string $activity Should be one of 'cp', 'pm', 'pp', 'ip' and 'tp'.
+ */
 function wants_anonymity($login_name, $activity)
 {
     $settings = & Settings::get_Settings($login_name);
@@ -1764,9 +1818,12 @@ function wants_anonymity($login_name, $activity)
 
 // -----------------------------------------------------------------------------
 
-// Returns the real name OR the username OR a user-specified 'other'.
-// (If the user hasn't specified anything in the preferences, the
-// real name will be returned.
+/**
+ * Returns the real name OR the username OR a user-specified 'other'.
+ *
+ * If the user hasn't specified anything in the preferences, the
+ * real name will be returned.
+ */
 function get_credit_name($login_name)
 {
     if ($login_name == '') {
@@ -1793,10 +1850,13 @@ function get_credit_name($login_name)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Return the PP-ers' comments for a certain project.
+ *
+ * They will be HTML-encoded and with line breaks
+ * converted to `<br>`.
+ */
 function get_formatted_postcomments($projectid)
-// Return the PP-ers' comments for a certain project
-// They will be HTML-encoded and with line breaks
-// converted to <br> .
 {
     $project = new Project($projectid);
 
@@ -1805,7 +1865,9 @@ function get_formatted_postcomments($projectid)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// Determines if the project's pages table exists
+/**
+ * Determine if the project's pages table exists
+ */
 function does_project_page_table_exist($projectid)
 {
     return DPDatabase::does_table_exist($projectid);
@@ -1813,7 +1875,9 @@ function does_project_page_table_exist($projectid)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// Confirm that $projectid is a well-formed project ID or raise an exception.
+/**
+ * Confirm that $projectid is a well-formed project ID or raise an exception.
+ */
 function validate_projectID($projectid)
 {
     if (1 != preg_match('/^projectID[0-9a-f]{13}$/', $projectid)) {
@@ -1824,9 +1888,12 @@ function validate_projectID($projectid)
     }
 }
 
-// Get a projectid from an array (usually $_GET or $_POST) and validate that
-// it is well-formed. This function mirrors the other get_*() functions in
-// misc.inc.
+/**
+ * Get a projectid from an array (usually $_GET or $_POST) and validate that
+ * it is well-formed.
+ *
+ * This function mirrors the other get_*() functions in `misc.inc`.
+ */
 function get_projectID_param($arr, $key, $allownull = false)
 {
     $projectid = @$arr[$key];
@@ -1853,7 +1920,9 @@ function get_projectID_param($arr, $key, $allownull = false)
     return $projectid;
 }
 
-// Confirm that $page_name is a well-formed page filename or raise an exception.
+/**
+ * Validate that $page_name is a well-formed page filename or raise an exception.
+ */
 function validate_page_image($page_name)
 {
     if (1 != preg_match('/^[a-zA-Z0-9_.-]{5,16}$/', $page_name)) {
@@ -1864,9 +1933,12 @@ function validate_page_image($page_name)
     }
 }
 
-// Get a page name from an array (usually $_GET or $_POST) and validate that
-// it is well-formed. This function mirrors the other get_*() functions in
-// misc.inc.
+/**
+ * Get a page name from an array (usually $_GET or $_POST) and validate that
+ * it is well-formed.
+ *
+ * This function mirrors the other get_*() functions in `misc.inc`.
+ */
 function get_page_image_param($arr, $key, $allownull = false)
 {
     $page_name = @$arr[$key];
@@ -1938,7 +2010,9 @@ function load_image_sources()
     return $image_sources;
 }
 
-// Can the current user see this image source based on the source's settings
+/**
+ * Can the current user see this image source based on the source's settings
+ */
 function can_user_see_image_source($image_source)
 {
     // info page visibility

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -17,23 +17,29 @@ $PROJECT_TRANSITIONS = [];
 
 class ProjectTransition
 {
+    /**
+     * Project Transition constructor
+     *
+     * A user who satisfies the $who_restriction can cause
+     * a project that satisfies $project_restriction
+     * to transit from $from_state to $to_state.
+     *
+     * @param array $options
+     *   Associative array containing the following keys
+     *   - project_restriction
+     *   - action_name
+     *   - confirmation_question
+     *   - detour
+     *   - settings_template
+     *   - collateral_actions
+     *   - disabled_during_SR
+     */
     public function __construct(
         $from_state,
         $to_state,
         $who_restriction,
         $options
-            // project_restriction
-            // action_name
-            // confirmation_question
-            // detour
-            // settings_template
-            // collateral_actions
-            // disabled_during_SR
-    )
-    // A user who satisfies the $who_restriction can cause
-    // a project that satisfies $project_restriction
-    // to transit from $from_state to $to_state.
-    {
+    ) {
         $this->from_state = $from_state;
         $this->to_state = $to_state;
         $this->who_restriction = $who_restriction;
@@ -140,15 +146,26 @@ class ProjectTransition
         die("transition has bad 'restriction' value: '$simple_who_restriction'");
     }
 
-    // Returns whether the transition is currently disabled
+    /**
+     * Returns whether the transition is currently disabled
+     */
     public function is_disabled($project)
     {
         return ($this->why_disabled($project) != '');
     }
 
-    // Returns the reason why the ProjectTransition is currently disabled
-    //
-    //   SR = Disabled during Smooth Reading
+    /**
+     * Returns the reason why the ProjectTransition is currently disabled
+     *
+     * Returns one of:
+     * - "" - no reason why it is disabled
+     * - "SR" - Disabled during Smooth Reading
+     *
+     * @param object $project
+     *   Project object
+     *
+     * @return string
+     */
     public function why_disabled($project)
     {
         if ($project->is_available_for_smoothreading() &&
@@ -163,18 +180,22 @@ class ProjectTransition
 
     // ---------------------------------------------------------------
 
+    /**
+     * Apply the transition to the given project, and perform any attendant
+     * processing.
+     *
+     * If there are any problems, return a string containing an error message.
+     * Otherwise, return an empty string.
+     *
+     * This function produces no output except for debugging messages.
+     *
+     * This function should be the only code that modifies the 'state'
+     * column of the 'projects' table.
+     *
+     * It should perhaps also be the only place that modifies these columns:
+     *     modifieddate checkedoutby postproofer postcomments
+     */
     public function do_state_change($project, $who, $extras)
-    // Apply the transition to the given project,
-    // and perform any attendant processing.
-    // If there are any problems, return a string containing an error message.
-    // Otherwise, return an empty string.
-    //
-    // This function produces no output except for debugging messages.
-    //
-    // This function should be the only code that modifies the 'state'
-    // column of the 'projects' table.
-    // It should perhaps also be the only place that modifies these columns:
-    //     modifieddate checkedoutby postproofer postcomments
     {
         global $testing;
 
@@ -332,10 +353,13 @@ class ProjectTransition
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Check whether the project seems ready to be released into the round.
+ *
+ * If it is, return an empty array.
+ * If it has problems, return an array of detailed error messages.
+ */
 function project_pre_release_check($project, $round)
-// Check whether the project seems ready to be released into the round.
-// If it is, return an empty array.
-// If it has problems, return an array of detailed error messages.
 {
     if (!$project->pages_table_exists) {
         return [_("There is no page-table.")];
@@ -384,9 +408,11 @@ function project_pre_release_check($project, $round)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an array of transitions that the given user
+ * can perform on the project (in its current state).
+ */
 function get_valid_transitions($project, $username)
-// Return an array of transitions that the given user
-// can perform on the project (in its current state).
 {
     global $PROJECT_TRANSITIONS;
 

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -57,10 +57,13 @@ class Quiz
         }
     }
 
-    // Get an array of quiz pages and the date the user passed them. The date
-    // will be null if the user did not attempt or pass the page (because we
-    // don't store non-passed attempts, we can't distinguish notpassed from
-    // not attempted).
+    /**
+     * Get an array of quiz pages and the date the user passed them.
+     *
+     * The date will be null if the user did not attempt or pass the page
+     * (because we don't store non-passed attempts, we can't distinguish not
+     * passed from not attempted).
+     */
     private function get_user_page_passes($username, $use_pass_requirements = true)
     {
         foreach (array_keys($this->pages) as $quiz_page_id) {
@@ -233,16 +236,24 @@ class QuizCharSuites
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return a valid quiz ID from an array
+ *
+ * If $arr[$key] is defined and is a valid quiz id, return it.
+ * Otherwise, die with an error message.
+ */
 function get_quiz_id_param($arr, $key)
-// If $arr[$key] is defined and is a valid quiz id, return it.
-// Otherwise, die with an error message.
 {
     return get_enumerated_param($arr, $key, null, array_keys(Quiz::$map_quiz_id_to_Quiz));
 }
 
+/**
+ * Return a valid quiz page ID from an array
+ *
+ * If $arr[$key] is defined and is a valid quiz page id, return it.
+ * Otherwise, die with an error message.
+ */
 function get_quiz_page_id_param($arr, $key)
-// If $arr[$key] is defined and is a valid quiz page id, return it.
-// Otherwise, die with an error message.
 {
     return get_enumerated_param($arr, $key, null, Quiz::$valid_quiz_page_ids);
 }

--- a/pinc/RandomRule.inc
+++ b/pinc/RandomRule.inc
@@ -31,7 +31,9 @@ class RandomRule
         return isset($this->table_row[$name]);
     }
 
-    // Load a specific rule into this object given its ID
+    /**
+     * Load a specific rule into this object given its ID
+     */
     public function load($id)
     {
         $sql = sprintf("
@@ -44,7 +46,9 @@ class RandomRule
         $this->table_row = mysqli_fetch_assoc($result);
     }
 
-    // Get a specific RandomRule given its document/anchor/langcode
+    /**
+     * Get a specific RandomRule given its document/anchor/langcode
+     */
     public static function load_from_anchor($document, $anchor, $langcode = 'en')
     {
         $sql = sprintf("
@@ -68,7 +72,9 @@ class RandomRule
         return new RandomRule($row["id"]);
     }
 
-    // Get a RandomRule object for a given document-langcode pair.
+    /**
+     * Get a RandomRule object for a given document-langcode pair.
+     */
     public static function get_random($document, $langcode = 'en')
     {
         $sql = sprintf("
@@ -91,7 +97,9 @@ class RandomRule
         return new RandomRule($row["id"]);
     }
 
-    // Return an array of RandomRule objects for a given document/langcode pair
+    /**
+     * Return an array of RandomRule objects for a given document/langcode pair
+     */
     public static function get_rules($document, $langcode = 'en')
     {
         $sql = sprintf("
@@ -114,8 +122,12 @@ class RandomRule
         return $rules;
     }
 
-    // Return an associative array containing metadata about the rules in
-    // the table. Useful primarily for the administartive interface.
+    /**
+     * Return an associative array containing metadata about the rules in
+     * the table.
+     *
+     * Useful primarily for the administrative interface.
+     */
     public static function get_summary()
     {
         $sql = "
@@ -138,7 +150,9 @@ class RandomRule
         return $summary;
     }
 
-    // Delete rules in the database matching a specific document/langcode pair
+    /**
+     * Delete rules in the database matching a specific document/langcode pair
+     */
     public static function delete_rules($document, $langcode)
     {
         $sql = sprintf("
@@ -153,9 +167,12 @@ class RandomRule
         DPDatabase::query($sql);
     }
 
-    // Reload rules by parsing a URL and reloading the rules found in it
-    // This function supports the HTML rendered from the in-code documents in faq/
-    // as well as the wiki-generated HTML for the guidelines at pgdp.net.
+    /**
+     * Reload rules by parsing a URL and reloading the rules found in it
+     *
+     * This function supports the HTML rendered from the in-code documents in faq/
+     * as well as the wiki-generated HTML for the guidelines at pgdp.net.
+     */
     public static function reload_rules($url, $document, $langcode)
     {
         // delete all existing random rules for this ($document, $langcode)
@@ -210,7 +227,9 @@ class RandomRule
         fclose($fhandle);
     }
 
-    // Add a rule to the database
+    /**
+     * Add a rule to the database
+     */
     private static function _add_rule($document, $langcode, $url, $anchor, $subject, $rule)
     {
         // skip "empty" rules, likely caused by parser errors

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -17,60 +17,70 @@ $Round_for_project_state_ = [];
 $Round_for_page_state_ = [];
 $PAGE_STATES_IN_ORDER = [];
 
-class Round extends Stage
 // A container for various constants relating to a particular round of proofreading.
+class Round extends Stage
 {
+    /**
+     * Round constructor
+     *
+     * @param array $pi_tools
+     *   A list of which tools should be available in the proofreading
+     *   interface's toolbox when proofreading a page in this round.
+     *   The format is:
+     *   ```
+     *   [
+     *       'popup_links' => [ 'link1', 'link2', ... ],
+     *       'tool_buttons' => [ 'button1', 'button2', ... ],
+     *       'tool_links' => [ 'link1', 'link2', ... ],
+     *   ]
+     *   ```
+     *   Alternatively, if you want all tools to be visible, use 'ALL'
+     *   for the array instead:
+     *   ```
+     *   [
+     *       'popup_links' => 'ALL',
+     *       'tool_buttons' => 'ALL',
+     *       'tool_links' => 'ALL',
+     *   ]
+     *   ```
+     *   See `pinc/ProofreadingToolbox.inc` for which tools are available
+     *   and their names.
+     * @param $daily_page_limit
+     *   This is either NULL (indicating no daily page limit for this round)
+     *   or a non-negative (though likely positive) integer.
+     * @param array $other_rounds_with_visible_usernames
+     *   An array of round_ids.
+     *   If user X worked on a page in this round, they can see the
+     *   username of another user Y who worked on the page *if* user Y
+     *   worked on the page in a round that appears in this parameter.
+     * @param array $honorifics
+     *   An array of integer => string items that determine a user's
+     *   "title" on the basis of their page tally in this round.
+     *   In each item:
+     *   - The number is a page-tally threshold.
+     *   - The string is the honorific for someone who has achieved that
+     *     threshold, but not the next higher.
+     *   (Needn't be in a particular order.)
+     */
     public function __construct(
-        $round_id,
-        $round_name,
+        $id,
+        $name,
         $access_minima,
         $after_satisfying_minima,
         $evaluation_criteria,
         $access_change_callback,
         $description,
         $document,
-
         $pi_tools,
-            // A list of which tools should be available in the proofreading
-            // interface's toolbox when proofreading a page in this round.
-            // The format is:
-            // [
-            //     'popup_links' => [ 'link1', 'link2', ... ],
-            //     'tool_buttons' => [ 'button1', 'button2', ... ],
-            //     'tool_links' => [ 'link1', 'link2', ... ],
-            // ]
-            // Alternatively, if you want all tools to be visible, use 'ALL'
-            // for the array instead:
-            // [
-            //     'popup_links' => 'ALL',
-            //     'tool_buttons' => 'ALL',
-            //     'tool_links' => 'ALL',
-            // ]
-            // See pinc/ProofreadingToolbox.inc for which tools are avaialble
-            // and their names.
-
         $daily_page_limit,
-            // This is either NULL (indicating no daily page limit for this round)
-            // or a non-negative (though likely positive) integer.
-
         $other_rounds_with_visible_usernames,
-            // An array of round_ids.
-            // If user X worked on a page in this round, they can see the
-            // username of another user Y who worked on the page *if* user Y
-            // worked on the page in a round that apppears in this parameter.
-
         $honorifics
-            // An array of integer => string items that determine a user's
-            // "title" on the basis of their page tally in this round.
-            // In each item:
-            // -- The number is a page-tally threshold.
-            // -- The string is the honorific for someone who has achieved that
-            //    threshold, but not the next higher.
-            // (Needn't be in a particular order.)
     ) {
+        $round_id = $id;
+
         parent::__construct(
-            $round_id,
-            $round_name,
+            $id,
+            $name,
             $access_minima,
             $after_satisfying_minima,
             $evaluation_criteria,
@@ -229,10 +239,13 @@ function get_Round_for_round_id($round_id)
 
 // ---------------------------
 
+/**
+ * Get a round object given a round number
+ *
+ * If `$round_number` is a valid proofreading-round number,
+ * return the appropriate Round instance. Otherwise, return NULL.
+ */
 function get_Round_for_round_number($round_number)
-// If $round_number is a valid proofreading-round number,
-// return the appropriate Round instance.
-// Otherwise, return NULL.
 {
     global $Round_for_round_number_;
     return array_get($Round_for_round_number_, $round_number, null);
@@ -269,20 +282,28 @@ function get_Round_for_text_column_name($text_column_name)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Return an SQL snippet used to sort rounds
+ *
+ * In an SQL query, if you `ORDER BY round_id`, it will use alphabetical order,
+ * which is not very useful. Instead, ORDER BY the result of this function,
+ * and it will use the canonical order-of-declaration for rounds.
+ */
 function sql_collater_for_round_id($round_id_column)
-// In an SQL query, if you "ORDER BY round_id", it will use alphabetical order,
-// which is not very useful. Instead, ORDER BY the result of this function,
-// and it will use the canonical order-of-declaration for rounds.
 {
     global $Round_for_round_id_;
     return sprintf("FIELD($round_id_column, %s)",
         surround_and_join(array_keys($Round_for_round_id_), "'", "'", ","));
 }
 
+/**
+ * Return an SQL snippet used to page states
+ *
+ * In an SQL query, if you `ORDER BY state`, it will use alphabetical order,
+ * which is not very useful. Instead, ORDER BY the result of this function,
+ * and it will use the canonical order-of-declaration for page states.
+ */
 function sql_collater_for_page_state($state_column)
-// In an SQL query, if you "ORDER BY state", it will use alphabetical order,
-// which is not very useful. Instead, ORDER BY the result of this function,
-// and it will use the canonical order-of-declaration for page states.
 {
     global $PAGE_STATES_IN_ORDER;
     return sprintf("FIELD($state_column, %s)",
@@ -291,10 +312,14 @@ function sql_collater_for_page_state($state_column)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Define pairs of rounds used for mentoring
+ *
+ * Asserts that, for difficulty='beginner' projects, pages done in one round
+ * (the "mentored" or "mentee" round) will garner feedback by qualified users
+ * ("mentors") in a subsequent round (the "mentoring" or "mentor" round).
+ */
 function declare_mentoring_pair($mentee_round_id, $mentor_round_id)
-// Asserts that, for difficulty='beginner' projects, pages done in one round
-// (the "mentored" or "mentee" round) will garner feedback by qualified users
-// ("mentors") in a subsequent round (the "mentoring" or "mentor" round).
 {
     $mentee_round = & get_Stage_for_id($mentee_round_id);
     $mentor_round = & get_Stage_for_id($mentor_round_id);

--- a/pinc/SettingsClass.inc
+++ b/pinc/SettingsClass.inc
@@ -1,53 +1,10 @@
 <?php
 
-// $Id$
-
 /**
- * Settings Class.
-
-  Note: Everything marked "Implementation:" is information
-        that should remain encapsulated inside the class.
-
- This class provides access to user settings.
-
- There are three setting types:
-
-1. Boolean settings. Return value is True or False.
- Example setting: post_proofer
-     ******
-    Implementation:
-        Setting to True.
-            Will ensure that a record exists with "yes" in the value column.
-        Setting to anything other than True
-            Will ensure that the record is deleted.
-        Getting.
-            Will return True if there is a record and the value column holds "yes".
-            Will return False otherwise.
-     ******
-
-2. Value settings. Non-empty string settings.
- Example: R1order (sort order of project listing) Example value: "GenreA" (Genre Ascending)
-     ******
-    Implementation:
-        Setting:
-            Will ensure that record is deleted if the provided value is anything
-                resolving to Null in PHP (including zero-valued numbers).
-            Will ensure that a record exists with the value column set to the string
-                value provided (or its PHP auto-conversion-string if other data type.)
-        Getting:
-            Will provide exactly what's in the value column. (Note this may result
-            in something-in/something-else-out if PHP auto-conversion took place.)
-     ******
-
-3. Boolean-string-settings (for want of a better name.) These are cases where a record
-is inserted to indicate that a boolean value is True for a user for (typically) a project.
-Example setting: "taskctr_notice", value "1018"
-     ******
-    Implementation:
-        Setting and Getting: Set and get exactly what's provided.
-*/
-
-
+ * Settings Class
+ *
+ * This class provides access to user settings stored in the user_settings table.
+ */
 class Settings
 {
     // Multi-dimensional array containing all user settings. Each setting
@@ -88,7 +45,6 @@ class Settings
         mysqli_free_result($result);
     }
 
-    // whom do I describe?
     public function UserName()
     {
         return $this->username ? $this->username : "[none]";
@@ -96,26 +52,51 @@ class Settings
 
     // -------------------------------------------------------------------------
 
-    // Setting to True
+    /**
+     * Set a setting to true
+     *
+     * @param string $settingCode
+     *
+     * @return void
+     */
     public function set_true($settingCode)
     {
         $this->set_boolean($settingCode, true);
     }
 
-    // Setting to False
+    /**
+     * Set a setting to false
+     *
+     * @param string $settingCode
+     *
+     * @return void
+     */
     public function set_false($settingCode)
     {
         $this->set_boolean($settingCode, false);
     }
 
+    /**
+     * A wrapper around set_value() for boolean values.
+     *
+     * @param string $settingCode
+     * @param boolean $boolval
+     *
+     * @return void
+     */
     public function set_boolean($settingCode, $boolval)
-    // A wrapper around set_value() for boolean values.
     {
         $this->set_value($settingCode, ($boolval ? 'yes' : null));
     }
 
-    // Return True iff the setting exists and its value is 'yes'.
-    // Otherwise, return False.
+    /**
+     * Return True iff the setting exists and its value is 'yes',
+     * otherwise, return False.
+     *
+     * @param string $settingCode
+     *
+     * @return boolean
+     */
     public function get_boolean($settingCode)
     {
         return ($this->get_value($settingCode) === 'yes');
@@ -156,9 +137,17 @@ class Settings
         DPDatabase::query($sql);
     }
 
-    // Set a setting to a specific value. If this is a multi-valued setting
-    // this will become a single-valued setting.
-    // If $value is NULL, remove the setting.
+    /**
+     * Set a setting to a specific value.
+     *
+     * If this is a multi-valued setting this will become a single-valued setting.
+     * If $value is NULL, remove the setting.
+     *
+     * @param string $settingCode
+     * @param mixed $value
+     *
+     * @return void
+     */
     public function set_value($settingCode, $value)
     {
         if ($this->username == '') {
@@ -176,9 +165,18 @@ class Settings
         }
     }
 
-    // If no record exists, return $default.
-    // Otherwise return what's in the Value column.
-    // Note: if setting is really boolean, this will NOT return True, but 'yes' (a string).
+    /**
+     * Get the value for a setting
+     *
+     * If no record exists, return `$default`. Otherwise return what's in the
+     * Value column. Note: if setting is really boolean, this will NOT return
+     * True, but 'yes' (a string).
+     *
+     * @param string $settingCode
+     * @param mixed $default
+     *
+     * @return mixed
+     */
     public function get_value($settingCode, $default = null)
     {
         $values = $this->get_values($settingCode);
@@ -198,7 +196,14 @@ class Settings
         return $values[0];
     }
 
-    // Load a setting value into the $settings_array data structure
+    /**
+     * Load a setting value into the $settings_array data structure
+     *
+     * @param string $setting
+     * @param mixed $value
+     *
+     * @return void
+     */
     private function _load_value($setting, $value)
     {
         if (isset($this->settings_array[$setting])) {
@@ -208,15 +213,31 @@ class Settings
         }
     }
 
-    // Add a value to the setting without changing it, even if it already
-    // exists. This allows a setting to have multiple values.
+    /**
+     * Add a value to the setting without changing it, even if it already
+     * exists.
+     *
+     * This allows a setting to have multiple values.
+     *
+     * @param string $settingCode
+     * @param mixed $value
+     *
+     * @return void
+     */
     public function add_value($settingCode, $value)
     {
         $this->_load_value($settingCode, $value);
         $this->_insert_setting_value($settingCode, $value);
     }
 
-    // Remove a setting:value pair
+    /**
+     * Remove a setting:value pair
+     *
+     * @param string $settingCode
+     * @param mixed $value
+     *
+     * @return void
+     */
     public function remove_value($settingCode, $value)
     {
         if (array_key_exists($settingCode, $this->settings_array) && in_array($value, $this->settings_array[$settingCode])) {
@@ -227,7 +248,13 @@ class Settings
         }
     }
 
-    // Returns an array of values for the setting
+    /**
+     * Returns an array of values for the setting
+     *
+     * @param string $settingCode
+     *
+     * @return mixed
+     */
     public function get_values($settingCode)
     {
         if (!array_key_exists($settingCode, $this->settings_array)) {
@@ -239,26 +266,39 @@ class Settings
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Count the number of settings for this user
+     *
+     * @return integer
+     */
     public function settings_count()
     {
         return count($this->settings_array);
     }
 
-    // Get an object for this $username. If such an object has
-    // already been created, return it. By using this function only
-    // and not the constructor, there will only be one object
-    // around for each user, and no problems will arise with
-    // setting/getting the same settings at various places.
-    // If the name is not set, null is returned.
-    //
-    // We use assignment-by-reference and return-by-reference (note the ampersands)
-    // to ensure that multiple returns for the same $username are references to
-    // the originally created object, rather than copies of it.
-    // (See the PHP manual under "Assignment Operators" and "References Explained".)
-    // Callers should also use assignment-by-reference, e.g.
-    //     $settings =& Settings::get_settings($username);
-    // to ensure that changes in settings are visible everywhere they should be.
-    //
+    /**
+     * Get a Settings object for a user.
+     *
+     * If such an object has already been created, return it. By using this
+     * function only and not the constructor, there will only be one object
+     * around for each user, and no problems will arise with
+     * setting/getting the same settings at various places.
+     * If the name is not set, null is returned.
+     *
+     * We use assignment-by-reference and return-by-reference (note the ampersands)
+     * to ensure that multiple returns for the same $username are references to
+     * the originally created object, rather than copies of it.
+     * (See the PHP manual under "Assignment Operators" and "References Explained".)
+     * Callers should also use assignment-by-reference, e.g.
+     * ```
+     * $settings =& Settings::get_settings($username);
+     * ```
+     * to ensure that changes in settings are visible everywhere they should be.
+     *
+     * @param string $username
+     *
+     * @return object Settings
+     */
     public static function & get_Settings($username)
     {
         static $Settings_for_ = [];
@@ -271,8 +311,15 @@ class Settings
         }
     }
 
-    // Return a list of unique usernames that have a specific setting
-    // specified (and optionally with a specific value).
+    /**
+     * Return a list of unique usernames that have a specific setting
+     * specified (and optionally with a specific value).
+     *
+     * @param string $setting
+     * @param mixed $value
+     *
+     * @return array
+     */
     public static function get_users_with_setting($setting, $value = null)
     {
         $usernames = [];

--- a/pinc/SettingsClass.inc
+++ b/pinc/SettingsClass.inc
@@ -80,7 +80,7 @@ class Settings
      * A wrapper around set_value() for boolean values.
      *
      * @param string $settingCode
-     * @param boolean $boolval
+     * @param bool $boolval
      *
      * @return void
      */
@@ -95,7 +95,7 @@ class Settings
      *
      * @param string $settingCode
      *
-     * @return boolean
+     * @return bool
      */
     public function get_boolean($settingCode)
     {
@@ -269,7 +269,7 @@ class Settings
     /**
      * Count the number of settings for this user
      *
-     * @return integer
+     * @return int
      */
     public function settings_count()
     {

--- a/pinc/SortUtility.inc
+++ b/pinc/SortUtility.inc
@@ -15,16 +15,23 @@ class SortableValue
     public $_sqlRuleAscending;
     public $_sqlRuleDescending;
 
-    // constructor.
-    // $name and $label are required. $name is the name of the value and is used
-    // as an HTTP-parameter when requesting that the view is sorted by this value.
-    // $label is displayed to the user as a descriptor of the value (typically
-    // column in an HTML-table).
-    // If $sqlRuleAscending is not provided, it is set to $name, that is, the
-    // ORDER BY-clause will be "ORDER BY $name".
-    // If $sqlRuleDescending is not provided, it will be the inverse of
-    // $sqlRuleAscending. With 'inverse', I mean that the inverse of
-    // "a, b DESC, c ASC" is "a DESC, b ASC, c DESC".
+    /**
+     * SortableValue constructor
+     *
+     * @param string $name
+     *   Name of the value and is used as an HTTP-parameter when requesting
+     *   that the view is sorted by this value.
+     * @param string $label
+     *   Displayed to the user as a descriptor of the value (typically
+     *   column in an HTML-table).
+     * @param string $sqlRuleAscending
+     *   If not provided, it is set to $name, that is, the
+     *   ORDER BY-clause will be "ORDER BY $name".
+     * @param string $sqlRuleDescending
+     *   If not provided, it will be the inverse of
+     *   `$sqlRuleAscending`. With 'inverse', I mean that the inverse of
+     * "a, b DESC, c ASC" is "a DESC, b ASC, c DESC".
+     */
     public function __construct($name, $label,
                          $sqlRuleAscending = null, $sqlRuleDescending = null)
     {
@@ -62,20 +69,26 @@ class SortableValue
         return join(', ', $newVars);
     }
 
-    // Returns the name of the SortableValue.
+    /**
+     * Returns the name of the SortableValue.
+     */
     public function getName()
     {
         return $this->_name;
     }
 
-    // Returns the label of the SortableValue.
+    /**
+     * Returns the label of the SortableValue.
+     */
     public function getLabel()
     {
         return $this->_label;
     }
 
-    // Depending on whether $direction is ASCENDING or DESCENDING,
-    // returns a SQL-snippet to be used in an ORDER BY-clause.
+    /**
+     * Returns a SQL-snippet to be used in an ORDER BY-clause
+     * depending on whether $direction is ASCENDING or DESCENDING
+     */
     public function getSQLRule($direction)
     {
         if ($direction == ASCENDING) {
@@ -103,11 +116,15 @@ class SortUtility
     public $_sortingValue;
     public $_sortingDirection;
 
-    // constructor
-    // $name should be unique on the entire site,
-    // since, if db-storing of sorting-options is
-    // turned on, the name will be used when
-    // storing the data.
+    /**
+     * SortUtility constructor
+     *
+     * @param string $name
+     *   Should be unique on the entire site,
+     *   since, if db-storing of sorting-options is
+     *   turned on, the name will be used when
+     *   storing the data.
+     */
     public function __construct($name)
     {
         $this->_name = $name;
@@ -116,8 +133,11 @@ class SortUtility
         $this->_checkForUserPreferenceOnSorting();
     }
 
-    // Returns true if a user choice is found, false otherwise.
-    // Those are, in order: HTTP-argument, saved setting in database
+    /**
+     * Returns true if a user choice is found, false otherwise.
+     *
+     * Those are, in order: HTTP-argument, saved setting in database
+     */
     public function _checkForUserPreferenceOnSorting()
     {
 
@@ -136,9 +156,11 @@ class SortUtility
         return false;
     }
 
-    // Sets the sorting rule to use. Will not take effect if
-    // there is an HTTP-argument or setting in the database
-    // specifying how to sort this data.
+    /**
+     * Sets the sorting rule to use. Will not take effect if
+     * there is an HTTP-argument or setting in the database
+     * specifying how to sort this data.
+     */
     public function setSortingRule($sortingValue, $sortingDirection = ASCENDING)
     {
         if (!$this->_checkForUserPreferenceOnSorting()) {
@@ -148,10 +170,12 @@ class SortUtility
         }
     }
 
-    // used internally. Tries to parse a sortingRule of
-    // the form "nameX" where 'name' is the name of a
-    // SortableValue and X is A or D, specifying
-    // ascending and descending, respectively.
+    /**
+     * Tries to parse a sortingRule of
+     * the form "nameX" where 'name' is the name of a
+     * SortableValue and X is A or D, specifying
+     * ascending and descending, respectively.
+     */
     public function _parseSortingRule($sortingRule)
     {
         if (preg_match('/A$/', $sortingRule)) {
@@ -175,9 +199,12 @@ class SortUtility
         return false;
     }
 
-    // Returns the SortableValue that should be sorted by.
-    // This is the one the user has choose to sort by,
-    // or the default as specified by setSortingRule(...).
+    /**
+     * Returns the SortableValue that should be sorted by.
+     *
+     * This is the one the user has choose to sort by,
+     * or the default as specified by setSortingRule(...).
+     */
     public function getSortingValue()
     {
         if (isset($this->_sortingValue)) {
@@ -191,8 +218,9 @@ class SortUtility
         }
     }
 
-    // Returns ASCENDING or DESCENDING specifying how
-    // to sort.
+    /**
+     * Returns ASCENDING or DESCENDING specifying how to sort.
+     */
     public function getSortingDirection()
     {
         if (isset($this->_sortingDirection)) {
@@ -202,30 +230,39 @@ class SortUtility
         }
     }
 
-    // Adds the SortableValue to the list.
+    /**
+     * Adds the SortableValue to the list.
+     */
     public function addSortableValue($sortableValue)
     {
         array_push($this->_collection, $sortableValue);
     }
 
-    // The SortableValues provided as arguments to this
-    // function will be used as SortableValues.
-    // Any SortableValues previously added using the
-    // addSortableValue(...)-function will be removed.
+    /**
+     * Sets the sortable values
+     *
+     * The SortableValues provided as arguments to this
+     * function will be used as SortableValues.
+     * Any SortableValues previously added using the
+     * addSortableValue(...)-function will be removed.
+     */
     public function setSortableValues()
     {
         $this->_collection = func_get_args();
     }
 
-    // Returns the number of SortableValues managed
-    // by this SortUtility.
+    /**
+     * Returns the number of SortableValues managed by this SortUtility.
+     */
     public function getValueCount()
     {
         return count($this->_collection);
     }
 
-    // Returns the SortableValue at the provided index, where
-    // $index ranges from 0 to getvalueCount() - 1, inclusive.
+    /**
+     * Returns the SortableValue at the provided index, where
+     * $index ranges from 0 to getvalueCount() - 1, inclusive.
+     */
     public function getValueAt($index)
     {
         if ($index >= 0 && $index < count($this->_collection)) {
@@ -235,14 +272,18 @@ class SortUtility
         }
     }
 
-    // Returns the name of the SortUtility.
+    /**
+     * Returns the name of the SortUtility.
+     */
     public function getName()
     {
         return $this->_name;
     }
 
-    // Returns a SQL-snippet for use in an ORDER BY-context,
-    // e.g. "name DESC, id".
+    /**
+     * Returns a SQL-snippet for use in an ORDER BY-context,
+     * for example "name DESC, id".
+     */
     public function getOrderBy()
     {
         $val = $this->getSortingValue();
@@ -261,25 +302,33 @@ class SortUtility
         }
     }
 
-    // Defines the primary SortableValue which is always appended
-    // to the end of the ORDER BY-string. This can e.g. be a
-    // name- or id-column by which sorting should be performed
-    // when the sorting value as selected by the user cannot
-    // distinguish between two or more rows in the database.
+    /**
+     * Defines the primary SortableValue which is always appended
+     * to the end of the ORDER BY-string.
+     *
+     * This can be a name- or id-column by which sorting should be performed
+     * when the sorting value as selected by the user cannot
+     * distinguish between two or more rows in the database.
+     */
     public function setPrimaryValue($primaryValue)
     {
         $this->_primaryValue = $primaryValue;
     }
 
-    // Returns the primary SortableValue.
+    /**
+     * Returns the primary SortableValue.
+     */
     public function getPrimaryValue()
     {
         return $this->primaryValue;
     }
 
-    // Returns a query string for sorting the view as now.
-    // This should be used when building a link for reloading
-    // the page for some reason, while keeping the sorting intact.
+    /**
+     * Returns a query string for sorting the view as now.
+     *
+     * This should be used when building a link for reloading
+     * the page for some reason, while keeping the sorting intact.
+     */
     public function getQueryStringForCurrentView($sortableValue = null)
     {
         $currentlySortedValue = $this->getSortingValue();
@@ -292,15 +341,18 @@ class SortUtility
         }
     }
 
-    // Returns a query string for sorting the SortableValue.
-    // This should be used when building a link for sorting the value.
-    //
-    // If the SortableValue is the one currently sorted by and
-    // it is sorted ascending, the query string will request that the
-    // value be sorted descending (i.e. it's a flip/flop-link). In all
-    // other cases will the direction be ascending.
-    //
-    // The argument defaults to the currently sorted value.
+    /**
+     * Returns a query string for sorting the SortableValue.
+     *
+     * This should be used when building a link for sorting the value.
+     *
+     * If the SortableValue is the one currently sorted by and
+     * it is sorted ascending, the query string will request that the
+     * value be sorted descending (i.e. it's a flip/flop-link). In all
+     * other cases will the direction be ascending.
+     *
+     * The argument defaults to the currently sorted value.
+     */
     public function getQueryStringForSortableValue($sortableValue)
     {
         $currentlySortedValue = $this->getSortingValue();

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -15,6 +15,18 @@ $Stage_for_id_ = [];
 
 class Stage extends Activity
 {
+    /**
+     * Stage constructor
+     *
+     * @param $description
+     *   A sentence or two explaining what happens in this stage.
+     * @param $document
+     *   The path (relative to `$code_url/faq/`) of a document that tells you
+     *   everything you need to know about working in this stage.
+     *   Or NULL if there is no such document.
+     * @param $relative_url
+     *   The "home" location (relative to `$code_url/`) of the stage.
+     */
     public function __construct(
         $id,
         $name,
@@ -22,16 +34,9 @@ class Stage extends Activity
         $after_satisfying_minima,
         $evaluation_criteria,
         $access_change_callback,
-            // The above parameters have the same semantics as for Activity.
-
         $description,
-            // A sentence or two explaining what happens in this stage.
         $document,
-            // The path (relative to $code_url/faq/) of a document that tells you
-            // everything you need to know about working in this stage.
-            // Or NULL if there is no such document.
         $relative_url
-            // The "home" location (relative to $code_url/) of the stage.
     ) {
         parent::__construct(
             $id,
@@ -51,9 +56,11 @@ class Stage extends Activity
     }
 
 
+    /**
+     * Display a page-header, either an image (if available) or a textual title
+     * for this stage.
+     */
     public function page_header($title)
-    // Display a page-header, either an image (if available) or a textual title
-    // for this stage.
     {
         echo "<h1>$title</h1>\n" . get_page_header_image($this->id);
     }
@@ -119,10 +126,13 @@ function get_stages_user_can_work_in($username)
     return $accessible_stages;
 }
 
+/**
+ * Return an array of stages for which the user has access to all prereq stages.
+ *
+ * If $include_accessible_stages is true, this array also includes
+ * stages the user has access to.
+ */
 function get_stages_for_which_user_has_access_to_prereqs($username, $include_accessible_stages = false)
-// Return an array of stages for which the user has access to all prereq
-// stages. If $include_accessible_stages is true, this array also includes
-// stages the user has access to.
 {
     global $Stage_for_id_;
 

--- a/pinc/TableDocumentation.inc
+++ b/pinc/TableDocumentation.inc
@@ -63,10 +63,12 @@ class TableDocumentation
 
     /**
      * Creates a markdown table of the data with the only the specified columns shown and in the specified order.
+     *
      * Every cell is padded right with spaces to ensure every column is as wide as the widest cell in that column.
      *
      * @param array $contents the data that is shown within the table
      * @param array $table_columns the columns to display
+     *
      * @return array array of strings -- the generate markdown table
      */
     public static function create_markdown_table(array $contents, array $table_columns): array
@@ -114,6 +116,7 @@ class TableDocumentation
      *
      * @param array $lines an array of strings -- the lines of the text
      * @param array $column_names column names of the current columns in the table
+     *
      * @return array an array of strings containing the text with updated column definitions
      */
     public static function update_column_definitions(array $lines, array $column_names): array
@@ -154,6 +157,7 @@ class TableDocumentation
      *
      * @param array $lines an array of strings -- the lines of the text
      * @param array $new_table an array of strings -- the new table
+     *
      * @return array an array of strings containing the text with the first table replaced with the second argument
      */
     public static function replace_first_table(array $lines, array $new_table): array
@@ -181,6 +185,7 @@ class TableDocumentation
      * Detects the first markdown table in the text.
      *
      * @param array $lines an array of strings -- the lines of the text
+     *
      * @return array an array of strings containing the first markdown table in the text
      */
     public static function detect_first_table_in_text(array $lines): array
@@ -199,7 +204,9 @@ class TableDocumentation
     }
 
     /**
-     * Detects columns in the text by finding column descriptions. A column description contains the name of the column
+     * Detects columns in the text by finding column descriptions.
+     *
+     * A column description contains the name of the column
      * prefixed by "## " (without quotes) and surrounded by `.
      *
      * For example, for a column named something_useful, its column description would look like this:
@@ -207,6 +214,7 @@ class TableDocumentation
      * ## `something_useful`
      *
      * @param array $lines an array of strings -- the lines of the text
+     *
      * @return array an array of strings containing the column names detected in text
      */
     public static function detect_columns_in_text(array $lines): array

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -28,9 +28,11 @@ include_once($relPath.'misc.inc');
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an array of TallyBoard objects, representing all
+ * boards on which there is some tally explicitly recorded.
+ */
 function get_all_current_tallyboards()
-// Return an array of TallyBoard objects, representing all
-// boards on which there is some tally explicitly recorded.
 {
     $tallyboards = [];
     $res = DPDatabase::query("
@@ -77,31 +79,34 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return an array containing two strings of SQL code to
+     * extract the current tallies for a (SQL-specified) set of holders.
+     *
+     * The resulting strings are:
+     * - a join-expression (for use in the FROM clause);
+     * - a select-expression (for use in the SELECT and/or WHERE clauses)
+     *   that yields the current tally for each selected holder.
+     *   (It could be just a column-name, but don't rely on that.
+     *   In particular, don't assume that this will work:
+     *   ```
+     *   $res = DPDatabase::query("SELECT ... $expr_for_tally FROM ...");
+     *   $row = mysqli_fetch_assoc($res);
+     *   ... $row[$expr_for_tally] ...
+     *   ```
+     *   Instead, if you want to use mysqli_fetch_assoc, this should work:
+     *   ```
+     *   $res = DPDatabase::query("SELECT ... $expr_for_tally AS foo FROM ...");
+     *   $row = mysqli_fetch_assoc($res);
+     *   ... $row['foo'] ...
+     *   ```
+     *
+     * @param string $holder_id_expr
+     *   String containing an SQL expression (typically just a column name)
+     *   that yields the holder_ids of the holders for whom you want to extract
+     *   tally data.
+     */
     public function get_sql_joinery_for_current_tallies($holder_id_expr)
-    // Return an array containing two strings of SQL code.
-    // You can use these in a SELECT statement when you want to
-    // extract the current tallies for a (SQL-specified) set of holders.
-    //
-    // $holder_id_expr is a string containing an SQL expression
-    // (typically just a column name) that yields the holder_ids
-    // of the holders for whom you want to extract tally data.
-    //
-    // The resulting strings are:
-    // -- a join-expression (for use in the FROM clause);
-    // -- a select-expression (for use in the SELECT and/or WHERE clauses)
-    //    that yields the current tally for each selected holder.
-    //    (It could be just a column-name, but don't rely on that.
-    //    In particular, don't assume that this will work:
-    //
-    //        $res = DPDatabase::query("SELECT ... $expr_for_tally FROM ...");
-    //        $row = mysqli_fetch_assoc($res);
-    //        ... $row[$expr_for_tally] ...
-    //
-    //    Instead, if you want to use mysqli_fetch_assoc, this should work:
-    //
-    //        $res = DPDatabase::query("SELECT ... $expr_for_tally AS foo FROM ...");
-    //        $row = mysqli_fetch_assoc($res);
-    //        ... $row['foo'] ...
     {
         static $n = 0;
         $n++;
@@ -138,10 +143,13 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return the given holder's current tally on this TallyBoard.
+     *
+     * Note that if you want tallies for multiple holders, it's probably
+     * more efficient to use SQL-joinery supplied by the previous method.
+     */
     public function get_current_tally($holder_id)
-    // Return the given holder's current tally on this TallyBoard.
-    // (Note that if you want tallies for multiple holders, it's probably
-    // more efficient to use SQL-joinery supplied by the previous method.)
     {
         $sql = sprintf("
             SELECT tally_value
@@ -168,9 +176,11 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return the given holder's rank, as determined by the current tallies
+     * on this TallyBoard.
+     */
     public function get_rank($holder_id)
-    // Return the given holder's rank, as determined
-    // by the current tallies on this TallyBoard.
     {
         $sql = sprintf("
             SELECT holder_id, tally_value
@@ -198,31 +208,32 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return the tally-neighborhood of the target holder.
+     *
+     * Returns an array where the keys are integers from the range
+     * [-$radius, +$radius], indicating a holder's position (w.r.t. tally)
+     * relative to the target holder. (So key=0 refers to the target holder.)
+     * The set of keys will be less than the full [-$radius, +$radius]
+     * range if the target holder holder is within $radius of the
+     * corresponding end of the ranked list.
+     *
+     * For a given key, the value is data for the corresponding neighbor:
+     * an associative array as returned by `mysqli_fetch_assoc()`, with an
+     * item added for the neighbor's rank.
+     *
+     * Parameters after `$radius` are an optimization for extracting
+     * other info from the database at the same time.
+     */
     public function get_neighborhood(
         $target_holder_id,
         $radius,
-        // The remaining params are an optimization for extracting
-        // other info from the database at the same time.
         $other_table,
         $holder_id_expr,
         $other_select_exprs,
         $tally_alias,
         $rank_alias
-    )
-    // Return the tally-neighborhood of the target holder. This is an array:
-    //
-    //    The keys are integers from the range [-$radius, +$radius],
-    //    indicating a holder's position (w.r.t. tally)
-    //    relative to the target holder.
-    //    (So key=0 refers to the target holder.)
-    //    The set of keys will be less than the full [-$radius, +$radius]
-    //    range if the target holder holder is within $radius of the
-    //    corresponding end of the ranked list.
-    //
-    //    For a given key, the value is data for the corresponding neighbor:
-    //    an associative array as returned by mysqli_fetch_assoc(), with an
-    //    item added for the neighbor's rank.
-    {
+    ) {
         assert($radius >= 0);
 
         $sql = sprintf("
@@ -294,12 +305,14 @@ class TallyBoard
 
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+    /**
+     * Take a snapshot of this TallyBoard's current data,
+     * and append it to the TallyBoard's history
+     * (ascribing it to $ascribe_time rather than the current time).
+     *
+     * If `$dry_run` is true, merely echo queries that would change db.
+     */
     public function take_snapshot($ascribe_time, $dry_run)
-    // Take a snapshot of this TallyBoard's current data,
-    // and append it to the TallyBoard's history
-    // (ascribing it to $ascribe_time rather than the current time).
-    // If $dry_run is true, merely echo queries that would change db.
-    //
     {
         $prev_ascribe_time = $this->get_time_of_latest_snapshot();
 
@@ -409,9 +422,11 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return the ascribed timestamp of the latest snapshot for this TallyBoard,
+     * or $default if there has been no snapshot yet.
+     */
     public function get_time_of_latest_snapshot($default = null)
-    // Return the ascribed timestamp of the latest snapshot for this TallyBoard,
-    // or $default if there has been no snapshot yet.
     {
         $sql = sprintf("
             SELECT MAX(timestamp) as max_timestamp
@@ -436,12 +451,16 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return an associative array of information about the given holder
+     * from the latest snapshot.
+     *
+     * Keys are:
+     * - timestamp
+     * - tally_delta
+     * - tally_value
+     */
     public function get_info_from_latest_snapshot($holder_id)
-    // Return an associative array of information about the given holder
-    // from the latest snapshot. Keys are:
-    //     'timestamp'
-    //     'tally_delta'
-    //     'tally_value'
     {
         $sql = sprintf("
             SELECT timestamp, tally_delta, tally_value
@@ -478,10 +497,14 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return an array of the largest recorded delta on this TallyBoard
+     *
+     * Array consisting of:
+     * - the given holder's largest recorded delta on this TallyBoard, and
+     * - the earliest timestamp for which that delta was recorded.
+     */
     public function get_info_re_largest_delta($holder_id)
-    // Return an array consisting of:
-    // -- the given holder's largest recorded delta on this TallyBoard, and
-    // -- the earliest timestamp for which that delta was recorded.
     {
         $sql = sprintf("
             SELECT tally_delta, timestamp
@@ -509,10 +532,14 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return an array of the best recorded rank on this TallyBoard
+     *
+     * Array consisting of:
+     * - the given holder's best recorded rank on this TallyBoard, and
+     * - the earliest timestamp for which that rank was recorded.
+     */
     public function get_info_re_best_rank($holder_id)
-    // Return an array consisting of:
-    // -- the given holder's best recorded rank on this TallyBoard, and
-    // -- the earliest timestamp for which that rank was recorded.
     {
         $sql = sprintf("
             SELECT best_rank, best_rank_timestamp
@@ -538,13 +565,16 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return all tally deltas recorded for the given holder
+     * since $min_timestamp.
+     *
+     * Specifically, the result is an array of key => value pairs,
+     * where key is the ascribed time of a snapshot,
+     * and value is the tally delta recorded for that time.
+     * (The items are sorted by timestamp.)
+     */
     public function get_deltas($holder_id, $min_timestamp)
-    // Return all tally deltas recorded for the given holder
-    // since $min_timestamp.
-    // Specifically, the result is an array of key => value pairs,
-    // where key is the ascribed time of a snapshot,
-    // and value is the tally delta recorded for that time.
-    // (The items are sorted by timestamp.)
     {
         $sql = sprintf("
             SELECT timestamp, tally_delta
@@ -569,16 +599,19 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Return the sum of the 'tally_delta' values at all timestamps such that
+     * `$start_timestamp < timestamp <= $end_timestamp`
+     *
+     * Note that the case of timestamp = $start_timestamp is excluded,
+     * because its delta is for the period preceding $start_timestamp.
+     *
+     * If (as is often the case) $start_timestamp and $end_timestamp
+     * match timestamps in the table, then the result should be the same
+     * as the difference between the tally_value at those two times.
+     * But summing the intervening deltas is the more general solution.
+     */
     public function get_delta_sum($holder_id, $start_timestamp, $end_timestamp)
-    // Return the sum of the 'tally_delta' values at all timestamps such that
-    //     $start_timestamp < timestamp <= $end_timestamp
-    // Note that the case of timestamp = $start_timestamp is excluded,
-    // because its delta is for the period preceding $start_timestamp.
-    //
-    // If (as is often the case) $start_timestamp and $end_timestamp
-    // match timestamps in the table, then the result should be the same
-    // as the difference between the tally_value at those two times.
-    // But summing the intervening deltas is the more general solution.
     {
         $sql = sprintf("
             SELECT SUM(tally_delta)
@@ -607,10 +640,13 @@ class TallyBoard
         return ($current_tally - $latest_snapshot_tally);
     }
 
+    /**
+     * Return an object whose members are various useful quantities
+     * from this tallyboard for the given holder.
+     *
+     * This is just a convenience function.
+     */
     public function get_vitals($holder_id)
-    // Return an object whose members are various useful quantities
-    // from this tallyboard for the given holder.
-    // (This is just a convenience function.)
     {
         $obj = new StdClass();
 
@@ -648,10 +684,14 @@ class TallyBoard
 
 class Ranker
 {
+    /**
+     * Ranker constructor
+     *
+     * @param bool $zero_begets_zero
+     *   If TRUE, a value of zero or less will yield the special rank of zero.
+     *   (Think of it as a null rank.)
+     */
     public function __construct($zero_begets_zero)
-    // If $zero_begets_zero is TRUE,
-    // a value of zero or less will yield the special rank of zero.
-    // (Think of it as a null rank.)
     {
         $this->zero_begets_zero = $zero_begets_zero;
 

--- a/pinc/ThemedTable.inc
+++ b/pinc/ThemedTable.inc
@@ -57,10 +57,12 @@ class ThemedTable
         }
     }
 
+    /**
+     * Set explicit column widths.
+     *
+     * If you don't call this method, <td> tags will be output without a 'width' attribute.
+     */
     public function set_column_widths()
-    // Set explicit column widths.
-    // (If you don't call this method, <td> tags
-    // will be output without a 'width' attribute.)
     {
         // There should be an arg (width) for each column.
         assert(func_num_args() == $this->n_cols);

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -11,7 +11,11 @@ class NonuniqueUserException extends Exception
 {
 }
 
-// all user errors extend from here and in range 300-399
+/**
+ * Base exception that all User exceptions should derive from.
+ *
+ * These exception codes range from 300 to 399
+ */
 class UserAccessException extends Exception
 {
     public function __construct($message = "", $code = 300)
@@ -341,14 +345,18 @@ class User
 
     // static functions
 
-    // Return the username of the currently-logged-in user
+    /**
+     * Return the username of the currently-logged-in user
+     */
     public static function current_username()
     {
         global $pguser;
         return $pguser;
     }
 
-    // Load the current user object
+    /**
+     * Load the current user object
+     */
     public static function load_current()
     {
         static $current_user = null;
@@ -367,8 +375,15 @@ class User
         return $current_user;
     }
 
-    // Load a User record by u_id
-    // e.g. $user = User::load_from_uid($u_id);
+    /**
+     * Load a User record by u_id
+     *
+     * Example: `$user = User::load_from_uid($u_id);`
+     *
+     * @param int $u_id
+     *
+     * @return object User
+     */
     public static function load_from_uid($u_id)
     {
         $user = new User();
@@ -376,8 +391,15 @@ class User
         return $user;
     }
 
-    // Load a User record by registration token
-    // e.g. $user = User::load_from_registration_token($reg_token);
+    /**
+     * Load a User record by registration token
+     *
+     * Example: `$user = User::load_from_registration_token($reg_token);`
+     *
+     * @param string $reg_token
+     *
+     * @return object User
+     */
     public static function load_from_registration_token($reg_token)
     {
         $user = new User();
@@ -385,8 +407,15 @@ class User
         return $user;
     }
 
-    // Load a User record by API key
-    // e.g. $user = User::load_from_api_key($api_key);
+    /**
+     * Load a User record by API key
+     *
+     * Example: `$user = User::load_from_api_key($api_key);`
+     *
+     * @param string $api_key
+     *
+     * @return object User
+     */
     public static function load_from_api_key($api_key)
     {
         $user = new User();
@@ -394,9 +423,18 @@ class User
         return $user;
     }
 
-    // Load a User record by email address. email address is not guaranteed to
-    // be unique and this may very likely raise a NonuniqueUserException
-    // e.g. $user = User::load_from_email($email);
+    /**
+     * Load a User record by email address
+     *
+     * Example: `$user = User::load_from_email($email);`
+     *
+     * @param string $email
+     *
+     * @throws NonuniqueUserException
+     *   The email address is not guaranteed to be unique.
+     *
+     * @return object User
+     */
     public static function load_from_email($email)
     {
         $user = new User();
@@ -404,8 +442,10 @@ class User
         return $user;
     }
 
-    // Static function to determine if the specified username is associated
-    // with a valid user without the overhead of creating an object.
+    /**
+     * Determine if the specified username is associated
+     * with a valid user without the overhead of creating an object.
+     */
     public static function is_valid_user($username, $strict = true)
     {
         $sql = sprintf("
@@ -439,7 +479,9 @@ class User
         return $is_valid;
     }
 
-    // Static function to return possible user referrer options
+    /**
+     * Return possible user referrer options
+     */
     public static function get_referrer_options()
     {
         return [
@@ -465,11 +507,14 @@ global $valid_username_chars_statement_for_elsewhere;
 $valid_username_chars_statement_for_reg_form = _("(Valid characters are: a-z A-Z 0-9 - . space)");
 $valid_username_chars_statement_for_elsewhere = _("(Valid characters are: a-z A-Z 0-9 @ - . _ space)");
 
+/**
+ * Check whether $username is a reasonable/acceptable User Name (ID).
+ *
+ * If it is, return an empty string.
+ * If not, return a string detailing the problem.
+ * (This is used at both registration and login.)
+ */
 function check_username($username, $registering = false)
-// Check whether $username is a reasonable/acceptable User Name (ID).
-// If it is, return an empty string.
-// If not, return a string detailing the problem.
-// (This is used at both registration and login.)
 {
     $username_max_len = 25;
     // This is the length of the 'username' field in the 'users' table.

--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -76,9 +76,13 @@ function provide_escape_links()
     echo "</ul>\n";
 }
 
+/**
+ * Look through request parameters for a parameter with one of the given names
+ * and a non-empty value.
+ *
+ * Return the value, or NULL if none found.
+ */
 function get_parameter_value($possible_names)
-// Look through request parameters for a parameter with one of the given names
-// and a non-empty value. Return the value, or NULL if none found.
 {
     foreach ($possible_names as $possible_name) {
         $v = @$_GET[$possible_name];

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -8,12 +8,17 @@ include_once($relPath.'Project.inc'); // does_project_page_table_exist()
 include($relPath.'udb_user.php'); // $archive_db_name
 
 
+/**
+ * Archive a project
+ *
+ * This will:
+ * - Move the project's page-table to the archive database.
+ * - Move the project's directory out of $projects_dir &
+ *   write out project's metadata to a JSON file.
+ *   (for later off-site migration).
+ * - Mark the project as having been archived.
+ */
 function archive_project($project, $dry_run)
-// -- Move the project's page-table to the archive database.
-// -- Move the project's directory out of $projects_dir &
-//    write out project's metadata to a JSON file.
-//    (for later off-site migration).
-// -- Mark the project as having been archived.
 {
     global $archive_projects_dir, $archive_db_name;
 
@@ -82,8 +87,10 @@ function archive_project($project, $dry_run)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Write out project's metadata to a JSON file within the archive
+ */
 function generate_project_metadata_json($project, $filename, $dry_run)
-// Write out project's metadata to a JSON file within the archive
 {
     $metadata = [
         "projectid" => $project->projectid,
@@ -105,9 +112,11 @@ function generate_project_metadata_json($project, $filename, $dry_run)
     }
 }
 
+/**
+ * Archive the ancillary info relating to $project
+ * or to any project that was merged into it (and then deleted).
+ */
 function archive_ancillary_data_for_project_etc($project, $indent, $dry_run)
-// Archive the ancillary info relating to $project
-// or to any project that was merged into it (and then deleted).
 {
     archive_ancillary_data_for_project($project, $indent, $dry_run);
 
@@ -156,11 +165,13 @@ function archive_ancillary_data_for_project($project, $indent, $dry_run)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * "Move" (copy and delete) rows pertaining to the given project
+ * from $table_name in the main db to $table_name in the archive db.
+ *
+ * Assumes that the table has a column named 'projectid'.
+ */
 function move_project_rows_to_archive_db($projectid, $table_name, $indent, $dry_run)
-// "Move" (i.e. copy and delete) rows pertaining to the given project
-// from $table_name in the main db to $table_name in the archive db.
-//
-// (Assumes that the table has a column named 'projectid'.)
 {
     global $archive_db_name;
 

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -693,9 +693,12 @@ function define_bad_byte_sequences()
 
 // =============================================================================
 
+/**
+ * Interpret each byte in the string as a code point.
+ *
+ * For example, interpreting it as encoded in ISO-8859-1?
+ */
 function _utf8_encode_string($seq)
-// Interpreting each byte in the string as a code point.
-// (I.e., interpreting it as encoded in ISO-8859-1?)
 {
     $result = "";
     foreach (str_split($seq) as $byte) {

--- a/pinc/comment_inclusions.inc
+++ b/pinc/comment_inclusions.inc
@@ -1,11 +1,20 @@
 <?php
 include_once($relPath.'authors.inc');
 
-// Project comments can contain one kind of special markup:
-//   [biography=....]
-// This markup should always be replaced with the proper biography before the
-// project comments are displayed, zipped up for the post-processor, etc.
-//
+/**
+ * Parse (render) project comments into HTML
+ *
+ * Project comments can be either Markdown or HTML. Sanitize the HTML if its
+ * in that format otherwise render the Markdown to save HTML.
+ *
+ * Comments can also contain one kind of special markup `[biography=....]`.
+ * This markup should always be replaced with the proper biography before the
+ * project comments are displayed, zipped up for the post-processor, etc.
+ *
+ * @param object $project Project object
+ *
+ * @return string
+ */
 function parse_project_comments($project)
 {
     global $relPath;

--- a/pinc/daily_page_limit.inc
+++ b/pinc/daily_page_limit.inc
@@ -24,11 +24,14 @@
 include_once($relPath.'User.inc');
 include_once($relPath.'TallyBoard.inc');
 
+/**
+ * Get the current daily page limit count for the user in a round
+ *
+ * The current "dpl count" for a user in a given round is the delta in their
+ * page-tally for that round since the last snapshot.
+ * (i.e., the net number of save-as-dones in that round today.)
+ */
 function get_dpl_count_for_user_in_round($username, $round)
-// The current "dpl count" for a user in a given round
-// is the delta in their page-tally for that round
-// since the last snapshot.
-// (i.e., the net number of save-as-dones in that round today.)
 {
     $user = new User($username);
 

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -15,8 +15,11 @@ include_once($relPath.'site_vars.php');
 
 // -----------------------------------------------------------------------------
 
-// Start a session. (The user has logged in.)
-// Record the session variable 'pguser' (from $userID)
+/**
+ * Start a session.
+ *
+ * Record the session variable 'pguser' (from $userID)
+ */
 function dpsession_begin($userID)
 {
     global $pguser;
@@ -29,11 +32,14 @@ function dpsession_begin($userID)
     _update_user_activity_time(true);
 }
 
-// Resume a session, if one exists.
-// If the request claimed to belong to a session, and that session is
-// valid/current/non-expired, then refresh the session, reinstate the
-// global variable ($pguser) of that session, and return TRUE.
-// Otherwise, return FALSE.
+/**
+ * Resume a session, if one exists.
+ *
+ * If the request claimed to belong to a session, and that session is
+ * valid/current/non-expired, then refresh the session, reinstate the
+ * global variable ($pguser) of that session, and return TRUE.
+ * Otherwise, return FALSE.
+ */
 function dpsession_resume()
 {
     global $pguser;
@@ -80,7 +86,9 @@ function dpsession_resume()
     return $user_is_logged_in;
 }
 
-// End a session. (The user has logged out.)
+/**
+ * End a session.
+ */
 function dpsession_end()
 {
     session_unset();

--- a/pinc/dpsql.inc
+++ b/pinc/dpsql.inc
@@ -118,14 +118,17 @@ function dpsql_dump_themed_query_result($result, $start_at = 0, $show_rank = DPS
 }
 // -----------------------------------------------------------------------------
 
+/**
+ * Constructs an array with a ($key => $value) pair for each row in $res
+ *
+ * $key is the first element of the row, and $value is the rest of the row.
+ *
+ * Typically, you'd use this when the first column in the result set satisfies
+ * a uniqueness constraint. If that's not the case, and two rows have the same
+ * value for the first element, the later one will overwrite the earlier one.
+ * However, this too can be a useful behaviour.
+ */
 function dpsql_fetch_all_keyed($res)
-// Constructs an array with a ($key => $value) pair for each row in $res:
-// $key is the first element of the row, and $value is the rest of the row.
-//
-// (Typically, you'd use this when the first column in the result set satisfies
-// a uniqueness constraint. If that's not the case, and two rows have the same
-// value for the first element, the later one will overwrite the earlier one.
-// However, this too can be a useful behaviour.)
 {
     $arr = [];
     while ($row = mysqli_fetch_row($res)) {
@@ -138,8 +141,10 @@ function dpsql_fetch_all_keyed($res)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an array of arrays, one for each column of the result-set.
+ */
 function dpsql_fetch_columns($res)
-// Return an array of arrays, one for each column of the result-set.
 {
     $columns = [];
     $num_cols = mysqli_num_fields($res);

--- a/pinc/email_address.inc
+++ b/pinc/email_address.inc
@@ -1,9 +1,12 @@
 <?php
 
+/**
+ * Check whether $email_address is a reasonable/acceptable E-mail Address.
+ *
+ * If it is, return an empty string.
+ * If it isn't, return a string detailing the problem.
+ */
 function check_email_address($email_address)
-// Check whether $email_address is a reasonable/acceptable E-mail Address.
-// If it is, return an empty string.
-// If it isn't, return a string detailing the problem.
 {
     $email_address_max_len = 100;
     // This is the length of the 'email' field in the 'users' table.

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -42,18 +42,21 @@ assert(PHPBB_VERSION == 3, "Only phpBB version 3 is supported");
 
 
 /**
-* return a table name with the phpBB table prefix prepended to it
-*/
+ * Return a table name with the phpBB table prefix prepended to it
+ */
 function phpbb_table($table)
 {
     global $forums_phpbb_table_prefix;
     return $forums_phpbb_table_prefix . "_" . $table;
 }
 
+/**
+ * Return the language string phpbb uses for $langcode for languages
+ * installed in the forum interface.
+ *
+ * Fall back to English if $langcode is not installed on the system.
+ */
 function phpbb_lang($locale = false)
-// Return the language string phpbb uses for $langcode for languages
-// installed in the forum interface. Fall back to English if $langcode
-// is not installed on the system.
 {
     if ($locale === false) {
         $locale = get_desired_language();
@@ -84,11 +87,15 @@ function phpbb_lang($locale = false)
     }
 }
 
+/**
+ * Implement or call the hashing function used by the forum to hash
+ * the password stored in the database.
+ *
+ * This is required because we store the hashed password in the
+ * non_activated_users table and use it directly when creating the account
+ * post-activation.
+ */
 function forum_password_hash($password)
-// Implement or call the hashing function used by the forum to hash
-// the password stored in the database. This is required because we
-// store the hashed password in the non_activated_users table and use
-// it directly when creating the account post-activation.
 {
     if (PHPBB_VERSION == 3) {
         // phpBB3 hashing function is involved, so we'll call it directly
@@ -99,15 +106,20 @@ function forum_password_hash($password)
     }
 }
 
+/**
+ * Creates a forum user with the specified username, password, and email.
+ *
+ * The DP registration process already digests the password, hence the
+ * need for $password_is_digested.
+ *
+ * Returns:
+ * - TRUE  - user successfully created
+ * - !TRUE (error string) - user creation failed
+ *
+ * Note: Use a strict comparison operator (=== or !==) against TRUE
+ * to evaluate the pass/fail status of this function.
+ */
 function create_forum_user($username, $password, $email, $password_is_digested = false)
-// Creates a forum user with the specified username, password, and email.
-// The DP registration process already digests the password, hence the
-// need for $password_is_digested.
-// Returns:
-//     TRUE  - user successfully created
-//     !TRUE (error string) - user creation failed
-// Note: Use a strict comparison operator (=== or !==) against TRUE
-// to evaluate the pass/fail status of this function.
 {
     if (PHPBB_VERSION == 3) {
         // Use the phpBB3 API to create the user, but do so via phpbb3.inc
@@ -143,15 +155,18 @@ function create_forum_user($username, $password, $email, $password_is_digested =
     }
 }
 
+/**
+ * Log in the user to the forums.
+ *
+ * Returns:
+ * - [TRUE, '']  - user sucessfully logged in
+ * - [FALSE, $reason] - login failed and the reason why, valid $reasons:
+ *   - incorrect_username
+ *   - incorrect_password
+ *   - too_many_attempts
+ *   - unknown
+ */
 function login_forum_user($username, $password)
-// Log in the user to the forums.
-// Returns:
-//     [TRUE, '']  - user sucessfully logged in
-//     [FALSE, $reason] - login failed and the reason why, valid $reasons:
-//         'incorrect_username'
-//         'incorrect_password'
-//         'too_many_attempts'
-//         'unknown'
 {
     global $forums_phpbb_dir;
 
@@ -235,8 +250,10 @@ function login_forum_user($username, $password)
     }
 }
 
+/**
+ * Log out the currently-authenticated user from the forum.
+ */
 function logout_forum_user()
-// Log out the currently-authenticated user from the forum.
 {
     global $forums_phpbb_dir;
     global $pguser;
@@ -286,10 +303,13 @@ function get_reset_password_url()
     }
 }
 
+/**
+ * Given a username, return details about the user.
+ *
+ * Returns an associative array. See $interested_columns for the keys.
+ * If the user isn't found, the function returns NULL.
+ */
 function get_forum_user_details($username)
-// Given a username, return details about the user.
-// Returns an associative array. See $interested_columns for the keys.
-// If the user isn't found, the function returns NULL.
 {
     $interested_columns = [
         "id",         // forum user id
@@ -376,8 +396,10 @@ function get_forum_user_details($username)
     return $return_data;
 }
 
+/**
+ * Given a forum username, return the forum user ID.
+ */
 function get_forum_user_id($username)
-// Given a forum username, return the forum user ID.
 {
     // Use a local in-memory cache so we don't pummel the database
     // for pages that end up calling this for the same small set
@@ -409,8 +431,10 @@ function get_forum_user_id($username)
     return $row["user_id"];
 }
 
+/**
+ * Given a forum rank number, return the text title of that rank.
+ */
 function get_forum_rank_title($rank)
-// Given a forum rank number, return the text title of that rank.
 {
     $query = sprintf("
         SELECT rank_title
@@ -431,30 +455,38 @@ function get_forum_rank_title($rank)
     return $row["rank_title"];
 }
 
+/**
+ * Given a forum username, return the email address.
+ */
 function get_forum_email_address($username)
-// Given a forum username, return the email address.
 {
     $user_details = get_forum_user_details($username);
 
     return $user_details["email"] ?? "";
 }
 
+/**
+ * Return a URL to the base of the forum
+ */
 function get_url_for_forum()
-// Return a URL to the base of the forum
 {
     global $forums_phpbb_url;
     return $forums_phpbb_url;
 }
 
+/**
+ * Return a URL that a user can use to manually log in to the forums.
+ */
 function get_url_for_forum_user_login()
-// Return a URL that a user can use to manually log in to the forums.
 {
     return get_url_for_forum() . "/ucp.php?mode=login";
 }
 
+/**
+ * Given a forum username, return a URL that can be used to
+ * access a form to send the user a message.
+ */
 function get_url_to_compose_message_to_user($username)
-// Given a forum username, return a URL that can be used to
-// access a form to send the user a message.
 {
     $userid = get_forum_user_id($username);
 
@@ -463,27 +495,37 @@ function get_url_to_compose_message_to_user($username)
     }
 }
 
+/**
+ * Given a forum id, return a URL that can be used to view the forum.
+ */
 function get_url_to_view_forum($forum_id)
-// Given a forum id, return a URL that can be used to view the forum.
 {
     return get_url_for_forum() . "/viewforum.php?f=$forum_id";
 }
 
+/**
+ * Given a topic id, return a URL that can be used to view the topic.
+ */
 function get_url_to_view_topic($topic_id)
-// Given a topic id, return a URL that can be used to view the topic.
 {
     return get_url_for_forum() . "/viewtopic.php?t=$topic_id";
 }
 
+/**
+ * Given a post id, return a URL that can be used to view the post.
+ */
 function get_url_to_view_post($post_id)
-// Given a post id, return a URL that can be used to view the post.
 {
     return get_url_for_forum() . "/viewtopic.php?p=$post_id#$post_id";
 }
 
+/**
+ * Given a forum username, return a URL that can be used to load the user's
+ * avatar.
+ *
+ * If no avatar is defined, this function returns NULL.
+ */
 function get_url_for_user_avatar($username)
-// Given a forum username, return a URL that can be used to load the user's
-// avatar. If no avatar is defined, this function returns NULL.
 {
     $user_details = get_forum_user_details($username);
 
@@ -511,32 +553,40 @@ function get_url_for_user_avatar($username)
     }
 }
 
+/**
+ * Return a URL that can be used to edit the current user's profile.
+ */
 function get_url_to_edit_profile()
-// Return a URL that can be used to edit the current user's profile.
 {
     if (PHPBB_VERSION == 3) {
         return get_url_for_forum() . "/ucp.php";
     }
 }
 
+/**
+ * Return a URL that can be used to view a given user's profile.
+ */
 function get_url_to_view_profile($user_id)
-// Return a URL that can be used to view a given user's profile.
 {
     if (PHPBB_VERSION == 3) {
         return get_url_for_forum() . "/memberlist.php?mode=viewprofile&u=$user_id";
     }
 }
 
+/**
+ * Return the URL for accessing the current user's inbox.
+ */
 function get_url_for_inbox()
-// Return the URL for accessing the current user's inbox.
 {
     if (PHPBB_VERSION == 3) {
         return get_url_for_forum() . "/ucp.php?i=pm&folder=inbox";
     }
 }
 
+/**
+ * Given a forum username, return the number of unread messages.
+ */
 function get_number_of_unread_messages($username)
-// Given a forum username, return the number of unread messages.
 {
     $forum_userid = get_forum_user_id($username);
 
@@ -563,11 +613,12 @@ function get_number_of_unread_messages($username)
     return $num_messages;
 }
 
+/**
+ * Confirm a specific topic ID exists.
+ *
+ * @return bool
+ */
 function does_topic_exist($topic_id)
-// Confirm a specific topic ID exists.
-// Returns:
-//     FALSE - doesn't exist
-//     TRUE  - does exist
 {
     $query = sprintf("
         SELECT 1
@@ -585,10 +636,13 @@ function does_topic_exist($topic_id)
     return $exists;
 }
 
+/**
+ * Given a forum topic, return the time of the last post
+ * in UNIX time format (seconds since UNIX epoch).
+ *
+ * If no topic is found, function returns NULL.
+ */
 function get_last_post_time_in_topic($topic_id)
-// Given a forum topic, return the time of the last post
-// in UNIX time format (seconds since UNIX epoch).
-// If no topic is found, function returns NULL.
 {
     // Validate that $topic_id is an integer and if not, return NULL
     if (!is_numeric($topic_id)) {
@@ -613,14 +667,18 @@ function get_last_post_time_in_topic($topic_id)
     return $row["max_post_time"];
 }
 
+/**
+ * Return details about a topic
+ *
+ * Returns the following details about a topic as an associative array.
+ * - topic_id         - the ID of the topic (for completeness)
+ * - title            - the title of the topic
+ * - num_replies      - the number of replies in the topic
+ * - forum_name       - name of the forum the topic is in
+ * - forum_id         - the id of the forum the topic is in
+ * - creator_username - the username of the topic creator
+ */
 function get_topic_details($topic_id)
-// Returns the following details about a topic as an associative array.
-//     topic_id         - the ID of the topic (for completeness)
-//     title            - the title of the topic
-//     num_replies      - the number of replies in the topic
-//     forum_name       - name of the forum the topic is in
-//     forum_id         - the id of the forum the topic is in
-//     creator_username - the username of the topic creator
 {
     global $forums_phpbb_dir;
 
@@ -673,6 +731,11 @@ function get_topic_details($topic_id)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Create a topic
+ *
+ * A proxy for phpbb[2|3]_create_topic() in external phpbb3.inc
+ */
 function topic_create(
     $forum_id,
     $post_subject,
@@ -680,9 +743,7 @@ function topic_create(
     $poster_name,
     $poster_is_real,
     $make_poster_watch_topic
-)
-// A proxy for phpbb[2|3]_create_topic() in external phpbb[2|3].inc
-{
+) {
     $args = func_get_args();
     $topic_id = call_phpbb_function('create_topic', $args);
 
@@ -695,24 +756,31 @@ function topic_create(
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Create a post
+ *
+ * A proxy for phpbb[2|3]_add_post() in external phpbb3.inc
+ */
 function topic_add_post(
     $topic_id,
     $post_subject,
     $post_text,
     $poster_name,
     $poster_is_real
-)
-// A proxy for phpbb[2|3]_add_post() in external phpbb[2|3].inc
-{
+) {
     $args = func_get_args();
     call_phpbb_function('add_post', $args);
 }
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Call a phpBB function in a separate process.
+ *
+ * It's risky to combine DP and phpBB code in the same PHP context,
+ * so we run the phpBB code in a separate process.
+ */
 function call_phpbb_function($func_name, $args)
-// It's risky to combine DP and phpBB code in the same PHP context,
-// so we run the phpBB code in a separate process.
 {
     // If $DEBUG is TRUE, output some additional debugging information useful
     // for figuring out where the calls into phpbb*.inc went wrong.
@@ -759,8 +827,10 @@ function call_phpbb_function($func_name, $args)
     return $last_line;
 }
 
+/**
+ * Work-around for escapeshellarg's anomalous treatment of empty args.
+ */
 function my_escapeshellarg($arg)
-// Work-around for escapeshellarg's anomalous treatment of empty args.
 {
     $s = escapeshellarg($arg);
     if (empty($s)) {

--- a/pinc/genres.inc
+++ b/pinc/genres.inc
@@ -1,8 +1,10 @@
 <?php
 
-// Return an associative array of genres in the format
-//     english_name => translated_name
-// sorted by the translated name
+/**
+ * Return an associative array of genres in the format
+ *     english_name => translated_name
+ * sorted by the translated name
+ */
 function load_genre_translation_array()
 {
     $genres = [

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -2,22 +2,25 @@
 // Localization setup
 include_once($relPath.'languages.inc');
 
-// Return a locale that best matches the language that the user wants and
-// that we have a site translation for. "Best" is tricky, because there are
-// multiple ways that a user could indicate (either explicitly or implicitly)
-// what language they want a page returned in. We walk through the following
-// possibilities in this order:
-// * If $_GET['lang'] is set (a page is requested as eg: default.php?lang=sr)
-//   and requested language is installed, then use that language and set
-//   language cookie so that after clicking on links user would remain in the
-//   language. This is useful for external linking to a localised version.
-// * If user is logged in, and has set language in user preferences, use that
-//   language.
-// * If user is not logged in, use language cookie, if there is one.
-// * If there is no cookie try to guess an appropriate language from browser's
-//   settings. There is no need to set the cookie because browser remains the
-//   same.
-// * If everything else fails, default to en_US.
+/**
+ * Return a locale that best matches the language that the user wants and
+ * that we have a site translation for.
+ *
+ * "Best" is tricky, because there are multiple ways that a user could
+ * indicate (either explicitly or implicitly) what language they want a page
+ * returned in. We walk through the following possibilities in this order:
+ * - If $_GET['lang'] is set (a page is requested as eg: default.php?lang=sr)
+ *   and requested language is installed, then use that language and set
+ *   language cookie so that after clicking on links user would remain in the
+ *   language. This is useful for external linking to a localised version.
+ * - If user is logged in, and has set language in user preferences, use that
+ *   language.
+ * - If user is not logged in, use language cookie, if there is one.
+ * - If there is no cookie try to guess an appropriate language from browser's
+ *   settings. There is no need to set the cookie because browser remains the
+ *   same.
+ * - If everything else fails, default to en_US.
+ */
 function get_desired_language()
 {
     // This function maybe called multiple times within a page load.
@@ -75,9 +78,12 @@ function configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_
     }
 }
 
-// Get the language (locale) for the specified user.
-// $user can be a User object or a username.
-// If $user is NULL, the current user's locale is returned.
+/**
+ * Get the language (locale) for the specified user.
+ *
+ * @param string|object $user
+ *   User object or a username. If NULL, the current user's locale is returned.
+ */
 function get_user_language($user = null)
 {
     if (!$user) {
@@ -91,7 +97,9 @@ function get_user_language($user = null)
     return $locale;
 }
 
-// Configure gettext for a specific user, useful for sending emails.
+/**
+ * Configure gettext for a specific user, useful for sending emails.
+ */
 function configure_gettext_for_user($user = null)
 {
     global $charset, $dyn_locales_dir, $system_locales_dir;
@@ -133,8 +141,12 @@ if (!function_exists('pgettext')) {
     }
 }
 
-// Return a localized date/time string for a date where $pattern is in ICU
-// format (https://unicode-org.github.io/icu/userguide/format_parse/datetime/).
+/**
+ * Return a localized date/time string for a date where $pattern is in ICU
+ * format.
+ *
+ * https://unicode-org.github.io/icu/userguide/format_parse/datetime/
+ */
 function icu_date($pattern, $timestamp = null, $user = null)
 {
     $locale = get_user_language($user);
@@ -147,7 +159,9 @@ function icu_date($pattern, $timestamp = null, $user = null)
     return $idf->format($timestamp);
 }
 
-// Return a localized date from a predefined template
+/**
+ * Return a localized date from a predefined template
+ */
 function icu_date_template($template, $timestamp = null, $user = null)
 {
     $templates = [

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -11,11 +11,14 @@ include_once($relPath.'misc.inc'); // get_integer_param()
 // Maybe it should include unshared stuff too, for completeness.)
 
 
+/**
+ * Retrieve the number of pages proofread by the current user.
+ *
+ * For demo purposes, allow the user (via the URL parameter 'numofpages')
+ * to pretend to have a different number of pages,
+ * as long as it's less than their actual number.
+ */
 function get_pages_proofed_maybe_simulated()
-// Retrieve the number of pages proofread by the current user.
-// For demo purposes, allow the user (via the URL parameter 'numofpages')
-// to pretend to have a different number of pages,
-// as long as it's less than their actual number.
 {
     global $pguser;
 
@@ -151,7 +154,9 @@ function maybe_output_new_proofer_message()
     }
 }
 
-// Help direct new proofers to projects to proof.
+/**
+ * Help direct new proofers to projects to proof.
+ */
 function maybe_output_new_proofer_project_message($project)
 {
     global $code_url, $ELR_round;

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -294,9 +294,10 @@ function users_by_country()
     ];
 }
 
+/**
+ * Return the array defined by $result[$i] = $arr[$i+1] - $arr[$i]
+ */
 function array_successive_differences($arr)
-// Return the array defined by:
-//     $result[$i] = $arr[$i+1] - $arr[$i]
 {
     $result = [];
     foreach ($arr as $key => $value) {
@@ -366,9 +367,10 @@ function curr_month_proj($which)
     ];
 }
 
+/**
+ * Return the array defined by $result[$i] = $arr[$i] - $arr[0]
+ */
 function array_subtract_first_from_each($arr)
-// Return the array defined by:
-//     $result[$i] = $arr[$i] - $arr[0]
 {
     $result = [];
     foreach ($arr as $key => $value) {
@@ -536,9 +538,10 @@ function total_pages_by_month_graph($tally_name)
     ];
 }
 
+/**
+ * Return the array defined by: $result[$i] = sum( $arr[$j] for $j up to and including $i )
+ */
 function array_accumulate($arr)
-// Return the array defined by:
-//     $result[$i] = sum( $arr[$j] for $j up to and including $i )
 {
     $result = [];
     $sum = 0;
@@ -755,9 +758,13 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
     ];
 }
 
+/**
+ * Return an SQL selector that can be used in a WHERE clause.
+ *
+ * @param string $which
+ *   A word denoting a round ID or a phase (NEW, PP, GB)
+ */
 function _get_project_state_selector($which, $desired_states = null)
-// This function returns an SQL selector that can be used in a WHERE clause.
-// $which is a word denoting a round ID or a phase (NEW, PP, GB)
 {
     global $project_state_phase_;
 
@@ -828,12 +835,14 @@ function get_round_backlog_stats($interested_phases)
 
 //--------------------------------------------------------------------------
 
-// Given a function and arguments that will generate graph data, attempt
-// to load the data from memcached first and fall back to the function and
-// cache the response.
-//
-// Note that the graph function might include _() so it's important that we
-// include the user's language in the key.
+/**
+ * Given a function and arguments that will generate graph data, attempt
+ * to load the data from memcached first and fall back to the function and
+ * cache the response.
+ *
+ * Note that the graph function might include _() so it's important that we
+ * include the user's language in the key.
+ */
 function query_graph_cache($function, $args = [], $expire_from_now = 3600)
 {
     $memcache = new Memcached();

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -9,8 +9,10 @@ define('SHOW_STATSBAR', true);
 // output the HTML header and footer for all pages that show output to the
 // user.
 
-// Output the opening HTML page code, including pulling in common styles,
-// page title, etc. eg:
+/**
+ * Output the opening HTML page code, including pulling in common styles,
+ * page title, etc.
+ */
 function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true)
 {
     global $code_url, $site_abbreviation;
@@ -128,7 +130,9 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
     }
 }
 
-// Output HTML page footer to close the page
+/**
+ * Output HTML page footer to close the page
+ */
 function output_html_footer($extra_args = [])
 {
     // close up the page
@@ -140,12 +144,16 @@ function output_html_footer($extra_args = [])
     echo "</html>\n";
 }
 
-// Browser caches are great, but they are a real PITA when we want to change
-// CSS/JS and it's still serving up the older version. This is particularly bad
-// when we're doing things like changing page editing interfaces.
-// To address that, append the file's timestamp as a query parameter to the file.
-// Apache will ignore this but when the value changes the browser will reread
-// the file. PHP's statcache should make this fast.
+/**
+ * Get a browser cache-busting key for a local URL
+ *
+ * Browser caches are great, but they are a real PITA when we want to change
+ * CSS/JS and it's still serving up the older version. This is particularly bad
+ * when we're doing things like changing page editing interfaces.
+ * To address that, append the file's timestamp as a query parameter to the file.
+ * Apache will ignore this but when the value changes the browser will reread
+ * the file. PHP's statcache should make this fast.
+ */
 function get_local_file_browser_cache_key($url)
 {
     global $code_url, $code_dir;

--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -4,9 +4,10 @@
 // system dictionaries used with WordCheck. The functions in language.inc
 // deal with localizations/translations and system locales.
 
-// Returns an associative array of those languages with a dictionary that is
-// installed on the system
-//   $array[$langcode]=$language;
+/**
+ * Returns an associative array of those languages with a dictionary that is
+ * installed on the system
+ */
 function get_languages_with_dictionaries()
 {
     global $aspell_prefix;
@@ -26,8 +27,11 @@ function get_languages_with_dictionaries()
     return $returnArray;
 }
 
-// Given a langcode, return the Unicode script that language is written in.
-// Will return "Latin" if the langcode is not known.
+/**
+ * Given a langcode, return the Unicode script that language is written in.
+ *
+ * Will return "Latin" if the langcode is not known.
+ */
 function get_script_for_langcode($langcode)
 {
     // This, decidedly incomplete, mapping was created by taking the list of
@@ -618,9 +622,11 @@ function get_iso_language_list()
     ];
 }
 
+/**
+ * For the given three-letter code, return the corresponding language-name,
+ * or null if not found.
+ */
 function langname_for_langcode3($langcode3)
-// For the given three-letter code, return the corresponding language-name,
-// or null if not found.
 {
     foreach (get_iso_language_list() as $entry) {
         if (in_array($langcode3, explode("/", $entry['lang_code']))) {
@@ -630,9 +636,11 @@ function langname_for_langcode3($langcode3)
     return null;
 }
 
+/**
+ * For the given language-name, return the corresponding three-letter code,
+ * or null if not found.
+ */
 function langcode3_for_langname($langname)
-// For the given language-name, return the corresponding three-letter code,
-// or null if not found.
 {
     foreach (get_iso_language_list() as $entry) {
         $entry_name = $entry['lang_name'];
@@ -648,8 +656,10 @@ function langcode3_for_langname($langname)
     return null;
 }
 
+/**
+ * Given a two-letter language code, return the language name or NULL
+ */
 function langname_for_langcode2($langcode2)
-// Given a two-letter language code, return the language name or NULL
 {
     $langcode3 = array_search($langcode2, get_iso_639_3_to_2_mapping());
     if ($langcode3) {
@@ -658,10 +668,13 @@ function langname_for_langcode2($langcode2)
     return null;
 }
 
+/**
+ * Given a language name, return the two-letter code if available.
+ *
+ * If a two letter code isn't available, but a three-letter one is, return that.
+ * If the language is not found return NULL.
+ */
 function langcode2_for_langname($langname)
-// Given a language name, return the two-letter code if available. If a two
-// letter code isn't available, but a three-letter one is, return that. If
-// the language is not found return NULL.
 {
     $mapping = get_iso_639_3_to_2_mapping();
     $fallback_code = null;
@@ -680,8 +693,10 @@ function langcode2_for_langname($langname)
     return $fallback_code;
 }
 
+/**
+ * Given a two- or three-letter language code return the language name or NULL.
+ */
 function langname_for_langcode($langcode)
-// Given a two- or three-letter language code return the language name or NULL.
 {
     return langname_for_langcode2($langcode) ?? langname_for_langcode3($langcode);
 }

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -27,8 +27,11 @@ function lang_code($language_code)
     return false;
 }
 
-// Return the 2-letter short code for the specified locale specifier.
-// If no locale is passed in, the locale of the current user is used.
+/**
+ * Return the 2-letter short code for the specified locale specifier.
+ *
+ * If no locale is passed in, the locale of the current user is used.
+ */
 function short_lang_code($langcode = false)
 {
     if ($langcode === false) {
@@ -38,8 +41,9 @@ function short_lang_code($langcode = false)
     return substr($langcode, 0, 2);
 }
 
-// Given a 2-letter language code, return the language name in that
-// language.
+/**
+ * Given a 2-letter language code, return the language name in that language.
+ */
 function lang_name($langcode)
 {
     global $lang_name_data;
@@ -51,7 +55,9 @@ function lang_name($langcode)
     return locale_get_display_language($langcode, $langcode);
 }
 
-// Given a 2-letter language code, return the language name in English.
+/**
+ * Given a 2-letter language code, return the language name in English.
+ */
 function eng_name($langcode)
 {
     global $eng_name_data;
@@ -63,8 +69,10 @@ function eng_name($langcode)
     return locale_get_display_language($langcode, "en");
 }
 
-// Given a 2-letter language code, return a name for that language both
-// in English and in the native language.
+/**
+ * Given a 2-letter language code, return a name for that language both
+ * in English and in the native language.
+ */
 function bilingual_name($langcode)
 {
     $a = eng_name($langcode);
@@ -79,9 +87,17 @@ function bilingual_name($langcode)
     }
 }
 
-// Return a direction for a given language. Returns either:
-// LTR for left-to-right languages
-// RTL for right-to-left languages
+/**
+ * Return a direction for a given language.
+ *
+ * Returns either:
+ * - LTR for left-to-right languages
+ * - RTL for right-to-left languages
+ *
+ * @param mixed $langcode
+ *
+ * @return string
+ */
 function lang_direction($langcode = false)
 {
     if ($langcode === false) {
@@ -101,7 +117,9 @@ function lang_direction($langcode = false)
     }
 }
 
-// Return all installed system locales
+/**
+ * Return all installed system locales
+ */
 function get_installed_system_locales()
 {
     global $charset;
@@ -127,11 +145,15 @@ function get_installed_system_locales()
     return $system_locales;
 }
 
-// Get a list of all locale translations.
-// $state can be one of:
-//   "all" - all installed locale translations
-//   "enabled" - locale translation is enabled
-//   "disabled" - locale translation is disabled
+/**
+ * Get a list of all locale translations.
+ *
+ * @param string $state
+ *   One of:
+ *   - "all" - all installed locale translations
+ *   - "enabled" - locale translation is enabled
+ *   - "disabled" - locale translation is disabled
+ */
 function get_installed_locale_translations($state = "all")
 {
     global $dyn_locales_dir;
@@ -219,10 +241,13 @@ function set_locale_translation_enabled($locale, $enable)
     }
 }
 
+/**
+ * Return an associative array for all translations a user can select.
+ *
+ * Keys are the locale and the value being the name of the
+ * language and the locale.
+ */
 function get_locale_translation_selection_options()
-// Return an associative array for all translations a user can select
-// with keys being the locale and the value being the name of the
-// language and the locale.
 {
     $translations = get_installed_locale_translations("enabled");
 
@@ -240,17 +265,23 @@ function get_locale_translation_selection_options()
     return $options;
 }
 
+/**
+ * Get the best matching locale code from the browser
+ *
+ * This code is largely inspired by the excellent write-up here:
+ * https://www.dyeager.org/2008/10/getting-browser-default-language-php.html
+ * accordingly:
+ * ```
+ * #########################################################
+ * # Copyright © 2008 Darrin Yeager                        #
+ * # https://www.dyeager.org/                              #
+ * # Licensed under BSD license.                           #
+ * #   https://www.dyeager.org/downloads/license-bsd.txt   #
+ * #########################################################
+ * ```
+ * On success it returns an installed locale. On failure it returns NULL.
+ */
 function get_locale_matching_browser_accept_language($http_accept)
-// This code is largely inspired by the excellent write-up here:
-// https://www.dyeager.org/2008/10/getting-browser-default-language-php.html
-// accordingly:
-//########################################################
-// Copyright © 2008 Darrin Yeager                        #
-// https://www.dyeager.org/                              #
-// Licensed under BSD license.                           #
-//   https://www.dyeager.org/downloads/license-bsd.txt   #
-//########################################################
-// On success it returns an installed locale. On failure it returns NULL.
 {
     // split the languages into their respective parts
     $browser_accepts = explode(",", $http_accept);
@@ -279,9 +310,11 @@ function get_locale_matching_browser_accept_language($http_accept)
     return null;
 }
 
+/**
+ * Given a browser's accept-language string, return a locale string
+ * that most closely matches it.
+ */
 function massage_browser_lang_code_to_locale($browser_lang_code)
-// Given a browser's accept-language string, return a locale string
-// that most closely matches it.
 {
     // system locales are always in the format xx_YY, but browsers can
     // send accepts in many different formats (eg: en, en-us, en-US)

--- a/pinc/links.inc
+++ b/pinc/links.inc
@@ -3,9 +3,11 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'forum_interface.inc');
 include_once($relPath.'misc.inc'); // attr_safe()
 
+/**
+ * Returns a string containing a snippet of HTML
+ * for a link that opens in a new window.
+ */
 function new_window_link($href, $linktext)
-// Returns a string containing a snippet of HTML
-// for a link that opens in a new window.
 {
     global $code_url;
 
@@ -19,9 +21,11 @@ function new_window_link($href, $linktext)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns a string containing a snippet of HTML
+ * for a link that opens in a specific target.
+ */
 function recycle_window_link($href, $linktext, $target)
-// Returns a string containing a snippet of HTML
-// for a link that opens in a specific target.
 {
     global $code_url;
 
@@ -35,9 +39,11 @@ function recycle_window_link($href, $linktext, $target)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns a string containing a snippet of HTML
+ * for a link that opens a help topic in a new window.
+ */
 function new_help_window_link($help_topic_id, $linktext)
-// Returns a string containing a snippet of HTML
-// for a link that opens a help topic in a new window.
 {
     global $code_url;
 
@@ -51,12 +57,15 @@ function new_help_window_link($help_topic_id, $linktext)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns a string containing a snippet of HTML
+ * for a link that opens a window to send a PM to the
+ * specified user.
+ *
+ * Specifying a NULL $target parameter will return a link to send
+ * a PM in the current window.
+ */
 function private_message_link($proofer_username, $target = "_blank")
-// returns a string containing a snippet of HTML
-// for a link that opens a window to send a PM to the
-// specified user.
-// Specifying a NULL $target parameter will return a link to send
-// a PM in the current window.
 {
     global $code_url;
 
@@ -81,11 +90,18 @@ function private_message_link($proofer_username, $target = "_blank")
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns HTML-safe URL for the given project page.
+ *
+ * @param array $query_param_array
+ *   Query parameters (without ?/&), e.g. ["detail_level=4"].
+ *   Should be `urlencode()` d if necessary
+ *
+ * @param string $anchor_link
+ *   Page anchor (without #), e.g "holds"
+ *   Should be `urlencode()` d if necessary
+ */
 function project_page_link_url($projectid, $query_param_array = null, $anchor_link = "")
-// Returns HTML-safe URL for the given project page.
-// Optional second argument is array of query parameters (without ?/&), e.g. ["detail_level=4"]
-// Optional third argument is page anchor (without #), e.g "holds"
-// NOTE: query_params and anchor_link should be urlencoded if necessary
 {
     global $code_url;
 
@@ -101,11 +117,18 @@ function project_page_link_url($projectid, $query_param_array = null, $anchor_li
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns a string containing an HTML link to return to a project page.
+ *
+ * @param array $query_param_array
+ *   Query parameters (without ?/&), e.g. ["detail_level=4"].
+ *   Should be `urlencode()` d if necessary
+ *
+ * @param string $anchor_link
+ *   Page anchor (without #), e.g "holds"
+ *   Should be `urlencode()` d if necessary
+ */
 function return_to_project_page_link($projectid, $query_param_array = null, $anchor_link = "")
-// Returns a string containing an HTML link to return to a project page.
-// Optional second argument is array of query parameters (without ?/&), e.g. ["detail_level=4"]
-// Optional third argument is page anchor (without #), e.g "holds"
-// NOTE: query_params and anchor_link should be urlencoded if necessary
 {
     $url = project_page_link_url($projectid, $query_param_array, $anchor_link);
     return sprintf(
@@ -116,8 +139,10 @@ function return_to_project_page_link($projectid, $query_param_array = null, $anc
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns a string containing a snippet of HTML to return to a round page.
+ */
 function return_to_round_page_link($round_id)
-// Returns a string containing a snippet of HTML to return to a round page.
 {
     global $code_url;
 
@@ -130,8 +155,10 @@ function return_to_round_page_link($round_id)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns a string containing a snippet of HTML to return to the Activity Hub.
+ */
 function return_to_activity_hub_link()
-// Returns a string containing a snippet of HTML to return to the Activity Hub.
 {
     global $code_url;
 

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -3,9 +3,10 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'pg.inc');
 
+/**
+ * Output a list of projects giving very brief information about each
+ */
 function list_projects_tersely($where_condition, $order_clause, $limit_clause)
-// List the specified projects,
-// giving very brief information about each.
 {
     $sql = "
         SELECT nameofwork, authorsname, language, postednum
@@ -33,10 +34,12 @@ function list_projects_tersely($where_condition, $order_clause, $limit_clause)
     echo "</ul>\n";
 }
 
+/**
+ * Output a list of projects giving brief information about each.
+ *
+ * url_base is the URL with the beginning of a query string, eg "foo.php?x=10&amp;" or "foo.php?"
+ */
 function list_projects($where_condition, $order_clause, $group_clause, $url_base, $per_page = 20, $offset = 0)
-// List the specified projects,
-// giving brief information about each.
-// url_base is the URL with the beginning of a query string, eg "foo.php?x=10&amp;" or "foo.php?"
 {
     global $code_url;
 
@@ -167,9 +170,13 @@ function list_projects($where_condition, $order_clause, $group_clause, $url_base
     echo "</ol>";
 }
 
+/**
+ * Return number of books posted to PG
+ *
+ * This function takes into account that some books are processed as several
+ * projects.
+ */
 function total_completed_projects()
-// return number of books posted to PG
-// (takes into account that some books are processed as several projects)
 {
     $psd = get_project_status_descriptor('posted');
     $sql = "

--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -1,14 +1,17 @@
 <?php
 include_once($relPath.'misc.inc'); // startswith()
 
+/**
+ * Redirect the browser to a new URL
+ *
+ * If possible it will use HTTP header redirection (via Location:). If that
+ * isn't possible, it will use a browser redirect (via a <meta> tag).
+ * If this is a test system ($testing=1 in site_vars.php) the redirect
+ * will be delayed by 15 seconds if content has already been sent to the
+ * client (determined if headers have been sent or if the output buffer
+ * has contents in it).
+ */
 function metarefresh($seconds, $url, $title = "", $body = "", $allow_external = false)
-// This function will redirect the browser to load a specific page. If
-// possible it will use HTTP header redirection (via Location:). If that
-// isn't possible, it will use a browser redirect (via a <meta> tag).
-// If this is a test system ($testing=1 in site_vars.php) the redirect
-// will be delayed by 15 seconds if content has already been sent to the
-// client (determined if headers have been sent or if the output buffer
-// has contents in it).
 {
     global $testing, $code_url;
 

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -3,8 +3,10 @@
 
 use voku\helper\UTF8;
 
+/**
+ * Return $arr[$key], or if it's not defined, $default.
+ */
 function array_get($arr, $key, $default)
-// Return $arr[$key], or if it's not defined, $default.
 {
     if (isset($arr[$key])) {
         return $arr[$key];
@@ -13,8 +15,10 @@ function array_get($arr, $key, $default)
     }
 }
 
+/**
+ * Given an array of arrays/objects, return the values of the desired field.
+ */
 function array_extract_field($array, $field)
-// Given an array of arrays/objects, return the values of the desired field.
 {
     $values = [];
     foreach ($array as $entity) {
@@ -27,12 +31,15 @@ function array_extract_field($array, $field)
     return $values;
 }
 
+/**
+ * Return an array whose values are the names of the properties
+ * whose values differ between the two objects $new and $old.
+ *
+ * If $remove_non_public is true, non-public values are not considered in
+ * the comparison and not returned.
+ * https://www.php.net/manual/en/language.types.array.php#language.types.array.casting
+ */
 function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
-// Return an array whose values are the names of the properties
-// whose values differ between the two objects $new and $old.
-// If $remove_non_public is true, non-public values are not considered in
-// the comparison and not returned.
-// https://www.php.net/manual/en/language.types.array.php#language.types.array.casting
 {
     $old_as_array = (array)$old;
     $new_as_array = (array)$new;
@@ -52,19 +59,33 @@ function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
     return $changed_fields;
 }
 
+/**
+ * Get and validate a value from an array against a known set of values
+ *
+ * If `$arr[$key]` is defined and is one of the strings in `$choices`,
+ * return that string.
+ * If it's not defined, and `$default` is non-null, return `$default`.
+ * If `$default` is null and `$allownull` is true, return null (useful for optional params).
+ *
+ * Example usages:
+ * - The direction must be asc/desc, and defaults to asc if not provided.
+ *   ```
+ *   $dir = get_enumerated_param( $_GET, 'direction', 'asc', ['asc', 'desc'] );
+ *   ```
+ * - The tally_name must be one of the rounds, but show a round menu if not specified.
+ *   ```
+ *   $round = get_enumerated_param( $_GET, 'tally_name', null, $rounds, true);
+ *   ```
+ *
+ * @param array $arr
+ * @param string $key
+ * @param mixed $default
+ * @param array $choices
+ * @param boolean $allownull
+ *
+ * @throws InvalidArgumentException
+ */
 function get_enumerated_param($arr, $key, $default, $choices, $allownull = false)
-// If $arr[$key] is defined and is one of the strings in $choices,
-// return that string.
-// If it's not defined, and $default is non-null, return $default.
-// If $default is null and $allownull is true, return null (useful for optional params).
-// Otherwise throw an InvalidArgumentException with an error.
-//
-// Example usages:
-//     $dir = get_enumerated_param( $_GET, 'direction', 'asc', array('asc', 'desc') );
-// The direction must be asc/desc, and defaults to asc if not provided.
-//
-//     $round = get_enumerated_param( $_GET, 'tally_name', null, $rounds, true);
-// The tally_name must be one of the rounds, but show a round menu if not specified.
 {
     {
         // sanity checks on the args
@@ -153,37 +174,87 @@ function get_enumerated_param($arr, $key, $default, $choices, $allownull = false
     }
 }
 
+/**
+ * Get and validate an integer from an array
+ *
+ * If `$arr[$key]` is defined and is the string-rep of an integer
+ * satisfying certain simple constraints, return that integer.
+ * If it's not defined, and `$default` is non-null, return `$default`.
+ * If it's not defined, and `$default` is null and `$allownull` is true, return null.
+ *
+ * Example usages:
+ * - If the script is not given a 'per_page' parameter via the $_GET array,
+ *   use a default value of 20. If it is supplied, ensure it's an integer
+ *   and that it's at least 1, with no upper limit.
+ *   ```
+ *   $per_page = get_integer_param($_GET, 'per_page', 20, 1, NULL );
+ *   ```
+ * - As before, except if no limit is provided, return null, so the caller can
+ *   know to display all pages rather than some arbitrary maximum.
+ *   ```
+ *   $per_page = get_integer_param($_GET, 'per_page', null, 1, null, true);
+ *   ```
+ *
+ * @param array $arr
+ * @param string $key
+ * @param integer|null $default
+ * @param integer|null $min
+ * @param integer|null $max
+ * @param boolean $allownull
+ *
+ * @throws InvalidArgumentException
+ *
+ * @see get_float_param()
+ */
 function get_integer_param($arr, $key, $default, $min, $max, $allownull = false)
-// If $arr[$key] is defined and is the string-rep of an integer
-// satisfying certain simple constraints, return that integer.
-// If it's not defined, and $default is non-null, return $default.
-// If it's not defined, and $default is null and $allownull is true, return null.
-// Otherwise, throw an InvalidArgumentException with an error.
-//
-// Example usages:
-//     $per_page = get_integer_param($_GET, 'per_page', 20, 1, NULL );
-// If the script is not given a 'per_page' parameter via the $_GET array,
-// use a default value of 20. If it is supplied, ensure it's an integer
-// and that it's at least 1, with no upper limit.
-//
-//     $per_page = get_integer_param($_GET, 'per_page', null, 1, null, true);
-// As before, except if no limit is provided, return null, so the caller can
-// know to display all pages rather than some arbitrary maximum.
 {
     return get_numeric_param("integer", $arr, $key, $default, $min, $max, $allownull);
 }
 
+/**
+ * Get and validate a float from an array
+ *
+ * If `$arr[$key]` is defined and is the string-rep of a float
+ * satisfying certain simple constraints, return that float.
+ * If it's not defined, and `$default` is non-null, return `$default`.
+ * If it's not defined, and `$default` is null and `$allownull` is true, return null.
+ *
+ * @param array $arr
+ * @param string $key
+ * @param float|null $default
+ * @param float|null $min
+ * @param float|null $max
+ * @param boolean $allownull
+ *
+ * @throws InvalidArgumentException
+ *
+ * @see get_integer_param()
+ */
 function get_float_param($arr, $key, $default, $min, $max, $allownull = false)
-// This function operates identically to get_integer_param() except for floats
 {
     return get_numeric_param("float", $arr, $key, $default, $min, $max, $allownull);
 }
 
+/**
+ * Get and validate a numeric value from an array
+ *
+ * This is the parent function of `get_integer_param()` and `get_float_param()`,
+ * use those versions instead.
+ *
+ * @param string $type - One of "integer" or "float"
+ * @param array $arr
+ * @param string $key
+ * @param integer|float|null $default
+ * @param integer|float|null $min
+ * @param integer|float|null $max
+ * @param boolean $allownull
+ *
+ * @throws InvalidArgumentException
+ *
+ * @see get_integer_param()
+ * @see get_float_param()
+ */
 function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
-// Parent function of get_integer_param() and get_float_param(), use those
-// versions instead.
-//
-// $type should be one of "integer" or "float".
 {
     {
         // sanity checks on the args
@@ -273,22 +344,33 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
     }
 }
 
+/**
+ * Get and validate a value from an array using a regex
+ *
+ * If `$arr[$key]` is defined and matches `$regex`, return it.
+ * If it's not defined, and `$default` is non-null, return `$default`.
+ * If it's not defined, and `$default` is null and `$allownull` is true, return null.
+ * Otherwise, throw an InvalidArgumentException with an error.
+ *
+ * Example usage:
+ * - Parameter 'word' is required, and its supplied value must consist entirely
+ *   of alphanumeric characters (including underscore).
+ *   ```
+ *   $word = get_param_matching_regex($_GET, 'word', NULL, '/^\w+$/')
+ *   ```
+ * @param array $arr
+ * @param string $key
+ * @param mixed $default
+ * @param string $regex
+ *   For security, $regex should almost certainly be anchored at both ends,
+ *   and should not contain:
+ *   - any complemented character classes (e.g. "[^A-Z]"), or
+ *   - (unescaped) '.' (e.g., in "/foo.+bar/").
+ * @param boolean $allownull
+ *
+ * @throws InvalidArgumentException
+ */
 function get_param_matching_regex($arr, $key, $default, $regex, $allownull = false)
-// If $arr[$key] is defined and matches $regex, return it.
-// If it's not defined, and $default is non-null, return $default.
-// If it's not defined, and $default is null and $allownull is true, return null.
-// Otherwise, throw an InvalidArgumentException with an error.
-//
-// NOTE:
-// For security, $regex should almost certainly be anchored at both ends,
-// and should not contain:
-//  -- any complemented character classes (e.g. "[^A-Z]"), or
-//  -- (unescaped) '.' (e.g., in "/foo.+bar/").
-//
-// Example usage:
-//     $word = get_param_matching_regex($_GET, 'word', NULL, '/^\w+$/')
-// Parameter 'word' is required, and its supplied value must consist entirely
-// of alphanumeric characters (including underscore).
 {
     // sanity checks on args
     {
@@ -337,18 +419,22 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull = fal
 
 // -----------------------------------------------------------------------------
 
-// Return a copy of a string correctly encoded for inclusion in an HTML
-// document. This is essentially a wrapper around htmlspecialchars() but it
-// is aware of the global character set. Using this wrapper means we don't
-// have to rely on the global $charset variable being accessible everywhere
-// we need to call htmlspecialchars().
-//
-// By default this escapes all quotes with ENT_QUOTES. This can be changed
-// with the $flags argument which is passed directly into htmlspecailchars().
-//
-// If the $charset global isn't defined, use whatever the PHP default_charset
-// is. Note that using default_charset is the default behavior for
-// htmlspecialchars in PHP >= 5.6, whereas 5.4 and 5.5 use UTF-8.
+/**
+ * Return a copy of a string correctly encoded for inclusion in an HTML
+ * document.
+ *
+ * This is essentially a wrapper around htmlspecialchars() but it
+ * is aware of the global character set. Using this wrapper means we don't
+ * have to rely on the global $charset variable being accessible everywhere
+ * we need to call htmlspecialchars().
+ *
+ * By default this escapes all quotes with ENT_QUOTES. This can be changed
+ * with the $flags argument which is passed directly into htmlspecailchars().
+ *
+ * If the $charset global isn't defined, use whatever the PHP default_charset
+ * is. Note that using default_charset is the default behavior for
+ * htmlspecialchars in PHP >= 5.6, whereas 5.4 and 5.5 use UTF-8.
+ */
 function html_safe($string, $flags = ENT_QUOTES)
 {
     $charset = @$GLOBALS['charset'];
@@ -363,35 +449,33 @@ function html_safe($string, $flags = ENT_QUOTES)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return a copy of $string that has been rendered safe to send as
+ * (part of) the value of an attribute in an HTML or XML document.
+ *
+ * The result is then safe for inclusion in attribute values,
+ * whether they are delimited by single- or double-quotes. E.g.:
+ * ```
+ * $result = attr_safe("Don't!");
+ * echo "<e attr='$result'>";
+ * echo "<e attr=\"$result\">";
+ * echo '<e attr="' . $result . '">';
+ * ```
+ *
+ * It does not encode valid HTML entities. The reason for this is
+ * that one of the intended usage scenarios for this function is to
+ * handle the results of gettext-translation, and we want to allow
+ * translators to use character references in their translations.
+ * For example, a French translator might translate `Name of work`
+ * as `Nom de l'&oelig;uvre`. If we have the code:
+ * ```
+ * echo "<e attr='" . attr_safe(_('Name of Work')) . "'>";
+ * ```
+ * then `_('Name of work')` would, in a French locale, evaluate to the string
+ * value `Nom de l'&oelig;uvre` and we want `attr_safe()` to return
+ * `Nom de l&#39;&oelig;uvre` not `Nom de l&#39;&amp;oelig;uvre`.
+ */
 function attr_safe($string)
-//  Return a copy of $string that has been rendered safe to send as
-//  (part of) the value of an attribute in an HTML or XML document.
-//
-//  The result is then safe for inclusion in attribute values,
-//  whether they are delimited by single- or double-quotes. E.g.:
-//      $result = attr_safe("Don't!");
-//      echo "<e attr='$result'>";
-//      echo "<e attr=\"$result\">";
-//      echo '<e attr="' . $result . '">';
-//
-//  It does not encode valid HTML entities. The reason for this is
-//  that one of the intended usage scenarios for this function is to
-//  handle the results of gettext-translation, and we want to allow
-//  translators to use character references in their translations.
-//  For example, a French translator might translate
-//      Name of work
-//  as
-//      Nom de l'&oelig;uvre
-//  If we have the code:
-//      echo "<e attr='" . attr_safe(_('Name of Work')) . "'>";
-//  then
-//      _('Name of work')
-//  would, in a French locale, evaluate to the string value:
-//      Nom de l'&oelig;uvre
-//  and we want attr_safe(...) to return:
-//      Nom de l&#39;&oelig;uvre
-//  not:
-//      Nom de l&#39;&amp;oelig;uvre
 {
     global $charset;
     if ($string === null) {
@@ -403,36 +487,41 @@ function attr_safe($string)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return a string that is safe for inclusion in a javascript string
+ * (surrounded by either single or double quotes).
+ *
+ * Does an implied `attr_safe()`, so the output can be enclosed directly
+ * in an html attribute.
+ *
+ * Example usage:
+ * ```
+ * echo '<script>alert("' . javascript_safe($string, $charset) . '"); </script>';
+ * echo "<script>alert('" . javascript_safe($string, $charset) . "'); </script>";
+ * echo '<a ... onClick=\'confirm("' . javascript_safe($string, $charset) . '")\'>';
+ * echo "<a ... onClick=\"confirm('" . javascript_safe($string, $charset) . '")\">";
+ * ```
+ *
+ * Here are the detailed conversions applied:
+ * - single quotes and double quotes are converted to \ooo octal notation
+ *   (this makes the result safe for inclusion inside an HTML attribute)
+ * - '<' is converted to \ooo octal: this guarantees that "</script>" is not
+ *   present in the returned string
+ * - backslash will be converted to \ooo octal too. It needs to be encoded
+ *   anyway, and \ooo allows to reuse the same regexp.
+ * - also convert anything that may be control characters to \ooo octal or
+ *   \uHHHH hexadecimal. That will notably ensure that line ending
+ *   characters are not present in the returned string.
+ *   (according to the ECMA-262 specification, line ending characters can
+ *   include weird characters such as \u2028 (Line separator) and \u2029
+ *   (Paragraph separator) in addition to the plain \r and \n.)
+ *   Specifically:
+ *   - If the encoding is latin-1, \ooo octal encoded will be used for
+ *     all characters in the range [\000-\017\177-\237]
+ *   - If the encoding is utf-8, \uHHHH encoding is used for all non-ASCII
+ *     characters, and \ooo for control ASCII chars [\000-\017\177]
+ */
 function javascript_safe($str, $encoding = null)
-// Return a string that is safe for inclusion in a javascript string
-// (surrounded by either single or double quotes).
-// Does an implied attr_safe(), so the output can be enclosed directly
-// in an html attribute.
-//
-// Example usage:
-// echo '<script>alert("' . javascript_safe($string, $charset) . '"); </script>';
-// echo "<script>alert('" . javascript_safe($string, $charset) . "'); </script>";
-// echo '<a ... onClick=\'confirm("' . javascript_safe($string, $charset) . '")\'>';
-// echo "<a ... onClick=\"confirm('" . javascript_safe($string, $charset) . '")\">";
-//
-// Here are the detailed conversions applied:
-// - single quotes and double quotes are converted to \ooo octal notation
-//   (this makes the result safe for inclusion inside an HTML attribute)
-// - '<' is converted to \ooo octal: this guarantees that "</script>" is not
-//   present in the returned string
-// - backslash will be converted to \ooo octal too. It needs to be encoded
-//   anyway, and \ooo allows to reuse the same regexp.
-// - also convert anything that may be control characters to \ooo octal or
-//   \uHHHH hexadecimal. That will notably ensure that line ending
-//   characters are not present in the returned string.
-//   (according to the ECMA-262 specification, line ending characters can
-//   include weird characters such as \u2028 (Line separator) and \u2029
-//   (Paragraph separator) in addition to the plain \r and \n.)
-//   Specifically:
-//   - If the encoding is latin-1, \ooo octal encoded will be used for
-//     all characters in the range [\000-\017\177-\237]
-//   - If the encoding is utf-8, \uHHHH encoding is used for all non-ASCII
-//     characters, and \ooo for control ASCII chars [\000-\017\177]
 {
     global $charset;
     if (!$encoding) {
@@ -462,7 +551,9 @@ function javascript_safe($str, $encoding = null)
 
 // -----------------------------------------------------------------------------
 
-// Use HTMLPurifier to sanitize HTML
+/**
+ * Sanitize HTML using HTMLPurifier
+ */
 function sanitize_html($html, $parent_tag = 'div')
 {
     $config = HTMLPurifier_Config::createDefault();
@@ -478,20 +569,21 @@ function sanitize_html($html, $parent_tag = 'div')
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return a string with normalized whitespace characters.
+ *
+ * Replaces each run of whitespace characters with a single space and
+ * strips the resulting string.
+ *
+ * For example, all of the following return `William Shakespeare`:
+ * ```
+ * echo normalize_whitespace("William  Shakespeare");
+ * echo normalize_whitespace("William Shakespeare ");
+ * echo normalize_whitespace(" William Shakespeare");
+ * echo normalize_whitespace("\tWilliam\tShakespeare\t");
+ * ```
+ */
 function normalize_whitespace($str)
-// Return a string with normalized whitespace characters.
-//
-// Example usage:
-//   echo normalize_whitespace("William  Shakespeare");
-//   echo normalize_whitespace("William Shakespeare ");
-//   echo normalize_whitespace(" William Shakespeare");
-//   echo normalize_whitespace("\tWilliam\tShakespeare\t");
-//
-//   They all return "William Shakespeare".
-//
-//
-// Replaces each run of whitespace characters with a single space and
-//   strips the resulting string.
 {
     return trim(preg_replace('/\s+/u', ' ', $str));
 }
@@ -499,7 +591,9 @@ function normalize_whitespace($str)
 
 // -----------------------------------------------------------------------------
 
-// Safely encode a string for use in an XML document.
+/**
+ * Safely encode a string for use in an XML document.
+ */
 function xmlencode($string)
 {
     global $charset;
@@ -534,20 +628,26 @@ function echo_html_comment($comment_body)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return TRUE iff $subject starts with $prefix.
+ */
 function startswith($subject, $prefix)
-// Return TRUE iff $subject starts with $prefix.
 {
     return (strncmp($subject, $prefix, strlen($prefix)) == 0);
 }
 
+/**
+ * Return TRUE iff $subject starts with $prefix ignoring case.
+ */
 function startswithnocase($subject, $prefix)
-// Return TRUE iff $subject starts with $prefix ignoring case.
 {
     return (strncasecmp($subject, $prefix, strlen($prefix)) == 0);
 }
 
+/**
+ * Return TRUE iff $subject ends with $suffix.
+ */
 function endswith($subject, $suffix)
-// Return TRUE iff $subject ends with $suffix.
 {
     return (substr($subject, -strlen($suffix)) == $suffix);
 }
@@ -592,20 +692,26 @@ function set_col_num($colname, $i)
     return sprintf("%s=%d", $colname, $i);
 }
 
-// Given an associative array, return a MySQL string that can be use in an
-// INSERT or UPDATE string.
-// $source_array is an associative array where the keys are MySQL column
-//    names and the values are the desired values to set in the database
-// $string_fields
-//    is a list of keys such that $source_array[$key] should be a string,
-//    otherwise the value is assumed to be an integer
-// This function checks that those expectations are satisfied, and constructs a
-// string of column=value 'assignments' that can be used in an SQL UPDATE
-// command (where each $key is assumed to be a column name). (String values
-// will be properly escaped in this string.)
-//
-// Currently this function will set default values ("" for strings, 0 for
-// numeric values) for all fields that are not within $source_array.
+/**
+ * Generate an SQL fragment to update columns in a table.
+ *
+ * Given an associative array, return a MySQL string that can be use in an
+ * INSERT or UPDATE string.
+ *
+ * This function constructs a string of `column=value` 'assignments' that can
+ * be used in an SQL UPDATE command (where each $key is assumed to be a column
+ * name). String values will be properly escaped in this string.
+ *
+ * Currently this function will set default values ("" for strings, 0 for
+ * numeric values) for all fields that are not within $source_array.
+ *
+ * @param array $source_array
+ *   An associative array where the keys are MySQL column
+ *   names and the values are the desired values to set in the database
+ * @param array $string_fields
+ *    A list of keys such that `$source_array[$key]` should be a string,
+ *    otherwise the value is assumed to be an integer
+ */
 function create_mysql_update_string($source_array, $string_fields = [])
 {
     $update_fields = [];
@@ -620,12 +726,17 @@ function create_mysql_update_string($source_array, $string_fields = [])
     return join(", ", $update_fields);
 }
 
-// Return a list of only the files directly inside in the specified directory.
-// On error, returns False.
-//
-// $dirpath: the directory to search in. May be relative to the cwd.
-// $validext: an array of extensions to check filenames against, may inclue the '.'
-// $with_path: If true, the list of returned names has the directory prepended.
+/**
+ * Return a list of only the files directly inside in the specified directory.
+ * On error, returns False.
+ *
+ * @param string $dirpath
+ *   The directory to search in. May be relative to the cwd.
+ * @param array $validext
+ *   An array of extensions to check filenames against, may include the '.'
+ * @param boolean $with_path
+ *   If true, the list of returned names has the directory prepended.
+ */
 function get_filelist($dirpath, $validext = [], $with_path = false)
 {
     $filelist = [];
@@ -658,25 +769,30 @@ function get_filelist($dirpath, $validext = [], $with_path = false)
 }
 
 
-// Flattens the contents of a directory recursively.
-//
-// For example, the following directory structure:
-//      dir1/
-//          a.txt
-//          dir2/
-//              b.txt
-//          dir3/
-//              dir4/
-//                  c.txt
-//
-// would be flattened like so:
-//      dir1/
-//          a.txt
-//          b.txt
-//          c.txt
-//
-// If the first argument is not an existing directory, an InvalidArgumentException will be thrown.
-// If it is unable to flatten the directory, it will throw a RuntimeException.
+/**
+ * Flattens the contents of a directory recursively.
+ *
+ * For example, the following directory structure:
+ * ```
+ * dir1/
+ *     a.txt
+ *     dir2/
+ *         b.txt
+ *     dir3/
+ *         dir4/
+ *             c.txt
+ * ```
+ *
+ * would be flattened like so:
+ * ```
+ * dir1/
+ *     a.txt
+ *     b.txt
+ *     c.txt
+ * ```
+ * If the first argument is not an existing directory, an InvalidArgumentException will be thrown.
+ * If it is unable to flatten the directory, it will throw a RuntimeException.
+ */
 function flatten_directory(string $directory_to_flatten)
 {
     if (!file_exists($directory_to_flatten) || !is_dir($directory_to_flatten)) {
@@ -708,16 +824,17 @@ function flatten_directory(string $directory_to_flatten)
     }
 }
 
-// -----------------------------------------------------------------------------
-// Return whether the file is a valid zip file.
-//
-// The following conditions are used to check whether the file is considered a valid zip file:
-//   * It must exist
-//   * It must have the zip file extension
-//   * It must be openable by ZipArchive
-//
-// If any of the conditions are not satisfied, it will return false, otherwise it will return true.
-// The extension check can be disabled by passing true as the second argument.
+/**
+ * Return whether the file is a valid zip file.
+ *
+ * The following conditions are used to check whether the file is considered a valid zip file:
+ * - It must exist
+ * - It must have the zip file extension
+ * - It must be openable by ZipArchive
+ *
+ * If any of the conditions are not satisfied, it will return false, otherwise it will return true.
+ * The extension check can be disabled by passing true as the second argument.
+ */
 function is_valid_zip_file(string $file_path, bool $ignore_extension_check = false): bool
 {
     if (!file_exists($file_path)) {
@@ -739,10 +856,12 @@ function is_valid_zip_file(string $file_path, bool $ignore_extension_check = fal
     return $result === true;
 }
 
-// Return an array of files contained within the zip archive.
-//
-// It uses the is_valid_zip_file function to check whether the argument is a valid zip file, if it
-// is not, an InvalidArgumentException is thrown.
+/**
+ * Return an array of files contained within the zip archive.
+ *
+ * It uses the is_valid_zip_file function to check whether the argument is a valid zip file, if it
+ * is not, an InvalidArgumentException is thrown.
+ */
 function list_files_in_zip(string $file_path): array
 {
     if (!is_valid_zip_file($file_path)) {
@@ -765,14 +884,16 @@ function list_files_in_zip(string $file_path): array
     return $files;
 }
 
-// Extracts the zip directory's contents into the output directory.
-//
-// It uses the is_valid_zip_file function to check whether the first argument is a valid zip file, if it
-// is not, an InvalidArgumentException is thrown.
-//
-// If the output directory does not exist or is not a valid directory, an InvalidArgumentException is thrown.
-//
-// Returns whether the extraction was successful.
+/**
+ * Extracts the zip directory's contents into the output directory.
+ *
+ * It uses the `is_valid_zip_file()` function to check whether the first argument is a valid zip file, if it
+ * is not, an InvalidArgumentException is thrown.
+ *
+ * If the output directory does not exist or is not a valid directory, an InvalidArgumentException is thrown.
+ *
+ * Returns whether the extraction was successful.
+ */
 function extract_zip_to(string $path_to_zip, string $output_directory): bool
 {
     if (!is_valid_zip_file($path_to_zip)) {
@@ -795,9 +916,12 @@ function extract_zip_to(string $path_to_zip, string $output_directory): bool
     return $zip->extractTo($output_directory);
 }
 
-// If there is a common base directory remove it.
-// Use is_valid_zip_file() to check the zip file,
-// if it is not valid, throw an InvalidArgumentException.
+/**
+ * Remove a common base directory within a zip file if it exists
+ *
+ * Uses `is_valid_zip_file()` to check the zip file,
+ * if it is not valid, throws an InvalidArgumentException.
+ */
 function remove_common_basedir_from_zip(string $path_to_zip)
 {
     if (!is_valid_zip_file($path_to_zip)) {
@@ -848,17 +972,19 @@ function remove_common_basedir_from_zip(string $path_to_zip)
     $zip->close();
 }
 
-// Creates a zip archive containing the specified files.
-//
-// The first argument represents the files to add to the zip archive and globing is allowed.
-// If there is a directory the files from it are added with its name prefixed (only one level)
-// The second argument represents the path to the zip archive which should be created.
-//
-// Returns whether the zip file was created successfully.
-//
-// Throws a InvalidArgumentException if:
-//   1) It cannot open a ZipArchive using the second argument as the path
-//   2) It cannot add one of the files specified by the first argument to the ZipArchive
+/**
+ * Creates a zip archive containing the specified files.
+ *
+ * The first argument represents the files to add to the zip archive and globing is allowed.
+ * If there is a directory the files from it are added with its name prefixed (only one level)
+ * The second argument represents the path to the zip archive which should be created.
+ *
+ * Returns whether the zip file was created successfully.
+ *
+ * Throws a InvalidArgumentException if:
+ * - It cannot open a ZipArchive using the second argument as the path
+ * - It cannot add one of the files specified by the first argument to the ZipArchive
+ */
 function create_zip_from(array $files_to_zip, string $path_to_zip): bool
 {
     $zip = new ZipArchive();
@@ -885,10 +1011,13 @@ function create_zip_from(array $files_to_zip, string $path_to_zip): bool
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an error message appropriate to $upload_error_code.
+ *
+ * The wording is taken from "Handling File Uploads: Error Messages Explained"
+ * in the PHP online documentation.
+ */
 function get_upload_err_msg($upload_error_code)
-// Return an error message appropriate to $upload_error_code.
-// (The wording is taken from "Handling File Uploads: Error Messages Explained"
-// in the PHP online documentation.)
 {
     switch ($upload_error_code) {
         case UPLOAD_ERR_OK:
@@ -912,7 +1041,9 @@ function get_upload_err_msg($upload_error_code)
     }
 }
 
-// Represent $n bytes as a  $m KB-- $m PB string
+/**
+ * Represent bytes in the largest reasonable units
+ */
 function humanize_bytes($n)
 {
     $i = 0;
@@ -927,19 +1058,24 @@ function humanize_bytes($n)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return the most common prefix and suffix in an array of strings.
+ *
+ * Given an array of N>0 strings, return an array
+ * `[$left_common, $middles, $right_common]` where:
+ * - $left_common is the maximal common prefix of the strings;
+ * - $right_common is the maximal common suffix, subject to the constraint that it
+ *   cannot include characters covered by the common prefix; and
+ * - $middles is an array of N strings, each being that part of the corresponding
+ *   input string that is not covered by the common prefix and suffix.
+ *
+ * That is
+ * ```
+ * $strings[$i] == $left_common . $middles[$i] . $right_common
+ * ```
+ * for all $i.
+ */
 function factor_strings($strings)
-// Given an array of N>0 strings, return an array
-//     [$left_common, $middles, $right_common]
-// where
-// $left_common is the maximal common prefix of the strings;
-// $right_common is the maximal common suffix, subject to the constraint that it
-//     cannot include characters covered by the common prefix; and
-// $middles is an array of N strings, each being that part of the corresponding
-//     input string that is not covered by the common prefix and suffix.
-//
-// That is,
-//     $strings[$i] == $left_common . $middles[$i] . $right_common
-// for all $i.
 {
     assert(count($strings) > 0);
 
@@ -1059,8 +1195,10 @@ function factor_strings($strings)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Determine if page requester is from localhost
+ */
 function requester_is_localhost()
-// function to determine if page requester is from localhost
 {
     if (php_sapi_name() == "cli") {
         return true;
@@ -1074,8 +1212,10 @@ function requester_is_localhost()
     }
 }
 
+/**
+ * Validate requester is localhost or exit
+ */
 function require_localhost_request($deny_cli = false)
-// If the requester is not localhost, bail
 {
     if (!requester_is_localhost() ||
         ($deny_cli && php_sapi_name() == 'cli')) {
@@ -1085,16 +1225,23 @@ function require_localhost_request($deny_cli = false)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Determine if the specified URL is for the current page by comparing the
+ * paths and the query parameters, but not any anchors.
+ *
+ * This function, by design, will return TRUE if the URL query parameters
+ * are a subset of the current page. For example, if the current page is:
+ * ```
+ * http://www.pgdp.net/c/tools/proofers/round.php?round_id=P1&numofpages=12
+ * ```
+ * and the URL to check is:
+ * ```
+ * http://www.pgdp.net/c/tools/proofers/round.php?round_id=P1
+ * ```
+ * the function will return TRUE despite the provided URL not having a
+ * numofpages parameter. The converse, however, is not true.
+ */
 function is_url_for_current_page($url)
-// Determine if the specified URL is for the current page by comparing the
-// paths and the query parameters, but not any anchors.
-// This function, by design, will return TRUE if the URL query parameters
-// are a subset of the current page. For example, if the current page is:
-//    http://www.pgdp.net/c/tools/proofers/round.php?round_id=P1&numofpages=12
-// and the URL to check is:
-//    http://www.pgdp.net/c/tools/proofers/round.php?round_id=P1
-// the function will return TRUE despite the provided URL not having a
-// numofpages parameter. The converse, however, is not true.
 {
     $url_components = parse_url($url);
 
@@ -1117,8 +1264,12 @@ function is_url_for_current_page($url)
     return true;
 }
 
+/**
+ * Given a humanized size of bytes return the number of bytes
+ *
+ * From http://php.net/manual/en/function.ini-get.php
+ */
 function return_bytes($size_str)
-// from http://php.net/manual/en/function.ini-get.php
 {
     switch (substr($size_str, -1)) {
         case 'M': case 'm': return (int)$size_str * 1048576;

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -81,7 +81,7 @@ function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
  * @param string $key
  * @param mixed $default
  * @param array $choices
- * @param boolean $allownull
+ * @param bool $allownull
  *
  * @throws InvalidArgumentException
  */
@@ -197,10 +197,10 @@ function get_enumerated_param($arr, $key, $default, $choices, $allownull = false
  *
  * @param array $arr
  * @param string $key
- * @param integer|null $default
- * @param integer|null $min
- * @param integer|null $max
- * @param boolean $allownull
+ * @param int|null $default
+ * @param int|null $min
+ * @param int|null $max
+ * @param bool $allownull
  *
  * @throws InvalidArgumentException
  *
@@ -224,7 +224,7 @@ function get_integer_param($arr, $key, $default, $min, $max, $allownull = false)
  * @param float|null $default
  * @param float|null $min
  * @param float|null $max
- * @param boolean $allownull
+ * @param bool $allownull
  *
  * @throws InvalidArgumentException
  *
@@ -244,10 +244,10 @@ function get_float_param($arr, $key, $default, $min, $max, $allownull = false)
  * @param string $type - One of "integer" or "float"
  * @param array $arr
  * @param string $key
- * @param integer|float|null $default
- * @param integer|float|null $min
- * @param integer|float|null $max
- * @param boolean $allownull
+ * @param int|float|null $default
+ * @param int|float|null $min
+ * @param int|float|null $max
+ * @param bool $allownull
  *
  * @throws InvalidArgumentException
  *
@@ -366,7 +366,7 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
  *   and should not contain:
  *   - any complemented character classes (e.g. "[^A-Z]"), or
  *   - (unescaped) '.' (e.g., in "/foo.+bar/").
- * @param boolean $allownull
+ * @param bool $allownull
  *
  * @throws InvalidArgumentException
  */
@@ -734,7 +734,7 @@ function create_mysql_update_string($source_array, $string_fields = [])
  *   The directory to search in. May be relative to the cwd.
  * @param array $validext
  *   An array of extensions to check filenames against, may include the '.'
- * @param boolean $with_path
+ * @param bool $with_path
  *   If true, the list of returned names has the directory prepended.
  */
 function get_filelist($dirpath, $validext = [], $with_path = false)

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -8,7 +8,9 @@ include_once($relPath.'../tools/proofers/PPage.inc'); // url_for_pi_do_particula
 include_once($relPath.'misc.inc'); // surround_and_join, attr_safe
 include_once($relPath.'links.inc'); // private_message_link
 
-// Given a project, return the rounds that contain useful data
+/**
+ * Given a project, return the rounds that contain useful data
+ */
 function get_rounds_to_display($project)
 {
     $project_round = get_Round_for_project_state($project->state);
@@ -41,35 +43,37 @@ function get_rounds_to_display($project)
     return $rounds_to_display;
 }
 
-/*
-Generator to return page table data for a project, one page at a time.
-Data is returned in an multi-level associative array that abstracts away
-the lower-level database structure. The returned format looks like:
-
-{
-    "image": "018.png",
-    "image_url": "https://www.pgdp.net/projects/projectID460978cb8e116/018.png",
-    "state": "P3.page_saved",
-    "image_size": 45541,
-    "pagerounds": {
-        "OCR": {
-            "page_size": "1445"
-        },
-        "P1": {
-            "page_size": "1446",
-            "is_diff": "0",
-            "username": "username",
-            "user_page_tally": "117"
-            "wordcheck_ran": "0",
-            "modified_timestamp": "1175026200",
-        },
-        "P2": {
-            ...
-        },
-        ...
-    }
-}
-*/
+/**
+ * Generator to return page table data for a project, one page at a time.
+ *
+ * Data is returned in an multi-level associative array that abstracts away
+ * the lower-level database structure. The returned format looks like:
+ * ```
+ * {
+ *     "image": "018.png",
+ *     "image_url": "https://www.pgdp.net/projects/projectID460978cb8e116/018.png",
+ *     "state": "P3.page_saved",
+ *     "image_size": 45541,
+ *     "pagerounds": {
+ *         "OCR": {
+ *             "page_size": "1445"
+ *         },
+ *         "P1": {
+ *             "page_size": "1446",
+ *             "is_diff": "0",
+ *             "username": "username",
+ *             "user_page_tally": "117"
+ *             "wordcheck_ran": "0",
+ *             "modified_timestamp": "1175026200",
+ *         },
+ *         "P2": {
+ *             ...
+ *         },
+ *         ...
+ *     }
+ * }
+ * ```
+ */
 function fetch_page_table_data($project, $page_selector = null, $proofed_in_round = null)
 {
     if (!$project->pages_table_exists) {
@@ -498,9 +502,11 @@ function changeSelection(sel) {
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Returns an array of Rounds representing those rounds
+ * for which the given project has some useful data.
+ */
 function get_rounds_with_data($projectid)
-// Returns an array of Rounds representing those rounds
-// for which the given project has some useful data.
 {
     $rounds_with_data = [];
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -54,9 +54,11 @@ function get_ELR_tallyboards()
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Add $amount to the user's page tally,
+ * and to the page tally of each team that the user currently belongs to.
+ */
 function page_tallies_add($tally_name, $username, $amount)
-// Add $amount to the user's page tally,
-// and to the page tally of each team that the user currently belongs to.
 {
     // get the user's u_id, and the teams that he/she belongs to
     $user = new User($username);
@@ -78,8 +80,9 @@ function page_tallies_add($tally_name, $username, $amount)
 
 // -----------------------------------------------------------------------------
 
-function get_daily_average($start_time, $total)
 // Not actually tally-specific, but that's all it's used for.
+
+function get_daily_average($start_time, $total)
 {
     $now = time();
     $seconds_since_start = $now - $start_time;
@@ -89,8 +92,10 @@ function get_daily_average($start_time, $total)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Return the user's page tally for the Entry-Level Round.
+ */
 function user_get_ELR_page_tally($username)
-// Return the user's page tally for the Entry-Level Round.
 {
     [$users_ELR_page_tallyboard, ] = get_ELR_tallyboards();
 
@@ -117,19 +122,22 @@ function user_get_ELR_page_tally($username)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Get the user's page tally neighborhood
+ *
+ * @param int $radius
+ *   (maximum) number of neighbors (on each side) to include in
+ *   the neighborhood. (It will include fewer that the maximum iff the target
+ *   user is within $radius of the corresponding end of the ranked list.)
+ *
+ * Return the page-tally neighborhood of $username.
+ * This is an array where keys are integers from the range [-$radius, +$radius],
+ * indicating a user's position relative to the target user (w.r.t. page tally).
+ * (So key=0 refers to the target user.)
+ * For a given key, the corresponding value is a PageTally_Neighbor object
+ * supplying various information about the page-tally neighbor.
+ */
 function user_get_page_tally_neighborhood($tally_name, $username, $radius)
-//
-// $radius is the (maximum) number of neighbors (on each side) to include in
-// the neighborhood. (It will include fewer that the maximum iff the target
-// user is within $radius of the corresponding end of the ranked list.)
-//
-// Return the page-tally neighborhood of $username.
-//    This is an array:
-//    The keys are integers from the range [-$radius, +$radius],
-//    indicating a user's position relative to the target user (w.r.t. page tally).
-//    (So key=0 refers to the target user.)
-//    For a given key, the corresponding value is a PageTally_Neighbor object
-//    supplying various information about the page-tally neighbor.
 {
     $user = new User($username);
 
@@ -212,8 +220,10 @@ class PageTally_Neighbor
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Should we anonymize information about the given user?
+ */
 function should_anonymize($username, $user_privacy_setting)
-// Should we anonymize information about the given user?
 {
     return !can_reveal_details_about($username, $user_privacy_setting);
 }
@@ -251,12 +261,16 @@ $SECONDS_TO_YESTERDAY = 1 + 3 * 60 * 60;
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an object whose attributes are various useful statistics about
+ * the site page tally.
+ *
+ * Return object attributes:
+ * - curr_day_{goal,actual}
+ * - prev_day_{goal,actual}
+ * - curr_month_{goal,actual}
+ */
 function get_site_page_tally_summary($tally_name)
-// Return an object whose attributes are various useful statistics re
-// the site page tally:
-//     curr_day_{goal,actual}
-//     prev_day_{goal,actual}
-//     curr_month_{goal,actual}
 {
     $site_stats = new StdClass();
 
@@ -319,6 +333,11 @@ function get_site_tally_goal_summed($tally_name, $date_condition)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return a string containing an SQL 'select' statement
+ * dealing with site-specific rows from the past_tallies table,
+ * and corresponding rows from the site_tally_goals table.
+ */
 function select_from_site_past_tallies_and_goals(
     $tally_name,
     $select,
@@ -326,9 +345,6 @@ function select_from_site_past_tallies_and_goals(
     $groupby,
     $orderby,
     $limit)
-// Return a string containing an SQL 'select' statement
-// dealing with site-specific rows from the past_tallies table,
-// and corresponding rows from the site_tally_goals table.
 {
     global $SECONDS_TO_YESTERDAY;
 
@@ -375,10 +391,13 @@ function select_from_site_past_tallies_and_goals(
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an array of the daily deltas in the holder's page tally for the past $days_back days,
+ * where $days_back is either the string "all" or a positive integer.
+ *
+ * In the returned array, each key is a date-string of the form "YYYY-MM-DD".
+ */
 function get_pages_per_day_for_past_n_days($tally_name, $holder_type, $holder_id, $days_back)
-// Return an array of the daily deltas in the holder's page tally for the past $days_back days,
-// where $days_back is either the string "all" or a positive integer.
-// In the returned array, each key is a date-string of the form "YYYY-MM-DD".
 {
     global $SECONDS_TO_YESTERDAY;
 

--- a/pinc/pg.inc
+++ b/pinc/pg.inc
@@ -8,8 +8,10 @@ $PGLAF_upload_url = "https://upload.pglaf.org";
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Given a PG etext number, return a URL for the PG catalog page for that text.
+ */
 function get_pg_catalog_url_for_etext($etext_number)
-// Given a PG etext number, return a URL for the PG catalog page for that text.
 {
     global $PG_home_url;
     return "$PG_home_url/ebooks/$etext_number";
@@ -17,9 +19,11 @@ function get_pg_catalog_url_for_etext($etext_number)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Given a PG etext number, return an HTML <a> element
+ * that links to the PG catalog page for that text.
+ */
 function get_pg_catalog_link_for_etext($etext_number, $link_text = null)
-// Given a PG etext number, return an HTML <a> element
-// that links to the PG catalog page for that text.
 {
     $url = get_pg_catalog_url_for_etext($etext_number);
 

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -160,6 +160,17 @@ function phpbb3_add_post(
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Create a post in phpBB
+ *
+ * Use submit_post() to post to a topic.
+ *
+ * - if $poster_is_real, deduce $poster_id from $poster_name;
+ *   otherwise use Anonymous (ie: guest)
+ * - attachsig is deduced from poster's preferences;
+ * - we override $user_ip;
+ * - we disable smilies
+ */
 function _insert_post(
     $forum_id,
     $topic_id,
@@ -168,14 +179,7 @@ function _insert_post(
     $poster_name,
     $poster_is_real,
     $watch_topic = null
-)
-// Use submit_post() to post to a topic.
-// -- if $poster_is_real, deduce $poster_id from $poster_name;
-//    otherwise use Anonymous (ie: guest)
-// -- attachsig is deduced from poster's preferences;
-// -- we override $user_ip;
-// -- we disable smilies
-{
+) {
     global $charset, $forums_phpbb_table_prefix;
 
     // see: https://phpbbmodders.net/articles/3.0/create_post/
@@ -306,8 +310,10 @@ function _insert_post(
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Die with a non-zero exit code.
+ */
 function die_nz($string)
-// Like die($string), but with a non-zero exit status.
 {
     echo $string, "\n";
     exit(1);

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -92,9 +92,12 @@ function get_user_proofreading_font($interface = null)
     return [$font_style, $font_size, $full_font_family, $font_size_family];
 }
 
-// return an array of strings which the user sees in the font selector
-// The array is indexed like get_available_proofreading_font_faces()
-// this is used in the format preview font selector.
+/**
+ * Return an array of strings which the user sees in the font selector
+ *
+ * The array is indexed like get_available_proofreading_font_faces()
+ * this is used in the format preview font selector.
+ */
 function get_font_styles($interface = null)
 {
     $font_styles = get_available_proofreading_font_faces();
@@ -107,11 +110,14 @@ function get_font_styles($interface = null)
     return $font_styles;
 }
 
-// return an array of font-family strings to use to render text
-// in the user's proofreading font plus the font fallback. Font faces
-// with spaces in them are esacped in _single quotes_
-// The array is indexed like get_available_proofreading_font_faces()
-// This is used above and to select fonts in the format preview.
+/**
+ * Return an array of font-family strings to use to render text
+ * in the user's proofreading font plus the font fallback.
+ *
+ * Font faces with spaces in them are esacped in _single quotes_.
+ * The array is indexed like get_available_proofreading_font_faces()
+ * This is used above and to select fonts in the format preview.
+ */
 function get_full_font_families($interface = null)
 {
     $full_font_family = [];

--- a/pinc/privacy.inc
+++ b/pinc/privacy.inc
@@ -1,8 +1,10 @@
 <?php
 include_once($relPath.'prefs_options.inc'); // PRIVACY_*
 
+/**
+ * Can we reveal (to the requestor) details about the given user?
+ */
 function can_reveal_details_about($username, $user_privacy_setting)
-// Can we reveal (to the requestor) details about the given user?
 {
     global $pguser; // the "requestor"
 

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -22,9 +22,11 @@ function user_can_add_project_pages($projectid)
     }
 }
 
+/**
+ * Politely abort if the current user
+ * is not allowed to edit the specified project
+ */
 function abort_if_cant_edit_project($projectid)
-// Politely abort if the current user
-// is not allowed to edit the specified project
 {
     global $site_manager_email_addr;
 

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -7,8 +7,10 @@ include_once($relPath.'../tools/project_manager/post_files.inc'); // page_info_q
 include_once('bad_bytes.inc');
 include_once('image_check.inc'); // get_image_size_error()
 
-// Transition callback function to prevent a project state change if PQC
-// results return an error.
+/**
+ * Transition callback function to prevent a project state change if PQC
+ * results return an error.
+ */
 function gate_on_pqc($projectid)
 {
     global $code_url;
@@ -525,8 +527,10 @@ function write_row_start(&$first_row)
     }
 }
 
-// We can calculate what round number a page text was selected from by
-// the number of proofers that has touched it.
+/**
+ * Calculate what round number a page text was selected from by
+ * the number of proofers that has touched it.
+ */
 function get_round_num_from_proofers($proofers)
 {
     $round_num = 0;
@@ -540,10 +544,12 @@ function get_round_num_from_proofers($proofers)
     return $round_num;
 }
 
+/**
+ * Return a string containing TD elements
+ * that present the byte-sequence $raw in various ways,
+ * and say why it's bad.
+ */
 function tds_for_bad_bytes($raw)
-// Returns a string containing TD elements
-// that present the byte-sequence $raw in various ways,
-// and say why it's bad.
 {
     $tds = "";
 

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -289,10 +289,14 @@ foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Return SQL segment that can be used to sort project states
+ *
+ * In an SQL query, if you "ORDER BY state", it will use alphabetical order,
+ * which is not very useful. Instead, ORDER BY the result of this function,
+ * and it will use the canonical order-of-declaration for project states.
+ */
 function sql_collater_for_project_state($state_column)
-// In an SQL query, if you "ORDER BY state", it will use alphabetical order,
-// which is not very useful. Instead, ORDER BY the result of this function,
-// and it will use the canonical order-of-declaration for project states.
 {
     global $PROJECT_STATES_IN_ORDER;
     return sprintf("FIELD($state_column, %s)",
@@ -302,16 +306,22 @@ function sql_collater_for_project_state($state_column)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 $project_status_descriptors = ['posted', 'PPd', 'proofed', 'created'];
 
+/**
+ * Return an object with details about a project status
+ *
+ * Returned object has attributes that are useful for:
+ * - finding
+ * - counting or
+ * - plotting a graph of
+ * projects having that status.
+ *
+ * @param string $which
+ *   A word denoting a possible status of a project, one of:
+ *   `created`, `proofed`, `PPd`, or `posted`.
+ *
+ * @return object
+ */
 function get_project_status_descriptor($which)
-// $which is a word denoting a possible status of a project
-// (created, proofed, PPd, or posted).
-// Return an object whose attributes hold various constants that
-// are useful for:
-// -- finding,
-// -- counting, or
-// -- plotting a graph of
-// projects having that status.
-// (Somewhat ad hoc, but useful.)
 {
     $obj = new stdClass();
 

--- a/pinc/project_trans.inc
+++ b/pinc/project_trans.inc
@@ -3,13 +3,15 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'Project.inc');
 include_once($relPath.'ProjectTransition.inc');
 
+/**
+ * Move the given project to the given state, and perform any attendant processing.
+ *
+ * If there are any problems, return a string containing an error message.
+ * Otherwise, return an empty string.
+ *
+ * This function produces no output except for debugging messages.
+ */
 function project_transition($projectid, $new_state, $who, $extras = [])
-// Move the given project to the given state,
-// and perform any attendant processing.
-// If there are any problems, return a string containing an error message.
-// Otherwise, return an empty string.
-//
-// This function produces no output except for debugging messages.
 {
     global $testing;
 

--- a/pinc/release_queue.inc
+++ b/pinc/release_queue.inc
@@ -4,10 +4,13 @@
 $today_MMDD = date('md', strtotime('today'));
 $tomorrow_MMDD = date('md', strtotime('tomorrow'));
 
+/**
+ * Expand certain sequences in $project_selector.
+ *
+ * Expanding date-related sequences means we don't have to
+ * update the queue's project_selector every day.
+ */
 function cook_project_selector($project_selector)
-// Expand certain sequences in $project_selector.
-// (Expanding date-related sequences means we don't have to
-// update the queue's project_selector every day.)
 {
     global $today_MMDD, $tomorrow_MMDD;
     return

--- a/pinc/send_mail.inc
+++ b/pinc/send_mail.inc
@@ -8,11 +8,26 @@ use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\PHPMailer\Exception;
 
+/**
+ * Send an email
+ *
+ * If this is for real, send the message. If we're testing, just report what
+ * would have been sent.
+ *
+ * @param string $to
+ *   Email address of the recipient
+ * @param string $subject
+ *   Email subject
+ * @param string $message
+ *   Email body
+ * @param string $from
+ *   Optional argument for who the email is from. May either take the form
+ *   `user@example.com` or `Example User <user@example.com>`.
+ * @param string $reply_to
+ *   Optional argument for who the email is from. May either take the form
+ *   `user@example.com` or `Example User <user@example.com>`.
+ */
 function send_mail($to, $subject, $message, $from = null, $reply_to = null)
-// If this is for real, send the message.
-// If we're testing, just report what would have been sent.
-// Optional $from and $reply_to arguments may either take the form
-// "user@example.com" or "Example User <user@example.com>"
 {
     global $testing, $phpmailer_smtp_config, $auto_email_addr, $site_name, $site_url;
 
@@ -118,9 +133,12 @@ function send_mail_project_manager($project, $info, $prefix)
     return send_mail($user->email, "$site_abbreviation: $prefix: \"$nameofwork\"", $body);
 }
 
-// Return text and HTML versions of standard email footer
-// We intentionally don't translate anything because we don't know
-// what the recipient's language is at this point.
+/**
+ * Return text and HTML versions of standard email footer
+ *
+ * We intentionally don't translate anything because we don't know
+ * what the recipient's language is at this point.
+ */
 function get_standard_email_footers()
 {
     global $site_url, $site_name;
@@ -143,9 +161,12 @@ function get_standard_email_footers()
     return [$text_footer, $html_footer];
 }
 
-// Split a string of form "user@example.com" or "Example User <user@example.com>"
-// into the name and the email address.
-// Name will be null if not specified.
+/**
+ * Split a string into an email and name.
+ *
+ * Split a string of form `user@example.com` or `Example User <user@example.com>`
+ * into the name and the email address. Name will be null if not specified.
+ */
 function get_name_address($string)
 {
     $string = rtrim($string, '>');
@@ -159,28 +180,39 @@ function get_name_address($string)
     return [$name, $address];
 }
 
-// Add linebreak to end of line for a Markdown email
-// Appends two spaces which are then rendered as <br> in HTML
+/**
+ * Add linebreak to end of line for a Markdown email
+ *
+ * Appends two spaces which are then rendered as <br> in HTML
+ */
 function mdmail_append_linebreak($line)
 {
     return $line . '  ';
 }
 
-// Return string for horizontal rule for a Markdown email
+/**
+ * Return string for horizontal rule for a Markdown email
+ */
 function mdmail_horizontal_rule()
 {
     return '---';
 }
 
-// Cause line to be indented for a Markdown email
-// Prepends 4 non-breaking spaces
+/**
+ * Cause line to be indented for a Markdown email
+ *
+ * Prepends 4 non-breaking spaces
+ */
 function mdmail_indent_line($line)
 {
     return str_repeat("\u{a0}", 4) . $line;
 }
 
-// Convert line to a heading in a Markdown email
-// Prepends number of hashes corresponding to level
+/**
+ * Convert line to a heading in a Markdown email
+ *
+ * Prepends number of hashes corresponding to level
+ */
 function mdmail_heading($level, $line)
 {
     return str_repeat('#', $level) . ' ' . $line;

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -166,11 +166,11 @@ function show_projects_for_smooth_reading()
  *   SQL condition (suitable for use in a WHERE clause on the 'projects' table)
  *   that selects all the projects that would be listed in the absence of a
  *   user's filter.
- * @param boolean $show_filter_block
+ * @param bool $show_filter_block
  *   Should we show the filter widget?
  * @param array $filter_custom_display_fields
  *   An array naming any custom fields that should appear in the filter widget.
- * @param boolean $allow_special_colors_legend
+ * @param bool $allow_special_colors_legend
  *   Should we show the special colors legend?
  *   (This can be overriden by the corresponding user preference.)
  * @param array $columns

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -150,6 +150,32 @@ function show_projects_for_smooth_reading()
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Output HTML to show projects in a given stage
+ *
+ * Generate a chunk of HTML consisting of:
+ * 1. an optional filter widget,
+ * 2. an optional "Special Days" color legend, and
+ * 3. a listing of projects.
+ *
+ * @param object $stage
+ *   An instance of the Stage class (or a subclass thereof).
+ *   This is used for various things, but most importantly,
+ *   $stage->id is deemed to identify this listing.
+ * @param string $initial_project_selector
+ *   SQL condition (suitable for use in a WHERE clause on the 'projects' table)
+ *   that selects all the projects that would be listed in the absence of a
+ *   user's filter.
+ * @param boolean $show_filter_block
+ *   Should we show the filter widget?
+ * @param array $filter_custom_display_fields
+ *   An array naming any custom fields that should appear in the filter widget.
+ * @param boolean $allow_special_colors_legend
+ *   Should we show the special colors legend?
+ *   (This can be overriden by the corresponding user preference.)
+ * @param array $columns
+ *   Which columns should appear in the listing.
+ */
 function show_projects_for_stage(
     $stage,
     $initial_project_selector,
@@ -158,29 +184,6 @@ function show_projects_for_stage(
     $allow_special_colors_legend,
     $columns,
     $optional_join_clause = "")
-// Generate a chunk of HTML consisting of:
-// (1) an optional filter widget,
-// (2) an optional "Special Days" color legend, and
-// (3) a listing of projects.
-//
-// Arguments:
-// $stage:
-//     An instance of the Stage class (or a subclass thereof).
-//     This is used for various things, but most importantly,
-//     $stage->id is deemed to identify this listing.
-// $initial_project_selector:
-//     A string containing an SQL condition (suitable for use in a
-//     WHERE clause on the 'projects' table) that selects all the
-//     projects that would be listed in the absence of a user's filter.
-// $show_filter_block:
-//     A boolean: should we show the filter widget?
-// $filter_custom_display_fields:
-//     An array naming any custom fields that should appear in the filter widget.
-// $allow_special_colors_legend:
-//     A boolean: should we show the special colors legend?
-//     (This can be overriden by the corresponding user preference.)
-// $columns:
-//     An array specifying which columns should appear in the listing.
 {
     global $pguser;
 
@@ -336,39 +339,44 @@ function show_projects_for_pool($pool, $checkedout_or_available)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// Create the sortable project listing.
+/**
+ * Output sortable project listing.
+ *
+ * @param string $filtered_project_selector
+ *   An SQL condition (on the 'projects' table) specifying
+ *   which projects to list.
+ * @param array $columns
+ *   The columns to include in the table, this is an associative
+ *   array with the key being the column name and the value
+ *   being an array consisting of:
+ *   - the column's name for the purposes of ext_sort
+ *   - the column's header-label.
+ * @param string $ext_sort_param_name
+ *   The parameter-name to use when specifying a sort order
+ *   in a URL query-string.
+ * @param string $ext_sort_setting_name
+ *   The setting name to use when saving the sort order in the db
+ * @param string $default_ext_sort
+ *   The sort to use when one isn't specified by url-parameter or db-setting.
+ * @param string $anchor
+ *   The anchor on the page to jump to
+ * @param object $stage
+ *   Stage object (Round, Pool, or Stage)
+ * @param string $optional_join_clause
+ *   If needed. Default to "", but useful/necessary for SR & PP
+ * @param $optional_select_clause
+ *   If needed. Default to "", but useful/necessary for PP
+ */
 function show_project_listing(
-
     $filtered_project_selector,
-        // an SQL condition (on the 'projects' table) specifying
-        // which projects to list.
-
     $columns,
-        // the columns to include in the table, this is an associative
-        // array with the key being the column name and the value
-        // being an array consisting of:
-        //     - the column's name for the purposes of ext_sort
-        //     - the column's header-label.
-
     $ext_sort_param_name,
-        // The parameter-name to use when specifying a sort order
-        // in a URL query-string.
     $ext_sort_setting_name,
-        // the setting name to use when saving the sort order in the db
     $default_ext_sort,
-        // The sort to use when one isn't specified by url-parameter or db-setting.
-
     $anchor,
-        // the anchor on the page to jump to
-
     $stage,
-        // stage object (Round, Pool, or Stage)
-
     $optional_join_clause = "",
-        // If needed. Default to "", but useful/necessary for SR & PP
-
     $optional_select_clause = ""
-        // If needed. Default to "", but useful/necessary for PP
 ) {
     global $code_url, $pguser, $testing;
 
@@ -597,28 +605,37 @@ function show_project_listing(
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Intelligently determine the user's intent for a sort criteria.
+ *
+ * It does this by:
+ * 1. Checking $_GET for explicit sort order changes
+ * 2. If that fails pulling the previous sort order from the database
+ * 3. If that fails using a default sort order (first column)
+ *
+ * After we have a sort criteria, validate it and fall back to
+ * the default sort column in ascending order if necessary.
+ * After validation the sort criteria is written to the database.
+ *
+ * Returns the array($curr_sql_sort_col, $curr_sql_sort_dir):
+ * - $curr_sql_sort_col - name of the column to sort by
+ * - $curr_sql_sort_dir - direction to sort by (asc or desc)
+ *
+ * @param array $columns
+ *   An associative array containing the valid columns in the table
+ * @param string $ext_sort_param_name
+ *   The parameter-name to use in the URL query-string
+ * @param string $ext_sort_setting_name
+ *   The setting to use in the usersettings table. This value
+ *   is also used in determining the sort order via the URL.
+ *   Doing so allows for multiple tables to be on the same
+ *   page and sorted in different orders.
+ * @param string $default_ext_sort
+ *   The sort to use when one isn't specified by url-parameter or db-setting.
+ *
+ * @return array
+ */
 function process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setting_name, $default_ext_sort)
-// This function's purpose is to intelligently determine the user's
-// intent for a sort criteria. It does this by:
-//   1. Checking $_GET for explicit sort order changes
-//   2. If that fails pulling the previous sort order from the database
-//   3. If that fails using a default sort order (first column)
-// After we have a sort criteria, validate it and fall back to
-// the default sort column in ascending order if necessary.
-// After validation the sort criteria is written to the database.
-// Arguments:
-//   $columns      - an associative array containing the valid columns in the
-//                   table
-//   $ext_sort_param_name - the parameter-name to use in the URL query-string
-//   $ext_sort_setting_name - the setting to use in the usersettings table. This value
-//                   is also used in determining the sort order via the URL.
-//                   Doing so allows for multiple tables to be on the same
-//                   page and sorted in different orders.
-//   $default_ext_sort - the sort to use when one isn't specified by
-//                   url-parameter or db-setting.
-// Returns the array($curr_sql_sort_col, $curr_sql_sort_dir):
-//   $curr_sql_sort_col - name of the column to sort by
-//   $curr_sql_sort_dir - direction to sort by (asc or desc)
 {
     global $pguser;
 

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -44,13 +44,17 @@ function get_news_page_last_modified_date($news_page_id)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Show the news block for the given page
+ *
+ * Output includes
+ * - a header,
+ * - all the 'current' news items,
+ * - a randomly-chosen 'recent' news item,
+ * where the news items are designated for the given page,
+ * or for every page.
+ */
 function show_news_for_page($news_page_id)
-// Show the news block for the given page, consisting of:
-// -- a header,
-// -- all the 'current' news items,
-// -- a randomly-chosen 'recent' news item,
-// where the news items are designated for the given page,
-// or for every page.
 {
     global $code_url;
 

--- a/pinc/slim_header.inc
+++ b/pinc/slim_header.inc
@@ -1,17 +1,19 @@
 <?php
 include_once($relPath."html_page_common.inc");
 
-// Output valid HTML for a non-themed page. The optional $extra_args variable
-// is an associative array to control what exactly is output. By default an
-// HTML 4.0 transitional page header is output and the body tag is opened.
-// $extra_args = array(
-//     'frameset' => FALSE (default) | TRUE
-//     'head_data' => strings to output as-is in <head> tag
-//     'css_files' => CSS files to include in the page
-//     'css_data' => CSS to include in the page
-//     'js_data'  => JS code to include in the page,
-//     'js_files' => array of .js files to link to
-//     'body_attributes' => body tag attributes to output
+/**
+ * Output valid HTML to begin a non-themed page.
+ *
+ * @param array $extra_args
+ *   An associative array to control what exactly is output. Valid keys:
+ *   - 'frameset' => FALSE (default) | TRUE
+ *   - 'head_data' => strings to output as-is in <head> tag
+ *   - 'css_files' => CSS files to include in the page
+ *   - 'css_data' => CSS to include in the page
+ *   - 'js_data'  => JS code to include in the page,
+ *   - 'js_files' => array of .js files to link to
+ *   - 'body_attributes' => body tag attributes to output
+ */
 function slim_header($title = "", $extra_args = [])
 {
     global $code_url;

--- a/pinc/smoothread.inc
+++ b/pinc/smoothread.inc
@@ -12,22 +12,18 @@ include_once($relPath.'user_project_info.inc'); // notify_project_event_subscrib
 *
 ****************************************************************************************/
 
-/***************************************************************************************
-*
-* function sr_users_is_commited: checks the association table for existing commitment
-*
-* inputs: projectid, username
-*
-* output: true/false regarding existence of commitment
-*
-* Remarks:
-*
-* Currently only a check for existence of record and field being > 0 is done. The latter
-* would allow the extension for a timestamp and the resetting to 0 if revoked in order
-* to still show users that have once committed but then revoked that commitment.
-*
-****************************************************************************************/
-
+/**
+ * Has the user committed to SR a specific project
+ *
+ * Currently only a check for existence of record and field being > 0 is done. The latter
+ * would allow the extension for a timestamp and the resetting to 0 if revoked in order
+ * to still show users that have once committed but then revoked that commitment.
+ *
+ * @param string $projectid
+ * @param string $username
+ *
+ * @return bool
+ */
 function sr_user_is_committed($projectid, $username)
 {
     $sql = sprintf("
@@ -43,23 +39,18 @@ function sr_user_is_committed($projectid, $username)
     return $count > 0;
 }
 
-
-/***************************************************************************************
-*
-* function sr_commit: inserts record into the association table for commitment
-*
-* inputs: projectid, username
-*
-* output: none
-*
-* Remarks:
-*
-* Currently the record is only inserted with the committed field being set to one.
-* This allows the future extension for a timestamp and the resetting to 0 if revoked in
-* order to still show users that have once committed but then revoked that commitment.
-*
-****************************************************************************************/
-
+/**
+ * Insert SR commitment from a user about a specific project
+ *
+ * Currently the record is only inserted with the committed field being set to one.
+ * This allows the future extension for a timestamp and the resetting to 0 if revoked in
+ * order to still show users that have once committed but then revoked that commitment.
+ *
+ * @param string $projectid
+ * @param string $username
+ *
+ * @return void
+ */
 function sr_commit($projectid, $username)
 {
     $sql = sprintf("
@@ -71,20 +62,14 @@ function sr_commit($projectid, $username)
     DPDatabase::query($sql);
 }
 
-/***************************************************************************************
-*
-* function sr_withdraw_commitment: deletes record from the association table for commitment
-*
-* inputs: projectid, username
-*
-* output: none
-*
-* Remarks:
-*
-* Currently the record is of commitment is deleted.
-*
-****************************************************************************************/
-
+/**
+ * Delete a commitment from a user to SR a specific project
+ *
+ * @param string $projectid
+ * @param string $username
+ *
+ * @return void
+ */
 function sr_withdraw_commitment($projectid, $username)
 {
     $sql = sprintf("
@@ -95,18 +80,13 @@ function sr_withdraw_commitment($projectid, $username)
     DPDatabase::query($sql);
 }
 
-/***************************************************************************************
-*
-* function sr_get_committed_users: provide list of users with sr-commitment to project
-*
-* inputs: projectid
-*
-* output: Array of usernames
-*
-* Remarks:
-*
-****************************************************************************************/
-
+/**
+ * Provide list of users with SR-commitment to project
+ *
+ * @param string $projectid
+ *
+ * @return string[]
+ */
 function sr_get_committed_users($projectid)
 {
     $sql = sprintf("
@@ -126,40 +106,28 @@ function sr_get_committed_users($projectid)
     return $list;
 }
 
-/***************************************************************************************
-*
-* function sr_number_users_committed: provide number of users with sr-commitment to project
-*
-* inputs: projectid
-*
-* output: number of users
-*
-* Remarks:
-*
-****************************************************************************************/
-
+/**
+ * Return number of users with SR-commitment to project
+ *
+ * @param string $projectid
+ *
+ * @return int
+ */
 function sr_number_users_committed($projectid)
 {
     return count(sr_get_committed_users($projectid));
 }
 
-
-/***************************************************************************************
-*
-* function sr_echo_commitment_form: create button and call page for database access
-*
-* inputs: projectid
-*
-* output: none
-*
-* Remarks:
-*
-* This calls a transient page executing the database function for inserting commitment
-* and provides the current URI for return to current page.
-*
-****************************************************************************************/
-
-
+/**
+ * Output HTML to call page to volunteer for SR
+ *
+ * This calls a transient page executing the database function for inserting commitment
+ * and provides the current URI for return to current page.
+ *
+ * @param string $projectid
+ *
+ * @return void
+ */
 function sr_echo_commitment_form($projectid)
 {
     global $code_url;
@@ -175,21 +143,16 @@ function sr_echo_commitment_form($projectid)
     echo "</form>\n";
 }
 
-/***************************************************************************************
-*
-* function sr_echo_withdrawal_form: create button and call page for database access
-*
-* inputs: projectid
-*
-* output: none
-*
-* Remarks:
-*
-* This calls a transient page executing the database function for withdrawing a commitment
-* and provides the current URI for return to current page.
-*
-****************************************************************************************/
-
+/**
+ * Output HTML to call page to withdraw SR commitment
+ *
+ * This calls a transient page executing the database function for inserting commitment
+ * and provides the current URI for return to current page.
+ *
+ * @param string $projectid
+ *
+ * @return void
+ */
 function sr_echo_withdrawal_form($projectid)
 {
     global $code_url;
@@ -205,13 +168,10 @@ function sr_echo_withdrawal_form($projectid)
     echo "</form>\n";
 }
 
-/***************************************************************************************
-*
-* Record and notify for smooth reading upload and deadline extension
-* which do not involve a state change
-*
-****************************************************************************************/
-
+/**
+ * Record and notify for smooth reading upload and deadline extension
+ * which do not involve a state change
+ */
 function handle_smooth_reading_change($project, $postcomments, $days, $extend)
 {
     global $pguser, $auto_post_to_project_topic;

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -1,7 +1,9 @@
 <?php
 include_once($relPath.'misc.inc');
 
-// return a set of hard-coded special days keyed by spec_code
+/**
+ * Return a set of hard-coded special days keyed by spec_code
+ */
 function load_common_special_days()
 {
     return [
@@ -86,8 +88,10 @@ function sort_special_days(&$special_days, $sort_by = "display_name")
     }
 }
 
-// Returns the special day array associated with this
-// project, or null if no such special day is specified.
+/**
+ * Returns the special day array associated with this
+ * project, or null if no such special day is specified.
+ */
 function get_special_day($special_code)
 {
     static $specials_array = [];
@@ -126,12 +130,13 @@ function get_special_day($special_code)
 }
 
 
-// outputs HTML showing the name of all SPECIAL DAYS
-// backed by their characteristic colour,
-// that have any projects within the set of projects
-// specified by $projects_where_clause (WHERE keyword NOT needed)
-// for use as a legend.
-
+/**
+ * Output HTML showing the name of all SPECIAL DAYS
+ * backed by their characteristic colour,
+ * that have any projects within the set of projects
+ * specified by $projects_where_clause (WHERE keyword NOT needed)
+ * for use as a legend.
+ */
 function echo_special_legend($projects_where_clause)
 {
     global $code_url;
@@ -190,7 +195,9 @@ function echo_special_legend($projects_where_clause)
     echo "</table>";
 }
 
-// Given a special day, return building blocks to construct a cell for a row
+/**
+ * Given a special day, return building blocks to construct a cell for a row
+ */
 function get_special_day_cell_parts($special_day, $include_title = true)
 {
     $background_color = str_replace("#", "", $special_day['color']);
@@ -208,8 +215,11 @@ function get_special_day_cell_parts($special_day, $include_title = true)
     return [$style, $contents];
 }
 
-// Select a reasonable text color given a specific background color.
-// From https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
+/**
+ * Select a reasonable text color given a specific background color.
+ *
+ * From https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
+ */
 function pick_text_color_given_bgcolor($bg_color, $light_color, $dark_color)
 {
     $color = str_replace("#", "", $bg_color);

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -264,19 +264,21 @@ $ELR_round = get_Round_for_round_number(1);
 
 // -----------------------------------------------------------------------------
 
+/*
+ * Check if the given user is allowed to get a new page
+ * of the given project in the given round
+ * (via "Start Proofreading" or "Save and Do Another"),
+ * otherwise, throw an exception explaining why not.
+ *
+ * You can assume that this function will be called only if:
+ * - the current user has general access to the round, and
+ * - the project is available in the round,
+ * so this function doesn't have to check for either of those.
+ *
+ * It also doesn't need to check whether any of the project's pages
+ * are actually available.
+ */
 function validate_user_can_get_pages_in_project($username, $project, $round)
-// Check if the given user is allowed to get a new page
-// of the given project in the given round
-// (via "Start Proofreading" or "Save and Do Another"),
-// Otherwise, throw an exception explaining why not.
-//
-// You can assume that this function will be called only if:
-// -- the current user has general access to the round, and
-// -- the project is available in the round,
-// so this function doesn't have to check for either of those.
-//
-// It also doesn't need to check whether any of the project's pages
-// are actually available.
 {
     // Projects with difficulty='beginner' are treated differently in
     // various ways.
@@ -374,11 +376,14 @@ function validate_user_can_get_pages_in_project($username, $project, $round)
     // None of the above restrictions apply.
 }
 
+/**
+ * Should $project be temporarily reserved for inexperienced users
+ * after becoming available in $round?
+ *
+ * If so, return the length of the reserve in days.
+ * If not, return 0.
+ */
 function get_reserve_length($project, $round)
-// Should $project be temporarily reserved for inexperienced users
-// after becoming available in $round?
-// If so, return the length of the reserve in days.
-// If not, return 0.
 {
     // We only reserve-for-newbies in P1.
     if ($round->id != 'P1') {
@@ -421,23 +426,25 @@ function get_reserve_length($project, $round)
 
 // -------------------------------------------------------------------
 
+/**
+ * Return an SQL blurb that can be used to sort projects in a round.
+ *
+ * On each round page, the order of the project list can be adjusted by
+ * clicking on column headers. If you want certain criteria to take precedence
+ * over such sorts, have this function return a string expressing those criteria
+ * as one or more ordering specifications (such as would appear in an ORDER BY
+ * clause in SQL), referring to columns of the projects table.
+ *
+ * For instance, to have beginner projects always appear at the top of
+ * every round's project list, this function could return one of:
+ * - `"(difficulty = 'beginner') DESC"`
+ * - `"IF( difficulty = 'beginner', 1, 2 )"`
+ * - `"CASE difficulty WHEN 'beginner' THEN 1 ELSE 2 END"`
+ *
+ * If you don't want any criteria to take precedence over column-sorts,
+ * return NULL or the empty string.
+ */
 function round_project_listing_presort($round)
-// On each round page, the order of the project list can be adjusted by
-// clicking on column headers. If you want certain criteria to take precedence
-// over such sorts, have this function return a string expressing those criteria
-// as one or more ordering specifications (such as would appear in an ORDER BY
-// clause in SQL), referring to columns of the projects table.
-//
-// For instance, to have beginner projects always appear at the top of
-// every round's project list, this function could return
-//     "(difficulty = 'beginner') DESC"
-// or
-//     "IF( difficulty = 'beginner', 1, 2 )"
-// or
-//     "CASE difficulty WHEN 'beginner' THEN 1 ELSE 2 END"
-//
-// If you don't want any criteria to take precedence over column-sorts,
-// return NULL or the empty string.
 {
     if (is_proofreading_round($round)) {
         return "
@@ -504,14 +511,18 @@ new Pool(
     ]
 );
 
+/**
+ * Echo the post-processor comments block.
+ *
+ * If a project is checked out for PP, and the post-processor is viewing
+ * the project page, then the page will have an editable text area
+ * entitled "Post-Processor's Comments".
+ *
+ * This function is called between the title and the text area,
+ * and should give (site-specific) instructions to the post-processor
+ * on how to use (or not use) the postcomments field.
+ */
 function echo_postcomments_instructions()
-// If a project is checked out for PP,
-// and the post-processor is viewing the project page,
-// then the page will have an editable text area
-// entitled "Post-Processor's Comments".
-// This function is called between the title and the text area,
-// and should give (site-specific) instructions to the post-processor
-// on how to use (or not use) the postcomments field.
 {
     global $wiki_url;
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -15,8 +15,10 @@ include_once($relPath.'post_processing.inc'); // count_pp_projects_past_threshol
 include_once($relPath.'misc.inc'); // endswith(), get_enumerated_param(), attr_safe(), endswith()
 include_once($relPath.'faq.inc');
 
-// Emit the opening markup and theme tags, and register a callback
-// to close the page after the caller finishes output.
+/**
+ * Emit the opening markup and theme tags, and register a callback
+ * to close the page after the caller finishes output.
+ */
 function output_header($nameofpage, $show_statsbar = true, $extra_args = [])
 {
     $user = User::load_current();
@@ -169,9 +171,11 @@ function html_logobar()
     }
 }
 
+/**
+ * Display the horizontal bar containing links to various important points
+ * within the site (and the login form if the user is not logged in).
+ */
 function html_navbar()
-// Display the horizontal bar containing links to various important points
-// within the site (and the login form if the user is not logged in).
 {
     global $code_url, $site_abbreviation, $blog_url, $wiki_url;
 
@@ -303,16 +307,19 @@ function html_navbar()
     echo "</div>\n";
 }
 
+/**
+ * Outputs entries in the navbar contained within $entries.
+ *
+ * Each $entry is an associative array containing either:
+ * - 'text' - text to display as-is without changes, can include HTML
+ * - 'url' and 'text' - a link using 'text' as the label
+ *
+ * Either one can also have a 'title' as well that will be placed in a title
+ * attribute on the <a> or <span> tag. The function also determines if the
+ * current page is one of the urls and if so it doesn't create the link but
+ * instead wraps the text in a span.currentpage tag.
+ */
 function headerbar_text_array($entries)
-// Prints out entries in the navbar contained within $entries.
-// Each $entry is an associative array containing either:
-//    'text' - text to display as-is without changes, can include HTML
-// or:
-//    'url' and 'text' - a link using 'text' as the label
-// Either one can also have a 'title' as well that will be placed in a title
-// attribute on the <a> or <span> tag. The function also determines if the
-// current page is one of the urls and if so it doesn't create the link but
-// instead wraps the text in a span.currentpage tag.
 {
     global $code_url;
 
@@ -505,9 +512,12 @@ function maybe_show_language_selector()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Return a list of round/stage links for the user
+ *
+ * The returned links are in a format usable by headerbar_text_array()
+ */
 function get_activity_links()
-// return a list of round/stage links for the user
-// the returned links are in a format usable by headerbar_text_array
 {
     global $Stage_for_id_, $ELR_round;
 
@@ -893,33 +903,43 @@ function show_key_help_links()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Calculate progress bar size and color properties
+ *
+ * A simple progress bar can be created by using the following HTML:
+ * ```
+ * <div class='progressbar $progress_bar_class' style='width: $width%;'>&nbsp;</div>
+ * ```
+ *
+ * The <div> can be placed inside another container used to control
+ * the total width. This function assists in calculating the $color and $width
+ * values used above in addition to returning the actual percentage of the
+ * goal achieved. In order for the progress bars to be themable, a class name
+ * is returned, instead of an actual color.
+ *
+ * Returns three values via a non-associative array():
+ * - progress_bar_width - percentage width of the progress bar in range [0-100]
+ * - progress_bar_class - class for color of progress bar using step-wise colors.
+ *   The classes will need to be defined in layout.less
+ *   for them to be applied to the progress bar.
+ * - percent_complete   - actual percentage complete in whole numbers
+ *
+ * @param integer $actual
+ *   Actual value obtained
+ * @param integer $goal
+ *   Goal for the day
+ * @param mixed $prorate_goal_for_color
+ *   if TRUE or 'day', the returned color will be calculated based
+ *   on how much of the current day has passed. If set to 'month'
+ *   the color will be based on how much of the month has passed.
+ *   This is useful so that at the beginning of a new timeframe the
+ *   bar isn't at the low color.
+ * @param array $color_thresholds
+ *   Associative array containing the class names to use for
+ *   each percentage completed range, eg:
+ *   `[100 => "goal-on-target", 75 => "goal-maybe", 0 => "goal-unlikely"]
+ */
 function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_color = true, $color_thresholds = null)
-// A simple progress bar can be created by using the following HTML:
-//   <div class='progressbar $progress_bar_class' style='width: $width%;'>&nbsp;</div>
-// The <div> can be placed inside another container used to control
-// the total width. This function assists in calculating the $color and $width
-// values used above in addition to returning the actual percentage of the
-// goal achieved. In order for the progress bars to be themable, a class name
-// is returned, instead of an actual color.
-// Arguments:
-//   actual           - actual value obtained
-//   goal             - goal
-//   prorate_goal_for_color
-//                    - if TRUE or 'day', the returned color will be calculated based
-//                      on how much of the current day has passed. If set to 'month'
-//                      the color will be based on how much of the month has passed.
-//                      This is useful so that at the beginning of a new timefram the
-//                      bar isn't at the low color.
-//   color_thresholds - associative array containing the class names to use for
-//                      each percentage completed range
-//                      eg: array(100 => "goal-on-target", 75 => "goal-maybe", 0 => "goal-unlikely");
-//
-// Returns three values via a non-associative array():
-//   progress_bar_width - percentage width of the progress bar in range [0-100]
-//   progress_bar_class - class for color of progress bar using step-wise colors.
-//                        The classes will need to be defined in layout.less
-//                        for them to be applied to the progress bar.
-//   percent_complete   - actual percentage complete in whole numbers
 {
     // Define the color classes used for the status bar graph
     if (!is_array($color_thresholds)) {
@@ -968,10 +988,13 @@ function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_col
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Given file name relative to $dyn_dir, find a matching image by testing
+ * for all web image extensions and return the full URL in $dyn_url.
+ *
+ * If no image is found for the file name, the function returns NULL.
+ */
 function get_dyn_image_url_for_file($filename)
-// Given file name relative to $dyn_dir, find a matching image by testing
-// for all web image extensions and return the full URL in $dyn_url.
-// If no image is found for the file name, the function returns NULL.
 {
     global $dyn_dir, $dyn_url;
 
@@ -988,8 +1011,9 @@ function get_dyn_image_url_for_file($filename)
     return null;
 }
 
-// Given a page basename, see if we have a header image for the page.
-// If so, return the <img>. If not, return "";
+/**
+ * Given a page basename return an <img> element for it
+ */
 function get_page_header_image($image)
 {
     // Try a locale-less image first
@@ -1009,24 +1033,34 @@ function get_page_header_image($image)
     return "";
 }
 
-// Output a tab bar of various view modes and a selected mode
-// $view_modes - a complex associative array, eg:
-//     [
-//         "mode1" => [
-//             "label" => "Tab label",
-//             "url" => "",         # optional URL
-//             "postscript" => "",  # optional postscript for after tab bar
-//         ],
-//         "mode2" => [
-//         ], ...
-//     ]
-// $selected_mode - which view mode (a key in $view_modes) is currently selected
-// $view_variable - the URL parameter to use when selecting a new mode,
-//     most commonly "show" but it can be anything
-// $url_addition - an optional string that will be appended to the URL. This can
-//     be other page parameters and/or a page anchor
-// $display_mode - one of "full" or "auto" - full will cause the bar to span the
-//     entire page while auto will only use as much horizontal space as needed.
+/**
+ * Output a tab bar of various view modes and a selected mode
+ *
+ * @param array $view_modes
+ *   A complex associative array, eg:
+ *   ```
+ *   [
+ *       "mode1" => [
+ *           "label" => "Tab label",
+ *           "url" => "",         # optional URL
+ *           "postscript" => "",  # optional postscript for after tab bar
+ *       ],
+ *       "mode2" => [
+ *       ], ...
+ *   ]
+ *   ```
+ * @param string $selected_mode
+ *   Which view mode (a key in $view_modes) is currently selected
+ * @param string $view_variable
+ *   The URL parameter to use when selecting a new mode,
+ *   most commonly "show" but it can be anything
+ * @param string $url_addition
+ *   An optional string that will be appended to the URL. This can
+ *   be other page parameters and/or a page anchor
+ * @param string $display_mode
+ *   One of "full" or "auto" - full will cause the bar to span the
+ *   entire page while auto will only use as much horizontal space as needed.
+ */
 function output_tab_bar($view_modes, $selected_mode, $view_variable, $url_addition = "", $display_mode = "full")
 {
     $div_style = $display_mode == "auto" ? "style='width: auto;'" : "";

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -924,9 +924,9 @@ function show_key_help_links()
  *   for them to be applied to the progress bar.
  * - percent_complete   - actual percentage complete in whole numbers
  *
- * @param integer $actual
+ * @param int $actual
  *   Actual value obtained
- * @param integer $goal
+ * @param int $goal
  *   Goal for the day
  * @param mixed $prorate_goal_for_color
  *   if TRUE or 'day', the returned color will be calculated based

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -2,30 +2,39 @@
 
 use voku\helper\UTF8;
 
-// Normalize UTF-8 strings to NFC
+/**
+ * Normalize UTF-8 strings to NFC
+ */
 function utf8_normalize($string)
 {
     $normalizer = new Normalizer();
     return $normalizer->normalize($string);
 }
 
-// Given one or more codepoints, return the UTF-8 character that it describes.
-// This is very similar to UTF8::hex_to_chr(), except if $codepoint contains
-// a > it is assumed to represent a combined character.
+/**
+ * Given one or more codepoints, return the UTF-8 character that it describes.
+ *
+ * This is very similar to UTF8::hex_to_chr(), except if $codepoint contains
+ * a > it is assumed to represent a combined character.
+ */
 function utf8_combined_chr($codepoint)
 {
     $codepoints = explode('>', $codepoint);
     return implode('', array_map('voku\helper\UTF8::hex_to_chr', $codepoints));
 }
 
-// Given a character, return the Unicode script it belongs to
+/**
+ * Given a character, return the Unicode script it belongs to
+ */
 function utf8_char_script($char)
 {
     $enum = IntlChar::getIntPropertyValue($char, IntlChar::PROPERTY_SCRIPT);
     return IntlChar::getPropertyValueName(IntlChar::PROPERTY_SCRIPT, $enum);
 }
 
-// Given a string, return an array of Unicode scripts used within the string.
+/**
+ * Given a string, return an array of Unicode scripts used within the string.
+ */
 function utf8_string_scripts($string)
 {
     $scripts = [];
@@ -56,10 +65,13 @@ function utf8_string_scripts($string)
     return array_unique($scripts);
 }
 
-// Get codepoints that are not normalized.
-// Returns an associative array where the key is the nonnormalized codepoint
-// and the value is the normalized version. If all codepoints are normalized
-// it returns an empty array.
+/**
+ * Get codepoints that are not normalized.
+ *
+ * Returns an associative array where the key is the nonnormalized codepoint
+ * and the value is the normalized version. If all codepoints are normalized
+ * it returns an empty array.
+ */
 function get_nonnormalized_codepoints($codepoints)
 {
     $characters = convert_codepoint_ranges_to_characters($codepoints);
@@ -75,7 +87,9 @@ function get_nonnormalized_codepoints($codepoints)
     return $nonnorm_codepoints;
 }
 
-// Given a single character, or a combined character, return its name
+/**
+ * Given a single character, or a combined character, return its name
+ */
 function utf8_character_name($characters)
 {
     $title_pieces = [];
@@ -85,8 +99,11 @@ function utf8_character_name($characters)
     return implode(" + ", $title_pieces);
 }
 
-// Split a string into chunks on Unicode script boundaries
-// Inherited characters are included in the chunk with the base character
+/**
+ * Split a string into chunks on Unicode script boundaries.
+ *
+ * Inherited characters are included in the chunk with the base character
+ */
 function split_multiscript_string($string)
 {
     $chunks = [];
@@ -133,7 +150,9 @@ function split_graphemes($string)
     }
 }
 
-// Split a Unicode string into codepoints keeping combining characters together
+/**
+ * Split a Unicode string into codepoints keeping combining characters together
+ */
 function utf8_codepoints_combining($string)
 {
     $codepoints = [];
@@ -143,13 +162,17 @@ function utf8_codepoints_combining($string)
     return $codepoints;
 }
 
-// Given a string, return a string of codepoints in U+ format
+/**
+ * Given a string, return a string of codepoints in U+ format
+ */
 function string_to_codepoints_string($string, $imploder = " ")
 {
     return implode($imploder, UTF8::codepoints($string, true));
 }
 
-// Filter to only characters in $string that are in $valid_codepoints.
+/**
+ * Filter to only characters in $string that are in $valid_codepoints.
+ */
 function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement = "")
 {
     $pattern_string = build_character_regex_filter($valid_codepoints);
@@ -165,7 +188,9 @@ function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement = ""
     return $result;
 }
 
-// Filter out any characters in $string that are in $remove_codepoints
+/**
+ * Filter out any characters in $string that are in $remove_codepoints
+ */
 function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement = "")
 {
     $pattern_string = build_character_regex_filter($remove_codepoints);
@@ -180,10 +205,14 @@ function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement = 
     return $result;
 }
 
-// Given a codepoint (U+####), return an escaped version of the
-// codepoint for use in a regex in the given language.
-// https://www.php.net/manual/en/regexp.reference.escape.php
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
+/**
+ * Given a codepoint (U+####), return an escaped version of the
+ * codepoint for use in a regex in the given language.
+ *
+ * https://www.php.net/manual/en/regexp.reference.escape.php
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
+ */
 function get_unicode_regex_class($codepoint, $lang = 'php')
 {
     $hex = str_replace("U+", "", $codepoint);
@@ -196,10 +225,17 @@ function get_unicode_regex_class($codepoint, $lang = 'php')
     }
 }
 
-// Take an array of Unicode codepoints (U+####), codepoint ranges
-// (U+####-U+####), or combined characters (U+####>U+####) and
-// return a regular expression character class to match a single
-// character. $lang is the consuming language (php or js).
+/**
+ * Take an array of Unicode codepoints (U+####), codepoint ranges
+ * (U+####-U+####), or combined characters (U+####>U+####) and
+ * return a regular expression character class to match a single
+ * character.
+ *
+ * @param array $codepoints
+ *
+ * @param string $lang
+ *   Consuming language (php or js).
+ */
 function build_character_regex_filter($codepoints, $lang = 'php')
 {
     $char_class = "";
@@ -231,9 +267,11 @@ function build_character_regex_filter($codepoints, $lang = 'php')
     return "^(?:" . implode("|", $alternatives) . ")\$";
 }
 
-// Take an array of Unicode codepoints (U+####), codepoint ranges
-// (U+####-U+####), or combined characters (U+####>U+####) and
-// return an array of unicode characters.
+/**
+ * Take an array of Unicode codepoints (U+####), codepoint ranges
+ * (U+####-U+####), or combined characters (U+####>U+####) and
+ * return an array of unicode characters.
+ */
 function convert_codepoint_ranges_to_characters($codepoints)
 {
     $return_array = [];
@@ -257,7 +295,9 @@ function convert_codepoint_ranges_to_characters($codepoints)
     return $return_array;
 }
 
-// Return an array of invalid characters and their count
+/**
+ * Return an array of invalid characters and their count
+ */
 function get_invalid_characters($string, $codepoints)
 {
     $string = utf8_filter_out_codepoints($string, $codepoints);
@@ -274,10 +314,12 @@ function get_invalid_characters($string, $codepoints)
     return $char_count;
 }
 
-// Convert a text file to UTF-8, guessing its encoding returns:
-// [ $success, $message ]
-// where $success is TRUE if the file is already UTF-8 or was
-// sucessfully converted. $message is a more detailed message.
+/**
+ * Convert a text file to UTF-8, guessing its.
+ *
+ * Returns `[ $success, $message ]` where $success is TRUE if the file is
+ * already UTF-8 or was successfully converted. $message is a more detailed message.
+ */
 function convert_text_file_to_utf8($filename)
 {
     $text = file_get_contents($filename);
@@ -305,14 +347,19 @@ function convert_text_file_to_utf8($filename)
     return [true, "$filename was converted from $encoding to UTF-8."];
 }
 
-// Attempt to detect a string's encoding from a subset of expected encodings:
-//   * UTF-8 (includes pure-ASCII which is a valid subset)
-//   * UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE based on the BOM
-//   * Windows-1252
-//   * ISO-8859-1
-// These strings match what mb_detect_encoding() would return. The function
-// returns False if it's unable to guess, although it will readily return
-// ISO-8859-1 in many circumstances.
+/**
+ * Attempt to detect a string's encoding from a subset of expected encodings
+ *
+ * Possible expected encodings:
+ * * UTF-8 (includes pure-ASCII which is a valid subset)
+ * * UTF-16BE, UTF-16LE, UTF-32BE, UTF-32LE based on the BOM
+ * * Windows-1252
+ * * ISO-8859-1
+ *
+ * These strings match what mb_detect_encoding() would return. The function
+ * returns False if it's unable to guess, although it will readily return
+ * ISO-8859-1 in many circumstances.
+ */
 function guess_string_encoding($text)
 {
     if (preg_match('//u', $text)) {
@@ -350,9 +397,11 @@ function guess_string_encoding($text)
     return 'ISO-8859-1';
 }
 
-// Return a list of Unicode codepoints we want to replace with some ASCII
-// equivalence. We convert these codepoints to ASCII up on page save in
-// DPage.inc.
+/**
+ * Return a list of Unicode codepoints we want to replace with some ASCII
+ * equivalence. We convert these codepoints to ASCII up on page save in
+ * DPage.inc.
+ */
 function get_utf8_to_ascii_codepoints()
 {
     return [
@@ -407,8 +456,10 @@ function get_utf8_to_ascii_codepoints()
     ];
 }
 
-// Return a list of disallowed codepoints. These codepoints are converted
-// to ASCII upon page save and are not valid in character suites.
+/**
+ * Return a list of disallowed codepoints. These codepoints are converted
+ * to ASCII upon page save and are not valid in character suites.
+ */
 function get_disallowed_codepoints()
 {
     $invalid_codepoints = [];

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -13,13 +13,18 @@ include_once($relPath.'misc.inc'); // get_upload_err_msg(), attr_safe(), return_
 
 define("RESUMABLE_UPLOAD_SIZE", 1024 * 1024 * 1024);  // 1GB
 
-// If uploading large files this function should be called near the beginning
-// of the page to which the upload is submitted (resumable or not). It detects
-// a problem which can occur with non-resumable uploads when the file uploaded
-// was larger than post_max_size and shows an error instead of failing silently.
-// We do this first because if the POST failed, $_REQUEST and $_POST are empty
-// and we have no data.
-// http://andrewcurioso.com/blog/archive/2010/detecting-file-size-overflow-in-php.html
+/**
+ * Detect too-large file uploads
+ *
+ * If uploading large files this function should be called near the beginning
+ * of the page to which the upload is submitted (resumable or not). It detects
+ * a problem which can occur with non-resumable uploads when the file uploaded
+ * was larger than post_max_size and shows an error instead of failing silently.
+ * We do this first because if the POST failed, $_REQUEST and $_POST are empty
+ * and we have no data.
+ *
+ * http://andrewcurioso.com/blog/archive/2010/detecting-file-size-overflow-in-php.html
+ */
 function detect_too_large()
 {
     if ($_SERVER['REQUEST_METHOD'] == 'POST' && empty($_POST) &&
@@ -72,17 +77,21 @@ function get_upload_args()
     ];
 }
 
-// This shows a form with a border for uploading a file using
-// a resumable process if supported by the browser.
-// The form is submitted to the php file in which it is used.
-// Extra content can be supplied in the $form_content parameter
-// this can be abritrary HTML/other inputs
-// and can contain a hidden input which can be used to
-// decide when to process the uploaded file using the validate_uploaded_file()
-// function below. Be careful to avoid $form_content clashing with
-// the names or ids used internally in this form.
-// It contains a 'choose file' button and a labeled submit button
-// and shows approprite messages to the user.
+/**
+ * Output a file upload form
+ *
+ * This shows a form with a border for uploading a file using
+ * a resumable process if supported by the browser.
+ * The form is submitted to the php file in which it is used.
+ * Extra content can be supplied in the $form_content parameter
+ * this can be arbitrary HTML/other inputs
+ * and can contain a hidden input which can be used to
+ * decide when to process the uploaded file using the validate_uploaded_file()
+ * function below. Be careful to avoid $form_content clashing with
+ * the names or ids used internally in this form.
+ * It contains a 'choose file' button and a labeled submit button
+ * and shows appropriate messages to the user.
+ */
 function show_upload_form($form_content, $submit_label)
 {
     $standard_blurb = _("The file must be Zipped (not gzip, tar, etc.) and have the .zip extension. The file name must consist of ASCII letters, digits, underscores, and/or hyphens. It must not begin with a hyphen and be no longer than 200 characters.");
@@ -137,14 +146,18 @@ class NoFileUploadedException extends Exception
 {
 }
 
-// This is called to process the posted information from the upload form
-// It returns a file_info with 'name' (the original file name)
-// and 'tmp_name' (the path to the file).
-// It checks for an empty file and for virus infection.
-// throws NoFileUploadedException if there is no file
-// throws a FileUploadException if there is a problem
-// if an exception is thrown any file will have been deleted.
-// verbose will echo progress messages - must disable apache gzip compression
+/**
+ * Validate uploaded file
+ *
+ * This is called to process the posted information from the upload form
+ * It returns a file_info with 'name' (the original file name)
+ * and 'tmp_name' (the path to the file).
+ * It checks for an empty file and for virus infection.
+ * throws NoFileUploadedException if there is no file
+ * throws a FileUploadException if there is a problem
+ * if an exception is thrown any file will have been deleted.
+ * verbose will echo progress messages - must disable apache gzip compression
+ */
 function validate_uploaded_file($verbose)
 {
     $file_path = "";

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -267,9 +267,11 @@ function notify_project_event_subscribers($project, $event, $extras = [])
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an array: keys are the same as array returned by get_subscribable_project_events(),
+ * each value is the number of subscriptions to that event for the given project.
+ */
 function get_n_users_subscribed_to_events_for_project($projectid)
-// Return an array: keys are the same as array returned by get_subscribable_project_events(),
-// each value is the number of subscriptions to that event for the given project.
 {
     $subscribable_project_events = get_subscribable_project_events();
     $items = [];
@@ -294,11 +296,13 @@ function get_n_users_subscribed_to_events_for_project($projectid)
     return $r;
 }
 
+/**
+ * Create a temp table named 'project_event_subscriptions_grouped_by_project'
+ * with two columns: 'projectid' and 'nouste_posted', where the latter gives the
+ * current number of users that are subscribed to the project's 'posted' event.
+ * ("nouste" = "number of users subscribed to event")
+ */
 function create_temporary_project_event_subscription_summary_table()
-// Create a temp table named 'project_event_subscriptions_grouped_by_project'
-// with two columns: 'projectid' and 'nouste_posted', where the latter gives the
-// current number of users that are subscribed to the project's 'posted' event.
-// ("nouste" = "number of users subscribed to event")
 {
     $sql = "
         CREATE TEMPORARY TABLE project_event_subscriptions_grouped_by_project

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -1033,7 +1033,7 @@ function get_site_possible_bad_word_lists()
  * @param string $pattern
  *   Regex that files must match to be included in the returned array.
  *   If blank all files will be returned.
- * @param boolean $urlbase
+ * @param bool $urlbase
  *   If TRUE files will be turned as a URL,
  *   I FALSE absolute filesystem paths are returned
  */
@@ -1147,7 +1147,7 @@ function get_distinct_words_in_text($text)
  *
  * @param string $text
  *   Page text
- * @param boolean $with_offsets:
+ * @param bool $with_offsets:
  *   If false (the default), the keys are just consecutive integers.
  *   If true, then for each value, the corresponding key is the offset
  *   (in $text) of the start of that word.

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -42,41 +42,98 @@ define('WC_PROJECT', 3);
 define('WC_PAGE', 4);
 
 
-// Wrapper functions for _get_bad_words_for_project_text() that abstract if
-// the function returns FREQS or LEVELS. See that function for arguments
-// and return values.
+/**
+ * Return a list of bad words within a project's page text and
+ * its frequency in the text.
+ *
+ * Returns an array consisting of:
+ * - an array: each key is a word in the text that is deemed bad;
+ *   the corresponding value is the word's frequency in $text
+ * - an array: each value is the name of a language that was used
+ * - an array: each value is a warning/error.
+ *
+ * @param string $text
+ *   The text for which bad words are sought.
+ *   This can be a string or an array of strings. If the latter, the
+ *   strings are conceptually separated by whitespace.  (So it's never
+ *   the case that a word begins in one string and ends in the next.)
+ * @param string $projectid
+ *   ID of project, needed for project languages and to load the custom
+ *   dictionaries
+ * @param string $aux_languages
+ *   Auxiliary language to check against.
+ * @param array $adhoc_good_words
+ *   Array of words to treat as good for this invocation only.
+ *
+ * @return array
+ */
 function get_bad_word_freqs_for_project_text($text, $projectid, $aux_language = '', $adhoc_good_words = [])
 {
     return _get_bad_words_for_project_text('FREQS', $text, $projectid, $aux_language, $adhoc_good_words);
 }
 
+/**
+ * Return a list of bad words within a project's page text and
+ * the specific level at which it was deemed bad
+ *
+ * Returns an array consisting of:
+ * - an array: each key is a word in the text that is deemed bad;
+ *   the corresponding value is one of the WC_* constants,
+ *   denoting the (most specific) level at which the word was deemed bad
+ * - an array: each value is the name of a language that was used
+ * - an array: each value is a warning/error.
+ *
+ * @param string $text
+ *   The text for which bad words are sought.
+ *   This can be a string or an array of strings. If the latter, the
+ *   strings are conceptually separated by whitespace.  (So it's never
+ *   the case that a word begins in one string and ends in the next.)
+ * @param string $projectid
+ *   ID of project, needed for project languages and to load the custom
+ *   dictionaries
+ * @param string $aux_languages
+ *   Auxiliary language to check against.
+ * @param array $adhoc_good_words
+ *   Array of words to treat as good for this invocation only.
+ *
+ * @return array
+ */
 function get_bad_word_levels_for_project_text($text, $projectid, $aux_language = '', $adhoc_good_words = [])
 {
     return _get_bad_words_for_project_text('LEVELS', $text, $projectid, $aux_language, $adhoc_good_words);
 }
 
-// Arguments:
-//   which_result_values - select either the bad word FREQS or LEVELS
-//   text - the text for which bad words are sought
-//          This can be a string or an array of strings. If the latter, the
-//          strings are conceptually separated by whitespace.  (So it's never
-//          the case that a word begins in one string and ends in the next.)
-//   projectid - id of project, needed for project languages
-//               and to load the custom dictionaries
-//   aux_languages - auxiliary language to check against
-//   adhoc_good_words - array of words to treat as good for this invocation only.
-//
-// Returns an array consisting of:
-//  -- an array: each key is a word in the text that is deemed bad;
-//     the corresponding value is either:
-//      -- the word's frequency in $text
-//         (if $which_result_values is 'FREQS')
-//     or
-//      -- one of the WC_* constants, denoting the (most specific) level at which
-//         the word was deemed bad
-//         (if $which_result_values is 'LEVELS')
-//  -- an array: each value is the name of a language that was used
-//  -- an array: each value is a warning/error.
+/**
+ * Return a list of bad words within a project's page text
+ *
+ * Returns an array consisting of:
+ * - an array: each key is a word in the text that is deemed bad;
+ *   the corresponding value is either:
+ *   - the word's frequency in $text
+ *     (if $which_result_values is 'FREQS')
+ *   - one of the WC_* constants, denoting the (most specific) level at which
+ *     the word was deemed bad
+ *     (if $which_result_values is 'LEVELS')
+ * - an array: each value is the name of a language that was used
+ * - an array: each value is a warning/error.
+ *
+ * @param string $which_result_values
+ *   One of FREQS or LEVELS
+ * @param string $text
+ *   The text for which bad words are sought.
+ *   This can be a string or an array of strings. If the latter, the
+ *   strings are conceptually separated by whitespace.  (So it's never
+ *   the case that a word begins in one string and ends in the next.)
+ * @param string $projectid
+ *   ID of project, needed for project languages and to load the custom
+ *   dictionaries
+ * @param string $aux_languages
+ *   Auxiliary language to check against.
+ * @param array $adhoc_good_words
+ *   Array of words to treat as good for this invocation only.
+ *
+ * @return array
+ */
 function _get_bad_words_for_project_text($which_result_values, $text, $projectid, $aux_language, $adhoc_good_words)
 {
     $messages = [];
@@ -123,21 +180,29 @@ function _get_bad_words_for_project_text($which_result_values, $text, $projectid
 }
 
 
-// Returns a list of bad words from a given text using the specified
-// languages to run the spellchecker and a set of word lists
-// Arguments:
-//      text - string or array of strings
-//      languages - array of language names
-//      word_lists - array with the keys:
-//          site_good - array of site good words
-//          site_bad  - array of site bad words
-//          project_good - array of good words from project
-//          project_bad - array of bad words from project
-//          adhoc_good - array of adhoc good words
-// Returns an array that includes:
-//      - array of text words with frequency
-//      - array of bad words
-//      - array of possible warning/error messages
+/**
+ * Returns a list of bad words from a given text using the specified
+ * languages to run the spellchecker and a set of word lists.
+ *
+ * Returns an array that includes:
+ * - array of text words with frequency
+ * - array of bad words
+ * - array of possible warning/error messages
+ *
+ * @param string $text
+ *   String or array of strings containing page text
+ * @param array $languages
+ *   Array of language names to use for the dictionary
+ * @param array $word_lists
+ *   Array with the keys:
+ *   * site_good - array of site good words
+ *   * site_bad  - array of site bad words
+ *   * project_good - array of good words from project
+ *   * project_bad - array of bad words from project
+ *   * adhoc_good - array of adhoc good words
+ *
+ * @return array
+ */
 function get_bad_words_for_text($text, $languages, $word_lists = [])
 {
     $input_words_w_freq = get_distinct_words_in_text($text);
@@ -224,17 +289,23 @@ class BadWordAccumulator
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // World-Level
 
-// returns a list of 'bad' words on a page
-// this implementation passes the text to aspell
-// Arguments:
-//   input_words_w_freq - an array whose keys are the distinct words of the input text
-//   languages - array of languages, used to load aspell dictionary
-//               for those languages if available
-//
-// Returns an array consisting of:
-//       -- an array of misspelled words,
-//       -- an array of messages (errors/warnings)
-//
+/**
+ * Returns a list of 'bad' words on a page
+ *
+ * This implementation passes the text to aspell
+ *
+ * Returns an array consisting of:
+ * - an array of misspelled words,
+ * - an array of messages (errors/warnings)
+ *
+ * @param array $input_words_w_freq
+ *   An array whose keys are the distinct words of the input text
+ * @param array $langauges
+ *   Array of languages, used to load aspell dictionary
+ *   for those languages if available
+ *
+ * @return array
+ */
 function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 {
     global $aspell_temp_dir;
@@ -335,13 +406,15 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
     return [$finalMisspellings, $messages];
 }
 
-// Return all words containing diacritical markup
-// Arguments:
-//   input_words_w_freq - an array whose keys are the distinct words of the input text
-//
-// Returns:
-//       -- an array of bad words
-//
+/**
+ * Return all words containing diacritical markup
+ *
+ * Returns:
+ * - an array of bad words
+ *
+ * @param array $input_words_w_freq
+ *   An array whose keys are the distinct words of the input text
+ */
 function get_bad_words_with_diacritical_markup($input_words_w_freq)
 {
     // Consider words that contain diacritical markup via []-notation.
@@ -378,14 +451,19 @@ function get_bad_words_with_diacritical_markup($input_words_w_freq)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // Site-Level
 
-// returns a list of 'bad' words in a text based on some pattern
-// Arguments:
-//   input_words_w_freq - an array whose keys are the distinct words of the input text
-//   languages - array of languages to check against
-//
-// Returns:
-//       -- an array of bad words
-//
+/**
+ * Returns a list of 'bad' words in a text based on some pattern
+ *
+ * Returns:
+ * - an array of bad words
+ *
+ * @param array $input_words_w_freq
+ *   An array whose keys are the distinct words of the input text
+ * @param array $languages
+ *   Array of languages to check against
+ *
+ * @return array
+ */
 function get_bad_words_via_pattern($input_words_w_freq, $languages)
 {
     [$langcode3s, $messages] = get_langcode3s_for_languages($languages);
@@ -510,8 +588,11 @@ function normalize_word_list($words)
 
 // -----------------------------------------------------------------------------
 
-// Delete any wordcheck_events for this project.
-// This is called when deleting a project.
+/**
+ * Delete any wordcheck_events for this project.
+ *
+ * This is called when deleting a project.
+ */
 function delete_project_wordcheck_events($projectid)
 {
     $sql = sprintf("
@@ -522,9 +603,11 @@ function delete_project_wordcheck_events($projectid)
     DPDatabase::query($sql);
 }
 
-// Merge the word list from the source project into the destination
-// project, and also copy the wordcheck events to the destination
-// project.
+/**
+ * Merge the word list from the source project into the destination
+ * project, and also copy the wordcheck events to the destination
+ * project.
+ */
 function merge_project_wordcheck_data($from_projectid, $to_projectid)
 {
     // good words
@@ -543,9 +626,11 @@ function merge_project_wordcheck_data($from_projectid, $to_projectid)
     copy_project_wordcheck_events($from_projectid, $to_projectid);
 }
 
-// Copy wordcheck events from one project to another project.
-// (This is used for instance when splitting or rejoining
-// project parts.)
+/**
+ * Copy wordcheck events from one project to another project.
+ *
+ * This is used for instance when splitting or rejoining project parts.
+ */
 function copy_project_wordcheck_events($from_projectid, $to_projectid)
 {
     $sql = sprintf("
@@ -585,11 +670,15 @@ function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions,
     DPDatabase::query($sql);
 }
 
-// Count the number of wordcheck_events for this project
-// which are more recent than $start_time, and which contain
-// suggestions. This function can be used as a faster alternative
-// to counting the result of load_wordcheck_events, when one does
-// not need the precise number of suggested words.
+/**
+ * Count the number of wordcheck_events for this project
+ * which are more recent than $start_time, and which contain
+ * suggestions.
+ *
+ * This function can be used as a faster alternative
+ * to counting the result of load_wordcheck_events, when one does
+ * not need the precise number of suggested words.
+ */
 function count_wordcheck_suggestion_events($projectid, $start_time = 0)
 {
     $sql = sprintf("
@@ -700,8 +789,10 @@ function load_site_possible_bad_words_given_project($projectid)
 
 // -----------------------------------------------------------------------------
 
-// return an associative array that maps the good/bad shorthand to
-// the filenames on disk
+/**
+ * Return an associative array that maps the good/bad shorthand to
+ * the filenames on disk
+ */
 function get_wordcheck_file_names()
 {
     return [
@@ -710,7 +801,16 @@ function get_wordcheck_file_names()
     ];
 }
 
-// $code must match one of the keys in array returned from get_wordcheck_file_names()
+/**
+ * Get a file info object for a project word list
+ *
+ * @param string $code
+ *   Must match one of the keys in array returned from `get_wordcheck_file_names()`
+ *
+ * @return object
+ *
+ * @see get_wordcheck_file_names()
+ */
 function get_project_word_file($projectid, $code)
 {
     global $projects_dir, $projects_url;
@@ -723,7 +823,14 @@ function get_project_word_file($projectid, $code)
                 "$projects_url/$projectid");
 }
 
-// $code must match one of the keys in the $filename_for_code array below.
+/**
+ * Get a file info object for a site word list
+ *
+ * @param string $code
+ *   Must match one of `good`, `bad`, `possible`
+ *
+ * @return object
+ */
 function get_site_word_file($langcode3, $code)
 {
     global $dyn_dir, $dyn_url;
@@ -740,15 +847,19 @@ function get_site_word_file($langcode3, $code)
                 "$dyn_url/words");
 }
 
-// Returns an object containing information about the specified
-// word-related file for the given project:
-// --- filename: its filename;
-// --- abs_path: its absolute path;
-// --- abs_url:  its absolute URL;
-// --- exists:   a boolean indicating whether it exists;
-// --- size:     its size in bytes;
-// --- mod_time: the time it was last modified, as a unix timestamp.
-// (size and mod_time are set to zero if the file doesn't exist.)
+/**
+ * Returns an object containing information about the specified
+ * word-related file for the given project.
+ *
+ * Attributes include:
+ * - filename: its filename
+ * - abs_path: its absolute path
+ * - abs_url:  its absolute URL
+ * - exists:   a boolean indicating whether it exists
+ * - size:     its size in bytes
+ * - mod_time: the time it was last modified, as a unix timestamp.
+ * Size and mod_time are set to zero if the file doesn't exist.
+ */
 function get_file_info_object($filename, $base_dir, $base_url)
 {
     clearstatcache();
@@ -768,10 +879,13 @@ function get_file_info_object($filename, $base_dir, $base_url)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// Load a list of words (one per line) from a file.
-// Returns:
-//   on success: an array of words
-//   on error:   a string containing an error message
+/**
+ * Load a list of words (one per line) from a file.
+ *
+ * Returns:
+ * - on success: an array of words
+ * - on error:   a string containing an error message
+ */
 function load_word_list($path)
 {
     if (!is_file($path)) {
@@ -807,8 +921,11 @@ function load_word_list($path)
     return $words;
 }
 
-// Save a list of words (one per line) to a file.
-// Return a string, either "Success" or an error message.
+/**
+ * Save a list of words (one per line) to a file.
+ *
+ * Return a string, either "Success" or an error message.
+ */
 function save_word_list($path, $words)
 {
     // standardize word list
@@ -858,8 +975,9 @@ function save_word_list($path, $words)
 
 // -----------------------------------------------------------------------------
 
-// Returns an associative array of all languages for a project
-//   $array[$langcode]=$language;
+/**
+ * Returns an associative array of all languages for a project
+ */
 function get_project_languages($projectid, $aux_language = null)
 {
     $returnArray = [];
@@ -885,35 +1003,40 @@ function get_project_languages($projectid, $aux_language = null)
 }
 
 
-// Returns an associative array of site word lists
-// with their corresponding URL
-//   $array[$absolute_filename]=$url_link_to_file;
+/**
+ * Returns an associative array of site word lists
+ * with their corresponding URL
+ */
 function get_site_good_bad_word_lists()
 {
     return get_site_word_files("/^(good|bad)_words\.[a-z]{3}\.txt$/");
 }
 
-// Returns an associative array of site possible bad word lists
-// with their corresponding URL
-//   $array[$absolute_filename]=$url_link_to_file;
+/**
+ * Returns an associative array of site possible bad word lists
+ * with their corresponding URL
+ */
 function get_site_possible_bad_word_lists()
 {
     return get_site_word_files("/^possible_bad_words\.[a-z]{3}\.txt$/");
 }
 
-// Arguments:
-//   $pattern - regex that files must match to be included
-//              in the returned array. If blank all files
-//              will be returned.
-//   $urlbase - if TRUE files will be turned as a URL,
-//              if FALSE absolute filesystem paths are returned
-//
-// Returns an associative array of words ifiles in the site's words
-// with their corresponding URL
-//   $array[$absolute_filename]=$url_link_to_file;
-//
-// Note: 'empty' files (2 bytes in size or smaller) are not returned
-// regardless of the pattern specified
+/**
+ * Get site word files that match a pattern
+ *
+ * Returns an associative array of words ifiles in the site's words
+ * with their corresponding URL.
+ *
+ * Note: 'empty' files (2 bytes in size or smaller) are not returned
+ * regardless of the pattern specified
+ *
+ * @param string $pattern
+ *   Regex that files must match to be included in the returned array.
+ *   If blank all files will be returned.
+ * @param boolean $urlbase
+ *   If TRUE files will be turned as a URL,
+ *   I FALSE absolute filesystem paths are returned
+ */
 function get_site_word_files($pattern = "", $urlbase = true)
 {
     global $dyn_dir;
@@ -953,12 +1076,14 @@ function get_site_word_files($pattern = "", $urlbase = true)
 
 // -----------------------------------------------------------------------------
 
-// Returns an array: each key is a distinct word in $text, and
-// the corresponding value is that word's frequency in $text.
-//
-// This function is equivalent to
-//     array_count_values(get_all_words_in_text($text));
-// but (when appropriate) avoids reifying the intermediate array.
+/**
+ * Returns an array: each key is a distinct word in $text, and
+ * the corresponding value is that word's frequency in $text.
+ *
+ * This function is equivalent to
+ * `array_count_values(get_all_words_in_text($text))`
+ * but (when appropriate) avoids reifying the intermediate array.
+ */
 function get_distinct_words_in_text($text)
 {
     // For a $text with typical-sized words, the memory consumed by the result
@@ -1016,21 +1141,25 @@ function get_distinct_words_in_text($text)
     return $input_words_w_freq;
 }
 
-// Returns an array whose values are all occurrences of all words in $text, in order
-// (i.e., with duplicates).
-//
-// $with_offsets:
-//    If false (the default), the keys are just consecutive integers.
-//    If true, then for each value, the corresponding key is the offset
-//        (in $text) of the start of that word.
-//
-//    If $text is project-sized, you should use $with_offsets=FALSE, otherwise
-//    you'll get back an array of (say) 200,000 entries with keys from about 0
-//    to (say) 1,000,000, and for some reason, PHP 4.4.2 (and maybe others) is
-//    ridiculously inefficient accessing such an array. (E.g., a simple var_dump
-//    took roughly an hour just to print the first four items in the array!)
-//    Note that it's *not* inefficient accessing an array with the same number
-//    of items, but having consecutive integers as the keys!
+/**
+ * Returns an array whose values are all occurrences of all words in $text,
+ * in order (i.e., with duplicates).
+ *
+ * @param string $text
+ *   Page text
+ * @param boolean $with_offsets:
+ *   If false (the default), the keys are just consecutive integers.
+ *   If true, then for each value, the corresponding key is the offset
+ *   (in $text) of the start of that word.
+ *
+ * If $text is project-sized, you should use $with_offsets=FALSE, otherwise
+ * you'll get back an array of (say) 200,000 entries with keys from about 0
+ * to (say) 1,000,000, and for some reason, PHP 4.4.2 (and maybe others) is
+ * ridiculously inefficient accessing such an array. (E.g., a simple var_dump
+ * took roughly an hour just to print the first four items in the array!)
+ * Note that it's *not* inefficient accessing an array with the same number
+ * of items, but having consecutive integers as the keys!
+ */
 function get_all_words_in_text($text, $with_offsets = false)
 {
     global $word_pattern;
@@ -1055,7 +1184,9 @@ function get_all_words_in_text($text, $with_offsets = false)
     }
 }
 
-// given an array of words, calculate the frequency
+/**
+ * Given an array of words, calculate the frequency
+ */
 function generate_frequencies($wordList)
 {
     $wordCount = array_count_values($wordList);
@@ -1063,12 +1194,16 @@ function generate_frequencies($wordList)
     return $wordCount;
 }
 
-// Given an array of language names, return a list of valid langcode3s.
-// Arguments:
-//      languages - array of language names
-// Returns an array of:
-//      array of langcode3s
-//      array of zero or more error/warning messages
+/**
+ * Given an array of language names, return a list of valid langcode3s.
+ *
+ * Returns an array of:
+ * - array of langcode3s
+ * - array of zero or more error/warning messages
+ *
+ * @param array $languages
+ *   Array of language names
+ */
 function get_langcode3s_for_languages($languages)
 {
     $messages = [];
@@ -1085,23 +1220,29 @@ function get_langcode3s_for_languages($languages)
     return [$langcode3s, $messages];
 }
 
-// function for comparing words similar to strnatcasecmp
-// but deterministicly; without the strnatcmp() call
-// if the words are the same discounting case, the calling
-// sort function would be non-deterministic based on PHP
-// docs (see online docs for usort()) and manual confirmation
+/**
+ * Comparison function for similar to strnatcasecmp but deterministic
+ *
+ * Without the strnatcmp() call if the words are the same discounting case,
+ * the calling sort function would be non-deterministic based on PHP
+ * docs (see online docs for usort()) and manual confirmation.
+ */
 function deterministicStrnatcasecmp($a, $b)
 {
     return ($cmp = strnatcasecmp($a, $b)) != 0 ? $cmp : strnatcmp($a, $b);
 }
 
-// rtrim version to use in array_walk
+/**
+ * rtrim version to use in array_walk
+ */
 function rtrim_walk(&$item)
 {
     $item = rtrim($item);
 }
 
-// Filter words to only those of a specific script + Inherited
+/**
+ * Filter words to only those of a specific script + Inherited
+ */
 function filter_words_to_script($words, $script)
 {
     $script_words = [];
@@ -1113,14 +1254,18 @@ function filter_words_to_script($words, $script)
     return $script_words;
 }
 
-// Return a list of words where characters within a word contain "uncommon"
-// Unicode scripts.
-// Arguments:
-//   words - an array of words
-//
-// Returns:
-//       -- the array: [words[], found_scripts[]]
-//
+/**
+ * Return a list of words where characters within a word contain "uncommon"
+ * Unicode scripts.
+ *
+ * Returns:
+ * - the array: [words[], found_scripts[]]
+ *
+ * @param array $words
+ *   An array of words
+ *
+ * @return array
+ */
 function get_words_with_uncommon_scripts($words)
 {
     global $common_unicode_scripts;

--- a/project.php
+++ b/project.php
@@ -1251,8 +1251,10 @@ function do_history()
     echo "</table>\n";
 }
 
+/**
+ * If the project's event-history has gaps, fill them with pseudo-events.
+ */
 function fill_gaps_in_events($in_events)
-// If the project's event-history has gaps, fill them with pseudo-events.
 {
     $out_events = [];
 

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -257,14 +257,17 @@ function in_string($needle, $haystack, $sensitive = 0)
     return (str_posn($haystack, $needle, $sensitive) !== false);
 }
 
+/**
+ * Find the numeric (0-based) position of
+ * the first occurrence of $needle in $haystack.
+ *
+ * The search is case-sensitive or not, depending on
+ * whether the value of $cs is true-ish or not (respectively).
+ *
+ * Returns FALSE if $needle is not found.
+ * Be careful to distinguish FALSE from 0.
+ */
 function str_posn($haystack, $needle, $cs)
-// Find the numeric (0-based) position of
-// the first occurrence of $needle in $haystack.
-// The search is case-sensitive or not, depending on
-// whether the value of $cs is true-ish or not (respectively).
-//
-// Returns FALSE if $needle is not found.
-// (Be careful to distinguish FALSE from 0.)
 {
     if ($cs) {
         return strpos($haystack, $needle);
@@ -428,9 +431,13 @@ function qp_choose_solution($text)
 
 // =============================================================================
 
+/**
+ * Compare two texts and if the outputs differ explain how
+ *
+ * If the two texts are the same, return FALSE.
+ * If they differ, output HTML that describes how they differ, and return TRUE.
+ */
 function qp_compare_texts($user_text, $soln_text)
-// If the two texts are the same, return FALSE.
-// If they differ, output HTML that describes how they differ, and return TRUE.
 {
     if ($user_text == $soln_text) {
         return false;

--- a/stats/includes/common.inc
+++ b/stats/includes/common.inc
@@ -1,9 +1,11 @@
 <?php
 // A file for (UI) code that's used by both user and team stats pages.
 
+/**
+ * Return a snippet of HTML that visually conveys
+ * the change in rank between $previous_rank and $current_rank.
+ */
 function showChangeInRank($previous_rank, $current_rank)
-// Return a snippet of HTML that visually conveys
-// the change in rank between $previous_rank and $current_rank.
 {
     if (empty($current_rank) || empty($previous_rank)) {
         // Normally, this means that the rank is zero,

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -67,9 +67,11 @@ function showMbrProfile($user)
     echo "</td></tr></table>";
 }
 
+/**
+ * Return a string like "Today!", or "Yesterday", or "2 days ago" depending on
+ * a timestamp
+ */
 function days_to_now($timestamp)
-// return a string like "Today!", or "Yesterday", or "2 days ago" depending on
-// a timestamp
 {
     // Ensure that all calls to this function have the same base time.
     static $now = null;

--- a/tasks.php
+++ b/tasks.php
@@ -309,10 +309,12 @@ $SearchParams_choices = [
 // a sitemanager/task_center_mgr whose u_id happens to be 999.
 // However, there's a fairly low chance of it ever being triggered.
 
+/**
+ * For each of the search parameters, echo its control (HTML markup),
+ * initializing it with any (valid) value that the current request
+ * has supplied for the parameter.
+ */
 function SearchParams_echo_controls()
-// For each of the search parameters, echo its control (HTML markup),
-// initializing it with any (valid) value that the current request
-// has supplied for the parameter.
 {
     global $SearchParams_choices, $tasks_url;
 
@@ -341,10 +343,12 @@ function SearchParams_echo_controls()
     echo "</table></form><br>\n";
 }
 
+/**
+ * Return a SQL condition that expresses the restriction on tasks
+ * implied by the values (if any) supplied for the search parameters
+ * by the current request.
+ */
 function SearchParams_get_sql_condition($request_params)
-// Return a SQL condition that expresses the restriction on tasks
-// implied by the values (if any) supplied for the search parameters
-// by the current request.
 {
     global $testing, $SearchParams_choices;
 
@@ -389,10 +393,12 @@ function SearchParams_get_sql_condition($request_params)
     return $condition;
 }
 
+/**
+ * Return a string (suitable for use in the 'query string' portion of a URL)
+ * that represents (and possibly just reiterates) the values (if any)
+ * supplied for the search parameters by the current request.
+ */
 function SearchParams_get_url_query_string()
-// Return a string (suitable for use in the 'query string' portion of a URL)
-// that represents (and possibly just reiterates) the values (if any)
-// supplied for the search parameters by the current request.
 {
     global $SearchParams_choices;
 
@@ -865,7 +871,9 @@ function handle_action_on_a_specified_task()
     }
 }
 
-// Add or remove a related task to the current task.
+/**
+ * Add or remove a related task to the current task.
+ */
 function process_related_task($pre_task, $action, $related_task_id)
 {
     global $pguser, $tasks_url;
@@ -902,7 +910,9 @@ function process_related_task($pre_task, $action, $related_task_id)
     metarefresh(0, "$tasks_url?task_id=$pre_task_id");
 }
 
-// Add or remove a related topic (forum thread) to the curent task.
+/**
+ * Add or remove a related topic (forum thread) to the curent task.
+ */
 function process_related_topic($pre_task, $action, $related_topic_id)
 {
     global $pguser, $tasks_url;
@@ -1021,17 +1031,21 @@ function TaskHeader($header, $show_new_alert = false)
     echo "<div style='clear: both;'></div>";
 }
 
-// Encode an array into text for insertion into the database.
+/**
+ * Encode an array into text for insertion into the database.
+ */
 function encode_array($a)
 {
     return base64_encode(serialize($a));
 }
 
-// Decode an array from its text form pulled into a PHP array.
-//
-// This should return an array, but if $str is empty,
-// unserialize("") === bool(false). In that case we explicitly return
-// an empty array.
+/**
+ * Decode an array from its text form pulled into a PHP array.
+ *
+ * This should return an array, but if $str is empty,
+ * unserialize("") === bool(false). In that case we explicitly return
+ * an empty array.
+ */
 function decode_array($str)
 {
     $a = unserialize(base64_decode($str));
@@ -1219,8 +1233,10 @@ function TaskForm($task)
     echo "</td></tr></table></form>\n";
 }
 
+/**
+ * Echo a <tr> element containing a label and a <select> for the given property.
+ */
 function property_echo_select_tr($property_id, $current_value, $options)
-// Echo a <tr> element containing a label and a <select> for the given property.
 {
     $label = property_get_label($property_id, false);
     echo "<tr><th>$label</th><td>\n";
@@ -1899,15 +1915,20 @@ function get_username_for_uid($u_id)
     return $user->username;
 }
 
-// Given a task row from the DB, produce an unescaped string representing
-// the task and suitable for display in a page title or similar.
+/**
+ * Given a task row from the DB, produce an unescaped string representing
+ * the task and suitable for display in a page title or similar.
+ */
 function title_string_for_task($pre_task)
 {
     return sprintf(_("Task #%d: %s"), $pre_task->task_id, $pre_task->task_summary);
 }
 
-// Get key corresponding to a task properties string
-// Input string must be a valid property value
+/**
+ * Get key corresponding to a task properties string
+ *
+ * Input string must be a valid property value
+ */
 function get_property_key($value, $array)
 {
     if (($key = array_search($value, $array)) === false) {

--- a/tools/authors/authors.inc
+++ b/tools/authors/authors.inc
@@ -7,9 +7,13 @@ $months = [_('Unknown'),
     _('July'), _('August'), _('September'),
     _('October'), _('November'), _('December'), ];
 
-// Arguments: the data to be displayed. If $author_id is FALSE, no biographies will be displayed.
-// If $author_id is not FALSE, all biographies that apply to that author id will be listed
-// and a link to the xml data will be provided.
+/**
+ * Output author details
+ *
+ * If $author_id is FALSE, no biographies will be displayed.
+ * If $author_id is not FALSE, all biographies that apply to that author id
+ * will be listed and a link to the xml data will be provided.
+ */
 function echo_author($last_name, $other_names, $born, $dead, $author_id)
 {
     global $code_url;

--- a/tools/authors/search.inc
+++ b/tools/authors/search.inc
@@ -111,7 +111,9 @@ function prepare_search()
     }
 }
 
-// prepare a string for use with LIKE
+/**
+ * Prepare a string for use with LIKE
+ */
 function sql_like_encode($str)
 {
     // escape quotes -- note: does not encode % and _ !
@@ -190,8 +192,10 @@ function search()
     return $search_result;
 }
 
-// Builds a query string by joining the arguments by '&',
-// ignoring arguments that are blank strings.
+/**
+ * Builds a query string by joining the arguments by '&',
+ * ignoring arguments that are blank strings.
+ */
 function build_query_string()
 {
     $count = func_num_args();

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -884,8 +884,10 @@ if ($action == SHOW_BLANK_ENTRY_FORM) {
     assert(false);
 }
 
-// Wrap a string to about 72 characters wide so it's
-// suitable for displaying in <pre>-formatted HTML email.
+/**
+ * Wrap a string to about 72 characters wide so it's
+ * suitable for displaying in <pre>-formatted HTML email.
+ */
 function ppv_report_wrap($string)
 {
     $string = wordwrap($string, 72);

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -452,10 +452,11 @@ class Loader
 
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+    /**
+     * Check if there is any reason to exclude the file from the load and
+     * return it as a string or the empty string if not.
+     */
     public function _check_file($filename)
-    // If there is any reason to exclude the file from the load,
-    // return it as a string.
-    // Otherwise, return empty string.
     {
         if (!is_file($filename)) {
             return _('not a regular file');

--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -331,10 +331,14 @@ function maybe_release_projects(
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * ReleaseRestirctor class
+ *
+ * An object of this class is responsible for imposing various queue-independent
+ * restrictions on the auto-release of projects into a given round.
+ * (E.g., not too many by the same author, not too many with the same PM.)
+ */
 class ReleaseRestrictor
-// An object of this class is responsible for imposing various queue-independent
-// restrictions on the auto-release of projects into a given round.
-// (E.g., not too many by the same author, not too many with the same PM.)
 {
     public $this_round_authors;
     public $this_round_pms;
@@ -487,16 +491,19 @@ class ReleaseRestrictor
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Set up temporary table active_page_counts,
+ * containing a row for each project in this round.
+ *
+ * Fields:
+ * - projectid
+ * - pages = number of pages yet to receive proofreading in this round
+ *
+ * This table is similar to projects.n_available_pages
+ * but contains slightly different information.
+ * Maybe they could be merged.
+ */
 function AP_setup($round)
-// Set up temporary table active_page_counts,
-// containing a row for each project in this round.
-// fields:
-//     projectid
-//     pages = number of pages yet to receive proofreading in this round
-//
-// This table is similar to projects.n_available_pages
-// but contains slightly different information.
-// Maybe they could be merged.
 {
     // If we had one table with all page info,
     // we could set up this table with a single

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -183,8 +183,10 @@ if ($L_text != $R_text) {
     echo $navigation_text;
 }
 
-// build up the text for the navigation bit, so we can repeat it
-// again at the bottom of the page
+/**
+ * Build up the text for the navigation bit, so we can repeat it
+ * again at the bottom of the page
+ */
 function do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_column_name, $L_user, $format,
                        $L_text_column_name, $R_text_column_name, $only_nonempty_diffs, $bb_diffs)
 {
@@ -279,7 +281,9 @@ function do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_c
     $navigation_text .= "\n</form>\n";
 }
 
-// discover whether the user is allowed to see proofreader names for this page
+/**
+ * Discover whether the user is allowed to see proofreader names for this page
+ */
 function can_see_names_for_page($projectid, $image)
 {
     global $pguser, $Round_for_round_id_;
@@ -316,7 +320,9 @@ function can_see_names_for_page($projectid, $image)
     return $answer;
 }
 
-// discover whether the user is allowed to navigate by proofreader for this page
+/**
+ * Discover whether the user is allowed to navigate by proofreader for this page
+ */
 function can_navigate_by_proofer($projectid, $L_user)
 {
     global $pguser;

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -589,9 +589,11 @@ class ProjectInfoHolder
 
     // -------------------------------------------------------------------------
 
+    /**
+     * In the project's text fields, replace sequences of space characters
+     * with a unique space, and trim beginning and end space
+     */
     public function normalize_spaces()
-    // In the project's text fields, replace sequences of space characters
-    // with a unique space, and trim beginning and end space
     {
         $this->project->nameofwork = preg_replace('/\s+/', ' ', trim($this->project->nameofwork));
         $this->project->authorsname = preg_replace('/\s+/', ' ', trim($this->project->authorsname));

--- a/tools/project_manager/post_files.inc
+++ b/tools/project_manager/post_files.inc
@@ -6,8 +6,10 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
 
+/**
+ * Generate the files needed for post-processing.
+ */
 function generate_post_files($project, $limit_round_id, $which_text, $include_proofers, $base_extra)
-// Generate the files needed for post-processing.
 {
     if (!$project->pages_table_exists) {
         throw new Exception(_("Project table not found, it may have been deleted or archived."));
@@ -56,7 +58,10 @@ function generate_post_files($project, $limit_round_id, $which_text, $include_pr
 }
 
 // -----------------------------------------------------------------------------
-// generate a zip file on the fly and download it
+
+/**
+ * Generate a zip file on the fly and download it
+ */
 function generate_interim_file($project, $limit_round_id, $which_text, $include_proofers)
 {
     if (!$project->pages_table_exists) {
@@ -134,8 +139,10 @@ function write_project_comments($project, $fp)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Return an array whose values are the page-texts in the query-result.
+ */
 function get_page_texts($pages_res)
-// Return an array whose values are the page-texts in the query-result.
 {
     $page_texts = [];
     while ([$page_text, $imagename, $proofer_names] = page_info_fetch($pages_res)) {
@@ -144,9 +151,12 @@ function get_page_texts($pages_res)
     return $page_texts;
 }
 
+/**
+ * Return the concatenation of the page-texts in the query-result.
+ *
+ * Similar to join_proofed_text, but without the page-separators.
+ */
 function join_page_texts($pages_res)
-// Return the concatenation of the page-texts in the query-result.
-// (Similar to join_proofed_text, but without the page-separators.)
 {
     $text = "";
     while ([$text_data, $filename, $proofer_names] = page_info_fetch($pages_res)) {
@@ -270,13 +280,17 @@ function page_info_query($projectid, $limit_round_id, $which_text)
     return $res;
 }
 
+/**
+ * Return information about a page
+ *
+ * For the next page in the query-result, return an array consisting of (in order):
+ * - the page text resulting from the page-editing rounds
+ * - the filename of the page image
+ * - an array of the usernames of the users who worked on the page in the rounds.
+ *
+ * If there's no next page, return FALSE
+ */
 function page_info_fetch($res)
-// For the next page in the query-result,
-// return an array consisting of (in order):
-// -- the page text resulting from the page-editing rounds;
-// -- the filename of the page image;
-// -- an array of the usernames of the users who worked on the page in the rounds.
-// If there's no next page, return FALSE;
 {
     $a = mysqli_fetch_row($res);
     if (!$a) {

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -659,7 +659,9 @@ function user_may_access_all_upload_dirs()
     return user_is_a_sitemanager();
 }
 
-// Is this a subdirectory of the user's home dir?
+/**
+ * Is this a subdirectory of the user's home dir?
+ */
 function is_subdir_of_home($dir)
 {
     global $home_dirname;
@@ -675,7 +677,9 @@ function is_subdir_of_home($dir)
     return strlen($rel) !== 0;
 }
 
-// May the user move files to the specified relative directory?
+/**
+ * May the user move files to the specified relative directory?
+ */
 function is_valid_move_destination($dir)
 {
     global $commons_rel_dir, $users_rel_dir, $home_dirname;
@@ -701,10 +705,13 @@ function is_valid_move_destination($dir)
     return strpos($rel, "/") === false;
 }
 
-// Canonicalise input paths by splitting into components,
-// removing empty components, rejecting parent traversal,
-// and re-joining them. Returns False is path contains
-// invalid components.
+/**
+ * Canonicalise input paths by splitting into components,
+ * removing empty components, rejecting parent traversal,
+ * and re-joining them.
+ *
+ * Returns False is path contains invalid components.
+ */
 function canonicalize_path($relpath)
 {
     $canonical_path = [];
@@ -720,8 +727,10 @@ function canonicalize_path($relpath)
     return join('/', $canonical_path);
 }
 
+/**
+ * Ascertain the current directory, validate it, and return the relative path
+ */
 function get_current_dir_relative_path($home_dirname)
-// Ascertain the current directory, validate it, and return the relative path
 {
     global $uploads_dir, $commons_rel_dir;
     $abs_uploads_dir = realpath($uploads_dir);
@@ -948,10 +957,14 @@ function get_actions_block($item_name, $valid_actions)
     return $form;
 }
 
+/**
+ * Confirm if the specified file is local
+ *
+ * If $filename is a valid filename parameter,
+ * and names a file in the current directory, return.
+ * Otherwise, print an error message and exit.
+ */
 function confirm_is_local_file($filename)
-// If $filename is a valid filename parameter,
-// and names a file in the current directory, return.
-// Otherwise, print an error message and exit.
 {
     confirm_is_local('F', $filename);
 }
@@ -1011,7 +1024,9 @@ function fatal_error($message)
     exit();
 }
 
-// return or echo a formatted informational or error message
+/**
+ * Return or echo a formatted informational or error message
+ */
 function get_message($type, $message)
 {
     if ($type == 'error') {
@@ -1030,7 +1045,9 @@ function show_message($type, $message)
     flush();
 }
 
-// Display a return link (to the 'showdir' view)
+/**
+ * Display a return link (to the 'showdir' view)
+ */
 function show_return_link($relpath = null)
 {
     global $curr_relpath;

--- a/tools/project_manager/update_illos.php
+++ b/tools/project_manager/update_illos.php
@@ -150,9 +150,13 @@ if ($operation == 'replace') {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Handle file upload problems, if any
+ *
+ * If there's a problem, return a string containing an error message.
+ * If no problem, return the empty string.
+ */
 function handle_upload($projectid, $image, $replacement_image_info)
-// If there's a problem, return a string containing an error message.
-// If no problem, return the empty string.
 {
     global $projects_dir;
 
@@ -189,9 +193,13 @@ function handle_upload($projectid, $image, $replacement_image_info)
     }
 }
 
+/**
+ * Handle file delete problems, if any
+ *
+ * If there's a problem, return a string containing an error message.
+ * If no problem, return the empty string.
+ */
 function handle_delete($projectid, $image)
-// If there's a problem, return a string containing an error message.
-// If no problem, return the empty string.
 {
     global $projects_dir;
 
@@ -205,9 +213,13 @@ function handle_delete($projectid, $image)
     }
 }
 
+/**
+ * Handle delete all problems, if any
+ *
+ * If there's a problem, return a string containing an error message.
+ * If no problem, return the empty string.
+ */
 function handle_delete_all($projectid, $nonpage_image_names)
-// If there's a problem, return a string containing an error message.
-// If no problem, return the empty string.
 {
     global $projects_dir;
 

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -30,7 +30,7 @@ function get_cutoff_string($cutoffOptions, $labelSuffix = "")
  *
  * @param array $cutoffOptions
  *   List of javascript cutoff options (eg: `[1,2,3,4,5]`)
- * @param integer $instances
+ * @param int $instances
  *   Number of word frequency tables to support
  *   (required for hiding/showing items of the correct table)
  */
@@ -144,7 +144,7 @@ function getInitialCutoff($idealCutoff, $cutoffOptions, $wordCount = null)
 /**
  * Outputs the word frequency table
  *
- * @param integer $initialFreq
+ * @param int $initialFreq
  *   Initial cutoff frequency, anything after this is hidden
  * @param array $cutoffOptions
  *   List of javascript cutoff options (eg: array(1,2,3,4,5))
@@ -157,7 +157,7 @@ function getInitialCutoff($idealCutoff, $cutoffOptions, $wordCount = null)
  *   [[CLASS]] - class of the td
  *   [[STYLE]] - style of the td
  *   ```
- * @param integer $instance
+ * @param int $instance
  *   Number uniquely identifying this instance, must be less
  *   than the $instances passed into `get_cutoff_script()`
  * @param array $auxData

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -8,12 +8,13 @@ include_once($relPath.'unicode.inc');
 
 use voku\helper\UTF8;
 
-// get_cutoff_string
-// Arguments:
-//   cutoffOptions - list of javascript cutoff options (eg: array(1,2,3,4,5))
-//
-// Returns a string with javascript links to effect showing or hiding parts of
-// the word list
+/**
+ * Returns a string with javascript links to effect showing or hiding parts of
+ * the word list
+ *
+ * @param array $cutoffOptions
+ *   List of javascript cutoff options (eg: `[1,2,3,4,5]`)
+ */
 function get_cutoff_string($cutoffOptions, $labelSuffix = "")
 {
     $cutoffString = "";
@@ -24,13 +25,15 @@ function get_cutoff_string($cutoffOptions, $labelSuffix = "")
     return $cutoffString;
 }
 
-// get_cutoff_script
-// Arguments:
-//   cutoffOptions - list of javascript cutoff options (eg: array(1,2,3,4,5))
-//   instances     - number of word frequency tables to support
-//                   (required for hiding/showing items of the correct table)
-//
-// Outputs the javascript used to show/hide parts of the word frequency tables
+/**
+ * Outputs the javascript used to show/hide parts of the word frequency tables
+ *
+ * @param array $cutoffOptions
+ *   List of javascript cutoff options (eg: `[1,2,3,4,5]`)
+ * @param integer $instances
+ *   Number of word frequency tables to support
+ *   (required for hiding/showing items of the correct table)
+ */
 function get_cutoff_script($cutoffOptions, $instances)
 {
     $cutoffJSArray = "";
@@ -100,8 +103,10 @@ function get_cutoff_script($cutoffOptions, $instances)
         EOS;
 } // end of get_cutoff_script
 
-// given the list of cutoff options and the word count
-// make sure the initial cutoff shows something
+/**
+ * Given the list of cutoff options and the word count
+ * make sure the initial cutoff shows something
+ */
 function getInitialCutoff($idealCutoff, $cutoffOptions, $wordCount = null)
 {
     // validate the idealCutoff is in $cutoffOptions
@@ -136,25 +141,36 @@ function getInitialCutoff($idealCutoff, $cutoffOptions, $wordCount = null)
     return $nextCutoff;
 }
 
-// printTableFrequencies
-// Arguments:
-//   initialFreq   - initial cutoff frequency, anything after this is hidden
-//   cutoffOptions - list of javascript cutoff options (eg: array(1,2,3,4,5))
-//   wordCount     - a table containing the word/frequency pairs already
-//                   sorted and ready for display
-//   instance      - number uniquely identifying this instance, must be less
-//                   than the $instances passed into get_cutoff_script
-//   auxData       - array with one or more of the following:
-//                       array($word => $data)
-//   checkbox      - array containing checkbox form elements for each word
-//
-// both wordCount and auxData component arrays can contain the following
-// special keys used for formatting
-//   [[TITLE]] - title of the column
-//   [[CLASS]] - class of the td
-//   [[STYLE]] - style of the td
-//
-// Outputs the word frequency table
+/**
+ * Outputs the word frequency table
+ *
+ * @param integer $initialFreq
+ *   Initial cutoff frequency, anything after this is hidden
+ * @param array $cutoffOptions
+ *   List of javascript cutoff options (eg: array(1,2,3,4,5))
+ * @param array $wordCount
+ *   A table containing the word/frequency pairs already
+ *   sorted and ready for display.
+ *   Can contain the following special keys used for formatting
+ *   ```
+ *   [[TITLE]] - title of the column
+ *   [[CLASS]] - class of the td
+ *   [[STYLE]] - style of the td
+ *   ```
+ * @param integer $instance
+ *   Number uniquely identifying this instance, must be less
+ *   than the $instances passed into `get_cutoff_script()`
+ * @param array $auxData
+ *   Array with one or more of the following `[$word => $data]`
+ *   Can contain the following special keys used for formatting
+ *   ```
+ *   [[TITLE]] - title of the column
+ *   [[CLASS]] - class of the td
+ *   [[STYLE]] - style of the td
+ *   ```
+ * @param array $checkbox
+ *   Array containing checkbox form elements for each word
+ */
 function printTableFrequencies($initialFreq, $cutoffOptions, $wordCount, $instance, $auxData = null, $checkbox = null)
 {
     // check that auxData is an array of arrays
@@ -247,9 +263,13 @@ function printTableFrequencies($initialFreq, $cutoffOptions, $wordCount, $instan
     echo '</table>';
 }
 
-// arrays with numeric and string keys don't multisort correctly
-// appending a space to the end of the numeric keys forces them
-// to strings and multisort works correctly
+/**
+ * Prep array for numeric sort
+ *
+ * Arrays with numeric and string keys don't multisort correctly
+ * Appending a space to the end of the numeric keys forces them
+ * to strings and multisort works correctly
+ */
 function prep_numeric_keys_for_multisort(&$assocArray)
 {
     if (!is_array($assocArray)) {

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -70,8 +70,8 @@ function get_requested_PPage($request_params)
 
 // ---------------------------------------------------------
 
-class PPage
 // The initial 'P' is for 'Presentation' (i.e., user interface).
+class PPage
 {
     public function __construct(&$lpage, $proj_state)
     {
@@ -264,10 +264,14 @@ class PPage
 
     // -------------------------------------------------------------------------
 
+    /**
+     * Attempt to save a page as done
+     *
+     * This is only an attempt, because a daily page limit might block the save,
+     * or prevent further saves.
+     * If there's a problem, this function does not return to the caller.
+     */
     public function attempt_to_save_as_done($text_data)
-    // This is only an attempt, because a daily page limit might block the save,
-    // or prevent further saves.
-    // If there's a problem, this function does not return to the caller.
     {
         global $code_url, $pguser;
 

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -160,8 +160,10 @@ function output_project_label($nameofwork, $authorsname, $date = null)
     }
 }
 
-// For each mentorable project (in this round), show a summary (one line per mentee)
-// and then a listing (one line per page).
+/**
+ * For each mentorable project (in this round), show a summary (one line per mentee)
+ * and then a listing (one line per page).
+ */
 function output_project_details($mentored_round, $projectid, $nameofwork, $authorsname)
 {
     global $code_url;

--- a/tools/proofers/image_block_enh.inc
+++ b/tools/proofers/image_block_enh.inc
@@ -5,11 +5,15 @@ include_once($relPath.'misc.inc');
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Get CSS styles for the image block enhanced
+ *
+ * $block_width_pc and $block_height_pc
+ * give the dimensions of the whole image block
+ * as percentages of its container box
+ * (which is typically the "proofframe" of the proofing interface).
+ */
 function ibe_get_styles()
-// $block_width_pc and $block_height_pc
-// give the dimensions of the whole image block
-// as percentages of its container box
-// (which is typically the "proofframe" of the proofing interface).
 {
     $user = User::load_current();
 

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -7,20 +7,27 @@ include_once($relPath.'unicode.inc');
 
 use voku\helper\UTF8;
 
-// Arguments:
-//   orig_text - original text to run through dictionary
-//   projectid - id of projected, needed for temp filename
-//               and to load the custom dictionaries
-//   imagefile - image filename, needed for temp filename
-//   aux_languages - auxiliary language to check against
-//   accepted_words - array of words that should not be considered misspelled
-//
-// Returns an array consisting of:
-//     -- a string containing the HTML code for the 'text' part of the spellcheck interface.
-//     -- an array of messages (errors/warnings)
-//     -- an array of names of languages used.
-//
-
+/**
+ * Build HTML for the WordCheck UI
+ *
+ * Returns an array consisting of:
+ * - a string containing the HTML code for the 'text' part of the spellcheck interface.
+ * - an array of messages (errors/warnings)
+ * - an array of names of languages used.
+ *
+ * @param text $orig_text
+ *   Original text to run through dictionary
+ * @param text $projectid
+ *   Id of projected, needed for temp filename and to load the custom dictionaries
+ * @param text $imagefile
+ *   Image filename, needed for temp filename
+ * @param text $aux_language
+ *   Auxiliary language to check against
+ * @param array $accepted_words
+ *   Array of words that should not be considered misspelled
+ *
+ * @return array
+ */
 function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $accepted_words)
 {
     global $puncCharacters;
@@ -185,19 +192,25 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
     return [$returnString, $languages, $messages, $highlightsUsed];
 }
 
-// adds HTML code to highlight text
+/**
+ * Adds HTML code to highlight text
+ */
 function _wrapHighlight($word, $highlightClass)
 {
     return "<span class='$highlightClass'>$word</span>";
 }
 
-// adds HTML code to punctuation to highlight it
+/**
+ * Adds HTML code to punctuation to highlight it
+ */
 function _wrapPunc($word)
 {
     return _wrapHighlight($word, "hl-punc");
 }
 
-// adds HTML code to highlight words in multiple scripts
+/**
+ * Adds HTML code to highlight words in multiple scripts
+ */
 function _wrapScriptWord($word, $scriptMap)
 {
     global $common_unicode_scripts;
@@ -215,13 +228,17 @@ function _wrapScriptWord($word, $scriptMap)
     return $returnString;
 }
 
-// adds HTML code to an accepted word to highlight it
+/**
+ * Adds HTML code to an accepted word to highlight it
+ */
 function _wrapAW($word)
 {
     return "<span class='aw'>$word</span>";
 }
 
-// adds HTML code to manage a bad word
+/**
+ * Adds HTML code to manage a bad word
+ */
 function _wrapBadWord($word, $origLineNum, $lineIndex, $wordLen, $badWordType)
 {
     global $code_url;

--- a/tools/site_admin/manage_site_word_lists.php
+++ b/tools/site_admin/manage_site_word_lists.php
@@ -124,7 +124,7 @@ if ($display_list) {
  * @param string $word_string
  *   String of words to save
  *
- * @return boolean
+ * @return bool
  */
 function _handle_action($action, $list_type, $language, $word_string)
 {

--- a/tools/site_admin/manage_site_word_lists.php
+++ b/tools/site_admin/manage_site_word_lists.php
@@ -107,18 +107,25 @@ if ($display_list) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// handle any actionable request
-// arguments:
-//        $action - action to take
-//                  one of: delete, deleteconfirmed, create, edit, save,
-//                  saveconfirmed, list
-//     $list_type - list type to operate on
-//                  one of: good, bad, possible_bad
-//      $language - the list language
-//   $word_string - string of words to save
-// return codes:
-//   TRUE - request was handled (don't display default list)
-//   FALSE - request wasn't handled (display list)
+/**
+ * Handle any actionable page request
+ *
+ * Returns:
+ * - TRUE - request was handled (don't display default list)
+ * - FALSE - request wasn't handled (display list)
+ *
+ * @param string $action
+ *   Action to take, one of: delete, deleteconfirmed, create, edit, save,
+ *   saveconfirmed, list
+ * @param string $list_type
+ *   List type to operate on one of: good, bad, possible_bad
+ * @param string $language
+ *   The list language
+ * @param string $word_string
+ *   String of words to save
+ *
+ * @return boolean
+ */
 function _handle_action($action, $list_type, $language, $word_string)
 {
     // look up the langcode3 for the language passed-in

--- a/tools/site_admin/shared_postednums.php
+++ b/tools/site_admin/shared_postednums.php
@@ -68,8 +68,10 @@ while ([$postednum, $count] = mysqli_fetch_row($res)) {
     ");
 }
 
+/**
+ * Determine if the given strings contain numerals '1', '2', '3' that go up
+ */
 function strings_count_up($strings)
-// The given strings contain numerals '1', '2', '3', etc.
 {
     for ($i = 0; $i < count($strings); $i++) {
         if ($strings[$i] == (''.($i + 1))) {

--- a/tools/site_admin/show_common_words_from_project_word_lists.php
+++ b/tools/site_admin/show_common_words_from_project_word_lists.php
@@ -117,12 +117,12 @@ if ($display_list) {
  *   List type to show one of: good, bad
  * @param string $language
  *   The list language
- * @param integer $cutoff
+ * @param int $cutoff
  *   Words that occur less than $cutoff percent are not shown
  * @param string $lang_match
  *   How to match the language one of: exact, primary, any
  *
- * @return boolean
+ * @return bool
  */
 function _handle_action($action, $list_type, $language, $cutoff, $lang_match)
 {

--- a/tools/site_admin/show_common_words_from_project_word_lists.php
+++ b/tools/site_admin/show_common_words_from_project_word_lists.php
@@ -104,19 +104,26 @@ if ($display_list) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// handle any actionable request
-// arguments:
-//        $action - action to take
-//                  one of: show, list
-//     $list_type - list type to show
-//                  one of: good, bad
-//      $language - the list language
-//        $cutoff - words that occur less than $cutoff percent are not shown
-//    $lang_match - how to match the language
-//                  one of: exact, primary, any
-// return codes:
-//   TRUE - request was handled (don't display default list)
-//   FALSE - request wasn't handled (display list)
+/**
+ * Handle an actionable page request
+ *
+ * Returns:
+ * - TRUE - request was handled (don't display default list)
+ * - FALSE - request wasn't handled (display list)
+ *
+ * @param string $action
+ *   Action to take one of: show, list
+ * @param string $list_type
+ *   List type to show one of: good, bad
+ * @param string $language
+ *   The list language
+ * @param integer $cutoff
+ *   Words that occur less than $cutoff percent are not shown
+ * @param string $lang_match
+ *   How to match the language one of: exact, primary, any
+ *
+ * @return boolean
+ */
 function _handle_action($action, $list_type, $language, $cutoff, $lang_match)
 {
     $display_list = false;

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -222,10 +222,10 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/**
+ * Show a form to edit a news item
+ */
 function show_item_editor($news_page_id, $action, $item_id)
-// Show a form:
-// -- to edit the text of an existing item (if requested), or
-// -- to compose a new item (otherwise).
 {
     global $locale_options;
     global $status_options;

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -285,8 +285,11 @@ if (!isset($action)) {
     }
 }
 
-// return filename or false if there is no file
-// if an exception is thrown any file will have been deleted.
+/**
+ * Return filename or false if there is no file
+ *
+ * If an exception is thrown any file will have been deleted.
+ */
 function process_file($project, $indicator, $stage, $returning_to_pool)
 {
     $temporary_path = "";
@@ -362,7 +365,10 @@ function process_file($project, $indicator, $stage, $returning_to_pool)
 }
 
 //----------------------------------------------------------------------------
-// Rename with the next available serial number
+
+/**
+ * Rename file with the next available serial number
+ */
 function make_backup_file($file_name, $ext)
 {
     for ($serial = 1; ; $serial += 1) {

--- a/userprefs.php
+++ b/userprefs.php
@@ -820,8 +820,8 @@ function _show_credits_wanted_adhoc()
 
 // ---------------------------------------------------------
 
-function _show_credit_name_adhoc()
 // Handles 'credit_name' and 'credit_other'.
+function _show_credit_name_adhoc()
 {
     global $userSettings;
 


### PR DESCRIPTION
This (huge) PR updates existing function comment blocks to DocBlock format. You can see the documentation it produces at https://www.pgdp.org/~cpeel/c/build/docs/

My goal was to take the comments that existed and morph them into DocBlock format. In most cases I didn't add `@param` or `@return` entries for functions that didn't already talk about them (see `misc.inc` for a notable exception). I've slogged through the diff twice to confirm it really only does touch the comments with the exceptions of:
* `pinc/RoundDescriptor.inc`
* `pinc/Pool.inc`

For these two files, the first two constructor parameters were renamed to match the parent class. This enables phpDocumentor to pull the documentation from the parent class automatically.

Given the size of this PR, my suggestion for reviewing would be to give a close eye on the two files mentioned above, a look at `misc.inc` and perhaps 5 other random files.

For thoroughness I've created a [update-all-func-comments](https://www.pgdp.org/~cpeel/c.branch/update-all-func-comments) sandbox but aside from the above two files, everything should just be moving comments around.