### PR TITLE
Update odd formatting

### DIFF
--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -155,12 +155,12 @@ class TimeColumn extends Column
             echo _("never");
         } else {
             switch ($this->time_format) {
-            case 'days':
-                echo sprintf("%.1f", (time() - $data) / 86400);
-                break;
-            default: // case 'date':
-                echo "<span class='nowrap'>" . icu_date_template("short", $data) . "</span>";
-                break;
+                case 'days':
+                    echo sprintf("%.1f", (time() - $data) / 86400);
+                    break;
+                default: // case 'date':
+                    echo "<span class='nowrap'>" . icu_date_template("short", $data) . "</span>";
+                    break;
             }
         }
     }

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -7,8 +7,8 @@ include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------
 
-global $n_rounds, $Round_for_round_id_, $Round_for_round_number_,
-    $Round_for_project_state_, $Round_for_page_state_, $PAGE_STATES_IN_ORDER;
+global $n_rounds, $Round_for_round_id_, $Round_for_round_number_;
+global $Round_for_project_state_, $Round_for_page_state_, $PAGE_STATES_IN_ORDER;
 
 $n_rounds = 0;
 $Round_for_round_id_ = [];

--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -108,9 +108,15 @@ function dump_request_info()
 
     foreach (['_GET', '_POST'] as $array_name) {
         switch ($array_name) {
-            case '_GET':  $array = $_GET; break;
-            case '_POST': $array = $_POST; break;
-            default: $array = []; assert(false);
+            case '_GET':
+                $array = $_GET;
+                break;
+            case '_POST':
+                $array = $_POST;
+                break;
+            default:
+                $array = [];
+                assert(false);
         }
         if ($array) {
             echo "$array_name\n";

--- a/pinc/faq.inc
+++ b/pinc/faq.inc
@@ -117,7 +117,7 @@ function make_forum_url($type, $id, $default)
     // If $id is non-zero, return a URL to a local forum/topic/post
     if ($id) {
         switch ($type) {
-           case "f":
+            case "f":
                 return get_url_to_view_forum($id);
             case "t":
                 return get_url_to_view_topic($id);

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -66,43 +66,43 @@ function user_logging_on($past, $preceding)
     $seconds_per_day = 24 * 60 * 60;
 
     switch ($past) {
-      case 'year':
-          $min_timestamp = time() - 366 * $seconds_per_day;
-          $date_format = '%Y-%m-%d';
-          break;
+        case 'year':
+            $min_timestamp = time() - 366 * $seconds_per_day;
+            $date_format = '%Y-%m-%d';
+            break;
 
-      case 'day':
-          $min_timestamp = time() - $seconds_per_day;
-          $date_format = '%H';
-          break;
+        case 'day':
+            $min_timestamp = time() - $seconds_per_day;
+            $date_format = '%H';
+            break;
 
-      default:
-          die("bad value for 'past'");
+        default:
+            die("bad value for 'past'");
     }
 
     switch ($preceding) {
-      case 'hour':
-          $title = _("Number of users newly logged in each hour");
-          $column_name = 'L_hour';
-          break;
+        case 'hour':
+            $title = _("Number of users newly logged in each hour");
+            $column_name = 'L_hour';
+            break;
 
-      case 'day':
-          $title = _('Number of users newly logged in over 24 hours');
-          $column_name = 'L_day';
-          break;
+        case 'day':
+            $title = _('Number of users newly logged in over 24 hours');
+            $column_name = 'L_day';
+            break;
 
-      case 'week':
-          $title = _("Number of users newly logged in over 7 days");
-          $column_name = 'L_week';
-          break;
+        case 'week':
+            $title = _("Number of users newly logged in over 7 days");
+            $column_name = 'L_week';
+            break;
 
-      case 'fourweek':
-          $title = _("Number of users newly logged in over 28 days");
-          $column_name = 'L_4wks';
-          break;
+        case 'fourweek':
+            $title = _("Number of users newly logged in over 28 days");
+            $column_name = 'L_4wks';
+            break;
 
-      default:
-          die("bad value for 'preceding'");
+        default:
+            die("bad value for 'preceding'");
     }
 
     ///////////////////////////////////////////////////

--- a/project.php
+++ b/project.php
@@ -356,7 +356,6 @@ function do_blurb_box($blurb)
         return;
     }
 
-//    echo "<br>";
     echo "<table class='blurb-box'>";
     echo "<tr><td class='center-align'>";
     echo $blurb;

--- a/quiz/generic/data/qd_formatting1.inc
+++ b/quiz/generic/data/qd_formatting1.inc
@@ -2,7 +2,7 @@
 
 
 $browser_title = _("Formatting Quiz");
-$intro_title = sprintf(_("Formatting Quiz, page %d"), 1); ;
+$intro_title = sprintf(_("Formatting Quiz, page %d"), 1);
 $initial_instructions = $initial_instructions__F;
 // Note that we don't translate the page text since it, obviously,
 // needs to match the image which is in English.

--- a/quiz/generic/data/qd_formatting2.inc
+++ b/quiz/generic/data/qd_formatting2.inc
@@ -2,7 +2,7 @@
 
 
 $browser_title = _("Formatting Quiz");
-$intro_title = sprintf(_("Formatting Quiz, page %d"), 2); ;
+$intro_title = sprintf(_("Formatting Quiz, page %d"), 2);
 $initial_instructions = $initial_instructions__F;
 // Note that we don't translate the page text since it, obviously,
 // needs to match the image which is in English.

--- a/quiz/generic/data/qd_formatting3.inc
+++ b/quiz/generic/data/qd_formatting3.inc
@@ -2,7 +2,7 @@
 
 
 $browser_title = _("Formatting Quiz");
-$intro_title = sprintf(_("Formatting Quiz, page %d"), 3); ;
+$intro_title = sprintf(_("Formatting Quiz, page %d"), 3);
 $initial_instructions = $initial_instructions__F;
 // Note that we don't translate the page text since it, obviously,
 // needs to match the image which is in English.

--- a/quiz/generic/data/qd_formatting4.inc
+++ b/quiz/generic/data/qd_formatting4.inc
@@ -2,7 +2,7 @@
 
 
 $browser_title = _("Formatting Quiz");
-$intro_title = sprintf(_("Formatting Quiz, page %d"), 4); ;
+$intro_title = sprintf(_("Formatting Quiz, page %d"), 4);
 $initial_instructions = $initial_instructions__F;
 // Note that we don't translate the page text since it, obviously,
 // needs to match the image which is in English.

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -167,8 +167,6 @@ function qp_text_contains_anticipated_error($text, $test)
             }
             break;
 
-        // -----------------------------------------------------------
-
         case "markupmissing":
             // It's an error if the text does not contain both $opentext and $closetext.
             // (A correct text will contain $opentext or $closetext [or both, really].)
@@ -209,8 +207,6 @@ function qp_text_contains_anticipated_error($text, $test)
                 return $test["error"];
             }
             break;
-
-        // -----------------------------------------------------------
 
         case "expectedlinebreaks":
             // It's an error if the portion of the text between $starttext and $stoptext
@@ -344,10 +340,9 @@ function qp_echo_error_html($message_id)
     // Challenge the quiz-taker to fix the error.
     echo "<p>";
     if (isset($message["challengetext"])) {
+        // XXX: Currently unused. Might be discontinued.
         echo $message["challengetext"];
-    }
-    // XXX: Currently unused. Might be discontinued.
-    else {
+    } else {
         echo $default_challenge;
     }
     echo "</p>\n";

--- a/tasks.php
+++ b/tasks.php
@@ -1670,25 +1670,42 @@ function RelatedPostings($tid)
 function property_get_label($property_id, $for_list_of_tasks)
 {
     switch ($property_id) {
-        case 'date_edited': return _('Date Edited');
-        case 'task_assignee': return _('Assigned To');
-        case 'task_browser': return _('Browser');
-        case 'task_category': return _('Category');
-        case 'task_id': return _('ID');
-        case 'task_os': return _('Operating System');
-        case 'task_priority': return _('Priority');
-        case 'task_severity': return _('Severity');
-        case 'task_status': return _('Status');
-        case 'task_summary': return _('Summary');
-        case 'task_type': return _('Task Type');
-        case 'votes': return _('Votes');
-        case 'additional_os': return '';
-        case 'additional_browser': return '';
-        case 'opened_composite': return _("Opened");
-        case 'edited_composite': return _("Last Edited");
-        case 'closed_composite': return _("Closed By");
-        case 'closed_reason': return _("Closed Reason");
-
+        case 'date_edited':
+            return _('Date Edited');
+        case 'task_assignee':
+            return _('Assigned To');
+        case 'task_browser':
+            return _('Browser');
+        case 'task_category':
+            return _('Category');
+        case 'task_id':
+            return _('ID');
+        case 'task_os':
+            return _('Operating System');
+        case 'task_priority':
+            return _('Priority');
+        case 'task_severity':
+            return _('Severity');
+        case 'task_status':
+            return _('Status');
+        case 'task_summary':
+            return _('Summary');
+        case 'task_type':
+            return _('Task Type');
+        case 'votes':
+            return _('Votes');
+        case 'additional_os':
+            return '';
+        case 'additional_browser':
+            return '';
+        case 'opened_composite':
+            return _("Opened");
+        case 'edited_composite':
+            return _("Last Edited");
+        case 'closed_composite':
+            return _("Closed By");
+        case 'closed_reason':
+            return _("Closed Reason");
         case 'percent_complete':
             return ($for_list_of_tasks ? _("Progress") : _("Percent Complete"));
     }
@@ -1709,22 +1726,35 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
     $raw_value = array_get($task_a, $property_id, null);
     switch ($property_id) {
         // The raw value is used directly:
-        case 'task_id': $fv = $raw_value; break; // maybe wrap in <a>
+        case 'task_id':
+            $fv = $raw_value;
+            break;
 
         // The raw value is an index into an array.
-        case 'closed_reason': return array_get($tasks_close_array, $raw_value, "");
-        case 'task_browser': return $browser_array[$raw_value];
-        case 'task_category': return $categories_array[$raw_value];
-        case 'task_os': return $os_array[$raw_value];
-        case 'task_priority': return $priority_array[$raw_value];
-        case 'task_severity': return $severity_array[$raw_value];
-        case 'task_status': return $tasks_status_array[$raw_value];
-        case 'task_type': return $tasks_array[$raw_value];
+        case 'closed_reason':
+            return array_get($tasks_close_array, $raw_value, "");
+        case 'task_browser':
+            return $browser_array[$raw_value];
+        case 'task_category':
+            return $categories_array[$raw_value];
+        case 'task_os':
+            return $os_array[$raw_value];
+        case 'task_priority':
+            return $priority_array[$raw_value];
+        case 'task_severity':
+            return $severity_array[$raw_value];
+        case 'task_status':
+            return $tasks_status_array[$raw_value];
+        case 'task_type':
+            return $tasks_array[$raw_value];
 
         // The raw value is an integer denoting seconds-since-epoch.
-        case 'date_edited': return date("d-M-Y", $raw_value);
-        case 'date_opened': return date("d-M-Y", $raw_value);
-        case 'date_closed': return $raw_value ? date("d-M-Y", $raw_value) : "";
+        case 'date_edited':
+            return date("d-M-Y", $raw_value);
+        case 'date_opened':
+            return date("d-M-Y", $raw_value);
+        case 'date_closed':
+            return $raw_value ? date("d-M-Y", $raw_value) : "";
 
         // Synthetic fields
         case 'opened_composite':
@@ -1748,9 +1778,12 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
                     );
 
         // The raw value is a user's u_id:
-        case 'opened_by': return $raw_value ? private_message_link_for_uid($raw_value) : "";
-        case 'edited_by': return $raw_value ? private_message_link_for_uid($raw_value) : "";
-        case 'closed_by': return $raw_value ? get_username_for_uid($raw_value) : "";
+        case 'opened_by':
+            return $raw_value ? private_message_link_for_uid($raw_value) : "";
+        case 'edited_by':
+            return $raw_value ? private_message_link_for_uid($raw_value) : "";
+        case 'closed_by':
+            return $raw_value ? get_username_for_uid($raw_value) : "";
         case 'task_assignee':
             return (
                 empty($raw_value)
@@ -1760,7 +1793,8 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
 
         // The raw value is some text typed in by a user:
         case 'task_summary':
-            $fv = html_safe($raw_value); break; // maybe wrap in <a>
+            $fv = html_safe($raw_value);
+            break;
 
         case 'task_details':
             $Parsedown = new Parsedown();

--- a/tools/change_sr_commitment.php
+++ b/tools/change_sr_commitment.php
@@ -28,19 +28,19 @@ $action = get_enumerated_param($_POST, 'action', null, ['commit', 'withdraw']);
 $refresh_url = @$_POST['next_url'];
 
 switch ($action) {
-case "commit":
-    sr_commit($projectid, $pguser);
-    $title = _("Volunteer to SR");
-    $body = sprintf(_("%1\$s, you have volunteered to smoothread project %2\$s."),
-        $pguser, $projectid);
-    break;
+    case "commit":
+        sr_commit($projectid, $pguser);
+        $title = _("Volunteer to SR");
+        $body = sprintf(_("%1\$s, you have volunteered to smoothread project %2\$s."),
+            $pguser, $projectid);
+        break;
 
-case "withdraw":
-    sr_withdraw_commitment($projectid, $pguser);
-    $title = _("Withdraw from SR");
-    $body = sprintf(_("%1\$s, you have withdrawn from Smooth Reading project %2\$s."),
-        $pguser, $projectid);
-    break;
+    case "withdraw":
+        sr_withdraw_commitment($projectid, $pguser);
+        $title = _("Withdraw from SR");
+        $body = sprintf(_("%1\$s, you have withdrawn from Smooth Reading project %2\$s."),
+            $pguser, $projectid);
+        break;
 }
 
 

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -246,13 +246,13 @@ class ImageSource
         echo "<input type='submit' name='edit' value='".attr_safe(_('Edit'))."'> ";
         echo "<br>\n";
         switch ($this->is_active) {
-            case('-1'):
+            case '-1':
                 echo "<input type='submit' name='approve' value='".attr_safe(_('Approve'))."'> ";
                 break;
-            case('0'):
+            case '0':
                 echo "<input type='submit' name='enable' value='".attr_safe(_('Enable'))."'> ";
                 break;
-            case('1'):
+            case '1':
                 echo "<input type='submit' name='disable' value='".attr_safe(_('Disable'))."'> ";
                 break;
         }
@@ -493,18 +493,18 @@ class ImageSource
     public function _get_status_cell($status, $class = '')
     {
         switch ($status) {
-          case(1):
-              $middle = _('Enabled');
-              $open = "<td class='enabled{$class}'>";
-              break;
-          case(0):
-              $middle = _('Disabled');
-              $open = "<td class='disabled{$class}'>";
-              break;
-          case(-1):
-              $middle = _('Pending Approval');
-              $open = "<td class='pending{$class}'>";
-              break;
+            case 1:
+                $middle = _('Enabled');
+                $open = "<td class='enabled{$class}'>";
+                break;
+            case 0:
+                $middle = _('Disabled');
+                $open = "<td class='disabled{$class}'>";
+                break;
+            case -1:
+                $middle = _('Pending Approval');
+                $open = "<td class='pending{$class}'>";
+                break;
         }
 
         return $open . $middle . '</td>';
@@ -523,13 +523,17 @@ class ImageSource
     {
         global $site_abbreviation;
         switch ($show_to) {
-            case '0': $to_whom = _("Image Managers Only");
+            case '0':
+                $to_whom = _("Image Managers Only");
                 break;
-            case '1':  $to_whom = _("Project Managers");
+            case '1':
+                $to_whom = _("Project Managers");
                 break;
-            case '2':  $to_whom = sprintf(_("Any %s User"), $site_abbreviation);
+            case '2':
+                $to_whom = sprintf(_("Any %s User"), $site_abbreviation);
                 break;
-            case '3':  $to_whom = _("All Users and Visitors");
+            case '3':
+                $to_whom = _("All Users and Visitors");
                 break;
         }
         return $to_whom;

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -164,21 +164,44 @@ if (is_null($action)) {
 $action_message = "";
 switch ($action) {
     // We always do showdir after the switch statement
-    case 'showdir':    break;
+    case 'showdir':
+        break;
     // Actions that prompt for additional information and we shouldn't showdir
-    case 'showupload': do_showupload(); exit;
-    case 'showmkdir':  do_showmkdir(); exit;
-    case 'showrename': do_showrename(); exit;
-    case 'showmove':   do_showmove(); exit;
-    case 'showdelete': do_showdelete(); exit;
+    case 'showupload':
+        do_showupload();
+        exit;
+    case 'showmkdir':
+        do_showmkdir();
+        exit;
+    case 'showrename':
+        do_showrename();
+        exit;
+    case 'showmove':
+        do_showmove();
+        exit;
+    case 'showdelete':
+        do_showdelete();
+        exit;
     // Actions that do an action and do not return an info message
-    case 'download':   do_download(); exit;
-    case 'upload':     do_upload(); exit;
+    case 'download':
+        do_download();
+        exit;
+    case 'upload':
+        do_upload();
+        exit;
     // Actions that do an action and upon success return an info message
-    case 'mkdir':      $action_message = do_mkdir(); break;
-    case 'rename':     $action_message = do_rename(); break;
-    case 'move':       $action_message = do_move(); break;
-    case 'delete':     $action_message = do_delete(); break;
+    case 'mkdir':
+        $action_message = do_mkdir();
+        break;
+    case 'rename':
+        $action_message = do_rename();
+        break;
+    case 'move':
+        $action_message = do_move();
+        break;
+    case 'delete':
+        $action_message = do_delete();
+        break;
     default:
         // no matching $action in input
         fatal_error(sprintf(_("Invalid action: '%s'"), html_safe($action)));

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -115,40 +115,28 @@ if (!$imso_code) {
         echo "<td>";
         switch ($row['ok_show_images']) {
             case 1:
-            {
                 echo _("Images can be published.");
                 break;
-            }
             case 0:
-            {
                 echo _("Images cannot be published.");
                 break;
-            }
             case -1:
             default:
-            {
                 echo _("Image publishing policy is unknown.");
                 break;
-            }
         }
         echo " "; // Space between policy statements
         switch ($row['ok_keep_images']) {
             case 1:
-            {
                 echo _("Images can be stored.");
                 break;
-            }
             case 0:
-            {
                 echo _("Images cannot be stored.");
                 break;
-            }
             case -1:
             default:
-            {
                 echo _("Image storage policy is unknown.");
                 break;
-            }
         }
         echo "</td>";
         echo "</tr>\n";

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -286,11 +286,15 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
         // as indicating a range.
         echo "<h3>";
         switch ($which) {
-            case 'from': echo _("Source Project:"); break;
-            case 'to':   echo _("Destination Project:"); break;
+            case 'from':
+                echo _("Source Project:");
+                break;
+            case 'to':
+                echo _("Destination Project:");
+                break;
             default:
-            // Shouldn't happen
-            break;
+                // Shouldn't happen
+                break;
         }
         echo "</h3>";
 

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -169,8 +169,7 @@ function show_toggles_form($username, $user_settings)
 
 function update_settings($user, $user_settings)
 {
-    global $boolean_user_settings, $value_user_settings,
-           $freeform_user_settings, $pguser;
+    global $boolean_user_settings, $value_user_settings, $freeform_user_settings, $pguser;
 
     $username = $user->username;
 

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -300,18 +300,14 @@ class SpecialDay
         foreach ($std_fields as $field) {
             switch ($field) {
                 case 'enable':
-                {
                     if (!isset($_POST[$field])) {
                         $this->$field = 0;
                     } else {
                         $this->$field = 1;
                     }
                     break;
-                }
                 default:
-                {
                     $this->$field = $_POST[$field];
-                }
             }
             $std_fields_sql[] = set_col_str($field, $this->$field);
         }
@@ -377,18 +373,18 @@ class SpecialDay
     public function _get_status_cell($status, $class = '')
     {
         switch ($status) {
-          case(1):
-              $middle = _('Enabled');
-              $open = "<td class='enabled{$class}'>";
-              break;
-          case(0):
-              $middle = _('Disabled');
-              $open = "<td class='disabled{$class}'>";
-              break;
-          default:
-              $middle = _('Invalid');
-              $open = "<td class='disabled{$class}'>";
-              break;
+            case 1:
+                $middle = _('Enabled');
+                $open = "<td class='enabled{$class}'>";
+                break;
+            case 0:
+                $middle = _('Disabled');
+                $open = "<td class='disabled{$class}'>";
+                break;
+            default:
+                $middle = _('Invalid');
+                $open = "<td class='disabled{$class}'>";
+                break;
         }
         return $open . $middle . '</td>';
     }


### PR DESCRIPTION
This is another prep PR for the upcoming php-cs-fixer v3 update. The new version Has Opinions about switch statements and a few other things that I thought would be easier to handle in a separate PR.

This has 4 commits which touch different things:
* Standardizes switch statements across the codebase
* Remove errant `;`s
* Massage multiline `global` statements (v3 wants to format these oddly)
* Tweak comments (v3 wants to place these in interesting places)

The PR is best viewed with the "ignore whitespace" option.

I think a code review should be sufficient for this PR, but because it's easy to do, here's a sandbox: [update-odd-formatting](https://www.pgdp.org/~cpeel/c.branch/update-odd-formatting/)