### PR TITLE
Update php-cs-fixer to v3

### DIFF
--- a/SETUP/import_old_configuration.php
+++ b/SETUP/import_old_configuration.php
@@ -30,8 +30,11 @@ function merge_configuration_files($old_filename, $new_filename)
             output_config_file_with_new_values($new_filename, $config_values);
 
     if (count($new_config_parameters)) {
-        fwrite($STDERR, sprintf("The following variables are in %s but not in %s, you may want confirm they are set to the values you want:\n",
-                $new_filename, $old_filename));
+        fwrite($STDERR, sprintf(
+            "The following variables are in %s but not in %s, you may want confirm they are set to the values you want:\n",
+            $new_filename,
+            $old_filename
+        ));
         ksort($new_config_parameters);
         foreach ($new_config_parameters as $parameter => $value) {
             fwrite($STDERR, "    $parameter=$value\n");
@@ -40,8 +43,11 @@ function merge_configuration_files($old_filename, $new_filename)
     }
 
     if (count($unused_config_parameters)) {
-        fwrite($STDERR, sprintf("These values are set in %s, but were not found in %s.\n",
-                $old_filename, $new_filename));
+        fwrite($STDERR, sprintf(
+            "These values are set in %s, but were not found in %s.\n",
+            $old_filename,
+            $new_filename
+        ));
         foreach ($unused_config_parameters as $parameter => $value) {
             fwrite($STDERR, "    $parameter=$value\n");
         }

--- a/SETUP/tests/MARCRecordTest.php
+++ b/SETUP/tests/MARCRecordTest.php
@@ -14,7 +14,8 @@ class MARCRecordTest extends PHPUnit\Framework\TestCase
         $yaz_array_b64 = file_get_contents("./data/yaz_array.b64");
         $this->YAZ_ARRAY = unserialize(base64_decode($yaz_array_b64));
         $this->YAZ_ARRAY_STR = base64_decode(
-            file_get_contents("./data/yaz_array_str.b64"));
+            file_get_contents("./data/yaz_array_str.b64")
+        );
     }
 
     private function _load_record()

--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -53,7 +53,8 @@ class SettingsTest extends PHPUnit\Framework\TestCase
 
         $settings = new Settings($this->TEST_USERNAME);
         $this->assertTrue(
-            $settings->get_boolean($this->PREFIX . "boolean_true"));
+            $settings->get_boolean($this->PREFIX . "boolean_true")
+        );
     }
 
     public function testSetFalse()
@@ -63,7 +64,8 @@ class SettingsTest extends PHPUnit\Framework\TestCase
 
         $settings = new Settings($this->TEST_USERNAME);
         $this->assertFalse(
-            $settings->get_boolean($this->PREFIX . "boolean_false"));
+            $settings->get_boolean($this->PREFIX . "boolean_false")
+        );
     }
 
     public function testSetSingleValue()
@@ -73,14 +75,18 @@ class SettingsTest extends PHPUnit\Framework\TestCase
 
         $settings = new Settings($this->TEST_USERNAME);
         $this->assertEquals(
-            $settings->get_value($this->PREFIX . "single_value"), "single");
+            $settings->get_value($this->PREFIX . "single_value"),
+            "single"
+        );
     }
 
     public function testSetSingleValueDefault()
     {
         $settings = new Settings($this->TEST_USERNAME);
         $this->assertEquals(
-            $settings->get_value($this->PREFIX . "nonexistent_value", "default"), "default");
+            $settings->get_value($this->PREFIX . "nonexistent_value", "default"),
+            "default"
+        );
     }
 
     public function testSetSingleValueAgain()
@@ -91,7 +97,9 @@ class SettingsTest extends PHPUnit\Framework\TestCase
 
         $settings = new Settings($this->TEST_USERNAME);
         $this->assertEquals(
-            $settings->get_value($this->PREFIX . "single_value"), "single2");
+            $settings->get_value($this->PREFIX . "single_value"),
+            "single2"
+        );
     }
 
     public function testAddMultivaluedSetting()
@@ -140,14 +148,17 @@ class SettingsTest extends PHPUnit\Framework\TestCase
 
         $settings->set_value($this->PREFIX . "multi_value", "value3");
         $this->assertEquals(
-            $settings->get_value($this->PREFIX . "multi_value"), "value3");
+            $settings->get_value($this->PREFIX . "multi_value"),
+            "value3"
+        );
     }
 
     public function testGetUsernamesWithSetting()
     {
         // Ensure no one has this setting already
         $usernames = Settings::get_users_with_setting(
-            $this->PREFIX . "specific_setting");
+            $this->PREFIX . "specific_setting"
+        );
         $this->assertEquals(0, count($usernames));
 
         // Add a user with this setting and confirm there is only one
@@ -155,7 +166,8 @@ class SettingsTest extends PHPUnit\Framework\TestCase
         $settings->add_value($this->PREFIX . "specific_setting", "value1");
 
         $usernames = Settings::get_users_with_setting(
-            $this->PREFIX . "specific_setting");
+            $this->PREFIX . "specific_setting"
+        );
         $this->assertEquals(1, count($usernames));
 
         // Add a second setting with a different value and confirm there is
@@ -163,12 +175,15 @@ class SettingsTest extends PHPUnit\Framework\TestCase
         // values.
         $settings->add_value($this->PREFIX . "specific_setting", "value2");
         $usernames = Settings::get_users_with_setting(
-            $this->PREFIX . "specific_setting");
+            $this->PREFIX . "specific_setting"
+        );
         $this->assertEquals(1, count($usernames));
 
         // Get a list querying for a specific setting and value
         $usernames = Settings::get_users_with_setting(
-            $this->PREFIX . "specific_setting", "value2");
+            $this->PREFIX . "specific_setting",
+            "value2"
+        );
         $this->assertEquals(1, count($usernames));
     }
 }

--- a/SETUP/tests/misc_ZipMethodsTest.php
+++ b/SETUP/tests/misc_ZipMethodsTest.php
@@ -156,16 +156,20 @@ class ZipMethodsTest extends PHPUnit\Framework\TestCase
 
     public function testCreatingZipFileFromDirectory()
     {
-        $this->assertTrue(create_zip_from(['manual_web/page_compare'],
-            self::TEMPORARY_EXTRACTION_DIRECTORY . '/manual_web.zip'));
+        $this->assertTrue(create_zip_from(
+            ['manual_web/page_compare'],
+            self::TEMPORARY_EXTRACTION_DIRECTORY . '/manual_web.zip'
+        ));
 
         $this->assertTrue(is_valid_zip_file(self::TEMPORARY_EXTRACTION_DIRECTORY . '/manual_web.zip'));
     }
 
     public function testCreatingZipFile()
     {
-        $this->assertTrue(create_zip_from(['./*.php'],
-            self::TEMPORARY_EXTRACTION_DIRECTORY . '/php_files.zip'));
+        $this->assertTrue(create_zip_from(
+            ['./*.php'],
+            self::TEMPORARY_EXTRACTION_DIRECTORY . '/php_files.zip'
+        ));
 
         $this->assertTrue(is_valid_zip_file(self::TEMPORARY_EXTRACTION_DIRECTORY . '/php_files.zip'));
     }
@@ -179,7 +183,9 @@ class ZipMethodsTest extends PHPUnit\Framework\TestCase
     public function testCreatingZipFileContainingNonExistingFiles()
     {
         $this->expectException(InvalidArgumentException::class);
-        create_zip_from(['this_does_not_exist'],
-            self::TEMPORARY_EXTRACTION_DIRECTORY . '/php_files.zip');
+        create_zip_from(
+            ['this_does_not_exist'],
+            self::TEMPORARY_EXTRACTION_DIRECTORY . '/php_files.zip'
+        );
     }
 }

--- a/SETUP/upgrade/19/20230601_prune_user_project_info.php
+++ b/SETUP/upgrade/19/20230601_prune_user_project_info.php
@@ -62,12 +62,15 @@ while ([$projectid] = mysqli_fetch_row($result)) {
 
     // delete the row -- because ($projectid, $username) is the primary key
     // we can delete it just based on those two fields alone
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         DELETE FROM user_project_info
         WHERE projectid = '%s'
             AND username in (%s)
-    ", DPDatabase::escape($projectid),
-    surround_and_join(array_map("DPDatabase::escape", $upi_users_to_delete), "'", "'", ","));
+    ",
+        DPDatabase::escape($projectid),
+        surround_and_join(array_map("DPDatabase::escape", $upi_users_to_delete), "'", "'", ",")
+    );
 
     mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
 

--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -53,7 +53,8 @@ if (!isset($user->id)) {
     } else {
         echo "<p>";
         echo sprintf(
-            _("There is no account with activation code '%s' waiting to be activated."), html_safe($reg_token)
+            _("There is no account with activation code '%s' waiting to be activated."),
+            html_safe($reg_token)
         );
         echo "</p>";
 
@@ -61,7 +62,9 @@ if (!isset($user->id)) {
         $mailto_url = "mailto:$general_help_email_addr";
         echo sprintf(
             _('For assistance, please contact <a href="%1$s">%2$s</a>.'),
-            $mailto_url, $general_help_email_addr);
+            $mailto_url,
+            $general_help_email_addr
+        );
         echo "</p>";
     }
 
@@ -85,29 +88,34 @@ if ($create_user_status !== true) {
     $mailto_url = "mailto:$general_help_email_addr";
     echo sprintf(
         _('For assistance, please contact <a href="%1$s">%2$s</a>.'),
-        $mailto_url, $general_help_email_addr);
+        $mailto_url,
+        $general_help_email_addr
+    );
     echo "\n";
     echo sprintf(
         _("Please include the account activation code %s in your email for assistance."),
-        $reg_token);
+        $reg_token
+    );
     echo "</p>\n";
     exit;
 }
 
 // Insert into 'real' table -- users
-$query = sprintf("
+$query = sprintf(
+    "
     INSERT INTO users (reg_token, real_name, username, email, date_created,
                        email_updates, referrer, referrer_details, http_referrer, u_neigh, u_intlang)
     VALUES ('%s', '%s', '%s', '%s', $user->date_created,
             $user->email_updates, '%s', '%s', '%s', 10, '%s')
-    ", DPDatabase::escape($reg_token),
-        DPDatabase::escape($user->real_name),
-        DPDatabase::escape($user->username),
-        DPDatabase::escape($user->email),
-        DPDatabase::escape($user->referrer),
-        DPDatabase::escape($user->referrer_details),
-        DPDatabase::escape($user->http_referrer),
-        DPDatabase::escape($user->u_intlang)
+    ",
+    DPDatabase::escape($reg_token),
+    DPDatabase::escape($user->real_name),
+    DPDatabase::escape($user->username),
+    DPDatabase::escape($user->email),
+    DPDatabase::escape($user->referrer),
+    DPDatabase::escape($user->referrer_details),
+    DPDatabase::escape($user->http_referrer),
+    DPDatabase::escape($user->u_intlang)
 );
 
 $result = DPDatabase::query($query);
@@ -122,9 +130,12 @@ $profile->u_ref = $u_id;
 $profile->save();
 
 // add ref to profile
-$refString = sprintf("
+$refString = sprintf(
+    "
     UPDATE users SET u_profile=%d WHERE u_id=%d
-    ", DPDatabase::escape($profile->id), $u_id
+    ",
+    DPDatabase::escape($profile->id),
+    $u_id
 );
 DPDatabase::query($refString);
 
@@ -136,8 +147,10 @@ printf(_("User %s activated successfully."), $user->username);
 echo " ";
 
 // TRANSLATORS: %s is the site name
-printf(_("Please check the e-mail being sent to you for further information about %s."),
-        $site_name);
+printf(
+    _("Please check the e-mail being sent to you for further information about %s."),
+    $site_name
+);
 echo "</p>";
 
 echo "<p>"._("Enter your password below to sign in and start proofreading!!") . "</p>";

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -85,8 +85,9 @@ if (count($_POST)) {
 
             echo "<p>";
             echo sprintf(
-               _("User %s registered successfully. Please check the e-mail being sent to you for further information about activating your account. This extra step is taken so that no-one can register you to the site without your knowledge."),
-               html_safe($username));
+                _("User %s registered successfully. Please check the e-mail being sent to you for further information about activating your account. This extra step is taken so that no-one can register you to the site without your knowledge."),
+                html_safe($username)
+            );
             echo "</p>";
             exit();
         } catch (Exception $exception) {

--- a/accounts/login.php
+++ b/accounts/login.php
@@ -57,9 +57,11 @@ if (!$success) {
 }
 
 // Look for user in 'users' table.
-$q = sprintf("
+$q = sprintf(
+    "
     SELECT * FROM users WHERE username='%s'
-    ", DPDatabase::escape($userNM)
+    ",
+    DPDatabase::escape($userNM)
 );
 $u_res = DPDatabase::query($q);
 $u_row = mysqli_fetch_assoc($u_res);

--- a/accounts/logout.php
+++ b/accounts/logout.php
@@ -14,5 +14,9 @@ if ($user_is_logged_in) {
     destroy_csrf_token();
 }
 
-metarefresh(0, "../default.php", _("Logout Complete"),
-     "<a href=\"../default.php\">"._("Return to DP Home Page.")."</a>");
+metarefresh(
+    0,
+    "../default.php",
+    _("Logout Complete"),
+    "<a href=\"../default.php\">"._("Return to DP Home Page.")."</a>"
+);

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -200,8 +200,10 @@ function create_or_update_project($project)
             throw new InvalidValue("At least one Character Suite is required.");
         }
 
-        $invalid_charsuites = array_diff($updates["character_suites"],
-            array_extract_field(CharSuites::get_all(), "name"));
+        $invalid_charsuites = array_diff(
+            $updates["character_suites"],
+            array_extract_field(CharSuites::get_all(), "name")
+        );
         if ($invalid_charsuites) {
             throw new InvalidValue(sprintf("%s is/are not valid Character Suites.", join(", ", $invalid_charsuites)));
         }
@@ -434,7 +436,8 @@ function api_v1_project_page_round($method, $data, $query_params)
         $user_column = $round->user_column_name;
     }
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT
             image,
             %s AS text,
@@ -442,7 +445,10 @@ function api_v1_project_page_round($method, $data, $query_params)
             state
         FROM %s
         WHERE image = '%s'
-    ", $text_column, $user_column, $data[":projectid"]->projectid,
+    ",
+        $text_column,
+        $user_column,
+        $data[":projectid"]->projectid,
         DPDatabase::escape($data[":pagename"])
     );
     $result = DPDatabase::query($sql);

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "phpmailer/phpmailer": "^6.8"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.18",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "^9.5.0"
     },
     "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1ce5a48de5eeabeede9f0a70e937408",
+    "content-hash": "0e12eb9c877e3288ee12acd5b6f60f70",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -112,20 +112,30 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.14.0",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "12ab42bd6e742c70c0a52f7b82477fcd44e64b75"
+                "reference": "523407fb06eb9e5f3d59889b3978d5bfe94299c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/12ab42bd6e742c70c0a52f7b82477fcd44e64b75",
-                "reference": "12ab42bd6e742c70c0a52f7b82477fcd44e64b75",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/523407fb06eb9e5f3d59889b3978d5bfe94299c8",
+                "reference": "523407fb06eb9e5f3d59889b3978d5bfe94299c8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2"
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
+            },
+            "suggest": {
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
             },
             "type": "library",
             "autoload": {
@@ -157,22 +167,22 @@
             ],
             "support": {
                 "issues": "https://github.com/ezyang/htmlpurifier/issues",
-                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.14.0"
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.16.0"
             },
-            "time": "2021-12-25T01:21:49+00:00"
+            "time": "2022-09-18T07:06:19+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.8.0",
+            "version": "v6.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "df16b615e371d81fb79e506277faea67a1be18f1"
+                "reference": "e88da8d679acc3824ff231fdc553565b802ac016"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/df16b615e371d81fb79e506277faea67a1be18f1",
-                "reference": "df16b615e371d81fb79e506277faea67a1be18f1",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/e88da8d679acc3824ff231fdc553565b802ac016",
+                "reference": "e88da8d679acc3824ff231fdc553565b802ac016",
                 "shasum": ""
             },
             "require": {
@@ -182,13 +192,13 @@
                 "php": ">=5.5.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "doctrine/annotations": "^1.2.6 || ^1.13.3",
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.3.5",
                 "roave/security-advisories": "dev-latest",
-                "squizlabs/php_codesniffer": "^3.7.1",
+                "squizlabs/php_codesniffer": "^3.7.2",
                 "yoast/phpunit-polyfills": "^1.0.4"
             },
             "suggest": {
@@ -231,7 +241,7 @@
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
             "support": {
                 "issues": "https://github.com/PHPMailer/PHPMailer/issues",
-                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.8.0"
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.8.1"
             },
             "funding": [
                 {
@@ -239,20 +249,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T14:43:22+00:00"
+            "time": "2023-08-29T08:26:30+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.26.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "143f1881e655bebca1312722af8068de235ae5dc"
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/143f1881e655bebca1312722af8068de235ae5dc",
-                "reference": "143f1881e655bebca1312722af8068de235ae5dc",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6de50471469b8c9afc38164452ab2b6170ee71c1",
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1",
                 "shasum": ""
             },
             "require": {
@@ -267,7 +277,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -306,7 +316,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -322,7 +332,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -400,16 +410,16 @@
         },
         {
             "name": "voku/portable-utf8",
-            "version": "6.0.5",
+            "version": "6.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-utf8.git",
-                "reference": "6c764c2c4fcad451a0f6622260a4934cfea08aa4"
+                "reference": "b8ce36bf26593e5c2e81b1850ef0ffb299d2043f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/6c764c2c4fcad451a0f6622260a4934cfea08aa4",
-                "reference": "6c764c2c4fcad451a0f6622260a4934cfea08aa4",
+                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/b8ce36bf26593e5c2e81b1850ef0ffb299d2043f",
+                "reference": "b8ce36bf26593e5c2e81b1850ef0ffb299d2043f",
                 "shasum": ""
             },
             "require": {
@@ -422,7 +432,11 @@
                 "voku/portable-ascii": "~2.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpstan/phpstan": "1.9.*@dev",
+                "phpstan/phpstan-strict-rules": "1.4.*@dev",
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0",
+                "thecodingmachine/phpstan-strict-rules": "1.0.*@dev",
+                "voku/phpstan-rules": "3.1.*@dev"
             },
             "suggest": {
                 "ext-ctype": "Use Ctype for e.g. hexadecimal digit detection",
@@ -471,7 +485,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-utf8/issues",
-                "source": "https://github.com/voku/portable-utf8/tree/6.0.5"
+                "source": "https://github.com/voku/portable-utf8/tree/6.0.13"
             },
             "funding": [
                 {
@@ -495,36 +509,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-10T12:32:31+00:00"
+            "time": "2023-03-08T08:35:38+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "composer/pcre",
-            "version": "1.0.1",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
+                "reference": "00104306927c7a0919b4ced2aaa6782c1e61a3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/00104306927c7a0919b4ced2aaa6782c1e61a3c9",
+                "reference": "00104306927c7a0919b4ced2aaa6782c1e61a3c9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "symfony/phpunit-bridge": "^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -552,7 +566,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.1"
+                "source": "https://github.com/composer/pcre/tree/3.1.1"
             },
             "funding": [
                 {
@@ -568,20 +582,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-21T20:24:37+00:00"
+            "time": "2023-10-11T07:11:09+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
                 "shasum": ""
             },
             "require": {
@@ -631,9 +645,9 @@
                 "versioning"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
+                "source": "https://github.com/composer/semver/tree/3.4.0"
             },
             "funding": [
                 {
@@ -649,31 +663,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T19:23:25+00:00"
+            "time": "2023-08-31T09:50:34+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.5",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a"
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/9e36aeed4616366d2b690bdce11f71e9178c579a",
-                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
                 "shasum": ""
             },
             "require": {
-                "composer/pcre": "^1",
-                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
+                "symfony/phpunit-bridge": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -699,7 +713,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
             },
             "funding": [
                 {
@@ -715,107 +729,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-24T20:20:32+00:00"
-        },
-        {
-            "name": "doctrine/annotations",
-            "version": "1.13.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
-                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "1.*",
-                "ext-tokenizer": "*",
-                "php": "^7.1 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^1.11 || ^2.0",
-                "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
-                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2",
-                "vimeo/psalm": "^4.10"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
-            },
-            "time": "2022-07-02T10:48:51+00:00"
+            "time": "2022-02-25T21:32:43+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^0.16 || ^1",
                 "phpstan/phpstan": "^1.4",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -842,7 +783,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -858,165 +799,67 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
-        },
-        {
-            "name": "doctrine/lexer",
-            "version": "1.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/lexer.git",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9.0",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.11"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "lexer",
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-02-28T11:07:21+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.19.3",
+            "version": "v3.35.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8"
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "ec1ccc264994b6764882669973ca435cf05bab08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
-                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/ec1ccc264994b6764882669973ca435cf05bab08",
+                "reference": "ec1ccc264994b6764882669973ca435cf05bab08",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.2 || ^2.0",
-                "doctrine/annotations": "^1.2",
+                "composer/semver": "^3.3",
+                "composer/xdebug-handler": "^3.0.3",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
-                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
-                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
-                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
-                "symfony/polyfill-php70": "^1.0",
-                "symfony/polyfill-php72": "^1.4",
-                "symfony/process": "^3.0 || ^4.0 || ^5.0",
-                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+                "php": "^7.4 || ^8.0",
+                "sebastian/diff": "^4.0 || ^5.0",
+                "symfony/console": "^5.4 || ^6.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0",
+                "symfony/filesystem": "^5.4 || ^6.0",
+                "symfony/finder": "^5.4 || ^6.0",
+                "symfony/options-resolver": "^5.4 || ^6.0",
+                "symfony/polyfill-mbstring": "^1.27",
+                "symfony/polyfill-php80": "^1.27",
+                "symfony/polyfill-php81": "^1.27",
+                "symfony/process": "^5.4 || ^6.0",
+                "symfony/stopwatch": "^5.4 || ^6.0"
             },
             "require-dev": {
-                "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.4",
-                "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.4.2",
-                "php-cs-fixer/accessible-object": "^1.0",
+                "facile-it/paraunit": "^1.3 || ^2.0",
+                "justinrainbow/json-schema": "^5.2",
+                "keradus/cli-executor": "^2.0",
+                "mikey179/vfsstream": "^1.6.11",
+                "php-coveralls/php-coveralls": "^2.5.3",
+                "php-cs-fixer/accessible-object": "^1.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
-                "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.5",
-                "phpunitgoodpractices/polyfill": "^1.5",
-                "phpunitgoodpractices/traits": "^1.9.1",
-                "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
-                "symfony/phpunit-bridge": "^5.2.1",
-                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+                "phpspec/prophecy": "^1.16",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/phpunit-bridge": "^6.2.3",
+                "symfony/yaml": "^5.4 || ^6.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
-                "ext-mbstring": "For handling non-UTF8 characters.",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
-                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+                "ext-mbstring": "For handling non-UTF8 characters."
             },
             "bin": [
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.19-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
-                },
-                "classmap": [
-                    "tests/Test/AbstractFixerTestCase.php",
-                    "tests/Test/AbstractIntegrationCaseFactory.php",
-                    "tests/Test/AbstractIntegrationTestCase.php",
-                    "tests/Test/Assert/AssertTokensTrait.php",
-                    "tests/Test/IntegrationCase.php",
-                    "tests/Test/IntegrationCaseFactory.php",
-                    "tests/Test/IntegrationCaseFactoryInterface.php",
-                    "tests/Test/InternalIntegrationCaseFactory.php",
-                    "tests/Test/IsIdenticalConstraint.php",
-                    "tests/Test/TokensWithObservedTransformers.php",
-                    "tests/TestCase.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1033,9 +876,15 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
             "support": {
-                "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.19.3"
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.35.1"
             },
             "funding": [
                 {
@@ -1043,20 +892,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-15T17:17:55+00:00"
+            "time": "2023-10-12T13:47:26+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1094,7 +943,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1102,20 +951,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.14.0",
+            "version": "v4.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
                 "shasum": ""
             },
             "require": {
@@ -1156,9 +1005,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
             },
-            "time": "2022-05-31T20:59:12+00:00"
+            "time": "2023-08-13T19:53:39+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1272,306 +1121,24 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "php-cs-fixer/diff",
-            "version": "v1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/dbd31aeb251639ac0b9e7e29405c1441907f5759",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
-                "symfony/process": "^3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "SpacePossum"
-                }
-            ],
-            "description": "sebastian/diff v2 backport support for PHP5.6",
-            "homepage": "https://github.com/PHP-CS-Fixer",
-            "keywords": [
-                "diff"
-            ],
-            "support": {
-                "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
-                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
-            },
-            "time": "2020-10-14T08:39:05+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
-                "webmozart/assert": "^1.9.1"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.2",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
-            },
-            "time": "2021-10-19T17:43:47+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
-            },
-            "time": "2022-03-15T21:29:03+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.2",
-                "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^6.0 || ^7.0",
-                "phpunit/phpunit": "^8.0 || ^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
-            },
-            "time": "2021-12-08T12:19:24+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.15",
+            "version": "9.2.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.13.0",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1586,8 +1153,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -1620,7 +1187,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
             },
             "funding": [
                 {
@@ -1628,7 +1196,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-07T09:28:20+00:00"
+            "time": "2023-09-19T04:57:46+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1873,20 +1441,20 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.21",
+            "version": "9.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
-                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1897,30 +1465,26 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-code-coverage": "^9.2.28",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
                 "phpunit/php-timer": "^5.0.2",
                 "sebastian/cli-parser": "^1.0.1",
                 "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
+                "sebastian/comparator": "^4.0.8",
                 "sebastian/diff": "^4.0.3",
                 "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
+                "sebastian/exporter": "^4.0.5",
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.0",
+                "sebastian/type": "^3.2",
                 "sebastian/version": "^3.0.2"
             },
-            "require-dev": {
-                "phpspec/prophecy-phpunit": "^2.0.1"
-            },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1928,7 +1492,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1959,7 +1523,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
             },
             "funding": [
                 {
@@ -1969,58 +1534,13 @@
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2022-06-19T12:14:25+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
-            },
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2023-09-19T05:39:22+00:00"
         },
         {
             "name": "psr/container",
@@ -2339,16 +1859,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
                 "shasum": ""
             },
             "require": {
@@ -2401,7 +1921,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
             },
             "funding": [
                 {
@@ -2409,7 +1929,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:49:45+00:00"
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2470,16 +1990,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -2524,7 +2044,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2532,20 +2052,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -2587,7 +2107,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -2595,20 +2115,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
                 "shasum": ""
             },
             "require": {
@@ -2664,7 +2184,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2672,20 +2192,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T14:18:36+00:00"
+            "time": "2022-09-14T06:03:37+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
                 "shasum": ""
             },
             "require": {
@@ -2728,7 +2248,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
             },
             "funding": [
                 {
@@ -2736,7 +2256,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-08-02T09:26:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2909,16 +2429,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -2957,10 +2477,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2968,7 +2488,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3027,16 +2547,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.0.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
-                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -3048,7 +2568,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -3071,7 +2591,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -3079,7 +2599,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-15T09:54:48+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3136,16 +2656,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.10",
+            "version": "v5.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000"
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4d671ab4ddac94ee439ea73649c69d9d200b5000",
-                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4f71842f24c2023b91237c72a365306f3c58827",
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827",
                 "shasum": ""
             },
             "require": {
@@ -3210,12 +2730,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.10"
+                "source": "https://github.com/symfony/console/tree/v5.4.28"
             },
             "funding": [
                 {
@@ -3231,7 +2751,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T13:00:04+00:00"
+            "time": "2023-08-07T06:12:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3302,16 +2822,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.9",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc"
+                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc",
-                "reference": "8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5dcc00e03413f05c1e7900090927bb7247cb0aac",
+                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac",
                 "shasum": ""
             },
             "require": {
@@ -3367,7 +2887,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -3383,7 +2903,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-05T16:45:39+00:00"
+            "time": "2023-07-06T06:34:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -3466,16 +2986,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.9",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "36a017fa4cce1eff1b8e8129ff53513abcef05ba"
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/36a017fa4cce1eff1b8e8129ff53513abcef05ba",
-                "reference": "36a017fa4cce1eff1b8e8129ff53513abcef05ba",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
                 "shasum": ""
             },
             "require": {
@@ -3510,7 +3030,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.9"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -3526,20 +3046,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-20T13:55:35+00:00"
+            "time": "2023-05-31T13:04:02+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.8",
+            "version": "v5.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9"
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/9b630f3427f3ebe7cd346c277a1408b00249dad9",
-                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ff4bce3c33451e7ec778070e45bd23f74214cd5d",
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d",
                 "shasum": ""
             },
             "require": {
@@ -3573,7 +3093,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.8"
+                "source": "https://github.com/symfony/finder/tree/v5.4.27"
             },
             "funding": [
                 {
@@ -3589,20 +3109,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-15T08:07:45+00:00"
+            "time": "2023-07-31T08:02:31+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.4.3",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "cc1147cb11af1b43f503ac18f31aa3bec213aba8"
+                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/cc1147cb11af1b43f503ac18f31aa3bec213aba8",
-                "reference": "cc1147cb11af1b43f503ac18f31aa3bec213aba8",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
+                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
                 "shasum": ""
             },
             "require": {
@@ -3642,7 +3162,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.3"
+                "source": "https://github.com/symfony/options-resolver/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -3658,20 +3178,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.26.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -3686,7 +3206,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3724,7 +3244,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3740,20 +3260,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.26.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85"
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/e440d35fa0286f77fb45b79a03fedbeda9307e85",
-                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
                 "shasum": ""
             },
             "require": {
@@ -3762,7 +3282,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3803,7 +3323,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3819,20 +3339,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.26.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
                 "shasum": ""
             },
             "require": {
@@ -3841,7 +3361,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3886,7 +3406,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3902,20 +3422,99 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T07:21:04+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v5.4.8",
+            "name": "symfony/polyfill-php81",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "597f3fff8e3e91836bb0bd38f5718b56ddbde2f3"
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/597f3fff8e3e91836bb0bd38f5718b56ddbde2f3",
-                "reference": "597f3fff8e3e91836bb0bd38f5718b56ddbde2f3",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.4.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
+                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
                 "shasum": ""
             },
             "require": {
@@ -3948,7 +3547,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.8"
+                "source": "https://github.com/symfony/process/tree/v5.4.28"
             },
             "funding": [
                 {
@@ -3964,7 +3563,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-08T05:07:18+00:00"
+            "time": "2023-08-07T10:36:04+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4051,16 +3650,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.4.5",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "4d04b5c24f3c9a1a168a131f6cbe297155bc0d30"
+                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/4d04b5c24f3c9a1a168a131f6cbe297155bc0d30",
-                "reference": "4d04b5c24f3c9a1a168a131f6cbe297155bc0d30",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f83692cd869a6f2391691d40a01e8acb89e76fee",
+                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee",
                 "shasum": ""
             },
             "require": {
@@ -4093,7 +3692,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.5"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4109,20 +3708,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-18T16:06:09+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.10",
+            "version": "v5.4.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097"
+                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/4432bc7df82a554b3e413a8570ce2fea90e94097",
-                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
+                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
                 "shasum": ""
             },
             "require": {
@@ -4179,7 +3778,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.10"
+                "source": "https://github.com/symfony/string/tree/v5.4.29"
             },
             "funding": [
                 {
@@ -4195,7 +3794,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T15:57:47+00:00"
+            "time": "2023-09-13T11:47:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4246,64 +3845,6 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
-            },
-            "time": "2022-06-03T18:03:27+00:00"
         }
     ],
     "aliases": [],

--- a/default.php
+++ b/default.php
@@ -57,15 +57,17 @@ echo ""
     . "<ul>\n"
     .   "<li>\n"
     .     sprintf(
-            _("<a href='%s'>Register</a> with the site as a volunteer"),
-            "$code_url/accounts/addproofer.php")
+        _("<a href='%s'>Register</a> with the site as a volunteer"),
+        "$code_url/accounts/addproofer.php"
+    )
     .     "<br>"
     .     _("and/or")
     .   "</li>\n"
     .   "<li>\n"
     .     sprintf(
-            _("<a href='%s'>Donate</a> to the Distributed Proofreaders Foundation."),
-            "http://www.pgdp.net/wiki/DPFoundation:Information_for_Donors")
+        _("<a href='%s'>Donate</a> to the Distributed Proofreaders Foundation."),
+        "http://www.pgdp.net/wiki/DPFoundation:Information_for_Donors"
+    )
     .   "</li>\n"
     . "</ul>"
     . "\n";
@@ -84,13 +86,15 @@ echo "\n"
 echo "<p>"
     . sprintf(
         _("It's easy to volunteer at Distributed Proofreaders. Simply <a href='%s'>register as a volunteer</a>. Once you've confirmed your registration by e-mail, you'll receive an introductory e-mail with basic instructions on how to log in and use the site. Then, you're ready to sign in and start learning to proofread or visit the smooth reading page to pick an e-book to read! Wherever you go, you'll find lots of information to help you get started."),
-        "$code_url/accounts/addproofer.php");
+        "$code_url/accounts/addproofer.php"
+    );
 
 $walkthrough_url = get_walkthrough_url();
 if ($walkthrough_url) {
     echo " " . sprintf(
         _("Please try our <a href='%s'>Walkthrough</a> for a preview of the steps involved when proofreading on this site."),
-        $walkthrough_url);
+        $walkthrough_url
+    );
 }
 
 echo "</p>"
@@ -152,5 +156,6 @@ echo "<hr><p class='center-align'>\n";
 echo sprintf(
     _('Questions or comments? Please contact us at <a href="%1$s">%2$s</a>.'),
     "mailto:$general_help_email_addr",
-    $general_help_email_addr);
+    $general_help_email_addr
+);
 echo "</p>\n";

--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -325,19 +325,19 @@ if ($i_type == 0) {
     echo "<form>\n";
     echo "<dl>\n";
     foreach (
-    [
-        "Save as 'In Progress'",
-        "Save as 'Done' & Proofread Next Page",
-        "Save as 'Done'",
-        'Stop Proofreading',
-        'Switch to Vertical/Horizontal',
-        'Show All Text',
-        'Return Page to Round',
-        'Report Bad Page',
-        'WordCheck',
-        'Preview',
-    ]
-    as $name) {
+        [
+            "Save as 'In Progress'",
+            "Save as 'Done' & Proofread Next Page",
+            "Save as 'Done'",
+            'Stop Proofreading',
+            'Switch to Vertical/Horizontal',
+            'Show All Text',
+            'Return Page to Round',
+            'Report Bad Page',
+            'WordCheck',
+            'Preview',
+        ]
+        as $name) {
         echo "<dt>";
         if ($name == 'Switch to Vertical/Horizontal') {
             echo "<input type='button' value='Switch to Vertical'> / ";

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -288,8 +288,12 @@ function main_form()
             } else {
                 $percent_translated = 0;
             }
-            echo sprintf(_('%1$s of %2$s translated (%3$d%%)'),
-                $translated_strings, $total_strings, $percent_translated);
+            echo sprintf(
+                _('%1$s of %2$s translated (%3$d%%)'),
+                $translated_strings,
+                $total_strings,
+                $percent_translated
+            );
             echo "</td>";
         } else {
             echo "<td></td>";
@@ -381,9 +385,12 @@ function manage_form($locale)
             . date("F d Y H:i:s", $po_file->last_modified) . ")";
 
         echo " - ";
-        echo sprintf(_('%1$s of %2$s translated (%3$d%%)'),
-            $translated_strings, $total_strings,
-            $translated_strings / $total_strings * 100);
+        echo sprintf(
+            _('%1$s of %2$s translated (%3$d%%)'),
+            $translated_strings,
+            $total_strings,
+            $translated_strings / $total_strings * 100
+        );
         echo "</p>";
 
         $pot_filename = "$dyn_locales_dir/messages.pot";
@@ -433,7 +440,8 @@ function manage_form($locale)
         echo "<input type='hidden' name='locale' value='$locale'>";
         $confirm = javascript_safe(
             _("Are you sure you want to delete this locale and its translation file?"),
-            $charset);
+            $charset
+        );
         echo "<input type='submit' onClick='return confirm(\"$confirm\");' value='"
             . attr_safe(_("Delete this locale")) . "'> ";
         echo _("Delete the locale directory, PO file and MO file.") . "<br>\n";

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -499,7 +499,8 @@ function show_user_access_chart($username)
         // "all sat?" column
         td_w_bgcolor(
             ($uao->all_minima_satisfied ? _('Yes') : _('No')),
-            $uao->all_minima_satisfied);
+            $uao->all_minima_satisfied
+        );
 
         $could_grant = false;
         $could_revoke = false;

--- a/pinc/BrowseUtility.inc
+++ b/pinc/BrowseUtility.inc
@@ -134,11 +134,18 @@ class BrowseUtility
         if ($this->_total_row_count == 0) {
             return _('No entries displayed.');
         } elseif ($this->_start == $this->_last_index) {
-            return sprintf(_('Displaying entry %1$d of %2$d.'),
-                     $this->_start + 1, $this->_total_row_count);
+            return sprintf(
+                _('Displaying entry %1$d of %2$d.'),
+                $this->_start + 1,
+                $this->_total_row_count
+            );
         } else {
-            return sprintf(_('Displaying entries %1$d-%2$d of %3$d.'),
-                     $this->_start + 1, $this->_last_index + 1, $this->_total_row_count);
+            return sprintf(
+                _('Displaying entries %1$d-%2$d of %3$d.'),
+                $this->_start + 1,
+                $this->_last_index + 1,
+                $this->_total_row_count
+            );
         }
     }
 

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -61,7 +61,8 @@ class CharSuite
             'Undefined property via __get(): ' . $name .
             ' in ' . $trace[0]['file'] .
             ' on line ' . $trace[0]['line'],
-            E_USER_NOTICE);
+            E_USER_NOTICE
+        );
         return null;
     }
 
@@ -77,7 +78,8 @@ class CharSuite
                 'Undefined property via __get(): ' . $name .
                 ' in ' . $trace[0]['file'] .
                 ' on line ' . $trace[0]['line'],
-                E_USER_NOTICE);
+                E_USER_NOTICE
+            );
             return null;
         }
     }

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -153,12 +153,14 @@ final class DPDatabase
 
     public static function is_table_utf8($table_name)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT TABLE_COLLATION
             FROM information_schema.tables
             WHERE table_schema='%s' AND table_name='%s'",
             self::$_db_name,
-            self::escape($table_name));
+            self::escape($table_name)
+        );
         $result = self::query($sql);
         $row = mysqli_fetch_assoc($result);
         $table_encoding = $row['TABLE_COLLATION'];
@@ -169,12 +171,14 @@ final class DPDatabase
 
     public static function does_table_exist($table_name)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT TABLE_NAME
             FROM information_schema.tables
             WHERE table_schema='%s' AND table_name='%s'",
             self::$_db_name,
-            self::escape($table_name));
+            self::escape($table_name)
+        );
         $result = self::query($sql);
         return mysqli_fetch_assoc($result) !== null;
     }

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -107,8 +107,8 @@ function project_add_page(
     $image_file_name,
     $txt_file_path,
     $user,
-    $now)
-{
+    $now
+) {
     validate_projectID($projectid);
     $txt_expr = file_content_expr($txt_file_path, $projectid);
 
@@ -258,10 +258,14 @@ function Page_modifyText($projectid, $image, $page_text, $text_column, $user)
 
 function Page_checkout($projectid, $image, $round, $user)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_avail_state],
-        null, null,
-        'checkout');
+        null,
+        null,
+        'checkout'
+    );
 
     $timestamp = time();
     $setters = join(", ", [
@@ -282,10 +286,14 @@ function Page_checkout($projectid, $image, $round, $user)
 
 function Page_saveAsInProgress($projectid, $image, $round, $user, $page_text)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_out_state, $round->page_temp_state],
-        $round->user_column_name, $user,
-        'saveAsInProgress');
+        $round->user_column_name,
+        $user,
+        'saveAsInProgress'
+    );
 
     $timestamp = time();
 
@@ -308,10 +316,14 @@ function Page_saveAsInProgress($projectid, $image, $round, $user, $page_text)
 
 function Page_saveAsDone($projectid, $image, $round, $user, $page_text)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_out_state, $round->page_temp_state],
-        $round->user_column_name, $user,
-        'saveAsDone');
+        $round->user_column_name,
+        $user,
+        'saveAsDone'
+    );
 
     $timestamp = time();
 
@@ -336,10 +348,14 @@ function Page_saveAsDone($projectid, $image, $round, $user, $page_text)
 
 function Page_reopen($projectid, $image, $round, $user)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_save_state, $round->page_temp_state],
-        $round->user_column_name, $user,
-        'reopen');
+        $round->user_column_name,
+        $user,
+        'reopen'
+    );
 
     $timestamp = time();
     $setters = join(", ", [
@@ -358,10 +374,14 @@ function Page_reopen($projectid, $image, $round, $user)
 
 function Page_returnToRound($projectid, $image, $round, $user)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_out_state, $round->page_temp_state],
-        $round->user_column_name, $user,
-        'returnToRound');
+        $round->user_column_name,
+        $user,
+        'returnToRound'
+    );
 
     $timestamp = time();
     $setters = join(", ", [
@@ -382,10 +402,14 @@ function Page_returnToRound($projectid, $image, $round, $user)
 
 function Page_reclaim($projectid, $image, $round, $user)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_out_state, $round->page_temp_state],
-        null, null,
-        'reclaim');
+        null,
+        null,
+        'reclaim'
+    );
 
     $setters = join(", ", [
         set_col_str("state", $round->page_avail_state),
@@ -402,10 +426,14 @@ function Page_reclaim($projectid, $image, $round, $user)
 
 function Page_clearRound($projectid, $image, $round, $user)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_save_state],
-        null, null,
-        'clearRound');
+        null,
+        null,
+        'clearRound'
+    );
 
     $setters = join(", ", [
         set_col_str("state", $round->page_avail_state),
@@ -434,10 +462,14 @@ $PAGE_BADNESS_REASONS = [
 
 function Page_markAsBad($projectid, $image, $round, $user, $reason)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_out_state, $round->page_temp_state],
-        $round->user_column_name, $user,
-        'markAsBad');
+        $round->user_column_name,
+        $user,
+        'markAsBad'
+    );
 
     $setters = join(", ", [
         set_col_str("state", $round->page_bad_state),
@@ -454,10 +486,14 @@ function Page_markAsBad($projectid, $image, $round, $user, $reason)
 
 function Page_eraseBadMark($projectid, $image, $round, $user)
 {
-    _Page_require($projectid, $image,
+    _Page_require(
+        $projectid,
+        $image,
         [$round->page_bad_state],
-        null, null,
-        'eraseBadMark');
+        null,
+        null,
+        'eraseBadMark'
+    );
 
     $setters = join(", ", [
         set_col_str("state", $round->page_avail_state),
@@ -480,8 +516,8 @@ function _Page_require(
     $allowed_states,
     $allowed_user_colname,
     $requesting_user,
-    $op_name)
-{
+    $op_name
+) {
     validate_projectID($projectid);
     $user_item = (is_null($allowed_user_colname) ? '0' : $allowed_user_colname);
     $sql = "
@@ -496,14 +532,14 @@ function _Page_require(
             . "    "
             . sprintf(
                 _("This operation (%s) requires that the page be in one of the following states:"),
-                $op_name)
+                $op_name
+            )
             . "\n"
             . "        "
             . implode(' ', $allowed_states)
             . "\n"
             . "    "
-            . sprintf(_("But it is in %s"), $curr_page_state)
-            ;
+            . sprintf(_("But it is in %s"), $curr_page_state);
         throw new ProjectPageException($err);
     }
 
@@ -519,8 +555,8 @@ function _Page_require(
                 . "    "
                 . sprintf(
                     _("This operation (%s) can only be done by the user who has the page checked out, which you are not."),
-                    $op_name)
-                ;
+                    $op_name
+                );
             throw new ProjectPageException($err);
         }
     }
@@ -728,7 +764,8 @@ function _log_page_event($projectid, $image, $event_type, $username, $round)
         $round_id_setting = "'" . DPDatabase::escape($round->id) . "'";
     };
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO page_events
         SET
             timestamp    = UNIX_TIMESTAMP(),
@@ -751,7 +788,8 @@ function _log_page_event($projectid, $image, $event_type, $username, $round)
 
 function _project_set_t_last_page_done($projectid, $timestamp)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE projects
         SET t_last_page_done = %d
         WHERE projectid = '%s'
@@ -770,7 +808,8 @@ function _project_adjust_n_pages($projectid, $adjustment)
         $expr = "n_pages + $adjustment";
     }
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE projects
         SET n_pages = %s
         WHERE projectid='%s'
@@ -801,7 +840,8 @@ function _project_adjust_n_available_pages($projectid, $adjustment)
         }
     }
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE projects
         SET n_available_pages = %s
         WHERE projectid = '%s'

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -196,8 +196,8 @@ function get_indicated_LPage(
     $proj_state,
     $imagefile,
     $page_state,
-    $reverting_to_orig)
-{
+    $reverting_to_orig
+) {
     // Make sure project is still in same state.
     // can throw NonexistentProjectException
     $project = new Project($projectid);
@@ -227,7 +227,10 @@ function get_indicated_LPage(
     if ($page_state != $current_page_state) {
         $err = sprintf(
             _('Page %1$s has changed state from %2$s to %3$s, so your request is invalid.'),
-            $imagefile, $page_state, $current_page_state);
+            $imagefile,
+            $page_state,
+            $current_page_state
+        );
         throw new ProjectPageException($err);
     }
 
@@ -409,7 +412,8 @@ class LPage
         // TRANSLATORS: %s is a url
         $body_blurb_messages[] = sprintf(
             _("Please visit %s to make any needed changes and make the page available for proofreading again."),
-            "$code_url/tools/project_manager/handle_bad_page.php?projectid={$this->projectid}&image={$this->imagefile}");
+            "$code_url/tools/project_manager/handle_bad_page.php?projectid={$this->projectid}&image={$this->imagefile}"
+        );
         $body_blurb_messages[] = _("Until this report has been resolved, the project will not be able to leave the current round.");
         $body_blurb_messages[] = _("If 10 pages are marked bad by at least 3 different users, the project will automatically be made unavailable.");
         $body_blurb = implode("\n\n", $body_blurb_messages);
@@ -464,7 +468,9 @@ class LPage
             if ($pguser != $current_round_user) {
                 $err = sprintf(
                     _('You (%1$s) do not have the necessary access to page %2$s'),
-                    $pguser, $this->imagefile);
+                    $pguser,
+                    $this->imagefile
+                );
                 throw new ProjectPageException($err);
             }
         }

--- a/pinc/NonactivatedUser.inc
+++ b/pinc/NonactivatedUser.inc
@@ -41,14 +41,20 @@ class NonactivatedUser
     public function __set($name, $value)
     {
         if (in_array($name, $this->unsettable_fields)) {
-            throw new DomainException(sprintf(
-                _("%s is an unsettable field"), $name)
+            throw new DomainException(
+                sprintf(
+                    _("%s is an unsettable field"),
+                    $name
+                )
             );
         }
 
         if (isset($this->$name) && in_array($name, $this->immutable_fields)) {
-            throw new DomainException(sprintf(
-                _("%s is an immutable field"), $name)
+            throw new DomainException(
+                sprintf(
+                    _("%s is an immutable field"),
+                    $name
+                )
             );
         }
 
@@ -81,14 +87,20 @@ class NonactivatedUser
         $result = DPDatabase::query($sql);
 
         if (mysqli_num_rows($result) == 0) {
-            throw new NonexistentNonactivatedUserException(sprintf(
-                _('No non_activated_user found with %1$s = %2$s'),
-                    $field, $value)
+            throw new NonexistentNonactivatedUserException(
+                sprintf(
+                    _('No non_activated_user found with %1$s = %2$s'),
+                    $field,
+                    $value
+                )
             );
         } elseif (mysqli_num_rows($result) > 1) {
-            throw new NonuniqueNonactivatedUserException(sprintf(
-                _('Multiple non_activated_users found with %1$s = %2$s'),
-                    $field, $value)
+            throw new NonuniqueNonactivatedUserException(
+                sprintf(
+                    _('Multiple non_activated_users found with %1$s = %2$s'),
+                    $field,
+                    $value
+                )
             );
         }
         $this->table_row = mysqli_fetch_assoc($result);
@@ -99,9 +111,12 @@ class NonactivatedUser
         // existing username in case and whitespace by doing a PHP string
         // compare.
         if ($strict and $field == 'username' and $this->username != $value) {
-            throw new NonexistentNonactivatedUserException(sprintf(
-                _('No non_activated_user found with %1$s = %2$s'),
-                    $field, $value)
+            throw new NonexistentNonactivatedUserException(
+                sprintf(
+                    _('No non_activated_user found with %1$s = %2$s'),
+                    $field,
+                    $value
+                )
             );
         }
 
@@ -128,7 +143,8 @@ class NonactivatedUser
         // possibility of an unlikely race condition where two simultaneous
         // registrations with the same ID would "succeed" where the second
         // request just saves over the prior one.
-        $query = sprintf("
+        $query = sprintf(
+            "
             INSERT INTO non_activated_users
             SET
                 id = '%s',
@@ -151,7 +167,8 @@ class NonactivatedUser
                 http_referrer = LEFT('%s', 256),
                 u_intlang = '%s',
                 user_password = '%s'
-        ", $this->table_row["id"],
+        ",
+            $this->table_row["id"],
             DPDatabase::escape($this->username),
             DPDatabase::escape($this->real_name),
             DPDatabase::escape($this->email),
@@ -184,7 +201,8 @@ class NonactivatedUser
             return;
         }
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             DELETE FROM non_activated_users
             WHERE id = '%s'",
             DPDatabase::escape($this->id)

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -206,7 +206,8 @@ class Project
 
     private function _load_from_db($projectid)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT *
             FROM projects
             WHERE projectid = '%s'",
@@ -288,8 +289,10 @@ class Project
         foreach ($user_fields as $field) {
             // only check non-empty fields
             if (!preg_match('/^\s*$/', $this->$field) && !User::is_valid_user($this->$field)) {
-                $errors[] = sprintf(_("%s must be an existing user - check case and spelling and ensure there is no trailing whitespace."),
-                    $labels[$field]);
+                $errors[] = sprintf(
+                    _("%s must be an existing user - check case and spelling and ensure there is no trailing whitespace."),
+                    $labels[$field]
+                );
             }
         }
 
@@ -355,7 +358,8 @@ class Project
             if (! preg_match('/^[1-9][0-9]*$/', $this->postednum)) {
                 $errors[] = sprintf(
                     _("Posted Number \"%s\" is not of the correct format."),
-                    $this->postednum);
+                    $this->postednum
+                );
                 // Occasionally, there will be a PG ebook that is still
                 // under U.S. copyright. This is indicated in their system
                 // by appending a 'C' to the etext number. The link to
@@ -612,7 +616,8 @@ class Project
             'Undefined property via __get(): ' . $name .
             ' in ' . $trace[0]['file'] .
             ' on line ' . $trace[0]['line'],
-            E_USER_NOTICE);
+            E_USER_NOTICE
+        );
         return null;
     }
 
@@ -764,7 +769,8 @@ class Project
     {
         $charsuite = CharSuites::resolve($charsuite);
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT projectid
             FROM project_charsuites
             WHERE charsuite_name='%s'",
@@ -825,7 +831,8 @@ class Project
                 $charsuite->title
             ));
         }
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO project_charsuites
             SET projectid='%s', charsuite_name='%s'",
             DPDatabase::escape($this->projectid),
@@ -842,7 +849,8 @@ class Project
         if (!in_array($charsuite, $existing_charsuites)) {
             return;
         }
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             DELETE FROM project_charsuites
             WHERE projectid='%s' AND charsuite_name='%s'",
             DPDatabase::escape($this->projectid),
@@ -864,7 +872,8 @@ class Project
         }
 
         // load regular character suites
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT charsuite_name
             FROM project_charsuites
             WHERE projectid='%s'",
@@ -1290,7 +1299,8 @@ class Project
             $post_body,
             $this->username,
             true,
-            $sign_PM_up);
+            $sign_PM_up
+        );
 
         // if topic_id is NULL, something went wrong when creating the topic
         if ($topic_id === null) {
@@ -1298,7 +1308,8 @@ class Project
         }
 
         // Save $topic_id in db and in $this.
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE projects
             SET topic_id=%d
             WHERE projectid='%s'",
@@ -1339,7 +1350,8 @@ class Project
     public function log_project_event($who, $event_type, $details1 = '', $details2 = '', $details3 = '')
     {
         validate_projectID($this->projectid);
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO project_events
             SET
                 timestamp  = UNIX_TIMESTAMP(),
@@ -1349,12 +1361,14 @@ class Project
                 details1   = '%s',
                 details2   = '%s',
                 details3   = '%s'
-        ", DPDatabase::escape($this->projectid),
+        ",
+            DPDatabase::escape($this->projectid),
             DPDatabase::escape($who),
             DPDatabase::escape($event_type),
             DPDatabase::escape($details1),
             DPDatabase::escape($details2),
-            DPDatabase::escape($details3));
+            DPDatabase::escape($details3)
+        );
         DPDatabase::query($sql);
     }
 
@@ -1378,7 +1392,8 @@ class Project
     public function get_hold_states()
     {
         $hold_states = [];
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT state
             FROM project_holds
             WHERE projectid='%s'",
@@ -1397,7 +1412,8 @@ class Project
 
         $values = [];
         foreach ($states as $state) {
-            $values[] = sprintf("('%s', '%s', 0)",
+            $values[] = sprintf(
+                "('%s', '%s', 0)",
                 DPDatabase::escape($this->projectid),
                 DPDatabase::escape($state)
             );
@@ -1471,7 +1487,8 @@ class Project
         send_mail_project_manager(
             $this,
             sprintf(_("This project is unable to transition out of %s because it is held. Please review the project and remove the hold. You will receive this notification only once unless you remove and re-add the hold or another page is proofread."), $state),
-            _("Project Held"));
+            _("Project Held")
+        );
         configure_gettext_for_user();
 
         $this->update_hold_state_notify_time($state);
@@ -1570,7 +1587,8 @@ class Project
     {
         $original_marc_array = $marc_record->get_yaz_array();
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO marc_records
             SET
                 projectid      = '%s',
@@ -1586,7 +1604,8 @@ class Project
     public function save_marc_record($marc_record)
     {
         $updated_marc_array = $marc_record->get_yaz_array();
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE marc_records
             SET
                 updated_array = '%s'
@@ -1606,7 +1625,8 @@ class Project
     public function load_marc_record()
     {
         $updated_record = new MARCRecord();
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT updated_array
             FROM marc_records
             WHERE projectid = '%s'",
@@ -1746,7 +1766,8 @@ class Project
 
 function project_has_a_hold_in_state($projectid, $state)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM project_holds
         WHERE projectid='%s'
@@ -1901,7 +1922,8 @@ function get_projectID_param($arr, $key, $allownull = false)
     if (isset($projectid) && !is_string($projectid)) {
         throw new InvalidArgumentException(sprintf(
             _("Parameter '%1\$s' is not a valid type"),
-            $key));
+            $key
+        ));
     }
 
     if ($projectid == null && $allownull) {
@@ -1946,7 +1968,8 @@ function get_page_image_param($arr, $key, $allownull = false)
     if (isset($page_name) && !is_string($page_name)) {
         throw new InvalidArgumentException(sprintf(
             _("Parameter '%1\$s' is not a valid type"),
-            $key));
+            $key
+        ));
     }
 
     if ($page_name == null && $allownull) {

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -267,7 +267,10 @@ class ProjectTransition
             }
 
             $settings_addition = preg_replace(
-                $patterns, $replacements, $this->settings_template);
+                $patterns,
+                $replacements,
+                $this->settings_template
+            );
 
             $settings .= ", $settings_addition";
         }
@@ -332,7 +335,8 @@ class ProjectTransition
             // Ensure it's in the appropriate forum for the project's new state.
             topic_change_forum(
                 $project->topic_id,
-                get_forum_id_for_project_state($this->to_state));
+                get_forum_id_for_project_state($this->to_state)
+            );
         }
 
         if ($this->collateral_actions) {
@@ -767,12 +771,14 @@ function round_release_collateral($old_project, $project, $transition, $who)
         send_mail_project_manager(
             $project,
             sprintf(_("This project has just become available for work in round %s."), $round->id),
-            _("Proofreading Started"));
+            _("Proofreading Started")
+        );
     } else {
         send_mail_project_manager(
             $project,
             sprintf(_('This project has been manually released by %1$s and has just become available in %2$s.'), $who, $round->name),
-            _("Proofreading Started (Manual Release)"));
+            _("Proofreading Started (Manual Release)")
+        );
     }
 
     configure_gettext_for_user();
@@ -878,7 +884,8 @@ function round_to_PP_avail_collateral($old_project, $project, $transition, $who)
         send_mail(
             $PPer_email_addr,
             "$site_abbreviation: Reserved book sent to PP pool",
-            $body_blurb);
+            $body_blurb
+        );
     }
 
     notify_project_event_subscribers($project, 'pp_enter');
@@ -928,7 +935,8 @@ function round_to_PP_out_collateral($old_project, $project, $transition, $who)
         configure_gettext_for_user($project->username);
         $body_blurb_messages[] = sprintf(
             _("This project has completed all rounds and has been checked out to the PPer who had it reserved, %s."),
-            $PPer_username);
+            $PPer_username
+        );
         $body_blurb_messages[] = _("You will be notified once it has completed post-processing.");
         $body_blurb = implode("\n\n", $body_blurb_messages);
         send_mail_project_manager($project, $body_blurb, _("Post-Processing Started"));
@@ -950,7 +958,8 @@ function round_to_PP_out_collateral($old_project, $project, $transition, $who)
         send_mail(
             $PPer_email_addr,
             "$site_abbreviation: Reserved book available for Post-Processing",
-            $body_blurb);
+            $body_blurb
+        );
     }
 
     notify_project_event_subscribers($project, 'pp_enter');
@@ -964,7 +973,8 @@ function PP_to_PP_out_collateral($old_project, $project, $transition, $who)
     $PPer_username = $project->checkedoutby;
     $body_blurb_messages[] = sprintf(
         _("This project has been checked out to %s for post-processing."),
-        $PPer_username);
+        $PPer_username
+    );
     $body_blurb_messages[] = _("You will be notified once it has completed post-processing.");
     $body_blurb = implode("\n\n", $body_blurb_messages);
     send_mail_project_manager($project, $body_blurb, _("Post-Processing Started"));
@@ -1211,9 +1221,10 @@ new ProjectTransition(
 // From PROJ_POST_FIRST_UNAVAILABLE:
 
 $pp_unavail_to_avail_confirm_question = sprintf(
-   _("This will clear the reserved PPer if there is one.") . " " .
+    _("This will clear the reserved PPer if there is one.") . " " .
    _("Are you sure you want to change the state of this project to %s?"),
-   project_states_text(PROJ_POST_FIRST_AVAILABLE));
+    project_states_text(PROJ_POST_FIRST_AVAILABLE)
+);
 
 new ProjectTransition(
     PROJ_POST_FIRST_UNAVAILABLE,
@@ -1253,10 +1264,12 @@ function to_unavailable_collateral($old_project, $project, $transition, $who)
 {
     // Always notify the PM
     configure_gettext_for_user($project->username);
-    $body_blurb_messages[] = sprintf(_('This project has been moved from %1$s to %2$s by %3$s.'),
-            project_states_text($transition->from_state),
-            project_states_text($transition->to_state),
-            $who);
+    $body_blurb_messages[] = sprintf(
+        _('This project has been moved from %1$s to %2$s by %3$s.'),
+        project_states_text($transition->from_state),
+        project_states_text($transition->to_state),
+        $who
+    );
     $body_blurb_messages[] = _("You will be notified when it is made available again.");
     $body_blurb = implode("\n\n", $body_blurb_messages);
     send_mail_project_manager($project, $body_blurb, project_states_text($transition->to_state));

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -70,15 +70,18 @@ class Quiz
             $pages_required_results[$quiz_page_id] = null;
         }
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT quiz_page, date
             FROM quiz_passes
             WHERE username = '%s'
                 AND quiz_page IN (%s)
                 AND result = 'pass'
             ORDER BY date
-        ", DPDatabase::escape($username),
-            surround_and_join(array_keys($this->pages), '"', '"', ","));
+        ",
+            DPDatabase::escape($username),
+            surround_and_join(array_keys($this->pages), '"', '"', ",")
+        );
         $result = DPDatabase::query($sql);
 
         while ($attempt = mysqli_fetch_object($result)) {
@@ -283,20 +286,24 @@ function record_quiz_attempt($username, $quiz_page_id, $result)
 
     if (mysqli_num_rows($res) > 0) {
         // The user has already passed this page; update the timestamp
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE quiz_passes
             SET date = %d
             WHERE username = '%s' AND quiz_page = '%s'
-        ", time(),
+        ",
+            time(),
             DPDatabase::escape($username),
             DPDatabase::escape($quiz_page_id)
         );
         DPDatabase::query($sql);
     } else {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO quiz_passes
             VALUES ('%s', %d, '%s', '%s')
-        ", DPDatabase::escape($username),
+        ",
+            DPDatabase::escape($username),
             time(),
             DPDatabase::escape($quiz_page_id),
             DPDatabase::escape($result)

--- a/pinc/RandomRule.inc
+++ b/pinc/RandomRule.inc
@@ -51,7 +51,8 @@ class RandomRule
      */
     public static function load_from_anchor($document, $anchor, $langcode = 'en')
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT id
             FROM rules
             WHERE
@@ -77,7 +78,8 @@ class RandomRule
      */
     public static function get_random($document, $langcode = 'en')
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT id
             FROM rules
             WHERE
@@ -102,7 +104,8 @@ class RandomRule
      */
     public static function get_rules($document, $langcode = 'en')
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT id
             FROM rules
             WHERE
@@ -155,7 +158,8 @@ class RandomRule
      */
     public static function delete_rules($document, $langcode)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             DELETE
             FROM rules
             WHERE
@@ -238,7 +242,8 @@ class RandomRule
         }
 
         // update rule URLs
-        $rule = preg_replace_callback('/<a href="([^"]*)"[^>]*/',
+        $rule = preg_replace_callback(
+            '/<a href="([^"]*)"[^>]*/',
             function ($match) use ($url) {
                 if (startswith($match[1], '#')) {
                     return '<a href="' . $url . $match[1] . '"';
@@ -259,7 +264,8 @@ class RandomRule
         $anchor = substr($anchor, 0, 255);
         $subject = substr($subject, 0, 255);
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO rules
             SET
                 document = '%s',

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -292,8 +292,10 @@ function get_Round_for_text_column_name($text_column_name)
 function sql_collater_for_round_id($round_id_column)
 {
     global $Round_for_round_id_;
-    return sprintf("FIELD($round_id_column, %s)",
-        surround_and_join(array_keys($Round_for_round_id_), "'", "'", ","));
+    return sprintf(
+        "FIELD($round_id_column, %s)",
+        surround_and_join(array_keys($Round_for_round_id_), "'", "'", ",")
+    );
 }
 
 /**
@@ -306,8 +308,10 @@ function sql_collater_for_round_id($round_id_column)
 function sql_collater_for_page_state($state_column)
 {
     global $PAGE_STATES_IN_ORDER;
-    return sprintf("FIELD($state_column, %s)",
-        surround_and_join($PAGE_STATES_IN_ORDER, "'", "'", ","));
+    return sprintf(
+        "FIELD($state_column, %s)",
+        surround_and_join($PAGE_STATES_IN_ORDER, "'", "'", ",")
+    );
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/SettingsClass.inc
+++ b/pinc/SettingsClass.inc
@@ -114,26 +114,32 @@ class Settings
 
     private function _insert_setting_value($settingCode, $value)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO usersettings
                 (username, setting, value)
             VALUES ('%s', '%s', '%s')
-        ", DPDatabase::escape($this->username),
+        ",
+            DPDatabase::escape($this->username),
             DPDatabase::escape($settingCode),
-            DPDatabase::escape($value));
+            DPDatabase::escape($value)
+        );
         DPDatabase::query($sql);
     }
 
     private function _delete_setting_value($settingCode, $value)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             DELETE FROM usersettings
             WHERE username = '%s'
                 AND setting = '%s'
                 AND value = '%s'
-        ", DPDatabase::escape($this->username),
+        ",
+            DPDatabase::escape($this->username),
             DPDatabase::escape($settingCode),
-            DPDatabase::escape($value));
+            DPDatabase::escape($value)
+        );
         DPDatabase::query($sql);
     }
 
@@ -242,7 +248,9 @@ class Settings
     {
         if (array_key_exists($settingCode, $this->settings_array) && in_array($value, $this->settings_array[$settingCode])) {
             $this->settings_array[$settingCode] = array_diff(
-                $this->settings_array[$settingCode], [$value]);
+                $this->settings_array[$settingCode],
+                [$value]
+            );
 
             $this->_delete_setting_value($settingCode, $value);
         }
@@ -330,8 +338,10 @@ class Settings
         ", DPDatabase::escape($setting));
 
         if ($value) {
-            $sql .= sprintf(" AND value='%s'",
-                DPDatabase::escape($value));
+            $sql .= sprintf(
+                " AND value='%s'",
+                DPDatabase::escape($value)
+            );
         }
 
         $result = DPDatabase::query($sql);

--- a/pinc/SortUtility.inc
+++ b/pinc/SortUtility.inc
@@ -32,9 +32,12 @@ class SortableValue
      *   `$sqlRuleAscending`. With 'inverse', I mean that the inverse of
      * "a, b DESC, c ASC" is "a DESC, b ASC, c DESC".
      */
-    public function __construct($name, $label,
-                         $sqlRuleAscending = null, $sqlRuleDescending = null)
-    {
+    public function __construct(
+        $name,
+        $label,
+        $sqlRuleAscending = null,
+        $sqlRuleDescending = null
+    ) {
         $this->_name = $name;
         $this->_label = $label;
         if (isset($sqlRuleAscending)) {
@@ -57,11 +60,11 @@ class SortableValue
         $count = 0;
         foreach ($vars as $var) {
             $oldVar = $var;
-            if (($newVar = str_replace(' ASC', ' DESC', $var)) != $oldVar)
-        ; // ASC -> DESC
-            elseif (($newVar = str_replace(' DESC', '', $var)) != $oldVar)
-        ; // DESC -> ASC
-            else {
+            if (($newVar = str_replace(' ASC', ' DESC', $var)) != $oldVar) {
+                // ASC -> DESC
+            } elseif (($newVar = str_replace(' DESC', '', $var)) != $oldVar) {
+                // DESC -> ASC
+            } else {
                 $newVar = "$var DESC";
             } // ASC -> DESC
             $newVars[$count++] = trim($newVar);
@@ -141,7 +144,7 @@ class SortUtility
     public function _checkForUserPreferenceOnSorting()
     {
 
-    // Did the user click a sorting link (or used bookmark)?
+        // Did the user click a sorting link (or used bookmark)?
         if (isset($_GET[$this->_name.'_order'])) {
             if ($this->_parseSortingRule($_GET[$this->_name.'_order'])) {
                 // Parameter was passed and evaluated ok.

--- a/pinc/TableDocumentation.inc
+++ b/pinc/TableDocumentation.inc
@@ -21,9 +21,13 @@ class TableDocumentation
             $columns_information[$index]['Field'] = "[`$field`](#$field)";
         }
 
-        return implode("\n",
-            TableDocumentation::create_markdown_table($columns_information,
-                ['Field', 'Type', 'Null', 'Key', 'Default', 'Extra']));
+        return implode(
+            "\n",
+            TableDocumentation::create_markdown_table(
+                $columns_information,
+                ['Field', 'Type', 'Null', 'Key', 'Default', 'Extra']
+            )
+        );
     }
 
     public function generate_column_definitions(): string

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -60,7 +60,8 @@ class TallyBoard
 
     public function add_to_tally($holder_id, $amount)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO current_tallies
             SET
                 tally_name  = '%s',
@@ -73,7 +74,8 @@ class TallyBoard
             DPDatabase::escape($this->holder_type),
             intval($holder_id),
             intval($amount),
-            intval($amount));
+            intval($amount)
+        );
         DPDatabase::query($sql);
     }
 
@@ -111,7 +113,8 @@ class TallyBoard
         static $n = 0;
         $n++;
         $alias = "current_tallies_$n";
-        $join_sql = sprintf("
+        $join_sql = sprintf(
+            "
             LEFT OUTER JOIN current_tallies AS $alias
             ON (
                 $alias.tally_name      = '%s'
@@ -119,7 +122,8 @@ class TallyBoard
                 AND $alias.holder_id   = $holder_id_expr
             )",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type));
+            DPDatabase::escape($this->holder_type)
+        );
         return [$join_sql, "IFNULL($alias.tally_value,0)"];
     }
 
@@ -127,7 +131,8 @@ class TallyBoard
 
     public function get_num_holders_with_positive_tally()
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT COUNT(*)
             FROM current_tallies
             WHERE
@@ -135,7 +140,8 @@ class TallyBoard
                 AND holder_type = '%s'
                 AND tally_value > 0",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type));
+            DPDatabase::escape($this->holder_type)
+        );
         $res = DPDatabase::query($sql);
         [$count] = mysqli_fetch_row($res);
         return $count;
@@ -151,7 +157,8 @@ class TallyBoard
      */
     public function get_current_tally($holder_id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT tally_value
             FROM current_tallies
             WHERE
@@ -160,7 +167,8 @@ class TallyBoard
                 AND holder_id   = %s",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id));
+            intval($holder_id)
+        );
         $res = DPDatabase::query($sql);
 
         $row = mysqli_fetch_assoc($res);
@@ -182,7 +190,8 @@ class TallyBoard
      */
     public function get_rank($holder_id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT holder_id, tally_value
             FROM current_tallies
             WHERE
@@ -190,7 +199,8 @@ class TallyBoard
                 AND holder_type = '%s'
             ORDER BY tally_value DESC",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type));
+            DPDatabase::escape($this->holder_type)
+        );
         $result = DPDatabase::query($sql);
         $ranker = new Ranker(true);
         while ([$h_id, $tally_value] = mysqli_fetch_row($result)) {
@@ -236,7 +246,8 @@ class TallyBoard
     ) {
         assert($radius >= 0);
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT
                 $holder_id_expr AS _holder_id,
                 IFNULL(tally_value,0) AS $tally_alias,
@@ -252,7 +263,8 @@ class TallyBoard
             WHERE tally_value > 0 OR $holder_id_expr='$target_holder_id'
             ORDER BY tally_value DESC, holder_id ASC",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type));
+            DPDatabase::escape($this->holder_type)
+        );
         $result = DPDatabase::query($sql);
         // Note that for the purposes of this function,
         // we pretend that holders with tally_value <= 0 don't exist,
@@ -331,29 +343,33 @@ class TallyBoard
             }
 
             // Get everyone's most recent saved tally.
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 SELECT holder_id, tally_value
                 FROM past_tallies
                 WHERE
                     timestamp       = $prev_ascribe_time
                     AND tally_name  = '%s'
                     AND holder_type = '%s'",
-                    DPDatabase::escape($this->tally_name),
-                    DPDatabase::escape($this->holder_type));
+                DPDatabase::escape($this->tally_name),
+                DPDatabase::escape($this->holder_type)
+            );
             $result = DPDatabase::query($sql);
             while ([$holder_id, $prev_tally_value] = mysqli_fetch_row($result)) {
                 $prev_tally_for_[$holder_id] = $prev_tally_value;
             }
 
             // Get everyone's best tally-rank so far.
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 SELECT holder_id, best_rank
                 FROM best_tally_rank
                 WHERE
                     tally_name      = '%s'
                     AND holder_type = '%s'",
-                    DPDatabase::escape($this->tally_name),
-                    DPDatabase::escape($this->holder_type));
+                DPDatabase::escape($this->tally_name),
+                DPDatabase::escape($this->holder_type)
+            );
             $result = DPDatabase::query($sql);
             while ([$holder_id, $best_rank] = mysqli_fetch_row($result)) {
                 $best_rank_for_[$holder_id] = $best_rank;
@@ -361,7 +377,8 @@ class TallyBoard
         }
 
         // Get everyone's current tally, in rank order.
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT holder_id, tally_value
             FROM current_tallies
             WHERE
@@ -369,7 +386,8 @@ class TallyBoard
                 AND holder_type = '%s'
             ORDER BY tally_value DESC",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type));
+            DPDatabase::escape($this->holder_type)
+        );
         $result = DPDatabase::query($sql);
 
         $ranker = new Ranker(true);
@@ -377,7 +395,8 @@ class TallyBoard
             $rank = $ranker->next($current_tally);
             $previous_tally = array_get($prev_tally_for_, $holder_id, 0);
             $tally_delta = $current_tally - $previous_tally;
-            $query = sprintf("
+            $query = sprintf(
+                "
                 INSERT INTO past_tallies
                 SET
                     timestamp   = $ascribe_time,
@@ -388,7 +407,8 @@ class TallyBoard
                     tally_value = $current_tally",
                 DPDatabase::escape($this->tally_name),
                 DPDatabase::escape($this->holder_type),
-                intval($holder_id));
+                intval($holder_id)
+            );
             if ($dry_run) {
                 // Normalize whitespace
                 $query = preg_replace('/\s+/', ' ', trim($query));
@@ -398,7 +418,8 @@ class TallyBoard
             }
 
             if ($rank > 0 && (!isset($best_rank_for_[$holder_id]) || $rank < $best_rank_for_[$holder_id])) {
-                $query = sprintf("
+                $query = sprintf(
+                    "
                     REPLACE INTO best_tally_rank
                     SET
                         tally_name  = '%s',
@@ -408,7 +429,8 @@ class TallyBoard
                         best_rank_timestamp = $ascribe_time",
                     DPDatabase::escape($this->tally_name),
                     DPDatabase::escape($this->holder_type),
-                    intval($holder_id));
+                    intval($holder_id)
+                );
                 if ($dry_run) {
                     // Normalize whitespace
                     $query = preg_replace('/\s+/', ' ', trim($query));
@@ -428,14 +450,16 @@ class TallyBoard
      */
     public function get_time_of_latest_snapshot($default = null)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT MAX(timestamp) as max_timestamp
             FROM past_tallies
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type));
+            DPDatabase::escape($this->holder_type)
+        );
         $result = DPDatabase::query($sql);
 
         $row = mysqli_fetch_assoc($result);
@@ -462,7 +486,8 @@ class TallyBoard
      */
     public function get_info_from_latest_snapshot($holder_id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT timestamp, tally_delta, tally_value
             FROM past_tallies
             WHERE
@@ -473,7 +498,8 @@ class TallyBoard
             LIMIT 1",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id));
+            intval($holder_id)
+        );
         $result = DPDatabase::query($sql);
 
         $info = mysqli_fetch_assoc($result);
@@ -506,7 +532,8 @@ class TallyBoard
      */
     public function get_info_re_largest_delta($holder_id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT tally_delta, timestamp
             FROM past_tallies
             WHERE
@@ -517,7 +544,8 @@ class TallyBoard
             LIMIT 1",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id));
+            intval($holder_id)
+        );
         $result = DPDatabase::query($sql);
 
         $info = mysqli_fetch_row($result);
@@ -541,7 +569,8 @@ class TallyBoard
      */
     public function get_info_re_best_rank($holder_id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT best_rank, best_rank_timestamp
             FROM best_tally_rank
             WHERE
@@ -550,7 +579,8 @@ class TallyBoard
                 AND holder_id   = %d",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id));
+            intval($holder_id)
+        );
         $result = DPDatabase::query($sql);
 
         $info = mysqli_fetch_row($result);
@@ -576,7 +606,8 @@ class TallyBoard
      */
     public function get_deltas($holder_id, $min_timestamp)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT timestamp, tally_delta
             FROM past_tallies
             WHERE
@@ -587,7 +618,8 @@ class TallyBoard
             ORDER BY timestamp ASC",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id));
+            intval($holder_id)
+        );
         $result = DPDatabase::query($sql);
 
         $delta_at_ = [];
@@ -613,7 +645,8 @@ class TallyBoard
      */
     public function get_delta_sum($holder_id, $start_timestamp, $end_timestamp)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT SUM(tally_delta)
             FROM past_tallies
             WHERE
@@ -624,7 +657,8 @@ class TallyBoard
                 AND timestamp <= $end_timestamp",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id));
+            intval($holder_id)
+        );
         $res = DPDatabase::query($sql);
         [$sum] = mysqli_fetch_row($res);
         return $sum;

--- a/pinc/ThemedTable.inc
+++ b/pinc/ThemedTable.inc
@@ -45,10 +45,10 @@ class ThemedTable
 
             echo "\n";
             echo "<tr>";
-                $maybe_colspan = "";
-                if ($this->n_cols > 1) {
-                    $maybe_colspan = "colspan='$this->n_cols'";
-                }
+            $maybe_colspan = "";
+            if ($this->n_cols > 1) {
+                $maybe_colspan = "colspan='$this->n_cols'";
+            }
             echo   "<th style='text-align: center;' $maybe_colspan>";
             echo     $title;
             echo     $possible_subtitle;

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -110,8 +110,11 @@ class User
     public function __set($name, $value)
     {
         if (isset($this->$name) && in_array($name, $this->immutable_fields)) {
-            throw new DomainException(sprintf(
-                _("%s is an immutable field"), $name)
+            throw new DomainException(
+                sprintf(
+                    _("%s is an immutable field"),
+                    $name
+                )
             );
         }
 
@@ -211,14 +214,20 @@ class User
 
         $result = DPDatabase::query($sql);
         if (mysqli_num_rows($result) == 0) {
-            throw new NonexistentUserException(sprintf(
-                _('No user found with %1$s = %2$s'),
-                    $field, $value)
+            throw new NonexistentUserException(
+                sprintf(
+                    _('No user found with %1$s = %2$s'),
+                    $field,
+                    $value
+                )
             );
         } elseif (mysqli_num_rows($result) > 1) {
-            throw new NonuniqueUserException(sprintf(
-                _('Multiple users found with %1$s = %2$s'),
-                    $field, $value)
+            throw new NonuniqueUserException(
+                sprintf(
+                    _('Multiple users found with %1$s = %2$s'),
+                    $field,
+                    $value
+                )
             );
         }
         $this->table_row = mysqli_fetch_assoc($result);
@@ -229,9 +238,12 @@ class User
         // existing username in case and whitespace by doing a PHP string
         // compare.
         if ($strict and $field == 'username' and $this->username != $value) {
-            throw new NonexistentUserException(sprintf(
-                _('No user found with %1$s = %2$s'),
-                    $field, $value)
+            throw new NonexistentUserException(
+                sprintf(
+                    _('No user found with %1$s = %2$s'),
+                    $field,
+                    $value
+                )
             );
         }
 

--- a/pinc/UserProfile.inc
+++ b/pinc/UserProfile.inc
@@ -35,8 +35,11 @@ class UserProfile
     public function __set($name, $value)
     {
         if (isset($this->$name) && in_array($name, $this->immutable_fields)) {
-            throw new DomainException(sprintf(
-                _("%s is an immutable field"), $name)
+            throw new DomainException(
+                sprintf(
+                    _("%s is an immutable field"),
+                    $name
+                )
             );
         }
 
@@ -63,9 +66,11 @@ class UserProfile
 
         $result = DPDatabase::query($sql);
         if (mysqli_num_rows($result) == 0) {
-            throw new NonexistentUserProfileException(sprintf(
-                _('No user profile found with id = %s'),
-                    $id)
+            throw new NonexistentUserProfileException(
+                sprintf(
+                    _('No user profile found with id = %s'),
+                    $id
+                )
             );
         }
         $this->table_row = mysqli_fetch_assoc($result);

--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -45,7 +45,8 @@ function provide_escape_links()
     // link to project home
     {
         $projectid = get_parameter_value(
-            ['projectid', 'projectname', 'project']);
+            ['projectid', 'projectname', 'project']
+        );
         try {
             validate_projectID($projectid);
 
@@ -59,10 +60,12 @@ function provide_escape_links()
     // link to round
     {
         $round = get_Round_for_project_state(
-            get_parameter_value(['proj_state', 'proofstate']));
+            get_parameter_value(['proj_state', 'proofstate'])
+        );
         if (is_null($round)) {
             $round = get_Round_for_page_state(
-                get_parameter_value(['pagestate', 'page_state']));
+                get_parameter_value(['pagestate', 'page_state'])
+            );
         }
         if (!is_null($round)) {
             echo "<li>" . return_to_round_page_link($round->id) . "</li>\n";

--- a/pinc/access_log.inc
+++ b/pinc/access_log.inc
@@ -18,7 +18,8 @@ function log_access_change($subject_username, $modifier_username, $activity_id, 
 
 function get_first_granted_date($username, $stage)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT timestamp
         FROM access_log
         WHERE subject_username = '%s'
@@ -42,7 +43,8 @@ function get_first_granted_date($username, $stage)
 
 function get_latest_access_change_entry($username, $activity_id)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM access_log
         WHERE subject_username = '%s'

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -105,9 +105,11 @@ function generate_project_metadata_json($project, $filename, $dry_run)
     if ($dry_run) {
         echo "    Write project metadata to $filename.\n";
     } else {
-        file_put_contents($filename, json_encode($metadata,
+        file_put_contents($filename, json_encode(
+            $metadata,
             JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE |
-            JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK))
+            JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK
+        ))
             or die("Error writing project metadata to $filename.");
     }
 }
@@ -122,14 +124,17 @@ function archive_ancillary_data_for_project_etc($project, $indent, $dry_run)
 
     // Check for any deleted projects that were merged into this project,
     // and archive their ancillary info too.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT projectid, modifieddate, state
         FROM projects
         WHERE state = '%s'
         AND deletion_reason = '%s'
         ORDER BY modifieddate
-    ", DPDatabase::escape(PROJ_DELETE),
-        DPDatabase::escape("merged into $project->projectid"));
+    ",
+        DPDatabase::escape(PROJ_DELETE),
+        DPDatabase::escape("merged into $project->projectid")
+    );
     $res2 = DPDatabase::query($sql);
     while ($project2 = mysqli_fetch_object($res2)) {
         archive_ancillary_data_for_project($project2, $indent, $dry_run);

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -669,8 +669,11 @@ function define_bad_byte_sequences()
                 ];
                 foreach ($midways as $before => $after) {
                     if (strpos($utf8_enc, $before)) {
-                        $description_m = sprintf("double-UTF8-encoded with midway conversion of x%02x to x%02x",
-                            ord($before), ord($after));
+                        $description_m = sprintf(
+                            "double-UTF8-encoded with midway conversion of x%02x to x%02x",
+                            ord($before),
+                            ord($after)
+                        );
                         $utf8_enc_m = str_replace($before, $after, $utf8_enc);
                         $double_enc_m = _utf8_encode_string($utf8_enc_m);
                         _install_bad_sequence($double_enc_m, $code_point, $description_m);
@@ -685,8 +688,12 @@ function define_bad_byte_sequences()
     if (0) {
         foreach ($_bad_byte_sequences as $raw => $remarks) {
             [$code_point, $why_bad] = $remarks;
-            echo sprintf("%s: U+%04x %s\n",
-                string_to_hex($raw), $code_point, $why_bad);
+            echo sprintf(
+                "%s: U+%04x %s\n",
+                string_to_hex($raw),
+                $code_point,
+                $why_bad
+            );
         }
     }
 }
@@ -816,7 +823,7 @@ function find_bad_byte_sequences_in_text(&$text)
 
         if (startswith($match, '&#')) {
             @$occurrences[$match] += 1;
-        // So if a page has (say) both &#62; and &#x3e;,
+            // So if a page has (say) both &#62; and &#x3e;,
             // those will show up separately in $occurrences.
             // But that seems unlikely, and not a big deal if it does happen.
         } elseif (array_key_exists($match, $_bad_byte_sequences)) {

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -138,7 +138,8 @@ function _session_set_handlers_and_start()
             "mysql_session_select",
             "mysql_session_write",
             "mysql_session_destroy",
-            "mysql_session_garbage_collect");
+            "mysql_session_garbage_collect"
+        );
 
         session_start();
     }
@@ -176,7 +177,8 @@ function mysql_session_write($sid, $value)
 {
     $expiration = time() + ini_get("session.cookie_lifetime");
 
-    $query = sprintf("
+    $query = sprintf(
+        "
         INSERT INTO sessions
             (sid, expiration, value)
         VALUES
@@ -188,7 +190,8 @@ function mysql_session_write($sid, $value)
         $expiration,
         DPDatabase::escape($value),
         $expiration,
-        DPDatabase::escape($value));
+        DPDatabase::escape($value)
+    );
     $result = DPDatabase::query($query);
     return $result;
 }
@@ -204,9 +207,11 @@ function mysql_session_destroy($sid)
 
 function mysql_session_garbage_collect($lifetime)
 {
-    $result = DPDatabase::query(sprintf(
-        "DELETE FROM sessions WHERE expiration < %d",
-        time() - $lifetime)
+    $result = DPDatabase::query(
+        sprintf(
+            "DELETE FROM sessions WHERE expiration < %d",
+            time() - $lifetime
+        )
     );
     return $result;
 }

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -309,19 +309,19 @@ class LanguageSearchElement extends ProjectSearchElement
         // for primary only match end also
         // need to check "with" to avoid matching "French, Old" etc.
         switch (get_lang_match($this->data)) {
-        case "primary":
-            $prefix = "^";
-            $suffix = "$";
-            break;
-        case "primwith":
-            $prefix = "^";
-            $suffix = "($| with.*)";
-            break;
-        case "anywhere":
-        default:
-            $prefix = ".*";
-            $suffix = "($| with.*)";
-            break;
+            case "primary":
+                $prefix = "^";
+                $suffix = "$";
+                break;
+            case "primwith":
+                $prefix = "^";
+                $suffix = "($| with.*)";
+                break;
+            case "anywhere":
+            default:
+                $prefix = ".*";
+                $suffix = "($| with.*)";
+                break;
         }
         return " AND language REGEXP '$prefix($langstring)$suffix'";
     }
@@ -364,7 +364,8 @@ function save_display($pguser, $filter_type, $data)
 
 function save_raw_data($pguser, $data_name, $data)
 {
-    $query = sprintf("
+    $query = sprintf(
+        "
         REPLACE INTO user_filters
         (username, filtertype, value)
         VALUES ('%s', '%s', '%s')",
@@ -387,7 +388,8 @@ function get_project_filter_display($pguser, $filter_type)
 
 function get_raw_saved_data($pguser, $data_name)
 {
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT value
         FROM user_filters
         WHERE username = '%s'

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -70,7 +70,8 @@ function phpbb_lang($locale = false)
         // just fall back to English (which phpBB comes with by default).
         $lang_attempts = [strtolower($locale), substr($locale, 0, 2)];
         foreach ($lang_attempts as $lang) {
-            $query = sprintf("
+            $query = sprintf(
+                "
                 SELECT *
                 FROM %s
                 WHERE lang_iso='%s'",
@@ -140,7 +141,8 @@ function create_forum_user($username, $password, $email, $password_is_digested =
 
         // if $password_is_digested we have to update the password in the DB directly
         if ($password_is_digested) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE %s
                 SET user_password='%s'
                 WHERE user_id=%d",
@@ -345,7 +347,8 @@ function get_forum_user_details($username)
     ];
 
     $return_data = [];
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT *
         FROM %s
         WHERE username='%s'",
@@ -373,7 +376,8 @@ function get_forum_user_details($username)
         "aol" => "aim",
         "location" => "from",
     ];
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT *
         FROM %s
         WHERE user_id = %d",
@@ -409,7 +413,8 @@ function get_forum_user_id($username)
     if (isset($uidCache[$username])) {
         return $uidCache[$username];
     }
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT user_id
         FROM %s
         WHERE username = '%s'",
@@ -436,7 +441,8 @@ function get_forum_user_id($username)
  */
 function get_forum_rank_title($rank)
 {
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT rank_title
         FROM %s
         WHERE rank_id = %d",
@@ -596,7 +602,8 @@ function get_number_of_unread_messages($username)
 
     if (PHPBB_VERSION == 3) {
         // from: includes/functions_privmsgs.php:get_folder($user_id)
-        $query = sprintf("
+        $query = sprintf(
+            "
             SELECT SUM(pm_unread)
             FROM %s
             WHERE user_id = %d",
@@ -620,7 +627,8 @@ function get_number_of_unread_messages($username)
  */
 function does_topic_exist($topic_id)
 {
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT 1
         FROM %s
         WHERE topic_id = %d",
@@ -648,7 +656,8 @@ function get_last_post_time_in_topic($topic_id)
     if (!is_numeric($topic_id)) {
         return null;
     }
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT MAX(post_time) as max_post_time
         FROM %s
         WHERE topic_id = %d",

--- a/pinc/genres.inc
+++ b/pinc/genres.inc
@@ -111,14 +111,16 @@ function maybe_create_temporary_genre_translation_table()
         // if the create table succeeded, populate the table
         DPDatabase::query($sql, true, false);
         foreach ($genres as $key => $value) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 INSERT INTO genre_translations
                 SET
                     genre = '%s',
                     trans_genre = '%s'
                 ",
                 DPDatabase::escape($key),
-                DPDatabase::escape($value));
+                DPDatabase::escape($value)
+            );
             DPDatabase::query($sql);
         }
     } catch (DBQueryError $error) {

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -108,12 +108,14 @@ function user_logging_on($past, $preceding)
     ///////////////////////////////////////////////////
     //query db and put results into arrays
 
-    $sql = sprintf("SELECT DATE_FORMAT(FROM_UNIXTIME(time_stamp), '%s'), $column_name
+    $sql = sprintf(
+        "SELECT DATE_FORMAT(FROM_UNIXTIME(time_stamp), '%s'), $column_name
         FROM user_active_log
         WHERE time_stamp >= %d
         ORDER BY time_stamp",
         DPDatabase::escape($date_format),
-        $min_timestamp);
+        $min_timestamp
+    );
     $result = DPDatabase::query($sql);
 
     [$datax, $datay] = dpsql_fetch_columns($result);
@@ -243,12 +245,14 @@ function users_by_language()
     $y = [];
 
     while ($r = mysqli_fetch_assoc($res)) {
-        array_push($x, (
-        $r['intlang'] ?
-            dgettext("iso_639", eng_name($r['intlang'])) :
-            _("Browser default")
-        )
-    );
+        array_push(
+            $x,
+            (
+                $r['intlang'] ?
+                dgettext("iso_639", eng_name($r['intlang'])) :
+                _("Browser default")
+            )
+        );
         array_push($y, $r['num']);
     }
 
@@ -336,14 +340,16 @@ function curr_month_proj($which)
     $maxday = get_number_of_days_in_current_month();
 
     //query db and put results into arrays
-    $sql = sprintf("SELECT DAYOFMONTH(date) as day, SUM(num_projects)
+    $sql = sprintf(
+        "SELECT DAYOFMONTH(date) as day, SUM(num_projects)
         FROM project_state_stats
         WHERE MONTH(date) = %d AND YEAR(date) = %d AND (%s)
         GROUP BY DAYOFMONTH(date)
         ORDER BY date",
         DPDatabase::escape($month),
         DPDatabase::escape($year),
-        $psd->state_selector);
+        $psd->state_selector
+    );
     $result = DPDatabase::query($sql);
 
     [$datax, $y_cumulative] = dpsql_fetch_columns($result);
@@ -398,14 +404,16 @@ function cumulative_month_proj($which)
     $maxday = get_number_of_days_in_current_month();
 
     //query db and put results into arrays
-    $sql = sprintf("SELECT DAYOFMONTH(date) as day, SUM(num_projects)
+    $sql = sprintf(
+        "SELECT DAYOFMONTH(date) as day, SUM(num_projects)
         FROM project_state_stats
         WHERE MONTH(date) = %s AND YEAR(date) = %s AND (%s)
         GROUP BY DAYOFMONTH(date)
         ORDER BY date",
         DPDatabase::escape($month),
         DPDatabase::escape($year),
-        $psd->state_selector);
+        $psd->state_selector
+    );
     $result = DPDatabase::query($sql);
 
     [$datax, $y_num_projects] = dpsql_fetch_columns($result);
@@ -512,7 +520,8 @@ function total_pages_by_month_graph($tally_name)
         "",
         "GROUP BY 1",
         "ORDER BY 1",
-        ""));
+        ""
+    ));
 
     [$datax, $datay1, $datay2] = dpsql_fetch_columns($result);
 
@@ -588,7 +597,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
 
         default:
             die("bad 'timeframe' value: '$title_timeframe'");
-      }
+    }
 
     switch ($c_or_i) {
         case 'increments':
@@ -606,13 +615,15 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
     // -----------------------------------------------------------------------------
 
     $result = DPDatabase::query(
-      select_from_site_past_tallies_and_goals(
-          $tally_name,
-          "SELECT {date}, tally_delta, goal",
-          $where_clause,
-          "",
-          "ORDER BY timestamp",
-          ""));
+        select_from_site_past_tallies_and_goals(
+            $tally_name,
+            "SELECT {date}, tally_delta, goal",
+            $where_clause,
+            "",
+            "ORDER BY timestamp",
+            ""
+        )
+    );
 
     [$datax, $datay1, $datay2] = dpsql_fetch_columns($result);
 

--- a/pinc/job_log.inc
+++ b/pinc/job_log.inc
@@ -6,7 +6,8 @@ function insert_job_log_entry($filename, $event, $comments, $tracetime = null)
         $tracetime = time();
     }
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO job_logs (filename, tracetime, event, comments)
         VALUES ('%s', %d, '%s', '%s')
     ",

--- a/pinc/links.inc
+++ b/pinc/links.inc
@@ -132,9 +132,9 @@ function return_to_project_page_link($projectid, $query_param_array = null, $anc
 {
     $url = project_page_link_url($projectid, $query_param_array, $anchor_link);
     return sprintf(
-             _("Return to the <a %s>project page</a>"),
-             "href='$url' target='_top'"
-           );
+        _("Return to the <a %s>project page</a>"),
+        "href='$url' target='_top'"
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -147,10 +147,10 @@ function return_to_round_page_link($round_id)
     global $code_url;
 
     return sprintf(
-             _("Return to <a %s>round %s</a>"),
-             "href='$code_url/tools/proofers/round.php?round_id=$round_id' target='_top'",
-             $round_id
-           );
+        _("Return to <a %s>round %s</a>"),
+        "href='$code_url/tools/proofers/round.php?round_id=$round_id' target='_top'",
+        $round_id
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -163,7 +163,7 @@ function return_to_activity_hub_link()
     global $code_url;
 
     return sprintf(
-             _("Return to the <a %s>Activity Hub</a>"),
-             "href='$code_url/activity_hub.php' target='_top'"
-           );
+        _("Return to the <a %s>Activity Hub</a>"),
+        "href='$code_url/activity_hub.php' target='_top'"
+    );
 }

--- a/pinc/mentorbanner.inc
+++ b/pinc/mentorbanner.inc
@@ -13,7 +13,8 @@ function mentor_banner($round)
 
     // We store the name of the project's language in the 'language' column
     // in its English form, hence the use of $eng_lang_name below.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT max(round((unix_timestamp() - modifieddate)/(24 * 60 * 60)))
             FROM projects
             WHERE
@@ -45,15 +46,18 @@ function mentor_banner($round)
             break;
     }
     echo "<p class='$class'>";
-    printf(ngettext(
+    printf(
+        ngettext(
             /* TRANSLATORS: %4 is the name of the user's UI language in their language;
             %1 is a URL; %2 is the round ID; %3 is the number of days. */
             _("Oldest %4\$s <a href='%1\$s'>MENTORS ONLY</a> book in %2\$s is %3\$d day old."),
             _("Oldest %4\$s <a href='%1\$s'>MENTORS ONLY</a> book in %2\$s is %3\$d days old."),
-            $oldest),
+            $oldest
+        ),
         "$code_url/tools/proofers/for_mentors.php",
         $round_id,
         $oldest,
-        $lang_name);
+        $lang_name
+    );
     echo "</p>";
 }

--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -17,7 +17,7 @@ function metarefresh($seconds, $url, $title = "", $body = "", $allow_external = 
 
     if ($testing && (headers_sent() || ob_get_length())) {
         $sec = $seconds + 15;
-    // That may not be long enough to read everything,
+        // That may not be long enough to read everything,
         // but it should be long enough to Select All + Copy.
     } else {
         $sec = $seconds;

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -108,7 +108,8 @@ function get_enumerated_param($arr, $key, $default, $choices, $allownull = false
         if (!is_string($s)) {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' is not a valid type"),
-                $key));
+                $key
+            ));
         }
 
         // Trim whitespace from both ends of the string.
@@ -144,13 +145,17 @@ function get_enumerated_param($arr, $key, $default, $choices, $allownull = false
             if (!is_numeric($s)) {
                 throw new InvalidArgumentException(sprintf(
                     _("Parameter '%1\$s' ('%2\$s') is not numeric"),
-                    $key, $s));
+                    $key,
+                    $s
+                ));
             }
             $s = 0 + $s;
             if (!is_int($s)) {
                 throw new InvalidArgumentException(sprintf(
                     _("Parameter '%1\$s' ('%2\$s') is not an integer"),
-                    $key, $s));
+                    $key,
+                    $s
+                ));
             }
         }
 
@@ -159,7 +164,10 @@ function get_enumerated_param($arr, $key, $default, $choices, $allownull = false
         } else {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' ('%2\$s') is not one of %3\$s"),
-                $key, $s, implode(", ", $choices)));
+                $key,
+                $s,
+                implode(", ", $choices)
+            ));
         }
     } else {
         // parameter not set, use default
@@ -167,7 +175,8 @@ function get_enumerated_param($arr, $key, $default, $choices, $allownull = false
             // There is no default. The parameter is required.
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' is required"),
-                $key));
+                $key
+            ));
         } else {
             return $default;
         }
@@ -290,7 +299,8 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
         if (!is_string($s)) {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' is not a valid type"),
-                $key));
+                $key
+            ));
         }
 
         // Trim whitespace from both ends of the string.
@@ -303,7 +313,9 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
             } else {
                 throw new InvalidArgumentException(sprintf(
                     _("Parameter '%1\$s' ('%2\$s') is not an integer"),
-                    $key, $s));
+                    $key,
+                    $s
+                ));
             }
         } elseif ($type == 'float') {
             // We'll accept an integer or a floating point number
@@ -314,20 +326,28 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
             } else {
                 throw new InvalidArgumentException(sprintf(
                     _("Parameter '%1\$s' ('%2\$s') is not a float"),
-                    $key, $s));
+                    $key,
+                    $s
+                ));
             }
         }
 
         if (!is_null($min) && $i < $min) {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' ('%2\$s') is less than the minimum %3\$d"),
-                $key, $s, $min));
+                $key,
+                $s,
+                $min
+            ));
         }
 
         if (!is_null($max) && $i > $max) {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' ('%2\$s') is greater than the maximum %3\$d"),
-                $key, $s, $max));
+                $key,
+                $s,
+                $max
+            ));
         }
 
         return $i;
@@ -337,7 +357,8 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
             // There is no default. The parameter is required.
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' is required"),
-                $key));
+                $key
+            ));
         } else {
             return $default;
         }
@@ -391,7 +412,8 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull = fal
         if (!is_string($s)) {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' is not a valid type"),
-                $key));
+                $key
+            ));
         }
 
         // Trim whitespace from both ends of the string.
@@ -402,7 +424,10 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull = fal
         } else {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' ('%2\$s') does not match the regex %3\$s"),
-                $key, $s, $regex));
+                $key,
+                $s,
+                $regex
+            ));
         }
     } else {
         // not set, use default
@@ -410,7 +435,8 @@ function get_param_matching_regex($arr, $key, $default, $regex, $allownull = fal
             // There is no default. The parameter is required.
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' is required"),
-                $key));
+                $key
+            ));
         } else {
             return $default;
         }
@@ -481,8 +507,12 @@ function attr_safe($string)
     if ($string === null) {
         return "";
     }
-    return htmlspecialchars($string, ENT_QUOTES, $charset,
-                            false /* $double_encode */);
+    return htmlspecialchars(
+        $string,
+        ENT_QUOTES,
+        $charset,
+        false // $double_encode
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -529,22 +559,31 @@ function javascript_safe($str, $encoding = null)
     }
 
     if (!strcasecmp($encoding, 'UTF-8')) {
-        $str = preg_replace_callback('/([\000-\037\"\'\\\\<\177])/',
+        $str = preg_replace_callback(
+            '/([\000-\037\"\'\\\\<\177])/',
             function ($matches) {
                 return sprintf("\\%03o", ord($matches[0]));
-            }, $str);
+            },
+            $str
+        );
 
         // convert non-7bit ascii characters to \uHHHH notation
-        $str = preg_replace_callback('/([^\000-\177])/u',
+        $str = preg_replace_callback(
+            '/([^\000-\177])/u',
             function ($matches) {
                 return sprintf("\\u%04x", UTF8::ord($matches[0]) & 0xffffff);
-            }, $str);
+            },
+            $str
+        );
     } else {
         // assume Latin-1 encoding
-        $str = preg_replace_callback('/([\000-\017\\\\"\'<\177-\237])/',
+        $str = preg_replace_callback(
+            '/([\000-\017\\\\"\'<\177-\237])/',
             function ($matches) {
                 return sprintf("\\%03o", ord($matches[0]));
-            }, $str);
+            },
+            $str
+        );
     }
     return $str;
 }
@@ -798,7 +837,8 @@ function flatten_directory(string $directory_to_flatten)
     if (!file_exists($directory_to_flatten) || !is_dir($directory_to_flatten)) {
         throw new InvalidArgumentException(sprintf(
             _("Argument '%1\$s' is not a valid output directory (it does not exist)."),
-            $directory_to_flatten));
+            $directory_to_flatten
+        ));
     }
 
     $iterator = new RecursiveDirectoryIterator($directory_to_flatten, RecursiveDirectoryIterator::SKIP_DOTS);
@@ -809,16 +849,23 @@ function flatten_directory(string $directory_to_flatten)
             $result = rmdir($file->getRealPath());
 
             if (!$result) {
-                throw new RuntimeException(sprintf(_("Could not remove directory '%1\$s' while flattening '%2\$s'."),
-                    $file->getRealPath(), $directory_to_flatten));
+                throw new RuntimeException(sprintf(
+                    _("Could not remove directory '%1\$s' while flattening '%2\$s'."),
+                    $file->getRealPath(),
+                    $directory_to_flatten
+                ));
             }
         } else {
             $new_name = $directory_to_flatten . '/' . $file->getFilename();
             $result = rename($file->getRealPath(), $new_name);
 
             if (!$result) {
-                throw new RuntimeException(sprintf(_("Could not move file '%1\$s' to '%2\$s' while flattening '%3\$s'."),
-                    $file->getRealPath(), $new_name, $directory_to_flatten));
+                throw new RuntimeException(sprintf(
+                    _("Could not move file '%1\$s' to '%2\$s' while flattening '%3\$s'."),
+                    $file->getRealPath(),
+                    $new_name,
+                    $directory_to_flatten
+                ));
             }
         }
     }
@@ -867,7 +914,8 @@ function list_files_in_zip(string $file_path): array
     if (!is_valid_zip_file($file_path)) {
         throw new InvalidArgumentException(sprintf(
             _("Argument '%1\$s' is not a valid zip file."),
-            $file_path));
+            $file_path
+        ));
     }
 
     $zip = new ZipArchive();
@@ -899,13 +947,15 @@ function extract_zip_to(string $path_to_zip, string $output_directory): bool
     if (!is_valid_zip_file($path_to_zip)) {
         throw new InvalidArgumentException(sprintf(
             _("Argument '%1\$s' is not a valid zip file."),
-            $path_to_zip));
+            $path_to_zip
+        ));
     }
 
     if (!file_exists($output_directory) || !is_dir($output_directory)) {
         throw new InvalidArgumentException(sprintf(
             _("Argument '%1\$s' is not a valid output directory (it does not exist)."),
-            $output_directory));
+            $output_directory
+        ));
     }
 
     $zip = new ZipArchive();
@@ -927,7 +977,8 @@ function remove_common_basedir_from_zip(string $path_to_zip)
     if (!is_valid_zip_file($path_to_zip)) {
         throw new InvalidArgumentException(sprintf(
             _("Argument '%1\$s' is not a valid zip file."),
-            $path_to_zip));
+            $path_to_zip
+        ));
     }
 
     $zip = new ZipArchive();
@@ -992,7 +1043,8 @@ function create_zip_from(array $files_to_zip, string $path_to_zip): bool
     if ($zip->open($path_to_zip, ZipArchive::CREATE) !== true) {
         throw new InvalidArgumentException(sprintf(
             _("Could not open '%1\$s' as a ZipArchive."),
-            $path_to_zip));
+            $path_to_zip
+        ));
     }
 
     foreach ($files_to_zip as $file) {

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -95,7 +95,8 @@ function fetch_page_table_data($project, $page_selector = null, $proofed_in_roun
         if (is_formatting_round($round)) {
             $wordcheck_query = "NULL as wordcheck_status$rn";
         } else {
-            $wordcheck_query = sprintf("
+            $wordcheck_query = sprintf(
+                "
                 (
                     SELECT count(*)
                     FROM wordcheck_events
@@ -104,8 +105,10 @@ function fetch_page_table_data($project, $page_selector = null, $proofed_in_roun
                         username = $round->user_column_name AND
                         round_id = '%s'
                 ) as wordcheck_status$rn
-            ", DPDatabase::escape($project->projectid),
-                DPDatabase::escape($round->id));
+            ",
+                DPDatabase::escape($project->projectid),
+                DPDatabase::escape($round->id)
+            );
         }
         $fields_to_get .= ",
             $prev_text_column_name = BINARY $round->text_column_name AS $round->textdiff_column_name,
@@ -203,8 +206,8 @@ function echo_page_table(
     $show_image_size,
     $disable_editing = false,
     $page_selector = null,
-    $proofed_in_round = null)
-{
+    $proofed_in_round = null
+) {
     global $projects_dir, $code_url, $pguser;
 
     $can_edit = $project->can_be_managed_by_current_user;
@@ -402,7 +405,12 @@ function echo_page_table(
                 && $page_res["pagerounds"][$project_round->id]["username"] == $pguser
                 && $page_state != $project_round->page_avail_state) {
                 $url = url_for_pi_do_particular_page(
-                    $projectid, $state, $imagename, $page_state, true);
+                    $projectid,
+                    $state,
+                    $imagename,
+                    $page_state,
+                    true
+                );
                 echo "<td><a href='$url'>"._("Edit")."</a></td>\n";
             } else {
                 echo "<td></td>";
@@ -547,10 +555,13 @@ function get_rounds_with_data($projectid)
 
 // -----------------------------------------------------------------------------
 
-function echo_cells_for_round($round, $diff_round_num, // <- These are the only "real" params.
+function echo_cells_for_round(
+    $round,
+    $diff_round_num, // <- These are the only "real" params.
     $page_res,
-    $projectid, $can_see_names_for_this_page)
-{
+    $projectid,
+    $can_see_names_for_this_page
+) {
     global $pguser, $code_url;
 
     $imagename = $page_res['image'];

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -102,7 +102,8 @@ function user_get_ELR_page_tally($username)
     [$joined_with_user_ELR_page_tallies, $user_ELR_page_tally_column] =
         $users_ELR_page_tallyboard->get_sql_joinery_for_current_tallies('u_id');
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT $user_ELR_page_tally_column
         FROM users $joined_with_user_ELR_page_tallies
         WHERE username='%s'",
@@ -144,7 +145,8 @@ function user_get_page_tally_neighborhood($tally_name, $username, $radius)
     $tallyboard = new TallyBoard($tally_name, 'U');
     $nb =
         $tallyboard->get_neighborhood(
-            $user->u_id, $radius,
+            $user->u_id,
+            $radius,
             'users',
             'u_id',
             'username, u_privacy, date_created, u_id',
@@ -279,18 +281,21 @@ function get_site_page_tally_summary($tally_name)
     $site_stats->curr_day_goal =
         get_site_tally_goal_summed(
             $tally_name,
-            "date = CURRENT_DATE");
+            "date = CURRENT_DATE"
+        );
 
     $site_stats->prev_day_goal =
         get_site_tally_goal_summed(
             $tally_name,
-            "date = (CURRENT_DATE - INTERVAL 1 DAY)");
+            "date = (CURRENT_DATE - INTERVAL 1 DAY)"
+        );
 
     $site_stats->curr_month_goal =
         get_site_tally_goal_summed(
             $tally_name,
             "YEAR(date) = YEAR(CURRENT_DATE) AND
-            MONTH(date) = MONTH(CURRENT_DATE)");
+            MONTH(date) = MONTH(CURRENT_DATE)"
+        );
 
     // Actuals
 
@@ -309,9 +314,11 @@ function get_site_page_tally_summary($tally_name)
 
     $today = getdate();
     $site_stats->curr_month_actual =
-        $tallyboard->get_delta_sum($holder_id,
+        $tallyboard->get_delta_sum(
+            $holder_id,
             mktime(0, 0, 0, $today['mon'], 1, $today['year']),
-            mktime(0, 0, 0, $today['mon'] + 1, 1, $today['year']))
+            mktime(0, 0, 0, $today['mon'] + 1, 1, $today['year'])
+        )
         +
         $site_stats->curr_day_actual;
 
@@ -320,7 +327,8 @@ function get_site_page_tally_summary($tally_name)
 
 function get_site_tally_goal_summed($tally_name, $date_condition)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT SUM(goal)
         FROM site_tally_goals
         WHERE tally_name = '%s' AND ($date_condition)",
@@ -344,8 +352,8 @@ function select_from_site_past_tallies_and_goals(
     $where,
     $groupby,
     $orderby,
-    $limit)
-{
+    $limit
+) {
     global $SECONDS_TO_YESTERDAY;
 
     if (empty($where)) {

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -16,7 +16,8 @@
 
 $this_is_top_level_cli_invocation = (
     php_sapi_name() == 'cli' &&
-    count(get_included_files()) == 1);
+    count(get_included_files()) == 1
+);
 // i.e., this file is being executed because it was the
 // script argument to a command-line invocation of php,
 // probably invoked by DP code via exec() or system().

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -15,7 +15,7 @@ function user_can_add_project_pages($projectid)
     // do this if the project already has some pages loaded.
     if (($state == PROJ_NEW || $state == PROJ_P1_UNAVAILABLE)
         && ($project->get_num_pages() > 0 || ! user_has_project_loads_disabled())
-        ) {
+    ) {
         return true;
     } else {
         return false;
@@ -37,8 +37,10 @@ function abort_if_cant_edit_project($projectid)
             <P>
             "._("There appears to be no such project")." ($projectid).
             <P>
-            ", sprintf(_("If this message is an error, contact a <a href='%s'>site manager</a>"),
-                "mailto:$site_manager_email_addr"), "
+            ", sprintf(
+            _("If this message is an error, contact a <a href='%s'>site manager</a>"),
+            "mailto:$site_manager_email_addr"
+        ), "
             <P><a href=\"projectmgr.php\">"._("Back")."</a>";
         exit;
     }
@@ -48,8 +50,10 @@ function abort_if_cant_edit_project($projectid)
             <P>
             "._("You are not authorized to manage this project.")." ($projectid).
             <P>
-            ", sprintf(_("If this message is an error, contact a <a href='%s'>site manager</a>"),
-                "mailto:$site_manager_email_addr"), "
+            ", sprintf(
+            _("If this message is an error, contact a <a href='%s'>site manager</a>"),
+            "mailto:$site_manager_email_addr"
+        ), "
             <P><a href=\"projectmgr.php\">"._("Back")."</a>";
         exit;
     }
@@ -63,9 +67,10 @@ function check_user_can_load_projects($exit_if_not)
               <div class='display-flex' style='margin-bottom:0.5em'><div class='callout'>"
             ._("You are not currently permitted to create new projects, or move projects out of the new project or unavailable states.")
             ."<br>\n"
-            .sprintf(_("If you believe you are receiving this message in error, please contact a <a href='%s'>site manager</a>."),
-                     "mailto:$site_manager_email_addr"
-                     )
+            .sprintf(
+                _("If you believe you are receiving this message in error, please contact a <a href='%s'>site manager</a>."),
+                "mailto:$site_manager_email_addr"
+            )
             ."
               </div></div>\n";
         if ($exit_if_not) {

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -356,8 +356,10 @@ function _test_project_for_missing_pages($projectid)
     );
 
     $test_name = _("Missing Pages");
-    $test_desc = sprintf(_("This manual test requires looking through each page of a project to see if there are missing pages. This is done by looking for missing page numbers, eg: image 100.png says it's page 80 and image 101.png says it's page 82. To perform this check, you can look at the pages online from the <a href='%s'>Page Details</a> page or download the project files from the project page and check them offline. Please check to make sure all illustration images are also loaded."),
-        "$code_url/tools/project_manager/page_detail.php?project=$projectid");
+    $test_desc = sprintf(
+        _("This manual test requires looking through each page of a project to see if there are missing pages. This is done by looking for missing page numbers, eg: image 100.png says it's page 80 and image 101.png says it's page 82. To perform this check, you can look at the pages online from the <a href='%s'>Page Details</a> page or download the project files from the project page and check them offline. Please check to make sure all illustration images are also loaded."),
+        "$code_url/tools/project_manager/page_detail.php?project=$projectid"
+    );
 
     $status = _("Manual");
     $summary = _("This is a manual test.");

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -42,8 +42,8 @@ function declare_project_state(
     $long_label,
     $forum,
     $phase,
-    $star_metal)
-{
+    $star_metal
+) {
     global $PROJECT_STATES_IN_ORDER;
     global $project_state_medium_label_;
     global $project_state_long_label_;
@@ -154,8 +154,8 @@ function declare_project_states_for_round($round_id, $round_name)
 declare_project_state(
     "PROJ_NEW",
     "project_new",
-     _("New Project"),
-     _("New Project"),
+    _("New Project"),
+    _("New Project"),
     $waiting_projects_forum_idx,
     'NEW',
     ''
@@ -299,8 +299,10 @@ foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
 function sql_collater_for_project_state($state_column)
 {
     global $PROJECT_STATES_IN_ORDER;
-    return sprintf("FIELD($state_column, %s)",
-        surround_and_join($PROJECT_STATES_IN_ORDER, "'", "'", ","));
+    return sprintf(
+        "FIELD($state_column, %s)",
+        surround_and_join($PROJECT_STATES_IN_ORDER, "'", "'", ",")
+    );
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -34,7 +34,8 @@ function show_projects_for_round($round, $show_filter_block = true, $allow_speci
         $show_filter_block,
         $filter_custom_display_fields,
         $allow_special_colors_legend,
-        $columns);
+        $columns
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -183,8 +184,8 @@ function show_projects_for_stage(
     $filter_custom_display_fields,
     $allow_special_colors_legend,
     $columns,
-    $optional_join_clause = "")
-{
+    $optional_join_clause = ""
+) {
     global $pguser;
 
     // SR is a special snowflake that prints its own header
@@ -686,7 +687,9 @@ function process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setti
             echo html_safe(
                 sprintf(
                     _("%1\$s supplies value '%2\$s'"),
-                    $provider_noun, $curr_ext_sort)
+                    $provider_noun,
+                    $curr_ext_sort
+                )
             );
             echo "</p>";
         }
@@ -721,7 +724,10 @@ function process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setti
             echo html_safe(
                 sprintf(
                     _("%1\$s value '%2\$s' has bad column part: '%3\$s'"),
-                    $provider_noun, $curr_ext_sort, $curr_ext_sort_col)
+                    $provider_noun,
+                    $curr_ext_sort,
+                    $curr_ext_sort_col
+                )
             );
             echo "\n</p>";
             continue;
@@ -738,7 +744,10 @@ function process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setti
                 sprintf(
                     // TRANSLATORS: "sort direction" refers to the sort order direction (ascending vs descending)
                     _("%1\$s value '%2\$s' has bad sort direction: '%3\$s'"),
-                    $provider_noun, $curr_ext_sort, $curr_ext_sort_dir)
+                    $provider_noun,
+                    $curr_ext_sort,
+                    $curr_ext_sort_dir
+                )
             );
 
             // We could skip to the next provider via 'continue',
@@ -752,7 +761,8 @@ function process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setti
             echo html_safe(
                 sprintf(
                     _("Using '%s' instead."),
-                    $curr_ext_sort_dir)
+                    $curr_ext_sort_dir
+                )
             );
             echo "\n</p>";
         }
@@ -775,7 +785,9 @@ function process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setti
                 echo html_safe(
                     sprintf(
                         _("DB setting '%1\$s' receives value '%2\$s'"),
-                        $ext_sort_setting_name, $curr_ext_sort)
+                        $ext_sort_setting_name,
+                        $curr_ext_sort
+                    )
                 );
                 echo "</p>";
             }

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -66,28 +66,34 @@ function show_news_for_page($news_page_id)
 
     // Get the set of 'current' news items
     // defined for the given page.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT date_posted, header, content, item_type
         FROM news_items
         WHERE status = 'current'
             AND (news_page_id = '%s' OR news_page_id = 'GLOBAL')
             AND (locale = '' OR locale = '%s')
         ORDER BY ORDERING DESC
-    ", DPDatabase::escape($news_page_id),
-        DPDatabase::escape($user_locale));
+    ",
+        DPDatabase::escape($news_page_id),
+        DPDatabase::escape($user_locale)
+    );
     $res_current = DPDatabase::query($sql);
 
     // Get a randomly selected news item from the set of
     // 'recent' news items defined for the given page.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT header, content, item_type
         FROM news_items
         WHERE status = 'recent'
             AND (news_page_id = '%s' OR news_page_id = 'GLOBAL')
             AND (locale = '' OR locale = '%s')
         ORDER BY RAND() LIMIT 1
-    ", DPDatabase::escape($news_page_id),
-        DPDatabase::escape($user_locale));
+    ",
+        DPDatabase::escape($news_page_id),
+        DPDatabase::escape($user_locale)
+    );
     $res_random = DPDatabase::query($sql);
 
     // -------------------------------------------

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -49,7 +49,9 @@ function load_special_days($load_common = false)
                 "color" => '#' . $row['color'],
 
                 // provide a localized option label
-                "option_label" => sprintf("%s (%s)", $row["display_name"],
+                "option_label" => sprintf(
+                    "%s (%s)",
+                    $row["display_name"],
                     date_format(
                         date_create(
                             sprintf("2000-%02d-%02d", $row["open_month"], $row["open_day"])
@@ -71,16 +73,24 @@ function sort_special_days(&$special_days, $sort_by = "display_name")
 
     if ($sort_by == "display_name") {
         array_multisort(
-            $display_name, SORT_NATURAL, SORT_ASC,
+            $display_name,
+            SORT_NATURAL,
+            SORT_ASC,
             $special_days
         );
     } elseif ($sort_by == "open_month,open_day") {
         $open_month = array_column($special_days, "open_month");
         $open_day = array_column($special_days, "open_day");
         array_multisort(
-            $open_month, SORT_NUMERIC, SORT_ASC,
-            $open_day, SORT_NUMERIC, SORT_ASC,
-            $display_name, SORT_NATURAL, SORT_ASC,
+            $open_month,
+            SORT_NUMERIC,
+            SORT_ASC,
+            $open_day,
+            SORT_NUMERIC,
+            SORT_ASC,
+            $display_name,
+            SORT_NATURAL,
+            SORT_ASC,
             $special_days
         );
     } else {

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -485,18 +485,17 @@ new Pool(
     null, // access_change_callback
     _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
     'post_proof.php',
-
     PROJ_POST_FIRST_CHECKED_OUT,
     PROJ_POST_FIRST_AVAILABLE,
-
     _("Manager"),
     'username',
-
     [
         "<p>",
         "<b>" . _("First Time Here?") . "</b>",
-        sprintf(_("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
-        "$code_url/faq/post_proof.php"),
+        sprintf(
+            _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
+            "$code_url/faq/post_proof.php"
+        ),
         _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
         sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
         _("If nothing interests you right now, check back later and there will be more!"),
@@ -539,7 +538,8 @@ function echo_postcomments_instructions()
         If you don't hear back from the PM within a reasonable amount of time,
         let the <a href='%s'>db-req</a> squirrels know about the issues
         so we can get the project fixed."),
-        "$wiki_url/Db-req")
+        "$wiki_url/Db-req"
+    )
         . '</p>';
     echo '<p>'
         . _("Note that your old comments will be replaced by those you enter here.")
@@ -571,25 +571,28 @@ new Pool(
     null, // access_change_callback
     _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
     'ppv.php',
-
     PROJ_POST_SECOND_CHECKED_OUT,
     PROJ_POST_SECOND_AVAILABLE,
-
     _("Post-Processor"),
     'postproofer',
-
     [
         "<p>",
         _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
-        sprintf(_("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
-            "$code_url/faq/ppv.php"),
-        sprintf(_("The PPV reporting form is <a href='%s'>here</a>."),
-            "$code_url/tools/post_proofers/ppv_report.php"),
+        sprintf(
+            _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
+            "$code_url/faq/ppv.php"
+        ),
+        sprintf(
+            _("The PPV reporting form is <a href='%s'>here</a>."),
+            "$code_url/tools/post_proofers/ppv_report.php"
+        ),
         "</p>",
 
         "<p>",
-        sprintf(_("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
-            get_url_to_view_forum($post_processing_forum_idx)),
+        sprintf(
+            _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
+            get_url_to_view_forum($post_processing_forum_idx)
+        ),
         "</p>",
     ]
 );

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -138,7 +138,8 @@ function html_logobar()
     echo "<span id='x-preserved'>";
     echo sprintf(
         _('%s titles preserved for the world!'),
-        number_format(total_completed_projects()));
+        number_format(total_completed_projects())
+    );
     echo "</span>\n";
     echo "<span id='month-preserved-summary'>";
     show_completed_projects(true);
@@ -609,8 +610,10 @@ function show_tally_specific_stats($tally_name)
     echo
         sprintf(
             _('%1$s users with at least one %2$s page'),
-            number_format($num_positive_users), $tally_name),
-        "\n";
+            number_format($num_positive_users),
+            $tally_name
+        ),
+    "\n";
 
     // ---------------------------------------------------------------------
 
@@ -622,7 +625,10 @@ function show_tally_specific_stats($tally_name)
         //Get the personal statistics array
         $neighbors =
             user_get_page_tally_neighborhood(
-                $tally_name, $user->username, $user->u_neigh);
+                $tally_name,
+                $user->username,
+                $user->u_neigh
+            );
         $usern = $neighbors[0];
 
         //get rank
@@ -635,7 +641,8 @@ function show_tally_specific_stats($tally_name)
             $round = get_Round_for_round_id($tally_name);
             if ($round) {
                 $rankname = $round->get_honorific_for_page_tally(
-                    $usern->get_current_page_tally());
+                    $usern->get_current_page_tally()
+                );
             } else {
                 $rankname = _('[unknown]');
             }
@@ -966,7 +973,7 @@ function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_col
     if ($prorate_goal_for_color == 'bar' || $prorate_goal_for_color === true) {
         $t_start_of_today = mktime(0, 0, 0, date('m'), date('d'), date('y'));
         $fraction_of_time_passed = (time() - $t_start_of_today) / (60 * 60 * 24);
-    // Note: Calculation assumes a 24-hour day which is true except
+        // Note: Calculation assumes a 24-hour day which is true except
         // possibly for the first and last days of daylight saving time
         // depending on how PHP calculates DST in the mktime() call.
     } elseif ($prorate_goal_for_color == 'month') {

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -285,8 +285,10 @@ function convert_codepoint_ranges_to_characters($codepoints)
         } elseif (strpos($codepoint, '-') !== false) {
             // we have a character range
             [$start, $end] = explode('-', $codepoint);
-            $return_array = array_merge($return_array,
-                UTF8::range(UTF8::hex_to_int($start), UTF8::hex_to_int($end)));
+            $return_array = array_merge(
+                $return_array,
+                UTF8::range(UTF8::hex_to_int($start), UTF8::hex_to_int($end))
+            );
         } else {
             // a single character or a combined character
             $return_array[] = utf8_combined_chr($codepoint);

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -201,7 +201,7 @@ function user_can_work_on_beginner_pages_in_round($round)
             || user_is_proj_facilitator()
             || $userSettings->get_boolean("see_BEGIN_R".$round_number)
             || $userSettings->get_boolean("{$round->id}_mentor.access")
-        ) {
+    ) {
         return true;
     }
 

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -24,7 +24,8 @@ various places:
 function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_row = false)
 {
     if ($ensure_row) {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO user_project_info
             SET
                 username            = '%s',
@@ -38,7 +39,8 @@ function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_
             $timestamp
         );
     } else {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE user_project_info
             SET t_latest_home_visit = %d
             WHERE username = '%s' AND projectid = '%s'",
@@ -52,7 +54,8 @@ function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_
 
 function upi_set_t_latest_page_event($username, $projectid, $timestamp)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO user_project_info
         SET
             username            = '%s',
@@ -63,7 +66,8 @@ function upi_set_t_latest_page_event($username, $projectid, $timestamp)
         DPDatabase::escape($username),
         DPDatabase::escape($projectid),
         $timestamp,
-        $timestamp);
+        $timestamp
+    );
     DPDatabase::query($sql);
 }
 
@@ -116,7 +120,8 @@ function set_user_project_event_subscription($username, $projectid, $event, $bit
     // Just to ensure that $event is valid; we don't use $event_label.
 
     // Now that we're sure the row exists, we can update it.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO user_project_info
         SET
             username    = '%s',
@@ -137,7 +142,8 @@ function user_is_subscribed_to_project_event($username, $projectid, $event)
     $event_label = get_label_for_event($event);
     // Just to ensure that $event is valid; we don't use $event_label.
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT iste_$event
         FROM user_project_info
         WHERE username    = '%s'
@@ -175,7 +181,8 @@ function notify_project_event_subscribers($project, $event, $extras = [])
     $projectid = $project->projectid;
     $title = $project->nameofwork;
 
-    $sql1 = sprintf("
+    $sql1 = sprintf(
+        "
         SELECT username
         FROM user_project_info
         WHERE projectid = '%s'
@@ -254,7 +261,8 @@ function notify_project_event_subscribers($project, $event, $extras = [])
     if ($event == 'posted') {
         // Take the number of users subscribed to the event
         // and record that as the project's "interest level".
-        $sql4 = sprintf("
+        $sql4 = sprintf(
+            "
             UPDATE projects
             SET int_level = %d
             WHERE projectid = '%s'",
@@ -280,7 +288,8 @@ function get_n_users_subscribed_to_events_for_project($projectid)
     }
     $selects = implode(',', $items);
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT $selects
         FROM user_project_info
         WHERE projectid='%s'",

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -221,7 +221,9 @@ function get_bad_words_for_text($text, $languages, $word_lists = [])
         $acc->add_bad_words($external_bad_words, WC_WORLD);
 
         $acc->add_bad_words(
-            get_bad_words_with_diacritical_markup($input_words_w_freq), WC_WORLD);
+            get_bad_words_with_diacritical_markup($input_words_w_freq),
+            WC_WORLD
+        );
     }
 
     // The site
@@ -230,7 +232,9 @@ function get_bad_words_for_text($text, $languages, $word_lists = [])
         $acc->add_bad_words(array_get($word_lists, "site_bad", []), WC_SITE);
 
         $acc->add_bad_words(
-            get_bad_words_via_pattern($input_words_w_freq, $languages), WC_SITE);
+            get_bad_words_via_pattern($input_words_w_freq, $languages),
+            WC_SITE
+        );
     }
 
     // The project
@@ -344,7 +348,8 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
                 ]);
                 //echo "<!-- aspell command: $aspell_command -->\n"; // Very useful for debugging
                 // build our list of possible misspellings
-                $misspellings[$langcode] = explode("\n",
+                $misspellings[$langcode] = explode(
+                    "\n",
                     str_replace("\r", "", shell_exec($aspell_command))
                 );
 
@@ -353,7 +358,8 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
                 // dictionaries like Ancient Greek that return all non-Greek
                 // words as misspelled.
                 $misspellings[$langcode] = filter_words_to_script(
-                    $misspellings[$langcode], get_script_for_langcode($langcode)
+                    $misspellings[$langcode],
+                    get_script_for_langcode($langcode)
                 );
             } else {
                 $messages[] = sprintf(_("Warning: no external dictionary installed for '%s'"), $language);
@@ -386,7 +392,8 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
             continue;
         }
         $misspellings[$lang_script] = array_intersect(
-            $misspellings[$lang_script], $words
+            $misspellings[$lang_script],
+            $words
         );
         unset($misspellings[$lang_code]);
     }
@@ -595,7 +602,8 @@ function normalize_word_list($words)
  */
 function delete_project_wordcheck_events($projectid)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         DELETE FROM wordcheck_events
         WHERE projectid='%s'",
         DPDatabase::escape($projectid)
@@ -633,7 +641,8 @@ function merge_project_wordcheck_data($from_projectid, $to_projectid)
  */
 function copy_project_wordcheck_events($from_projectid, $to_projectid)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO wordcheck_events
             (projectid, timestamp, image, round_id, username, suggestions, corrections)
         SELECT '%s', timestamp, image, round_id, username, suggestions, corrections
@@ -681,7 +690,8 @@ function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions,
  */
 function count_wordcheck_suggestion_events($projectid, $start_time = 0)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT count(*) AS numevents FROM wordcheck_events
         WHERE projectid='%s'
         AND timestamp>%d AND suggestions<>''",
@@ -700,7 +710,8 @@ function count_wordcheck_suggestion_events($projectid, $start_time = 0)
 
 function load_wordcheck_events($projectid, $start_time = 0)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT * FROM wordcheck_events
         WHERE projectid='%s'
         AND timestamp>%d",
@@ -818,9 +829,11 @@ function get_project_word_file($projectid, $code)
     $filename_for_code = get_wordcheck_file_names();
     assert(array_key_exists($code, $filename_for_code));
 
-    return get_file_info_object($filename_for_code[$code],
-                "$projects_dir/$projectid",
-                "$projects_url/$projectid");
+    return get_file_info_object(
+        $filename_for_code[$code],
+        "$projects_dir/$projectid",
+        "$projects_url/$projectid"
+    );
 }
 
 /**
@@ -842,9 +855,11 @@ function get_site_word_file($langcode3, $code)
     ];
     assert(array_key_exists($code, $filename_for_code));
 
-    return get_file_info_object($filename_for_code[$code],
-                "$dyn_dir/words",
-                "$dyn_url/words");
+    return get_file_info_object(
+        $filename_for_code[$code],
+        "$dyn_dir/words",
+        "$dyn_url/words"
+    );
 }
 
 /**

--- a/project.php
+++ b/project.php
@@ -404,7 +404,8 @@ function do_project_info_table()
         $cooked_reason = preg_replace(
             '/\b(projectID[0-9a-f]{13})\b/',
             '<a href="project.php?id=\1">\1</a>',
-            $project->deletion_reason);
+            $project->deletion_reason
+        );
         echo_row_a(_("Reason for Deletion"), $cooked_reason);
     }
 
@@ -474,12 +475,14 @@ function do_project_info_table()
     echo_row_a(
         _("Last Edit of Project Info"),
         icu_date_template("long+time", $project->t_last_edit)
-        . $current_time_addition);
+        . $current_time_addition
+    );
 
     echo_row_a(
         _("Last State Change"),
         icu_date_template("long+time", $project->modifieddate),
-        true);
+        true
+    );
 
     if ($round) {
         $last_proofread_time = $project->get_last_proofread_time($round);
@@ -533,8 +536,11 @@ function do_project_info_table()
         echo_row_a(
             _("PG etext number"),
             $postednum . " &ndash; " .
-            sprintf(_("<a href='%s'>Read this text</a> at Project Gutenberg"),
-                 get_pg_catalog_url_for_etext($postednum)));
+            sprintf(
+                _("<a href='%s'>Read this text</a> at Project Gutenberg"),
+                get_pg_catalog_url_for_etext($postednum)
+            )
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -653,9 +659,9 @@ function do_project_info_table()
 
         if ($round) {
             $a = sprintf(
-                    _("The <a href='%s'>Guidelines</a> give detailed instructions for working in this round."),
-                    get_faq_url($round->document)
-                );
+                _("The <a href='%s'>Guidelines</a> give detailed instructions for working in this round."),
+                get_faq_url($round->document)
+            );
             $b = _('The instructions below are particular to this project, and <b>take precedence over those guidelines</b>.');
 
             $time_str = icu_date_template("long+time", $project->t_last_change_comments);
@@ -775,7 +781,12 @@ function recentlyproofed($wlist)
             $timestamp = $row[$round->time_column_name];
             $pagestate = $row["state"];
             $eURL = url_for_pi_do_particular_page(
-                $projectid, $state, $imagefile, $pagestate, true);
+                $projectid,
+                $state,
+                $imagefile,
+                $pagestate,
+                true
+            );
 
             if ($row["wordcheck_status"] == null) {
                 $wordcheck_status = '';
@@ -897,7 +908,8 @@ function do_early_uploads()
                 _('For FTP uploads, use host=%1$s account=%2$s password=%3$s'),
                 "<b>$uploads_host</b>",
                 "<b>$uploads_account</b>",
-                "<i>" . html_safe($uploads_password) . "</i>");
+                "<i>" . html_safe($uploads_password) . "</i>"
+            );
         }
 
         echo "</p>";
@@ -1141,8 +1153,8 @@ function do_history()
 
         $event_type = $event['event_type'];
         echo "<td>",
-             array_get($event_type_labels, $event_type, $event_type),
-             "</td>\n";
+        array_get($event_type_labels, $event_type, $event_type),
+        "</td>\n";
         // count columns so we can fill up space after
         $spare_cols = 3;
 

--- a/quiz/generic/quiz_defaults.inc
+++ b/quiz/generic/quiz_defaults.inc
@@ -577,7 +577,7 @@ $messages["G_extrah"] = [
     "message_body" => sprintf(
         _("Vowels in Greek words can have the following diacritical marks (accents): %s When transliterating Greek, you should ignore all of these except for the first one (the 'rough breathing' mark), which is curved like a C."),
         "\n<br><img src='images/Greek_accents.png' width='200' height='33'><br>\n"
-        ),
+    ),
     "wiki_ref" => sprintf(_("See the <a href='%s#Diacritical_Marks' target='_blank'>Diacritical Marks</a> section of the wiki page for details."), $Greek_translit_url),
 ];
 $messages["G_smooth_rough"] = [

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -624,7 +624,7 @@ function qp_echo_link_to_hint_if_it_exists($message_id, $hint_number)
 
         if (isset($hint["linktext"])) {
             echo $hint["linktext"];
-        // XXX: Currently unused. Might be discontinued.
+            // XXX: Currently unused. Might be discontinued.
         } else {
             echo $default_hintlink;
         }

--- a/quiz/tuts/tut_p_greek_2.php
+++ b/quiz/tuts/tut_p_greek_2.php
@@ -15,8 +15,10 @@ echo "<p>" . _("<b>Note:</b> For the purposes of this quiz, please use the vowel
 echo "<h3>" . _("Diacritical Marks") . "</h3>\n";
 echo "<p>" . _("Vowels in Greek words can have the following diacritical marks (accents):") . "<br>\n";
 echo "<img src='../generic/images/Greek_accents.png' width='200' height='33' alt='" . _("accented Greek vowels") . "'></p>\n";
-echo "<p>" . sprintf(_("When transliterating Greek, you should ignore all of these except for the first one (the \"rough breathing\" mark).  If a vowel has a rough breathing mark over it, we indicate this by adding an \"<kbd>h</kbd>\" to the start of the transliterated word.  For example, these two words: %s would be transliterated as <kbd>[Greek: hodous]</kbd> and <kbd>[Greek: odous]</kbd>, respectively."),
-                     "<br>\n<img src='../generic/images/rough_smooth_breathing.png' width='214' height='45' alt='" . _("two Greek words differing only in breathing mark") . "'><br>\n") . "</p>\n";
+echo "<p>" . sprintf(
+    _("When transliterating Greek, you should ignore all of these except for the first one (the \"rough breathing\" mark).  If a vowel has a rough breathing mark over it, we indicate this by adding an \"<kbd>h</kbd>\" to the start of the transliterated word.  For example, these two words: %s would be transliterated as <kbd>[Greek: hodous]</kbd> and <kbd>[Greek: odous]</kbd>, respectively."),
+    "<br>\n<img src='../generic/images/rough_smooth_breathing.png' width='214' height='45' alt='" . _("two Greek words differing only in breathing mark") . "'><br>\n"
+) . "</p>\n";
 echo "<p>" . _("The breathing mark may be combined with another accent, which sometimes makes it difficult to tell which way the breathing mark goes, especially in badly printed text.  They can become easier to see if you enlarge the image. If a vowel has both a breathing mark and an acute or grave accent in the image, the breathing mark normally appears on the left.  Other clues which can help in identifying a rough breathing mark are: ") . "</p>\n";
 echo "<ul>\n";
 echo "<li>" . _("Rough breathing marks only come at the beginning of a word.  (There are rare exceptions, though.)") . "</li>\n";

--- a/quiz/tuts/tut_p_old_3.php
+++ b/quiz/tuts/tut_p_old_3.php
@@ -31,8 +31,11 @@ echo "</table>\n";
 echo "<p>" . _("These may be proofread as macrons <kbd>ū</kbd>, tildes <kbd>ũ</kbd>, or according to the meaning (i.e. <kbd>u[n]</kbd> or <kbd>u[m]</kbd>), depending on the Project Manager's instructions.") . "</p>\n";
 
 echo "<h3>" . _("Blackletter") . "</h3>\n";
-echo "<p>" . sprintf(_("Text like this: %1\$s is in a font known as <i>blackletter</i>.  If you have trouble reading it, see the wiki article on <a href='%2\$s' target='_blank'>Proofing blackletter</a> for images of the alphabet in that font."),
-                    "<br>\n<img src='../generic/images/blackletter_sample.png' width='207' height='52' alt='Sample Text'><br>", $blackletter_url) . "</p>\n";
+echo "<p>" . sprintf(
+    _("Text like this: %1\$s is in a font known as <i>blackletter</i>.  If you have trouble reading it, see the wiki article on <a href='%2\$s' target='_blank'>Proofing blackletter</a> for images of the alphabet in that font."),
+    "<br>\n<img src='../generic/images/blackletter_sample.png' width='207' height='52' alt='Sample Text'><br>",
+    $blackletter_url
+) . "</p>\n";
 echo "<p>" . _("The hyphen in blackletter usually looks like a slanted equals sign.  Treat this just like a normal hyphen, and rejoin words that are hyphenated across lines.  You may need to leave hyphens as <kbd>-*</kbd> more frequently than in other projects, because spelling and hyphenation in older texts is often unpredictable.") . "</p>\n";
 
 echo "<p><a href='../generic/main.php?quiz_page_id=p_old_3'>" . _("Continue to quiz page") . "</a></p>\n";

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -85,8 +85,10 @@ function days_to_now($timestamp)
     } elseif ($days == 1) {
         return _("Yesterday");
     } else {
-        return sprintf(ngettext(_("%s day ago"), _("%s days ago"), $days),
-            number_format($days));
+        return sprintf(
+            ngettext(_("%s day ago"), _("%s days ago"), $days),
+            number_format($days)
+        );
     }
 }
 
@@ -123,7 +125,7 @@ function showMbrDpProfile($user)
     $t->row(
         _("Stats Feed"),
         showXmlButton($user->username)
-        );
+    );
 
     $t->end();
 }
@@ -232,8 +234,8 @@ function showForumProfile($username)
     if ($bb_user["rank"] != 0) {
         $bb_title = get_forum_rank_title($bb_user["rank"]);
         $t->row(
-               '',
-               $bb_title
+            '',
+            $bb_title
         );
     }
 
@@ -432,8 +434,10 @@ function showMbrPageStats($user, $tally_name)
         }
     }
 
-    $daysInRoundString = sprintf(_("%s days"),
-        number_format($daysInRoundInteger)); // '1,234 days' (not localized)
+    $daysInRoundString = sprintf(
+        _("%s days"),
+        number_format($daysInRoundInteger)
+    ); // '1,234 days' (not localized)
 
     $bestDayTime = date("M. jS, Y", ($vitals->best_delta_timestamp - 1));
 
@@ -505,7 +509,10 @@ function showMbrNeighbors($user, $tally_name)
 
     $neighbors =
         user_get_page_tally_neighborhood(
-            $tally_name, $user->username, 4);
+            $tally_name,
+            $user->username,
+            4
+        );
     foreach ($neighbors as $rel_posn => $neighbor) {
         $rank = $neighbor->get_current_page_tally_rank();
         $pagescompleted = number_format($neighbor->get_current_page_tally());

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -445,7 +445,8 @@ function stripAllString($ttext)
     return str_replace(
         ['[b]', '[B]', '[/b]', '[/B]', '[i]', '[I]', '[/i]', '[/I]', '[p]', '[P]', '[/p]', '[/P]', '[lb]', '[LB]'],
         ['<b>', '<b>', '</b>', '</b>', '<i>', '<i>', '</i>', '</i>', '<p>', '<p>', '</p>', '</p>', '<br>', '<br>'],
-        html_safe(strip_tags($ttext), ENT_NOQUOTES));
+        html_safe(strip_tags($ttext), ENT_NOQUOTES)
+    );
 }
 
 function unstripAllString($ttext)
@@ -453,7 +454,8 @@ function unstripAllString($ttext)
     return str_replace(
         ['<b>', '</b>', '<i>', '</i>', '<p>', '</p>', '<br>'],
         ['[b]', '[/b]', '[i]', '[/i]', '[p]', '[/p]', '[lb]'],
-        $ttext);
+        $ttext
+    );
 }
 
 function showEdit($tname, $ttext, $twebpage, $tedit, $tsid)

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -12,9 +12,17 @@ include_once('../includes/member.inc');
 require_login();
 
 $order = get_enumerated_param(
-    $_GET, 'order', 'u_id', ['u_id', 'username', 'date_created']);
+    $_GET,
+    'order',
+    'u_id',
+    ['u_id', 'username', 'date_created']
+);
 $direction = get_enumerated_param(
-    $_GET, 'direction', 'asc', ['asc', 'desc']);
+    $_GET,
+    'direction',
+    'asc',
+    ['asc', 'desc']
+);
 $mstart = get_integer_param($_GET, 'mstart', 0, 0, null);
 $uname = normalize_whitespace(array_get($_GET, 'uname', ''));
 $uexact = array_get($_GET, 'uexact', '') == 'yes';
@@ -23,8 +31,10 @@ if ($uname) {
     if ($uexact) {
         $where_clause = sprintf("WHERE username = '%s'", DPDatabase::escape($uname));
     } else {
-        $where_clause = sprintf("WHERE username LIKE '%%%s%%'",
-            DPDatabase::escape_like_wildcards(DPDatabase::escape($uname)));
+        $where_clause = sprintf(
+            "WHERE username LIKE '%%%s%%'",
+            DPDatabase::escape_like_wildcards(DPDatabase::escape($uname))
+        );
     }
 
     // Not using sprintf() here because of the wildcard where_clause above.

--- a/stats/misc_stats1.php
+++ b/stats/misc_stats1.php
@@ -39,7 +39,8 @@ if (isset($start) && isset($end)) {
          AND past_tallies.timestamp - $SECONDS_TO_YESTERDAY < $end_timestamp",
         "GROUP BY 1",
         "ORDER BY 1",
-        "");
+        ""
+    );
     $result = DPDatabase::query($sql);
     [$datax, $datay] = dpsql_fetch_columns($result);
     $graph_config = [
@@ -140,7 +141,9 @@ function show_top_days($n, $when)
             "",
             "ORDER BY 2 DESC",
             "LIMIT $n"
-        ), 1, DPSQL_SHOW_RANK
+        ),
+        1,
+        DPSQL_SHOW_RANK
     );
 
     echo "<br>\n";
@@ -190,7 +193,9 @@ function show_month_sums($which)
             "GROUP BY 1",
             "ORDER BY $order",
             $limit
-        ), 1, DPSQL_SHOW_RANK
+        ),
+        1,
+        DPSQL_SHOW_RANK
     );
 
     echo "<br>\n";
@@ -215,7 +220,9 @@ function show_months_with_most_days_over($n)
             "GROUP BY 1",
             "ORDER BY 2 DESC",
             "LIMIT 10"
-        ), 1, DPSQL_SHOW_RANK
+        ),
+        1,
+        DPSQL_SHOW_RANK
     );
 
     echo "<br>\n";

--- a/stats/proof_stats.php
+++ b/stats/proof_stats.php
@@ -29,7 +29,8 @@ $users_tallyboard = new TallyBoard($tally_name, 'U');
 // TRANSLATORS: %s is a page tally name (i.e. 'P1' or 'F2' or 'R*')
 $sql_upt_column_name = sprintf(_("%s Pages Completed"), $tally_name);
 
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT
         IF(u_privacy = %d, '%s', username) AS '%s',
         $user_page_tally_column AS '%s'
@@ -37,7 +38,8 @@ $sql = sprintf("
     WHERE $user_page_tally_column > 0
     ORDER BY 2 DESC, 1 ASC
     LIMIT 100
-", PRIVACY_ANONYMOUS,
+",
+    PRIVACY_ANONYMOUS,
     DPDatabase::escape(_("Anonymous")),
     DPDatabase::escape(_("Proofreader")),
     DPDatabase::escape($sql_upt_column_name)

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -122,7 +122,8 @@ function _show_round_queues($round, $listing_view_mode)
         echo "</tr>\n";
     }
 
-    $q_sql = sprintf("
+    $q_sql = sprintf(
+        "
         SELECT *
         FROM queue_defns
         WHERE round_id='%s' AND ((%s) OR (SUBSTR(name, 1, 1) = '*'))
@@ -156,7 +157,8 @@ function _show_round_queues($round, $listing_view_mode)
             $errors[] = sprintf(
                 _('There is a syntax error in the project selector for #%1$d "%2$s"'),
                 $qd->ordering,
-                $qd->name);
+                $qd->name
+            );
             $link_cell = html_safe($qd->name);
         } else {
             $ename = urlencode($qd->name);
@@ -212,7 +214,8 @@ function _show_queue_details($round, $name, $unheld_only)
 {
     global $code_url, $user_can_see_queue_settings;
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM queue_defns
         WHERE round_id='%s' AND name='%s'",

--- a/stats/round_backlog_days.php
+++ b/stats/round_backlog_days.php
@@ -31,9 +31,11 @@ $today = getdate();
 foreach ($stats as $phase => $pages) {
     $tallyboard = new TallyBoard($phase, 'S');
 
-    $pages_last_week = $tallyboard->get_delta_sum($holder_id,
+    $pages_last_week = $tallyboard->get_delta_sum(
+        $holder_id,
         mktime(0, 0, 0, $today['mon'], $today['mday'] - 7, $today['year']),
-        mktime(0, 0, 0, $today['mon'], $today['mday'], $today['year']));
+        mktime(0, 0, 0, $today['mon'], $today['mday'], $today['year'])
+    );
 
     $avg_pages_per_day[$phase] = $pages_last_week / 7;
 

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -61,7 +61,8 @@ show_news_for_page("STATS");
 
 function count_books_in_state($state, $clauses = "")
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT COUNT(*) AS numbooks
         FROM projects
         WHERE state = '%s'
@@ -81,76 +82,76 @@ $table = new ThemedTable(
 
 $table->set_column_alignments('left', 'right');
 
-   //get total users active in the last 7 days
-    $begin_time = time() - 604800; // in seconds
-    $users = DPDatabase::query("SELECT count(*) AS numusers FROM users
+//get total users active in the last 7 days
+$begin_time = time() - 604800; // in seconds
+$users = DPDatabase::query("SELECT count(*) AS numusers FROM users
                           WHERE t_last_activity > $begin_time");
-    $row = mysqli_fetch_assoc($users);
-    $totalusers = $row["numusers"];
+$row = mysqli_fetch_assoc($users);
+$totalusers = $row["numusers"];
 
-    $table->row(
-        _("Proofreaders active in the last 7 days:"),
-        $totalusers
-    );
+$table->row(
+    _("Proofreaders active in the last 7 days:"),
+    $totalusers
+);
 
-    //get total books posted  in the last 7 days
-    $totalbooks = count_books_in_state(PROJ_SUBMIT_PG_POSTED, "AND modifieddate >= $begin_time");
+//get total books posted  in the last 7 days
+$totalbooks = count_books_in_state(PROJ_SUBMIT_PG_POSTED, "AND modifieddate >= $begin_time");
 
-    $table->row(
-        _("Books posted in the last 7 days:"),
-        $totalbooks
-    );
+$table->row(
+    _("Books posted in the last 7 days:"),
+    $totalbooks
+);
 
 
 
-    $view_books = _("(View)");
-    //get total first round books waiting to be released
-    $totalfirstwaiting = count_books_in_state(PROJ_P1_WAITING_FOR_RELEASE);
+$view_books = _("(View)");
+//get total first round books waiting to be released
+$totalfirstwaiting = count_books_in_state(PROJ_P1_WAITING_FOR_RELEASE);
 
-    $table->row(
-        _("Books waiting to be released for first round:"),
-        $totalfirstwaiting
-    );
+$table->row(
+    _("Books waiting to be released for first round:"),
+    $totalfirstwaiting
+);
 
-    //get total non-English books waiting to be released
-    $totalnonwaiting = count_books_in_state(PROJ_P1_WAITING_FOR_RELEASE, "AND language != 'English'");
+//get total non-English books waiting to be released
+$totalnonwaiting = count_books_in_state(PROJ_P1_WAITING_FOR_RELEASE, "AND language != 'English'");
 
-    $table->row(
-        _("Non-English Books waiting to be released for first round:"),
-        $totalnonwaiting
-    );
+$table->row(
+    _("Non-English Books waiting to be released for first round:"),
+    $totalnonwaiting
+);
 
-    //get total books waiting to be post processed
-    $totalwaitingpost = count_books_in_state(PROJ_POST_FIRST_AVAILABLE);
+//get total books waiting to be post processed
+$totalwaitingpost = count_books_in_state(PROJ_POST_FIRST_AVAILABLE);
 
-    $table->row(
-        _("Books waiting for post processing:"),
-        $totalwaitingpost
-    );
+$table->row(
+    _("Books waiting for post processing:"),
+    $totalwaitingpost
+);
 
-    //get total books being post processed
-    $totalinpost = count_books_in_state(PROJ_POST_FIRST_CHECKED_OUT);
+//get total books being post processed
+$totalinpost = count_books_in_state(PROJ_POST_FIRST_CHECKED_OUT);
 
-    $table->row(
-        _("Books being post processed:"),
-        $totalinpost
-    );
+$table->row(
+    _("Books being post processed:"),
+    $totalinpost
+);
 
-    //get total books in verify
-    $totalverify = count_books_in_state(PROJ_POST_SECOND_AVAILABLE);
+//get total books in verify
+$totalverify = count_books_in_state(PROJ_POST_SECOND_AVAILABLE);
 
-    $table->row(
-        _("Books waiting to be verified:"),
-        $totalverify
-    );
+$table->row(
+    _("Books waiting to be verified:"),
+    $totalverify
+);
 
-    //get total books in verifying
-    $totalverifying = count_books_in_state(PROJ_POST_SECOND_CHECKED_OUT);
+//get total books in verifying
+$totalverifying = count_books_in_state(PROJ_POST_SECOND_CHECKED_OUT);
 
-    $table->row(
-        _("Books being verified:"),
-        $totalverifying
-    );
+$table->row(
+    _("Books being verified:"),
+    $totalverifying
+);
 
 $table->end();
 
@@ -240,18 +241,18 @@ $table->end();
 // Miscellaneous Graphs
 
 $table = new ThemedTable(
-  2,
-  _("Miscellaneous Graphs")
+    2,
+    _("Miscellaneous Graphs")
 );
 
 $table->row(
-  "<a href='user_logon_graphs.php'>" . _("User Logon Graphs") . "</a>",
-  "<a href='pages_in_states.php'>" . _("Pages in States") . "</a>"
+    "<a href='user_logon_graphs.php'>" . _("User Logon Graphs") . "</a>",
+    "<a href='pages_in_states.php'>" . _("Pages in States") . "</a>"
 );
 
 $table->row(
-  "<a href='equilibria.php'>" . _("Pages Saved per Day (Equilibria)") . "</a>",
-  "<a href='misc_user_graphs.php'>" . _("User Graphs") . "</a>",
+    "<a href='equilibria.php'>" . _("Pages Saved per Day (Equilibria)") . "</a>",
+    "<a href='misc_user_graphs.php'>" . _("User Graphs") . "</a>",
 );
 
 $table->end();

--- a/stats/teams/new_team.php
+++ b/stats/teams/new_team.php
@@ -39,7 +39,8 @@ if (isset($_POST['mkPreview'])) {
     showTeamProfile($curTeam, /* $preview= */ true);
     echo "</div><br>";
 } elseif (isset($_POST['mkMake'])) {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT id
         FROM user_teams
         WHERE teamname = '%s'",
@@ -60,7 +61,8 @@ if (isset($_POST['mkPreview'])) {
         showEdit($teamname, $text_data, $teamwebpage, 1, 0);
         echo "<br></div><br>";
     } else {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO user_teams
                 (teamname, team_info, webpage, createdby, owner, created)
             VALUES(LEFT('%s', 50), '%s', LEFT('%s', 255), '%s', %d, %d)
@@ -75,7 +77,8 @@ if (isset($_POST['mkPreview'])) {
         DPDatabase::query($sql);
         $tid = mysqli_insert_id(DPDatabase::get_connection());
         if (!empty($tavatar)) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE user_teams
                 SET avatar='%s'
                 WHERE id = %d",
@@ -87,7 +90,8 @@ if (isset($_POST['mkPreview'])) {
             uploadImages(0, $tid, "avatar");
         }
         if (!empty($ticon)) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE user_teams
                 SET icon='%s'
                 WHERE id = %d",

--- a/stats/teams/team_topic.php
+++ b/stats/teams/team_topic.php
@@ -52,12 +52,13 @@ Use this area to have a discussion with your fellow teammates! :-D
     $post_subject = $tname;
 
     $topic_id = topic_create(
-                $forum_id,
-                $post_subject,
-                $message,
-                $towner_name,
-                true,
-                false);
+        $forum_id,
+        $post_subject,
+        $message,
+        $towner_name,
+        true,
+        false
+    );
 
     //Update user_teams with topic_id so it won't be created again
     $update_team = DPDatabase::query("UPDATE user_teams SET topic_id=$topic_id WHERE id=$team_id");

--- a/stats/teams/tedit.php
+++ b/stats/teams/tedit.php
@@ -61,7 +61,8 @@ if (isset($_GET['tid'])) {
     showTeamProfile($curTeam, /*$preview = */ true);
     echo "</div><br>";
 } elseif (isset($_POST['edMake'])) {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT id
         FROM user_teams
         WHERE id != %d
@@ -85,7 +86,8 @@ if (isset($_GET['tid'])) {
         echo "<br></div><br>";
     } else {
         if (!empty($tavatar)) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE user_teams
                 SET avatar='%s'
                 WHERE id = %d",
@@ -97,7 +99,8 @@ if (isset($_GET['tid'])) {
             uploadImages(0, $tid, "avatar");
         }
         if (!empty($ticon)) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE user_teams
                 SET icon='%s'
                 WHERE id = %d",
@@ -109,7 +112,8 @@ if (isset($_GET['tid'])) {
             uploadImages(0, $tid, "icon");
         }
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE user_teams
             SET
                 teamname = LEFT('%s', 50),

--- a/stats/teams/tlist.php
+++ b/stats/teams/tlist.php
@@ -9,9 +9,17 @@ include_once('../includes/team.inc');
 require_login();
 
 $order = get_enumerated_param(
-        $_GET, 'order', 'teamname', ['id', 'teamname', 'member_count']);
+    $_GET,
+    'order',
+    'teamname',
+    ['id', 'teamname', 'member_count']
+);
 $direction = get_enumerated_param(
-        $_GET, 'direction', 'asc', ['asc', 'desc']);
+    $_GET,
+    'direction',
+    'asc',
+    ['asc', 'desc']
+);
 $tstart = get_integer_param($_GET, 'tstart', 0, 0, null);
 $tname = normalize_whitespace(array_get($_GET, 'tname', ''));
 $texact = array_get($_GET, 'texact', '') == 'yes';
@@ -20,8 +28,10 @@ if ($tname) {
     if ($texact) {
         $where_body = sprintf("teamname = '%s'", DPDatabase::escape($tname));
     } else {
-        $where_body = sprintf("teamname LIKE '%%%s%%'",
-            DPDatabase::escape_like_wildcards(DPDatabase::escape($tname)));
+        $where_body = sprintf(
+            "teamname LIKE '%%%s%%'",
+            DPDatabase::escape_like_wildcards(DPDatabase::escape($tname))
+        );
     }
 
     $tResult = select_from_teams($where_body, "ORDER BY $order $direction LIMIT $tstart,20");
@@ -57,20 +67,20 @@ echo "<br>";
 //Display of user teams
 echo "<table class='themed theme_striped'>\n";
 echo "<tr>";
-    echo "<th></th>";
-    if ($order == "teamname" && $direction == "asc") {
-        $newdirection = "desc";
-    } else {
-        $newdirection = "asc";
-    }
-        echo "<th><a href='tlist.php?tname=" . attr_safe($tname) . "&amp;tstart=$tstart&amp;order=teamname&amp;direction=$newdirection'>"._("Team Name")."</a></th>";
-    if ($order == "member_count" && $direction == "desc") {
-        $newdirection = "asc";
-    } else {
-        $newdirection = "desc";
-    }
-        echo "<th class='center-align'><a href='tlist.php?tname=" . attr_safe($tname) . "&amp;tstart=$tstart&amp;order=member_count&amp;direction=$newdirection'>"._("Total Members")."</a></th>";
-    echo "<th class='center-align'>"._("Options")."</th>";
+echo "<th></th>";
+if ($order == "teamname" && $direction == "asc") {
+    $newdirection = "desc";
+} else {
+    $newdirection = "asc";
+}
+echo "<th><a href='tlist.php?tname=" . attr_safe($tname) . "&amp;tstart=$tstart&amp;order=teamname&amp;direction=$newdirection'>"._("Team Name")."</a></th>";
+if ($order == "member_count" && $direction == "desc") {
+    $newdirection = "asc";
+} else {
+    $newdirection = "desc";
+}
+echo "<th class='center-align'><a href='tlist.php?tname=" . attr_safe($tname) . "&amp;tstart=$tstart&amp;order=member_count&amp;direction=$newdirection'>"._("Total Members")."</a></th>";
+echo "<th class='center-align'>"._("Options")."</th>";
 echo "</tr>\n";
 
 if (!empty($tRows)) {

--- a/tasks.php
+++ b/tasks.php
@@ -482,7 +482,8 @@ function create_task_from_form_submission($formsub)
         $task_assignee_user = User::load_from_uid($newt_assignee);
     }
 
-    $sql_query = sprintf("
+    $sql_query = sprintf(
+        "
         INSERT INTO tasks
         SET
             task_summary     = '%s',
@@ -676,7 +677,8 @@ function handle_action_on_a_specified_task()
         }
     } elseif ($action == 'reopen') {
         NotificationMail($task_id, "$pguser reopened this task.");
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE tasks
             SET
                 task_status = %d,
@@ -713,7 +715,8 @@ function handle_action_on_a_specified_task()
             $edit_browser = (int) get_enumerated_param($_POST, 'task_browser', null, array_keys($browser_array));
             $edit_percent = (int) get_enumerated_param($_POST, 'percent_complete', null, array_keys($percent_complete_array));
 
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE tasks
                 SET
                     task_summary     = '%s',
@@ -752,9 +755,12 @@ function handle_action_on_a_specified_task()
     } elseif ($action == 'close') {
         if (user_is_a_sitemanager() || user_is_taskcenter_mgr()) {
             $tc_reason = (int) get_enumerated_param($_POST, 'closed_reason', null, array_keys($tasks_close_array));
-            NotificationMail($task_id,
-                "$pguser closed this task.\nThe reason for closing was: " . $tasks_close_array[$tc_reason] . ".");
-            $sql = sprintf("
+            NotificationMail(
+                $task_id,
+                "$pguser closed this task.\nThe reason for closing was: " . $tasks_close_array[$tc_reason] . "."
+            );
+            $sql = sprintf(
+                "
                 UPDATE tasks
                 SET
                     percent_complete = %d,
@@ -785,7 +791,8 @@ function handle_action_on_a_specified_task()
         $comment = trim(array_get($_POST, 'task_comment', ''));
         if ($comment) {
             NotificationMail($task_id, "$pguser commented:\n\n$comment");
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 INSERT INTO tasks_comments (task_id, u_id, comment_date, comment)
                 VALUES (%d, %d, %d, '%s')",
                 $task_id,
@@ -795,7 +802,8 @@ function handle_action_on_a_specified_task()
             );
             DPDatabase::query($sql);
 
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE tasks
                 SET date_edited = %d, edited_by = %d
                 WHERE task_id = %d",
@@ -836,7 +844,8 @@ function handle_action_on_a_specified_task()
         // Do not insert two votes for the same user
         $meTooCount = get_me_too_count($task_id, $requester_u_id);
         if ($meTooCount == 0) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 INSERT INTO tasks_votes (task_id, u_id, vote_os, vote_browser)
                 VALUES (%d, %d, %d, %d)",
                 $task_id,
@@ -854,7 +863,8 @@ function handle_action_on_a_specified_task()
         $comment = trim(array_get($_POST, 'task_comment', ''));
         [$u_id, $comment_date] = explode('_', $comment_id, 2);
         if (($u_id === $requester_u_id && $now_sse - $comment_date <= 86400) || user_is_a_sitemanager()) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE tasks_comments SET comment='%s'
                 WHERE task_id = %d AND u_id = %d AND comment_date = %d",
                 DPDatabase::escape($comment),
@@ -945,7 +955,8 @@ function process_related_topic($pre_task, $action, $related_topic_id)
         unset($related_topics[array_search($related_topic_id, $related_topics)]);
     }
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE tasks
         SET related_postings = '%s'
         WHERE task_id = %d",
@@ -1246,7 +1257,8 @@ function property_echo_select_tr($property_id, $current_value, $options)
 
 function load_task($tid, $is_assoc = true)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM tasks
         WHERE task_id = %d",
@@ -1373,7 +1385,8 @@ function property_echo_value_tr($property_id, $row, $show_if_empty = true)
 
 function get_me_too_count($task_id, $requester_u_id)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT count(*)
         FROM tasks_votes
         WHERE task_id = %d AND u_id = %d",
@@ -1445,7 +1458,8 @@ function create_anchor_for_comment($u_id, $comment_date)
 function TaskComments($tid, $action)
 {
     global $tasks_url, $requester_u_id, $now_sse;
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM tasks_comments
         WHERE task_id = %d
@@ -1572,7 +1586,8 @@ function RelatedTasks($tid)
 
 function load_related_tasks($task_id)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT task_id_1, task_id_2
         FROM tasks_related_tasks
         WHERE task_id_1 = %d
@@ -1602,7 +1617,8 @@ function insert_related_task($task1, $task2)
     $task_id_2 = max($task1, $task2);
 
     // See if the association already exists
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT COUNT(*) AS count
         FROM tasks_related_tasks
         WHERE task_id_1 = %d
@@ -1618,7 +1634,8 @@ function insert_related_task($task1, $task2)
     }
 
     // Now do the insertion
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO tasks_related_tasks
         SET task_id_1 = %d, task_id_2 = %d",
         $task_id_1,
@@ -1633,7 +1650,8 @@ function remove_related_task($task1, $task2)
     $task_id_2 = max($task1, $task2);
 
     // Now do the insertion
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         DELETE FROM tasks_related_tasks
         WHERE task_id_1 = %d
             AND task_id_2 = %d",
@@ -1746,7 +1764,7 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
             $fv = $raw_value;
             break;
 
-        // The raw value is an index into an array.
+            // The raw value is an index into an array.
         case 'closed_reason':
             return array_get($tasks_close_array, $raw_value, "");
         case 'task_browser':
@@ -1764,7 +1782,7 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
         case 'task_type':
             return $tasks_array[$raw_value];
 
-        // The raw value is an integer denoting seconds-since-epoch.
+            // The raw value is an integer denoting seconds-since-epoch.
         case 'date_edited':
             return date("d-M-Y", $raw_value);
         case 'date_opened':
@@ -1772,28 +1790,31 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
         case 'date_closed':
             return $raw_value ? date("d-M-Y", $raw_value) : "";
 
-        // Synthetic fields
+            // Synthetic fields
         case 'opened_composite':
-            return sprintf("%s &mdash; %s",
-                        date("d-M-Y", $task_a["date_opened"]),
-                        private_message_link_for_uid($task_a['opened_by'])
-                    );
+            return sprintf(
+                "%s &mdash; %s",
+                date("d-M-Y", $task_a["date_opened"]),
+                private_message_link_for_uid($task_a['opened_by'])
+            );
         case 'edited_composite':
-            return sprintf("%s &mdash; %s",
-                        date("d-M-Y", $task_a["date_edited"]),
-                        private_message_link_for_uid($task_a['edited_by'])
-                    );
+            return sprintf(
+                "%s &mdash; %s",
+                date("d-M-Y", $task_a["date_edited"]),
+                private_message_link_for_uid($task_a['edited_by'])
+            );
         case 'closed_composite':
             if (!$task_a["date_closed"]) {
                 return "";
             }
 
-            return sprintf("%s &mdash; %s",
-                        date("d-M-Y", $task_a["date_closed"]),
-                        private_message_link_for_uid($task_a['closed_by'])
-                    );
+            return sprintf(
+                "%s &mdash; %s",
+                date("d-M-Y", $task_a["date_closed"]),
+                private_message_link_for_uid($task_a['closed_by'])
+            );
 
-        // The raw value is a user's u_id:
+            // The raw value is a user's u_id:
         case 'opened_by':
             return $raw_value ? private_message_link_for_uid($raw_value) : "";
         case 'edited_by':
@@ -1807,7 +1828,7 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
                 : private_message_link_for_uid($raw_value)
             );
 
-        // The raw value is some text typed in by a user:
+            // The raw value is some text typed in by a user:
         case 'task_summary':
             $fv = html_safe($raw_value);
             break;
@@ -1817,7 +1838,7 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
             $Parsedown->setSafeMode(true);
             return $Parsedown->text($raw_value);
 
-        // The raw value is an integer denoting state of progress:
+            // The raw value is an integer denoting state of progress:
         case 'percent_complete':
             // Calculate the width for the container based on if this is a
             // task listing or a task details
@@ -1836,7 +1857,8 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
         case 'votes':
             // If this is the task listing, $raw_value will be set
             if (!isset($raw_value)) {
-                $sql = sprintf("
+                $sql = sprintf(
+                    "
                     SELECT count(*) AS count
                     FROM tasks_votes
                     WHERE task_id = %d",
@@ -1855,7 +1877,8 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
 
             // no break
         case 'additional_os':
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 SELECT DISTINCT vote_os
                 FROM tasks_votes
                 WHERE task_id = %d",
@@ -1878,7 +1901,8 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
 
             // no break
         case 'additional_browser':
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 SELECT DISTINCT vote_browser
                 FROM tasks_votes
                 WHERE task_id = %d",

--- a/tools/authors/add.php
+++ b/tools/authors/add.php
@@ -60,7 +60,8 @@ if (isset($last_name)) {
         // insert into the database
         if ($author_id) {
             // edit existing author
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE authors
                 SET last_name='%s', other_names='%s',
                     byear=%d, bmonth=%d, bday=%d, bcomments='%s',
@@ -81,7 +82,8 @@ if (isset($last_name)) {
             $msg = _('The author was successfully updated in the database!');
         } else {
             // add new author to database
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 INSERT INTO authors
                     (last_name, other_names,
                         byear, bmonth, bday, bcomments,
@@ -335,10 +337,13 @@ $message = @$_GET['message'];
 if (isset($message)) {
     echo '<p>' . html_safe($message) . '</p>';
 } elseif (isset($_POST['Preview'])) {
-    echo_author($last_name, $other_names,
-                format_date($byear, $bmonth, $bday, $bcomments),
-                format_date($dyear, $dmonth, $dday, $dcomments),
-                 ($_POST['author_id'] ?? false));
+    echo_author(
+        $last_name,
+        $other_names,
+        format_date($byear, $bmonth, $bday, $bcomments),
+        format_date($dyear, $dmonth, $dday, $dcomments),
+        ($_POST['author_id'] ?? false)
+    );
     echo '<br>';
     if (isset($_POST['author_id'])) {
         $author_id = $_POST['author_id'];

--- a/tools/authors/addbio.php
+++ b/tools/authors/addbio.php
@@ -47,12 +47,14 @@ if (isset($_GET['author_id'])) {
             $msg = _('The biography was successfully updated in the database!');
         } else {
             // add to database
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 INSERT INTO biographies
                     (author_id, bio)
                 VALUES(%d, '%s')",
                 $author_id,
-                DPDatabase::escape($bio));
+                DPDatabase::escape($bio)
+            );
             $result = DPDatabase::query($sql);
             $bio_id = mysqli_insert_id(DPDatabase::get_connection());
             $msg = _('The biography was successfully entered into the database!');

--- a/tools/authors/authors.inc
+++ b/tools/authors/authors.inc
@@ -73,10 +73,12 @@ function format_date_from_sqlset($row, $bd)
 // $bd is 'b' or 'd'
 function format_date_from_array($row, $bd)
 {
-    return format_date($row[$bd.'year'],
-                       $row[$bd.'month'],
-                       $row[$bd.'day'],
-                       $row[$bd.'comments']);
+    return format_date(
+        $row[$bd.'year'],
+        $row[$bd.'month'],
+        $row[$bd.'day'],
+        $row[$bd.'comments']
+    );
 }
 
 function format_date($year, $month, $day, $comments)

--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -136,7 +136,8 @@ if (isset($_POST) && count($_POST) > 0) {
         $sql = sprintf(
             "UPDATE authors SET enabled = '%s' WHERE author_id = %d",
             DPDatabase::escape($enable_author_values[$i]),
-            $enable_author_ids[$i]);
+            $enable_author_ids[$i]
+        );
         DPDatabase::query($sql);
     }
 }

--- a/tools/authors/search.inc
+++ b/tools/authors/search.inc
@@ -19,10 +19,10 @@ include_once($relPath."misc.inc"); // get_enumerated_param(), attr_safe(), html_
 function prepare_search()
 {
     global $last_name, $other_names,
-           $sql_what_to_list, $human_what_to_list, $human_order,
-           $query, $query_without_view, $sortUtility,
-           $sort_author_id, $sort_last_name, $sort_other_names,
-           $sort_born, $sort_dead;
+    $sql_what_to_list, $human_what_to_list, $human_order,
+    $query, $query_without_view, $sortUtility,
+    $sort_author_id, $sort_last_name, $sort_other_names,
+    $sort_born, $sort_dead;
 
     $view = get_enumerated_param($_REQUEST, 'view', null, ['enabled', 'disabled', 'all'], true);
 
@@ -33,11 +33,13 @@ function prepare_search()
     $sort_born = new SortableValue('born', 'Birth', 'byear,bmonth,bday,bcomments');
     $sort_dead = new SortableValue('dead', 'Death', 'dyear,dmonth,dday,dcomments');
 
-    $sortUtility->setSortableValues($sort_author_id,
-                                    $sort_last_name,
-                                    $sort_other_names,
-                                    $sort_born,
-                                    $sort_dead);
+    $sortUtility->setSortableValues(
+        $sort_author_id,
+        $sort_last_name,
+        $sort_other_names,
+        $sort_born,
+        $sort_dead
+    );
 
     // if no ordering is requested, sort by ID (ascending)
     $sortUtility->setSortingRule($sort_author_id);
@@ -150,9 +152,13 @@ function echo_search_form()
     echo "<h2>" . _("Search") . "</h2>";
     echo "<p>" . _('Case insensitive.') . " ";
     echo sprintf(
-            _('Use %1$s for partial matches or %2$s to match exactly one character.' .
+        _('Use %1$s for partial matches or %2$s to match exactly one character.' .
             '%3$s encodes start-of-string and %4$s encodes end-of-string.'),
-            '<b>*</b>', '<b>?</b>', '<b>^</b>', '<b>$</b>'); ?>
+        '<b>*</b>',
+        '<b>?</b>',
+        '<b>^</b>',
+        '<b>$</b>'
+    ); ?>
     <form method="GET">
     <table class='themed' style='width: auto;'>
     <tr><td>Last name:</td><td><input type="text" name="last_name" size="20" value="<?php echo $last_name; ?>"></td></tr>

--- a/tools/change_sr_commitment.php
+++ b/tools/change_sr_commitment.php
@@ -31,15 +31,21 @@ switch ($action) {
     case "commit":
         sr_commit($projectid, $pguser);
         $title = _("Volunteer to SR");
-        $body = sprintf(_("%1\$s, you have volunteered to smoothread project %2\$s."),
-            $pguser, $projectid);
+        $body = sprintf(
+            _("%1\$s, you have volunteered to smoothread project %2\$s."),
+            $pguser,
+            $projectid
+        );
         break;
 
     case "withdraw":
         sr_withdraw_commitment($projectid, $pguser);
         $title = _("Withdraw from SR");
-        $body = sprintf(_("%1\$s, you have withdrawn from Smooth Reading project %2\$s."),
-            $pguser, $projectid);
+        $body = sprintf(
+            _("%1\$s, you have withdrawn from Smooth Reading project %2\$s."),
+            $pguser,
+            $projectid
+        );
         break;
 }
 

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -80,9 +80,11 @@ if (!is_null($transition->confirmation_question) && $confirmed != 'yes') {
         <input type='hidden' name='confirmed'  value='yes'>
         <input type='hidden' name='return_uri' value='$return_uri'>"
         // TRANSLATORS: %1$s is a button labeled "confirm transition change".
-        . sprintf(_("If so, %1\$s, otherwise go back to <a href='%2\$s'>where you were</a>"),
+        . sprintf(
+            _("If so, %1\$s, otherwise go back to <a href='%2\$s'>where you were</a>"),
             "<input type='submit' value='" . attr_safe(_("confirm transition change")) . "'>",
-            $return_uri)
+            $return_uri
+        )
         . "</form>";
     exit();
 }
@@ -95,7 +97,7 @@ if (!empty($transition->detour)) {
     if (is_callable($transition->detour)) {
         $detour_function = $transition->detour;
         $detour_function($projectid);
-    // detour function will either do it's thing and return here,
+        // detour function will either do it's thing and return here,
         // or output content and exit
     } else {
         $title = _("Transferring...");
@@ -129,9 +131,9 @@ if (!empty($transition->detour)) {
     }
 }
 
-    // Return the user to the screen they were at
-    // when they requested the state change.
-    $refresh_url = $return_uri;
+// Return the user to the screen they were at
+// when they requested the state change.
+$refresh_url = $return_uri;
 
 metarefresh(2, $refresh_url, $title, $body);
 

--- a/tools/pending_access_requests.php
+++ b/tools/pending_access_requests.php
@@ -134,19 +134,19 @@ foreach ($activity_ids as $activity_id) {
             echo   "<td>";
             echo     $t_latest_request_f;
             echo " <span style='white-space: nowrap'>(",
-                sprintf(_("%s days"), $t_latest_request_d), ")</span>";
+            sprintf(_("%s days"), $t_latest_request_d), ")</span>";
             echo   "</td>";
             echo   "<td>";
             echo     $t_latest_deny_f;
             if ($t_latest_deny_d >= 0) {
                 echo " <span style='white-space: nowrap'>(",
-                    sprintf(_("%s days"), $t_latest_deny_d), ")</span>";
+                sprintf(_("%s days"), $t_latest_deny_d), ")</span>";
             }
             echo   "</td>";
             echo   "<td>";
             echo     $t_last_on_site_f;
             echo " <span style='white-space: nowrap'>(",
-                sprintf(_("%s days"), $t_last_on_site_d), ")</span>";
+            sprintf(_("%s days"), $t_last_on_site_d), ")</span>";
             echo   "</td>";
             echo "</tr>";
             echo "\n";

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -108,7 +108,8 @@ mysqli_free_result($result);
 $pp_date = "";
 
 // earliest transition from PPV.avail to PPV.checked out
-$sql = sprintf("SELECT timestamp FROM project_events
+$sql = sprintf(
+    "SELECT timestamp FROM project_events
     WHERE projectid = '%s'
       AND event_type = 'transition'
       AND details1 = '%s'
@@ -117,7 +118,8 @@ $sql = sprintf("SELECT timestamp FROM project_events
     LIMIT 1",
     DPDatabase::escape($projectid),
     DPDatabase::escape(PROJ_POST_SECOND_AVAILABLE),
-    DPDatabase::escape(PROJ_POST_SECOND_CHECKED_OUT));
+    DPDatabase::escape(PROJ_POST_SECOND_CHECKED_OUT)
+);
 $result = DPDatabase::query($sql);
 $row = mysqli_fetch_assoc($result);
 mysqli_free_result($result);
@@ -125,7 +127,8 @@ if ($row) {
     $earliest_in_ppv = $row["timestamp"];
 
     // latest transition from PP.checked out to PPV.avail
-    $sql = sprintf("SELECT timestamp FROM project_events
+    $sql = sprintf(
+        "SELECT timestamp FROM project_events
         WHERE projectid = '%s'
           AND event_type = 'transition'
           AND details1 = '%s'
@@ -416,8 +419,11 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
             _("Post-Processed by"),
             $project->postproofer
                 . "<br>"
-                . sprintf(_("Number of posted books post-processed by %1\$s: %2\$d"),
-                    $project->postproofer, $number_post_processed)
+                . sprintf(
+                    _("Number of posted books post-processed by %1\$s: %2\$d"),
+                    $project->postproofer,
+                    $number_post_processed
+                )
         )
         . tr_w_two_cells(
             _("Submitted by PP on"),
@@ -574,7 +580,8 @@ if ($action == SHOW_BLANK_ENTRY_FORM) {
         } else {
             $message = sprintf(
                 _("There were problems with %d form inputs, as detailed below. Please fix them and re-submit."),
-                $n_form_problems);
+                $n_form_problems
+            );
         }
         echo "\n<p class='form_problem'>$message</p>\n";
 

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -666,7 +666,7 @@ class Loader
             echo "<p>";
             echo "(", _("Usually these are illustrations."), ")\n";
             echo _("They will simply be copied into the project directory."),
-                "</p>\n";
+            "</p>\n";
             echo "<table class='basic striped'>";
             foreach ($this->non_page_files as $filename) {
                 echo "<tr><td>$filename</td></tr>\n";
@@ -777,9 +777,11 @@ class Loader
 
         // Non-page files
         foreach ($this->non_page_files as $filename) {
-            $this->_do_command(sprintf("cp %s %s",
+            $this->_do_command(sprintf(
+                "cp %s %s",
                 escapeshellarg($filename),
-                escapeshellarg($this->dest_project_dir)));
+                escapeshellarg($this->dest_project_dir)
+            ));
         }
 
         // Page files
@@ -818,7 +820,8 @@ class Loader
                             $src_image_file_name,
                             $src_text_file_path,
                             $pguser,
-                            $now);
+                            $now
+                        );
                     } catch (DBQueryError $error) {
                         echo "<p class='error'>";
                         echo "for base=$base, project_add_page raised a DB error";
@@ -826,9 +829,11 @@ class Loader
                     }
                 }
 
-                $this->_do_command(sprintf("cp %s %s",
+                $this->_do_command(sprintf(
+                    "cp %s %s",
                     escapeshellarg($src_image_file_name),
-                    escapeshellarg($this->dest_project_dir)));
+                    escapeshellarg($this->dest_project_dir)
+                ));
             } else {
                 if ($text_a == 'replace') {
                     if ($this->dry_run) {
@@ -844,7 +849,8 @@ class Loader
                             $this->projectid,
                             $db_image_file_name,
                             $src_text_file_path,
-                            $pguser);
+                            $pguser
+                        );
                     }
                 }
 
@@ -865,16 +871,20 @@ class Loader
                                 $this->projectid,
                                 $db_image_file_name,
                                 $src_image_file_name,
-                                $pguser);
+                                $pguser
+                            );
                         }
 
                         $this->_do_command("rm " . escapeshellarg(
-                            "$this->dest_project_dir/$db_image_file_name"));
+                            "$this->dest_project_dir/$db_image_file_name"
+                        ));
                     }
 
-                    $this->_do_command(sprintf("cp %s %s",
+                    $this->_do_command(sprintf(
+                        "cp %s %s",
                         escapeshellarg($src_image_file_name),
-                        escapeshellarg($this->dest_project_dir)));
+                        escapeshellarg($this->dest_project_dir)
+                    ));
                 }
             }
         }

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -80,13 +80,15 @@ if ($one_project) {
 
     $condition = "0";
     foreach ($Round_for_round_id_ as $round_id => $round) {
-        $condition .= sprintf("
+        $condition .= sprintf(
+            "
             OR state = '%s'
             OR state = '%s'
             OR state = '%s'",
-        DPDatabase::escape($round->project_available_state),
-        DPDatabase::escape($round->project_complete_state),
-        DPDatabase::escape($round->project_bad_state));
+            DPDatabase::escape($round->project_available_state),
+            DPDatabase::escape($round->project_complete_state),
+            DPDatabase::escape($round->project_bad_state)
+        );
     }
 
     insert_job_log_entry(
@@ -171,7 +173,8 @@ while ([$projectid] = mysqli_fetch_row($allprojects)) {
         $n_hours_to_wait = 4;
         $max_reclaimable_time = time() - $n_hours_to_wait * 60 * 60;
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT image
             FROM $projectid
             WHERE state IN ('%s','%s')
@@ -179,7 +182,8 @@ while ([$projectid] = mysqli_fetch_row($allprojects)) {
             ORDER BY image ASC",
             $round->page_out_state,
             $round->page_temp_state,
-            $max_reclaimable_time);
+            $max_reclaimable_time
+        );
         try {
             $res = DPDatabase::query($sql);
         } catch (DBQueryError $error) {
@@ -297,8 +301,11 @@ if (!$one_project) {
     insert_job_log_entry(
         'automodify.php',
         'END',
-        sprintf("post autorelease, started at %d, took %d seconds",
-            $start_time, time() - $start_time)
+        sprintf(
+            "post autorelease, started at %d, took %d seconds",
+            $start_time,
+            time() - $start_time
+        )
     );
 } else {
     insert_job_log_entry(

--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -63,12 +63,14 @@ function autorelease_for_round($round)
     echo "\n";
     echo "Starting autorelease for round {$round->id}...\n";
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM queue_defns
         WHERE round_id='%s'
         ORDER BY ordering",
-        DPDatabase::escape($round->id));
+        DPDatabase::escape($round->id)
+    );
     $q_res = DPDatabase::query($sql);
 
     if (mysqli_num_rows($q_res) == 0) {
@@ -104,12 +106,14 @@ function autorelease_for_round($round)
 
     // Release of Different types of Projects from various logical queues
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM queue_defns
         WHERE enabled AND round_id='%s'
         ORDER BY ordering",
-        DPDatabase::escape($round->id));
+        DPDatabase::escape($round->id)
+    );
     $q_res = DPDatabase::query($sql);
 
     while ($qd = mysqli_fetch_object($q_res)) {
@@ -222,7 +226,8 @@ function maybe_release_projects(
     // escaped state selector separately.
     $escaped_state = sprintf(
         "state = '%s'",
-        DPDatabase::escape($round->project_waiting_state));
+        DPDatabase::escape($round->project_waiting_state)
+    );
 
     $sql = "
         SELECT *
@@ -349,12 +354,14 @@ class ReleaseRestrictor
         // ----------------------------------------------------------
         // First, get the set of all authors with works in this round
         $this->this_round_authors = [];
-        $sql = sprintf("
+        $sql = sprintf(
+            "
                 SELECT authorsname
                 FROM projects
                 WHERE state = '%s'
                 ORDER BY authorsname",
-                DPDatabase::escape($round->project_available_state));
+            DPDatabase::escape($round->project_available_state)
+        );
         $author_res = DPDatabase::query($sql);
         while ($author_row = mysqli_fetch_assoc($author_res)) {
             $author = $author_row['authorsname'];
@@ -369,12 +376,14 @@ class ReleaseRestrictor
         // ----------------------------------------------------------
         // Next, get the set of all PMs with works in this round
         $this->this_round_pms = [];
-        $sql = sprintf("
+        $sql = sprintf(
+            "
                 SELECT username
                 FROM projects
                 WHERE state = '%s'
                 ORDER BY username",
-                DPDatabase::escape($round->project_available_state));
+            DPDatabase::escape($round->project_available_state)
+        );
         $pm_res = DPDatabase::query($sql);
         while ($pm_row = mysqli_fetch_assoc($pm_res)) {
             $pm = $pm_row['username'];
@@ -521,11 +530,13 @@ function AP_setup($round)
     DPDatabase::query($sql);
 
     // Get a list of active projects.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT projectid
         FROM projects
         WHERE state = '%s'",
-        DPDatabase::escape($round->project_available_state));
+        DPDatabase::escape($round->project_available_state)
+    );
     $projects_res = DPDatabase::query($sql);
 
     // Run through them and fill up the table.
@@ -543,13 +554,15 @@ function AP_teardown($round)
 function AP_add_project($round, $projectid)
 {
     validate_projectID($projectid);
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO active_page_counts
         SELECT
             '$projectid',
             SUM( state != '%s' ) as pages
         FROM $projectid",
-        DPDatabase::escape($round->page_save_state));
+        DPDatabase::escape($round->page_save_state)
+    );
     DPDatabase::query($sql);
 }
 
@@ -562,7 +575,8 @@ function AP_evaluate_criteria($round, $cooked_project_selector, $release_criteri
     // escaped state selector separately.
     $sum_projects = sprintf(
         "SUM(projects.state='%s')",
-        DPDatabase::escape($round->project_available_state));
+        DPDatabase::escape($round->project_available_state)
+    );
 
     $sql = "
         SELECT

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -80,12 +80,14 @@ $L_label = new_window_link("../page_browser.php?project=$projectid&imagefile=$im
 $R_label = new_window_link("../page_browser.php?project=$projectid&imagefile=$image&mode=text&round_id=$R_round_id", $R_round_name);
 
 validate_projectID($projectid);
-$query = sprintf("
+$query = sprintf(
+    "
     SELECT $L_text_column_name, $R_text_column_name,
         $L_user_column_name, $R_user_column_name
     FROM $projectid
     WHERE image='%s'",
-    DPDatabase::escape($image));
+    DPDatabase::escape($image)
+);
 
 $res = DPDatabase::query($query);
 [$L_text, $R_text, $L_user, $R_user] = mysqli_fetch_row($res);
@@ -125,8 +127,19 @@ output_header("$title: $project_title", NO_STATSBAR, $extra_args);
 echo "<h1>" . html_safe($project_title) . "</h1>\n";
 echo "<h2>$image_link</h2>\n";
 
-do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_column_name, $L_user, $format,
-              $L_text_column_name, $R_text_column_name, $only_nonempty_diffs, $bb_diffs);
+do_navigation(
+    $projectid,
+    $image,
+    $L_round_num,
+    $R_round_num,
+    $L_user_column_name,
+    $L_user,
+    $format,
+    $L_text_column_name,
+    $R_text_column_name,
+    $only_nonempty_diffs,
+    $bb_diffs
+);
 echo $navigation_text;
 
 echo "\n<p>" . return_to_project_page_link($projectid, ["expected_state=$state"]) . "\n";
@@ -187,9 +200,19 @@ if ($L_text != $R_text) {
  * Build up the text for the navigation bit, so we can repeat it
  * again at the bottom of the page
  */
-function do_navigation($projectid, $image, $L_round_num, $R_round_num, $L_user_column_name, $L_user, $format,
-                       $L_text_column_name, $R_text_column_name, $only_nonempty_diffs, $bb_diffs)
-{
+function do_navigation(
+    $projectid,
+    $image,
+    $L_round_num,
+    $R_round_num,
+    $L_user_column_name,
+    $L_user,
+    $format,
+    $L_text_column_name,
+    $R_text_column_name,
+    $only_nonempty_diffs,
+    $bb_diffs
+) {
     global $navigation_text;
     $jump_to_js = "this.form.image.value=this.form.jumpto[this.form.jumpto.selectedIndex].value; this.form.submit();";
 
@@ -305,9 +328,11 @@ function can_see_names_for_page($projectid, $image)
         }
 
         validate_projectID($projectid);
-        $query = sprintf("
+        $query = sprintf(
+            "
             SELECT $fields from $projectid WHERE image = '%s'",
-            DPDatabase::escape($image));
+            DPDatabase::escape($image)
+        );
         $res = DPDatabase::query($query);
         $page_res = mysqli_fetch_array($res);
         foreach ($page_res as $page_user) {

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -521,8 +521,15 @@ class ProjectInfoHolder
         $this->row(_("Image Source"), 'image_source_list', $this->project->image_source);
         $this->row(_("Image Preparer"), 'DP_user_field', $this->project->image_preparer, 'image_preparer', sprintf(_("%s user who scanned or harvested the images."), $site_abbreviation));
         $this->row(_("Text Preparer"), 'DP_user_field', $this->project->text_preparer, 'text_preparer', sprintf(_("%s user who prepared the text files."), $site_abbreviation));
-        $this->row(_("Extra Credits<br>(to be included in list of names--no URLs)"),
-                                               'extra_credits_field', $this->project->extra_credits, null, '', '', true);
+        $this->row(
+            _("Extra Credits<br>(to be included in list of names--no URLs)"),
+            'extra_credits_field',
+            $this->project->extra_credits,
+            null,
+            '',
+            '',
+            true
+        );
         if ($this->project->scannercredit != '') {
             $this->row(_("Scanner Credit (deprecated)"), 'text_field', $this->project->scannercredit, 'scannercredit');
         }

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -35,12 +35,14 @@ function show_query_form()
         echo "<p>";
         echo sprintf(
             _("Until you do so, click <a href='%s'>here</a> for creating a new project."),
-            'editproject.php?action=createnew');
+            'editproject.php?action=createnew'
+        );
         echo "</p>";
         echo "<p>";
         echo sprintf(
             _("If you believe you should be seeing the Create Project page please contact a <a href='%s'>Site Administrator</a>"),
-            "mailto:".$GLOBALS['site_manager_email_addr']);
+            "mailto:".$GLOBALS['site_manager_email_addr']
+        );
         echo "</p>";
     } else {
         echo "<h1>$title</h1>";
@@ -121,7 +123,9 @@ function do_search_and_show_hits()
         echo "<p>";
         $url = "editproject.php?action=createnew";
         echo sprintf(
-            _("Please try again. If the problem recurs, please create your project manually by following this <a href='%s'>link</a>."), $url);
+            _("Please try again. If the problem recurs, please create your project manually by following this <a href='%s'>link</a>."),
+            $url
+        );
         echo "</p>";
         exit();
     }
@@ -137,7 +141,8 @@ function do_search_and_show_hits()
         echo "<p>";
         echo sprintf(
             _("%d results returned. Note that some non-book results may not be displayed."),
-            yaz_hits($id));
+            yaz_hits($id)
+        );
         echo "</p>";
         echo "<p>";
         echo _("Please pick a result from below:");

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -46,7 +46,8 @@ if (!$resolution) {
     validate_projectID($projectid);
     $sql = sprintf(
         "SELECT * FROM $projectid WHERE image='%s'",
-        DPDatabase::escape($image));
+        DPDatabase::escape($image)
+    );
     $result = DPDatabase::query($sql);
     $page = mysqli_fetch_assoc($result);
     $state = $page['state'];
@@ -323,16 +324,23 @@ function update_image($projectid, $image)
             echo "<p><b>" . sprintf(_("Update of Original Image %s Complete!"), $image) . "</b></p>";
         } else {
             echo "<p class='error'>"._("Image NOT updated.<br>");
-            echo sprintf(_("The uploaded file type (%1\$s) does not match the original file type (%2\$s)."),
-                $tmp_image_ext, $org_image_ext) . "</p>";
-            echo "<p>" . sprintf(_("Click <a href='%s'>here</a> to return."),
-                "handle_bad_page.php?projectid=$projectid&image=$image&modify=image") . "</p>";
+            echo sprintf(
+                _("The uploaded file type (%1\$s) does not match the original file type (%2\$s)."),
+                $tmp_image_ext,
+                $org_image_ext
+            ) . "</p>";
+            echo "<p>" . sprintf(
+                _("Click <a href='%s'>here</a> to return."),
+                "handle_bad_page.php?projectid=$projectid&image=$image&modify=image"
+            ) . "</p>";
             exit;
         }
     } else {
         echo "<p class='error'>"._("The uploaded file must be a PNG or JPG file!") . "</p>";
-        echo "<p>". sprintf(_("Click <a href='%s'>here</a> to return."),
-                "handle_bad_page.php?projectid=$projectid&image=$image&modify=image") . "</p>";
+        echo "<p>". sprintf(
+            _("Click <a href='%s'>here</a> to return."),
+            "handle_bad_page.php?projectid=$projectid&image=$image&modify=image"
+        ) . "</p>";
         exit;
     }
 }

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -15,9 +15,12 @@ require_login();
 
 $page_url = "$code_url/tools/project_manager/manage_image_sources.php?";
 
-$action = get_enumerated_param($_REQUEST, 'action', 'show_sources',
-              ['show_sources', 'add_source', 'update_oneshot']
-          );
+$action = get_enumerated_param(
+    $_REQUEST,
+    'action',
+    'show_sources',
+    ['show_sources', 'add_source', 'update_oneshot']
+);
 
 $can_edit = user_is_image_sources_manager();
 
@@ -359,9 +362,9 @@ class ImageSource
             '3' => _('Publicly Visible'), ]
             as $val => $opt) {
             {
-            $editing .= "<option value='$val' " .
-                ($existing_value == $val ? 'selected' : '') .
-                ">$opt</option>";
+                $editing .= "<option value='$val' " .
+                    ($existing_value == $val ? 'selected' : '') .
+                    ">$opt</option>";
             }
         }
         $editing .= "</select><br>";
@@ -402,7 +405,8 @@ class ImageSource
             $this->info_page_visibility = '1' ;
         }
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             REPLACE INTO image_sources
             SET
                 code_name = LEFT('%s', 10),
@@ -449,7 +453,9 @@ class ImageSource
         $this->_set_field('info_page_visibility', 1);
 
         $notify_users = Settings::get_users_with_setting(
-            'is_approval_notify', $this->code_name);
+            'is_approval_notify',
+            $this->code_name
+        );
 
         foreach ($notify_users as $username) {
             $user = new User($username);
@@ -470,7 +476,8 @@ class ImageSource
 
     public function _set_field($field, $value)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE image_sources
             SET $field = '%s'
             WHERE code_name = '%s'",

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -58,16 +58,16 @@ class Comparator
         echo "<form action='page_compare.php' method='GET'>
             <input type='hidden' name='project' value='$this->projectid'>
             <input type='hidden' name='compare'>",
-            "<div>", _("Compare rounds:"), "</div>\n",
-            "<div class='grid-wrapper'>\n",
-            // TRANSLATORS: "Round 1" and "Round 2" are repeated below in "Pages I worked on in Round 1" etc.
-            "<div>", _("Round 1"), "</div><div>", $this->selector_string($this->L_round_id, "L_round_id", $this->L_round_options), "</div>\n",
-            "<div>", _("Round 2"), "</div><div>", $this->selector_string($this->R_round_id, "R_round_id", $this->R_round_options), "</div></div>\n",
-            "<p>", _("Show:"), "<br>\n",
-            $this->radio_string('all', _("All pages")), "<br>\n",
-            $this->radio_string('left', _("Pages I worked on in Round 1")), "<br>\n",
-            $this->radio_string('right', _("Pages I worked on in Round 2")), "</p>\n",
-            "<input type='submit' value=", attr_safe(_('Go')), "></form>\n";
+        "<div>", _("Compare rounds:"), "</div>\n",
+        "<div class='grid-wrapper'>\n",
+        // TRANSLATORS: "Round 1" and "Round 2" are repeated below in "Pages I worked on in Round 1" etc.
+        "<div>", _("Round 1"), "</div><div>", $this->selector_string($this->L_round_id, "L_round_id", $this->L_round_options), "</div>\n",
+        "<div>", _("Round 2"), "</div><div>", $this->selector_string($this->R_round_id, "R_round_id", $this->R_round_options), "</div></div>\n",
+        "<p>", _("Show:"), "<br>\n",
+        $this->radio_string('all', _("All pages")), "<br>\n",
+        $this->radio_string('left', _("Pages I worked on in Round 1")), "<br>\n",
+        $this->radio_string('right', _("Pages I worked on in Round 2")), "</p>\n",
+        "<input type='submit' value=", attr_safe(_('Go')), "></form>\n";
 
         // if this is first entry don't do anything else
         if (!$this->go_compare) {
@@ -90,12 +90,14 @@ class Comparator
             case 'right':
                 $condition = sprintf(
                     "$R_round->user_column_name = '%s'",
-                    DPDatabase::escape($username));
+                    DPDatabase::escape($username)
+                );
                 break;
             case 'left':
                 $condition = sprintf(
                     "$L_round->user_column_name = '%s'",
-                    DPDatabase::escape($username));
+                    DPDatabase::escape($username)
+                );
                 break;
             default: // all
                 $condition = "1";

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -64,12 +64,16 @@ if ($project->check_pages_table_exists($warn_message)) {
     echo "<p>";
     if (!is_null($username_for_page_selection)) {
         if (is_null($round_for_page_selection)) {
-            echo sprintf(_("Showing only the pages of user '%s'."),
-                          html_safe($username_for_page_selection));
+            echo sprintf(
+                _("Showing only the pages of user '%s'."),
+                html_safe($username_for_page_selection)
+            );
         } else {
-            echo sprintf(_("Showing only the pages of user '%1\$s' in round %2\$s."),
-                          html_safe($username_for_page_selection),
-                          html_safe($round_for_page_selection));
+            echo sprintf(
+                _("Showing only the pages of user '%1\$s' in round %2\$s."),
+                html_safe($username_for_page_selection),
+                html_safe($round_for_page_selection)
+            );
         }
         $blurb = _("Show all pages instead.");
         echo "&nbsp;&nbsp;";

--- a/tools/project_manager/page_operations.inc
+++ b/tools/project_manager/page_operations.inc
@@ -11,11 +11,13 @@ include_once($relPath.'page_tally.inc');
 function page_del($projectid, $image)
 {
     validate_projectID($projectid);
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT image
         FROM $projectid
         WHERE image = '%s'",
-        DPDatabase::escape($image));
+        DPDatabase::escape($image)
+    );
     $result = DPDatabase::query($sql);
     if (mysqli_num_rows($result) == 0) {
         return _("There is no page with that imagename.");
@@ -48,12 +50,14 @@ function page_clear($projectid, $image)
     }
 
     validate_projectID($projectid);
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT state, %s
         FROM $projectid
         WHERE image = '%s'",
         $round->user_column_name,
-        DPDatabase::escape($image));
+        DPDatabase::escape($image)
+    );
     $result = DPDatabase::query($sql);
     $row = mysqli_fetch_row($result);
     if (!$row) {

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -20,9 +20,13 @@ $user_settings = Settings::get_Settings($user->username);
 $default_view = $user_settings->get_value("pm_view", "user_all");
 
 try {
-    $show_view = get_enumerated_param($_GET, 'show', $default_view,
+    $show_view = get_enumerated_param(
+        $_GET,
+        'show',
+        $default_view,
         ['search_form', 'search', 'user_all', 'user_active',
-            'blank', 'set_columns', 'config', ]);
+            'blank', 'set_columns', 'config', ]
+    );
 } catch (Exception $e) {
     $show_view = 'blank';
 }

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -166,7 +166,7 @@ switch ($action) {
     // We always do showdir after the switch statement
     case 'showdir':
         break;
-    // Actions that prompt for additional information and we shouldn't showdir
+        // Actions that prompt for additional information and we shouldn't showdir
     case 'showupload':
         do_showupload();
         exit;
@@ -182,14 +182,14 @@ switch ($action) {
     case 'showdelete':
         do_showdelete();
         exit;
-    // Actions that do an action and do not return an info message
+        // Actions that do an action and do not return an info message
     case 'download':
         do_download();
         exit;
     case 'upload':
         do_upload();
         exit;
-    // Actions that do an action and upon success return an info message
+        // Actions that do an action and upon success return an info message
     case 'mkdir':
         $action_message = do_mkdir();
         break;
@@ -634,8 +634,10 @@ function do_showdelete()
     $form_content = "<p style='margin-top: 0em;'>";
     $form_content .= _("<b>Warning:</b> Deletion is permanent and cannot be undone.") . " ";
     $form_content .= _("This script does not check that folders are empty.</p>");
-    $form_content .= "<p><b>" . sprintf($question_template,
-        "<input type='text' name='del_file' size='50' maxsize='50' value='" . attr_safe($item_name) . "' READONLY>") . "</b></p>";
+    $form_content .= "<p><b>" . sprintf(
+        $question_template,
+        "<input type='text' name='del_file' size='50' maxsize='50' value='" . attr_safe($item_name) . "' READONLY>"
+    ) . "</b></p>";
 
     show_form(
         'delete',

--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -70,10 +70,13 @@ foreach ($suggestions as $suggestion) {
 
 $project_name = get_project_name($projectid);
 echo "<h2>",
-    // TRANSLATORS: %1$s is a word and %2$s is a project name.
-    sprintf(_("Suggestion context for '%1\$s' in %2\$s"),
-        $word, $project_name),
-    "</h2>";
+// TRANSLATORS: %1$s is a word and %2$s is a project name.
+sprintf(
+    _("Suggestion context for '%1\$s' in %2\$s"),
+    $word,
+    $project_name
+),
+"</h2>";
 
 echo "<p>";
 echo "<a href='show_word_context.php?projectid=$projectid&amp;word=$encWord'>" .
@@ -102,11 +105,11 @@ foreach ($word_suggestions as $suggestion) {
     foreach ($context_strings as $lineNum => $context_string) {
         $context_string = _highlight_word(html_safe($context_string, ENT_NOQUOTES), $word);
         echo "<b>" . _("Line") . "</b>: ",
-            // TRANSLATORS: %1$d is the approximate line number, and
-            // %2$d is the total number of lines when displaying the
-            // context of a word.
-            sprintf(_('~%1$d of %2$d'), $lineNum, $totalLines),
-            " &nbsp; | &nbsp; ";
+        // TRANSLATORS: %1$d is the approximate line number, and
+        // %2$d is the total number of lines when displaying the
+        // context of a word.
+        sprintf(_('~%1$d of %2$d'), $lineNum, $totalLines),
+        " &nbsp; | &nbsp; ";
         echo "<b>" . _("Context") . "</b>:<br><span class='mono'>$context_string</span><br>";
     }
     echo "</p>";

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -194,7 +194,8 @@ if (!$imso_code) {
         echo "<p>";
         echo sprintf(
             _("See other lists of Ebooks being produced with images from %s: "),
-                $imso['full_name']);
+            $imso['full_name']
+        );
         echo $links_list;
         echo "</p>";
 

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -90,9 +90,9 @@ while ([$page_text, $page, $proofer_names] = page_info_fetch($pages_res)) {
     foreach ($context_strings as $lineNum => $context_string) {
         $context_string = _highlight_word(html_safe($context_string, ENT_NOQUOTES), $word);
         echo "<b>", _("Line"), "</b>: ",
-            // TRANSLATORS: %1$d is the approximate line number, %2$d is the total number of lines
-            sprintf(_('~%1$d of %2$d'), $lineNum, $totalLines),
-            " &nbsp; | &nbsp; ";
+        // TRANSLATORS: %1$d is the approximate line number, %2$d is the total number of lines
+        sprintf(_('~%1$d of %2$d'), $lineNum, $totalLines),
+        " &nbsp; | &nbsp; ";
         echo "<b>" . _("Context") . "</b>:<br><span class='mono'>$context_string</span><br>";
     }
     echo "</p>";

--- a/tools/project_manager/update_illos.php
+++ b/tools/project_manager/update_illos.php
@@ -96,10 +96,10 @@ if (isset($success_msg)) {
     if ($err_msg == '') {
         echo "<p>", $success_msg, "</p>\n";
         echo "<p>",
-            "<a href='$code_url/tools/proofers/images_index.php?project=$projectid'>",
-            _('Return to Images Index'),
-            "</a>",
-            "</p>\n";
+        "<a href='$code_url/tools/proofers/images_index.php?project=$projectid'>",
+        _('Return to Images Index'),
+        "</a>",
+        "</p>\n";
         exit;
     } else {
         echo "<p class='error'>";

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -26,8 +26,7 @@ function url_for_pi_do_whichever_page($projectid, $proj_state, $escape_amp = fal
         . "?"
         . "projectid=$projectid"
         . $amp
-        . "proj_state=$proj_state"
-    ;
+        . "proj_state=$proj_state";
 }
 
 function url_for_pi_do_particular_page($projectid, $proj_state, $imagefile, $page_state, $escape_amp = false)
@@ -46,8 +45,7 @@ function url_for_pi_do_particular_page($projectid, $proj_state, $imagefile, $pag
         . $amp
         . "proj_state=$proj_state"
         . $amp
-        . "page_state=$page_state"
-    ;
+        . "page_state=$page_state";
 }
 
 // -----------------------------------------------------------------------------
@@ -62,7 +60,11 @@ function get_requested_PPage($request_params)
     $reverting = get_integer_param($request_params, 'reverting', 0, 0, 1);
 
     $lpage = get_indicated_LPage(
-        $projectid, $proj_state, $imagefile, $page_state, $reverting
+        $projectid,
+        $proj_state,
+        $imagefile,
+        $page_state,
+        $reverting
     );
 
     return new PPage($lpage, $proj_state);
@@ -140,7 +142,8 @@ class PPage
         } else {
             $amp = '&';
         }
-        return implode($amp,
+        return implode(
+            $amp,
             [
                 'projectid='  . $this->lpage->projectid,
                 'proj_state=' . $this->proj_state,
@@ -310,7 +313,7 @@ class PPage
             . sprintf(
                 _("You will be able to save more pages in %s after server midnight."),
                 $round->id
-              )
+            )
             . "</p>\n";
 
         echo "<ul>\n"
@@ -323,8 +326,7 @@ class PPage
             .   "<li>"
             .     return_to_activity_hub_link()
             .   "</li>\n"
-            . "</ul>\n"
-            ;
+            . "</ul>\n";
 
         // Do not return to caller.
         exit;

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -87,9 +87,9 @@ if (count($other_mentoring_rounds) > 0) {
 if (!user_can_work_on_beginner_pages_in_round($mentoring_round)) {
     echo "<p class='warning'>";
     echo sprintf(
-            _("You do not have access to 'Mentors Only' projects in %s."),
-            $mentoring_round->id
-        );
+        _("You do not have access to 'Mentors Only' projects in %s."),
+        $mentoring_round->id
+    );
     echo "</p>\n";
     exit;
 }
@@ -191,7 +191,8 @@ function get_beginner_projects_in_state($state, $mentored_round)
 {
     $mentored_round_detail = $mentored_round . '.proj_done';
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT
             projects.projectid,
             projects.nameofwork,

--- a/tools/proofers/greek2ascii.php
+++ b/tools/proofers/greek2ascii.php
@@ -82,8 +82,10 @@ echo attr_safe(_("Italic"))?>" title="<?php echo attr_safe(_("Italic Glyphs"))?>
 <?php
 echo "<p>" . _("The Greek glyphs above are <b>clickable</b>.") . "</p>";
 // TRANSLATORS: %s is an image of a rough-breathing mark.
-echo sprintf("<p>" . _("Diacritical marks may be ignored except for the rough-breathing mark, (%s) above the letter. For these, put '<code>h</code>' before the letter <em>unless</em> the word begins with '<code>r</code>'. For those, put '<code>h</code>' <em>after</em> the '<code>r</code>'."),
-    "<img src='gfx/greekrough.png' height='12' width='10'>") . "</p>";
+echo sprintf(
+    "<p>" . _("Diacritical marks may be ignored except for the rough-breathing mark, (%s) above the letter. For these, put '<code>h</code>' before the letter <em>unless</em> the word begins with '<code>r</code>'. For those, put '<code>h</code>' <em>after</em> the '<code>r</code>'."),
+    "<img src='gfx/greekrough.png' height='12' width='10'>"
+) . "</p>";
 ?>
 </td>
 </tr>

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -18,11 +18,11 @@ $project = new Project($projectid);
 if (!is_null($zip_type)) {
     switch ($zip_type) {
         case "illos":
-           $files_list = $project->get_illustrations();
-           break;
+            $files_list = $project->get_illustrations();
+            break;
         case "pages":
-           $files_list = $project->get_page_names_from_db();
-           break;
+            $files_list = $project->get_page_names_from_db();
+            break;
         default:
             throw new InvalidArgumentException("Invalid image type specified");
     }

--- a/tools/proofers/mktable.php
+++ b/tools/proofers/mktable.php
@@ -79,7 +79,9 @@ for ($j = 0; $j < $col; $j++) {
 echo "</tr>";
 
 // Output additional rows
-$a = []; $lng = []; $tll = [];
+$a = [];
+$lng = [];
+$tll = [];
 for ($i = 0; $i < $row; $i++) {
     echo "<tr>";
 
@@ -125,7 +127,7 @@ for ($i = 0; $i < $row; $i++) {
         $cell_contents = htmlspecialchars($table_contents[$i][$j], ENT_NOQUOTES, $charset);
         echo "<td>";
         echo "<textarea style='height: 6em; width: 15em; white-space: pre;' ",
-                "name='$name'>$cell_contents</textarea>";
+        "name='$name'>$cell_contents</textarea>";
         echo "</td>";
     }
     echo "</tr>";

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -31,22 +31,26 @@ $pool_sort_options = get_sort_options($pool_column_specs);
 // pull the last selected option from UserSettings.
 $userSettings = & Settings::get_Settings($pguser);
 $round_view = get_enumerated_param(
-    $_GET, "round_view",
+    $_GET,
+    "round_view",
     $userSettings->get_value("my_projects:round_view", "recent"),
     array_keys($round_view_options)
 );
 $pool_view = get_enumerated_param(
-    $_GET, "pool_view",
+    $_GET,
+    "pool_view",
     $userSettings->get_value("my_projects:pool_view", "reserved"),
     array_keys($pool_view_options)
 );
 $round_sort = get_enumerated_param(
-    $_GET, 'round_sort',
+    $_GET,
+    'round_sort',
     $userSettings->get_value("my_projects:round_sort", "timeD"),
     $round_sort_options
 );
 $pool_sort = get_enumerated_param(
-    $_GET, 'pool_sort',
+    $_GET,
+    'pool_sort',
     $userSettings->get_value("my_projects:pool_sort", "titleA"),
     $pool_sort_options
 );
@@ -112,8 +116,11 @@ if (mysqli_num_rows($res) == 0) {
         if ($row->state == PROJ_DELETE) {
             // it's been deleted. see if it's been merged into another one.
             if (str_contains($row->deletion_reason, 'merged') &&
-                (1 == preg_match('/\b(projectID[0-9a-f]{13})\b/',
-                                 $row->deletion_reason, $matches))) {
+                (1 == preg_match(
+                    '/\b(projectID[0-9a-f]{13})\b/',
+                    $row->deletion_reason,
+                    $matches
+                ))) {
                 // get the dope from the project it was merged into
                 $project = new Project($matches[1]);
                 if ($project->archived == '1') {
@@ -574,7 +581,8 @@ function get_round_query_result($round_view, $round_sort, $round_column_specs, $
     }
 
     if ($round_view == "available") {
-        $avail_state_clause = sprintf("
+        $avail_state_clause = sprintf(
+            "
             AND projects.state in (%s)",
             surround_and_join($avail_states, "'", "'", ',')
         );

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -177,7 +177,8 @@ try {
         case B_RETURN_PAGE_TO_ROUND:
             $ppage->returnToRound($pguser);
             leave_proofing_interface(
-                _("Return to Round"));
+                _("Return to Round")
+            );
             break;
 
         case B_REPORT_BAD_PAGE:
@@ -224,7 +225,13 @@ try {
             // functions for returning the round ID and the page number
             // without the mess below
             save_wordcheck_event(
-                $projectid, $ppage->lpage->round->id, $page, $pguser, $accepted_words, $corrections);
+                $projectid,
+                $ppage->lpage->round->id,
+                $page,
+                $pguser,
+                $accepted_words,
+                $corrections
+            );
 
             $ppage->saveAsInProgress($correct_text, $pguser);
             leave_spellcheck_mode($ppage);
@@ -242,7 +249,13 @@ try {
             unset($_SESSION[$wcTempCorrections]);
 
             save_wordcheck_event(
-                $projectid, $ppage->lpage->round->id, $page, $pguser, $accepted_words, []);
+                $projectid,
+                $ppage->lpage->round->id,
+                $page,
+                $pguser,
+                $accepted_words,
+                []
+            );
 
             $ppage->saveAsInProgress($correct_text, $pguser);
             leave_spellcheck_mode($ppage);
@@ -272,7 +285,13 @@ try {
             unset($_SESSION[$wcTempCorrections]);
 
             save_wordcheck_event(
-                $projectid, $ppage->lpage->round->id, $page, $pguser, $accepted_words, []);
+                $projectid,
+                $ppage->lpage->round->id,
+                $page,
+                $pguser,
+                $accepted_words,
+                []
+            );
 
             // 2. Save the current page as done
             $ppage->attempt_to_save_as_done($correct_text);

--- a/tools/proofers/proof.php
+++ b/tools/proofers/proof.php
@@ -23,7 +23,7 @@ if (!$expected_state) {
 
     echo "<p>";
     echo sprintf(
-         ('Warning: Project "%1$s" is no longer in state "%2$s"; it is now in state "%3$s".'),
+        ('Warning: Project "%1$s" is no longer in state "%2$s"; it is now in state "%3$s".'),
         $project->nameofwork,
         project_states_text($expected_state),
         project_states_text($project->state)

--- a/tools/proofers/proof_frame.php
+++ b/tools/proofers/proof_frame.php
@@ -101,8 +101,10 @@ if (isset($_GET['page_state'])) {
         if ($project->can_be_managed_by_user($pguser)) {
             $body = $err . "<br> " . return_to_project_page_link($projectid);
         } else {
-            $body = $err . "<br> " . sprintf(_("Return to the <a %s>project listing page</a>."),
-                "href='round.php?round_id={$round->id}' target='_top'");
+            $body = $err . "<br> " . sprintf(
+                _("Return to the <a %s>project listing page</a>."),
+                "href='round.php?round_id={$round->id}' target='_top'"
+            );
         }
         $title = _("Unable to get an available page");
         slim_header($title);

--- a/tools/proofers/report_bad_page.php
+++ b/tools/proofers/report_bad_page.php
@@ -105,8 +105,10 @@ if (!isset($_POST['submitted']) || $_POST['submitted'] != 'true') {
         $frame1 = "../../activity_hub.php";
         $title = _("Stop Proofreading");
 
-        $body = sprintf(_("Return to the <a %s>Activity Hub</a>."),
-                                       "href='$frame1' target='_top'");
+        $body = sprintf(
+            _("Return to the <a %s>Activity Hub</a>."),
+            "href='$frame1' target='_top'"
+        );
         slim_header($title);
         echo $body;
         exit;

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -148,7 +148,8 @@ $time_limit = time() - $days * 24 * 60 * 60;
 // the slower evaluation query and route everyone else to the faster and more
 // performant one.
 if ($use_eval_query) {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT
             page_events.projectid,
             state,
@@ -162,11 +163,14 @@ if ($use_eval_query) {
               timestamp > %d
         GROUP BY page_events.projectid
         ORDER BY time_of_latest_save DESC
-    ", DPDatabase::escape($work_round->id),
+    ",
+        DPDatabase::escape($work_round->id),
         DPDatabase::escape($username),
-        $time_limit);
+        $time_limit
+    );
 } else {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT
             user_project_info.projectid,
             state,
@@ -178,8 +182,10 @@ if ($use_eval_query) {
               t_latest_page_event > %d
         GROUP BY user_project_info.projectid
         ORDER BY t_latest_page_event DESC
-    ", DPDatabase::escape($username),
-        $time_limit);
+    ",
+        DPDatabase::escape($username),
+        $time_limit
+    );
 }
 $res2 = DPDatabase::query($sql);
 
@@ -307,13 +313,16 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
 
     // See if the user worked on any pages in this round
     validate_projectID($projectid);
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT COUNT(*)
         FROM {$projectid}
         WHERE {$work_round->user_column_name} = '%s' AND
               {$work_round->time_column_name} > %d
-        ", DPDatabase::escape($username),
-        $time_limit);
+        ",
+        DPDatabase::escape($username),
+        $time_limit
+    );
     $work_pages_done_result = DPDatabase::query($sql);
     [$pages_worked_in_review_round] = mysqli_fetch_row($work_pages_done_result);
     mysqli_free_result($work_pages_done_result);
@@ -323,13 +332,16 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
     }
 
     // see if it finished the work round
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT MAX(timestamp)
         FROM project_events
         WHERE projectid = '%s' AND
               details2 = '%s'
-       ", DPDatabase::escape($projectid),
-        DPDatabase::escape($work_round->project_complete_state));
+       ",
+        DPDatabase::escape($projectid),
+        DPDatabase::escape($work_round->project_complete_state)
+    );
     $work_round_result = DPDatabase::query($sql);
     [$max_done_timestamp] = mysqli_fetch_row($work_round_result);
     mysqli_free_result($work_round_result);
@@ -345,15 +357,18 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
     }
 
     // see if it actually went through the review round.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT COUNT(*) 
         FROM project_events
         WHERE projectid = '%s' AND
               details2 ='%s' AND
               timestamp >= %d
-       ", DPDatabase::escape($projectid),
+       ",
+        DPDatabase::escape($projectid),
         DPDatabase::escape($review_round->project_available_state),
-        $max_done_timestamp);
+        $max_done_timestamp
+    );
     $review_round_result = DPDatabase::query($sql);
     [$done_in_rround] = mysqli_fetch_row($review_round_result);
     mysqli_free_result($review_round_result);
@@ -410,7 +425,8 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
     $diffLinkString = "";
     if ($sampleLimit > 0) {
         validate_projectID($projectid);
-        $query = sprintf("
+        $query = sprintf(
+            "
            SELECT image 
            FROM $projectid AS proj 
            WHERE $has_been_saved_in_review_round AND 
@@ -418,8 +434,10 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
                  {$work_round->user_column_name} = '%s'
            ORDER BY {$work_round->time_column_name} DESC, image 
            LIMIT %d
-        ", DPDatabase::escape($username),
-            $sampleLimit);
+        ",
+            DPDatabase::escape($username),
+            $sampleLimit
+        );
         $result = DPDatabase::query($query);
         $diffLinkString = "";
         while ([$image] = mysqli_fetch_row($result)) {

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -46,8 +46,10 @@ if ($pagesproofed <= 100 && $ELR_round->id == $round_id) {
     if ($pagesproofed > 80) {
         echo "<p class='small italic'>";
         // TRANSLATORS: Simple Proofreading Rules are the strings listed in pinc/simple_proof_text.inc
-        printf(_("After you proofread a few more pages, the following introductory Simple Proofreading Rules will be removed from this page. However, they are permanently available <a href='%s'>here</a> if you wish to refer to them later. (You can bookmark that link if you like.)"),
-            "$code_url/faq/simple_proof_rules.php");
+        printf(
+            _("After you proofread a few more pages, the following introductory Simple Proofreading Rules will be removed from this page. However, they are permanently available <a href='%s'>here</a> if you wish to refer to them later. (You can bookmark that link if you like.)"),
+            "$code_url/faq/simple_proof_rules.php"
+        );
         echo "</p>";
     }
 
@@ -65,8 +67,10 @@ if ($rule && $pagesproofed >= 10) {
 
     if ($pagesproofed < 40) {
         echo "<p class='sans-serif small italic'>";
-        printf(_("Now that you have proofread 10 pages you can see the Random Rule. Every time this page is refreshed, a random rule is selected from the <a href='%s'>Guidelines</a> and displayed in this section"),
-            $round_doc_url);
+        printf(
+            _("Now that you have proofread 10 pages you can see the Random Rule. Every time this page is refreshed, a random rule is selected from the <a href='%s'>Guidelines</a> and displayed in this section"),
+            $round_doc_url
+        );
         echo "<br>";
         echo _("(This explanatory line will eventually vanish.)");
         echo "</p>";
@@ -77,9 +81,11 @@ if ($rule && $pagesproofed >= 10) {
     echo "<i>".$rule->subject."</i><br>";
     echo "<p>".$rule->rule."</p>";
     // TRANSLATORS: %1$s is the linked name of a random Guideline section.
-    printf(_("See the %1\$s section of the <a href='%2\$s'>Guidelines</a>"),
+    printf(
+        _("See the %1\$s section of the <a href='%2\$s'>Guidelines</a>"),
         "<a href='$round_doc_url#".$rule->anchor."'>".$rule->subject."</a>",
-        $round_doc_url);
+        $round_doc_url
+    );
     echo "</div>";
 }
 

--- a/tools/search.php
+++ b/tools/search.php
@@ -11,8 +11,12 @@ include_once($relPath.'ProjectSearchResults.inc');
 require_login();
 
 try {
-    $show_view = get_enumerated_param($_GET, 'show', 'search_form',
-        ['search_form', 'search', 'set_columns', 'config']);
+    $show_view = get_enumerated_param(
+        $_GET,
+        'show',
+        'search_form',
+        ['search_form', 'search', 'set_columns', 'config']
+    );
 } catch (Exception $e) {
     $show_view = 'search_form';
 }

--- a/tools/set_project_event_subs.php
+++ b/tools/set_project_event_subs.php
@@ -31,11 +31,13 @@ slim_header(_("Event Subscriptions"));
 
 _html_ul(
     _("You are now subscribed to these events for this project:"),
-    $subs);
+    $subs
+);
 
 _html_ul(
     _("You are now unsubscribed from these events for this project:"),
-    $unsubs);
+    $unsubs
+);
 
 function _html_ul($header, $items)
 {

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -50,26 +50,51 @@ $repeat_project = get_enumerated_param($_POST, 'repeat_project', null, ['TO', 'F
 
 switch ($action) {
     case 'showform':
-        display_form($projectid_, $from_image_, $page_name_handling,
-                     $transfer_notifications, $add_deletion_reason,
-                     $merge_wordcheck_data, $repeat_project, false);
+        display_form(
+            $projectid_,
+            $from_image_,
+            $page_name_handling,
+            $transfer_notifications,
+            $add_deletion_reason,
+            $merge_wordcheck_data,
+            $repeat_project,
+            false
+        );
         break;
 
     case 'showagain':
-        display_form($projectid_, $from_image_, $page_name_handling,
-                     $transfer_notifications, $add_deletion_reason,
-                     $merge_wordcheck_data, $repeat_project, true);
+        display_form(
+            $projectid_,
+            $from_image_,
+            $page_name_handling,
+            $transfer_notifications,
+            $add_deletion_reason,
+            $merge_wordcheck_data,
+            $repeat_project,
+            true
+        );
         break;
 
     case 'check':
-        do_stuff($projectid_, $from_image_, $page_name_handling,
-                  $transfer_notifications, $add_deletion_reason,
-                  $merge_wordcheck_data, true);
+        do_stuff(
+            $projectid_,
+            $from_image_,
+            $page_name_handling,
+            $transfer_notifications,
+            $add_deletion_reason,
+            $merge_wordcheck_data,
+            true
+        );
 
         echo "<form method='post'>\n";
-        display_hiddens($projectid_, $from_image_, $page_name_handling,
-                        $transfer_notifications, $add_deletion_reason,
-                        $merge_wordcheck_data);
+        display_hiddens(
+            $projectid_,
+            $from_image_,
+            $page_name_handling,
+            $transfer_notifications,
+            $add_deletion_reason,
+            $merge_wordcheck_data
+        );
         echo "\n<input type='hidden' name='action' value='docopy'>";
         echo "\n<input type='submit' name='submit_button' value='" . attr_safe(_("Do it")) ."'>";
         echo "\n</form>";
@@ -77,9 +102,15 @@ switch ($action) {
         break;
 
     case 'docopy':
-        do_stuff($projectid_, $from_image_, $page_name_handling,
-                  $transfer_notifications, $add_deletion_reason,
-                  $merge_wordcheck_data, false);
+        do_stuff(
+            $projectid_,
+            $from_image_,
+            $page_name_handling,
+            $transfer_notifications,
+            $add_deletion_reason,
+            $merge_wordcheck_data,
+            false
+        );
 
         echo "<hr>\n";
         $url = "$code_url/tools/project_manager/page_detail.php?project={$projectid_['to']}&amp;show_image_size=0";
@@ -95,9 +126,14 @@ switch ($action) {
         echo "<input type='radio' name='repeat_project' id='rp-3' value='NONE' CHECKED>";
         echo "<label for='rp-3'>" . _("Neither") . "</label>";
 
-        display_hiddens($projectid_, $from_image_, $page_name_handling,
-                        $transfer_notifications, $add_deletion_reason,
-                        $merge_wordcheck_data);
+        display_hiddens(
+            $projectid_,
+            $from_image_,
+            $page_name_handling,
+            $transfer_notifications,
+            $add_deletion_reason,
+            $merge_wordcheck_data
+        );
 
         echo "<input type='hidden' name='action' value='showagain'>\n";
         echo "<input type='submit' name='submit_button' value='" . attr_safe(_("Again!")) . "'>\n";
@@ -111,10 +147,16 @@ switch ($action) {
         break;
 }
 
-function display_form($projectid_, $from_image_, $page_name_handling,
-                      $transfer_notifications, $add_deletion_reason,
-                      $merge_wordcheck_data, $repeat_project, $repeating)
-{
+function display_form(
+    $projectid_,
+    $from_image_,
+    $page_name_handling,
+    $transfer_notifications,
+    $add_deletion_reason,
+    $merge_wordcheck_data,
+    $repeat_project,
+    $repeating
+) {
     echo "<form method='post'>\n";
     echo "<table class='copy'>\n";
 
@@ -162,12 +204,24 @@ function display_form($projectid_, $from_image_, $page_name_handling,
     echo "</fieldset>\n";
     echo "</td></tr>\n";
 
-    do_radio_button_pair(_("Transfer event notifications:"),
-        "transfer_notifications", $repeating, $transfer_notifications);
-    do_radio_button_pair(_("Add deletion reason to source project:"),
-        "add_deletion_reason", $repeating, $add_deletion_reason);
-    do_radio_button_pair(_("Merge WordCheck files and events into destination project:"),
-        "merge_wordcheck_data", $repeating, $merge_wordcheck_data);
+    do_radio_button_pair(
+        _("Transfer event notifications:"),
+        "transfer_notifications",
+        $repeating,
+        $transfer_notifications
+    );
+    do_radio_button_pair(
+        _("Add deletion reason to source project:"),
+        "add_deletion_reason",
+        $repeating,
+        $add_deletion_reason
+    );
+    do_radio_button_pair(
+        _("Merge WordCheck files and events into destination project:"),
+        "merge_wordcheck_data",
+        $repeating,
+        $merge_wordcheck_data
+    );
 
     echo "<tr><td></td><td>";
     echo "<input type='hidden' name='action' value='check'>\n";
@@ -206,10 +260,14 @@ function do_radio_button_pair($prompt, $input_name, $repeating, $first_is_checke
     echo "</td></tr>\n";
 }
 
-function display_hiddens($projectid_, $from_image_, $page_name_handling,
-                         $transfer_notifications, $add_deletion_reason,
-                         $merge_wordcheck_data)
-{
+function display_hiddens(
+    $projectid_,
+    $from_image_,
+    $page_name_handling,
+    $transfer_notifications,
+    $add_deletion_reason,
+    $merge_wordcheck_data
+) {
     echo "\n<input type='hidden' name='from_image_[lo]'        value='" . attr_safe($from_image_['lo']) . "'>";
     echo "\n<input type='hidden' name='from_image_[hi]'        value='" . attr_safe($from_image_['hi']) . "'>";
     echo "\n<input type='hidden' name='projectid_[from]'       value='" . attr_safe($projectid_['from']) . "'>";
@@ -220,11 +278,15 @@ function display_hiddens($projectid_, $from_image_, $page_name_handling,
     echo "\n<input type='hidden' name='merge_wordcheck_data'   value='" . attr_safe($merge_wordcheck_data) . "'>";
 }
 
-function do_stuff($projectid_, $from_image_, $page_name_handling,
-                   $transfer_notifications, $add_deletion_reason,
-                   $merge_wordcheck_data,
-                   $just_checking)
-{
+function do_stuff(
+    $projectid_,
+    $from_image_,
+    $page_name_handling,
+    $transfer_notifications,
+    $add_deletion_reason,
+    $merge_wordcheck_data,
+    $just_checking
+) {
     if (is_null($projectid_)) {
         error_and_die("No projectid data supplied to do_stuff()");
     }
@@ -412,7 +474,8 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
             $max_dst_base = (
                 strcmp($max_dst_fileid, $max_dst_image_base) > 0
                 ? $max_dst_fileid
-                : $max_dst_image_base);
+                : $max_dst_image_base
+            );
             $c_dst_format = '%0' . strlen($max_dst_base) . 'd';
             $c_dst_start_b = 1 + intval($max_dst_base);
         }
@@ -580,14 +643,16 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
                 sprintf("'%s'", DPDatabase::escape($c_dst_image)),
                 sprintf("'%s'", DPDatabase::escape($c_dst_fileid)),
             ],
-            $items_list_template);
+            $items_list_template
+        );
 
         $insert = "
             INSERT INTO {$projectid_['to']}
             SELECT $items_list
             FROM {$projectid_['from']}
         ";
-        $query = sprintf("
+        $query = sprintf(
+            "
             %s
             WHERE image = '%s'",
             $insert,
@@ -629,7 +694,8 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
         $subscribable_project_events = get_subscribable_project_events();
         $count = 0;
         foreach ($subscribable_project_events as $event => $label) {
-            $query = sprintf("
+            $query = sprintf(
+                "
                 SELECT username FROM user_project_info
                 WHERE projectid = '%s' AND
                     iste_$event = 1",
@@ -637,9 +703,12 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
             );
             $res1 = DPDatabase::query($query);
             while ([$username] = mysqli_fetch_row($res1)) {
-                set_user_project_event_subscription($username,
-                                                     $projectid_['to'],
-                                                     $event, 1);
+                set_user_project_event_subscription(
+                    $username,
+                    $projectid_['to'],
+                    $event,
+                    1
+                );
                 $count++;
             }
         }
@@ -648,12 +717,13 @@ function do_stuff($projectid_, $from_image_, $page_name_handling,
 
     if ($add_deletion_reason) {
         echo "<p>" . _("Adding deletion reason to source project.") . "</p>\n";
-        $query = sprintf("
+        $query = sprintf(
+            "
               UPDATE projects
               SET deletion_reason = 'merged into %s'
               WHERE projectid = '%s'",
-              $projectid_['to'], // validated input
-              $projectid_['from'] // validated input
+            $projectid_['to'], // validated input
+            $projectid_['from'] // validated input
         );
         echo "<code>" . html_safe($query) . "</code>";
         if ($for_real) {

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -78,11 +78,13 @@ if ($action == 'default') {
     try {
         $user = new NonactivatedUser($username);
     } catch (NonexistentNonactivatedUserException $exception) {
-        printf(_("No user '%s' was was found in the list of non-validated users."),
-            html_safe($username));
+        printf(
+            _("No user '%s' was was found in the list of non-validated users."),
+            html_safe($username)
+        );
         echo "<p>",
-            sprintf(_("Note that you can also <a href='%s'>list all user accounts awaiting activation</a>"), "?action=list_all"),
-            "</p>";
+        sprintf(_("Note that you can also <a href='%s'>list all user accounts awaiting activation</a>"), "?action=list_all"),
+        "</p>";
         exit;
     }
 

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -15,9 +15,12 @@ if (!user_is_a_sitemanager()) {
 
 $page_url = "$code_url/tools/site_admin/manage_special_days.php";
 
-$action = get_enumerated_param($_REQUEST, 'action', 'show_specials',
-              ['show_specials', 'add_special', 'update_oneshot']
-          );
+$action = get_enumerated_param(
+    $_REQUEST,
+    'action',
+    'show_specials',
+    ['show_specials', 'add_special', 'update_oneshot']
+);
 
 // Action 'update_oneshot' is used as a target for form submit buttons. The
 // desired action is based on the submit button's name. Here we do the action
@@ -57,8 +60,10 @@ if ($action == 'update_oneshot') {
         ];
         foreach ($numeric_fields as $field => $string) {
             if ($_POST[$field] == '' || !ctype_digit($_POST[$field])) {
-                $errmsgs .= sprintf(_("Field %s does not contain a valid number."),
-                                $string) . "<br>";
+                $errmsgs .= sprintf(
+                    _("Field %s does not contain a valid number."),
+                    $string
+                ) . "<br>";
             }
         }
 
@@ -127,11 +132,13 @@ class SpecialDay
         $this->enable = 0;
 
         if (!is_null($spec_code)) {
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 SELECT *
                 FROM special_days
                 WHERE spec_code = '%s'",
-                DPDatabase::escape($spec_code));
+                DPDatabase::escape($spec_code)
+            );
             $result = DPDatabase::query($sql);
             $source_fields = mysqli_fetch_assoc($result);
 
@@ -351,7 +358,8 @@ class SpecialDay
 
     public function _set_field($field, $value)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE special_days
             SET $field = '%s'
             WHERE spec_code = '%s'",

--- a/tools/site_admin/project_jump.php
+++ b/tools/site_admin/project_jump.php
@@ -124,8 +124,13 @@ function do_stuff($projectid, $new_state, $just_checking)
     ", DPDatabase::escape($new_state), DPDatabase::escape($projectid));
     DPDatabase::query($sql);
     echo "    jumped to : $new_state\n";
-    $project->log_project_event($pguser, 'transition', $project->state,
-                       $new_state, 'Project jumped to correct state');
+    $project->log_project_event(
+        $pguser,
+        'transition',
+        $project->state,
+        $new_state,
+        'Project jumped to correct state'
+    );
     echo "</pre>";
 }
 

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -115,7 +115,8 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
         case 'add':
             // Save a new site news item
             $content = strip_tags($content, $allowed_tags);
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 INSERT INTO news_items
                 SET
                     id           = NULL,
@@ -126,13 +127,15 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
                     item_type    = LEFT('%s', 16),
                     header       = LEFT('%s', 256),
                     content      = '%s'
-            ", DPDatabase::escape($news_page_id),
-               time(),
-               DPDatabase::escape($item_status),
-               DPDatabase::escape($locale),
-               DPDatabase::escape($item_type),
-               DPDatabase::escape($header),
-               DPDatabase::escape($content));
+            ",
+                DPDatabase::escape($news_page_id),
+                time(),
+                DPDatabase::escape($item_status),
+                DPDatabase::escape($locale),
+                DPDatabase::escape($item_type),
+                DPDatabase::escape($header),
+                DPDatabase::escape($content)
+            );
             DPDatabase::query($sql);
             // by default, new items go at the top
             $sql = "
@@ -188,7 +191,8 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
         case 'edit_update':
             // Save an update to a specific site news item
             $content = strip_tags($content, $allowed_tags);
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE news_items
                 SET
                     status    = LEFT('%s', 8),
@@ -197,12 +201,14 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
                     header    = LEFT('%s', 256),
                     content   = '%s'
                 WHERE id = %d
-            ", DPDatabase::escape($item_status),
-               DPDatabase::escape($locale),
-               DPDatabase::escape($item_type),
-               DPDatabase::escape($header),
-               DPDatabase::escape($content),
-               $item_id);
+            ",
+                DPDatabase::escape($item_status),
+                DPDatabase::escape($locale),
+                DPDatabase::escape($item_type),
+                DPDatabase::escape($header),
+                DPDatabase::escape($content),
+                $item_id
+            );
             DPDatabase::query($sql);
 
             $sql = sprintf("
@@ -345,13 +351,16 @@ function show_all_news_items_for_page($news_page_id)
     foreach ($categories as $category) {
         $status = $category['status'];
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT *
             FROM news_items
             WHERE news_page_id = '%s' AND status = '%s'
             ORDER BY {$category['order_by']}
-        ", DPDatabase::escape($news_page_id),
-           DPDatabase::escape($status));
+        ",
+            DPDatabase::escape($news_page_id),
+            DPDatabase::escape($status)
+        );
         $result = DPDatabase::query($sql);
 
         if (mysqli_num_rows($result) == 0) {
@@ -417,11 +426,14 @@ function update_news_item_status($item_id, $status)
 
 function news_change_made($news_page_id)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         REPLACE INTO news_pages
         SET news_page_id = '%s', t_last_change = %d
-    ", DPDatabase::escape($news_page_id),
-       time());
+    ",
+        DPDatabase::escape($news_page_id),
+        time()
+    );
     DPDatabase::query($sql);
 }
 

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -1,5 +1,5 @@
 <?php
- $relPath = "../pinc/";
+$relPath = "../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc'); // array_get()
 
@@ -30,7 +30,7 @@ $chunk_filename = "$staging_dir/$hashed_filename.part.$chunk_number";
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (file_exists($chunk_filename)) {
         header("HTTP/1.0 200 Ok");
-    // continue to try to reassemble
+        // continue to try to reassemble
     } else {
         header("HTTP/1.0 404 Not Found");
         exit;

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -141,9 +141,11 @@ if ($stage == 'post_1') {
     echo "<p>", _("The upload failed."), "</p>\n";
     echo "<p>", get_big_upload_blurb(), "</p>";
 
-    echo "<p>" . sprintf(_("Please go <a href='%s'>back</a> and try uploading
+    echo "<p>" . sprintf(
+        _("Please go <a href='%s'>back</a> and try uploading
         the original again or uploading a smaller placeholder instead."),
-        "javascript:history.back()") . "</p>";
+        "javascript:history.back()"
+    ) . "</p>";
 
     exit;
 }
@@ -256,12 +258,15 @@ if (!isset($action)) {
 
         if (($stage == "in_prog_1") || ($stage == "in_prog_2")) {
             // record postcomments in projects table
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE projects
                 SET postcomments = CONCAT(postcomments, '%s')
                 WHERE projectid = '%s'
-            ", DPDatabase::escape($postcomments),
-                DPDatabase::escape($projectid));
+            ",
+                DPDatabase::escape($postcomments),
+                DPDatabase::escape($projectid)
+            );
             DPDatabase::query($sql);
         }
 

--- a/userprefs.php
+++ b/userprefs.php
@@ -243,7 +243,9 @@ function echo_general_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Name'), 'real_name', 'name',
+        _('Name'),
+        'real_name',
+        'name',
         $user->real_name,
         'textfield',
         ['100%', 'required', '']
@@ -263,13 +265,17 @@ function echo_general_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('E-mail'), 'email', 'email',
+        _('E-mail'),
+        'email',
+        'email',
         $user->email,
         'emailfield',
         ['100%', 'required', $email_warning]
     );
     show_preference(
-        _('Interface Language'), 'u_intlang', 'intlang',
+        _('Interface Language'),
+        'u_intlang',
+        'intlang',
         $user->u_intlang,
         'dropdown',
         $u_intlang_options
@@ -278,7 +284,9 @@ function echo_general_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('E-mail Updates'), 'email_updates', 'updates',
+        _('E-mail Updates'),
+        'email_updates',
+        'updates',
         $user->email_updates,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
@@ -291,7 +299,9 @@ function echo_general_tab($user)
         $theme_options[$option_value] = $option_label;
     }
     show_preference(
-        _('Theme'), 'i_theme', 'theme',
+        _('Theme'),
+        'i_theme',
+        'theme',
         $user->i_theme,
         'dropdown',
         $theme_options
@@ -306,7 +316,9 @@ function echo_general_tab($user)
         _("Reset Password")
     );
     show_preference(
-        _('Statistics Bar Alignment'), 'u_align', 'align',
+        _('Statistics Bar Alignment'),
+        'u_align',
+        'align',
         $user->u_align,
         'radio_group',
         [1 => _("Left"), 0 => _("Right")]
@@ -315,13 +327,17 @@ function echo_general_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Statistics'), 'u_privacy', 'privacy',
+        _('Statistics'),
+        'u_privacy',
+        'privacy',
         $user->u_privacy,
         'dropdown',
         $i_stats_privacy
     );
     show_preference(
-        _('Show Rank Neighbors'), 'u_neigh', 'neighbors',
+        _('Show Rank Neighbors'),
+        'u_neigh',
+        'neighbors',
         $user->u_neigh,
         'dropdown',
         get_rank_neighbor_options()
@@ -330,7 +346,9 @@ function echo_general_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Credits Wanted'), null, 'creditswanted',
+        _('Credits Wanted'),
+        null,
+        'creditswanted',
         null,
         'credits_wanted_adhoc',
         null
@@ -339,7 +357,9 @@ function echo_general_tab($user)
     // 'show', rather than 'hide' since 'hide: no' seems double-negated (to me).
     $show_special_colors = !$userSettings->get_boolean('hide_special_colors');
     show_preference(
-        _('Show Special Colors'), 'show_special_colors', 'showspecialcolors',
+        _('Show Special Colors'),
+        'show_special_colors',
+        'showspecialcolors',
         ($show_special_colors ? 'yes' : 'no'),
         'dropdown',
         ['yes' => _('Yes'), 'no' => _('No')]
@@ -348,7 +368,9 @@ function echo_general_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Credit Name'), null, 'creditname',
+        _('Credit Name'),
+        null,
+        'creditname',
         null,
         'credit_name_adhoc',
         null
@@ -407,7 +429,9 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Profile Name'), 'profilename', 'profilename',
+        _('Profile Name'),
+        'profilename',
+        'profilename',
         $user->profile->profilename,
         'textfield',
         ['100%', 'required', '']
@@ -439,13 +463,17 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Screen Resolution'), 'i_res', 'screenres',
+        _('Screen Resolution'),
+        'i_res',
+        'screenres',
         $user->profile->i_res,
         'dropdown',
         $i_resolutions
     );
     show_preference(
-        _('Launch in New Window'), 'i_newwin', 'newwindow',
+        _('Launch in New Window'),
+        'i_newwin',
+        'newwindow',
         $user->profile->i_newwin,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
@@ -454,13 +482,17 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Interface Type'), 'i_type', 'facetype',
+        _('Interface Type'),
+        'i_type',
+        'facetype',
         $user->profile->i_type,
         'radio_group',
         [0 => _("Standard"), 1 => _("Enhanced")]
     );
     show_preference(
-        _('Show Toolbar'), 'i_toolbar', 'toolbar',
+        _('Show Toolbar'),
+        'i_toolbar',
+        'toolbar',
         $user->profile->i_toolbar,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
@@ -469,7 +501,9 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Interface Layout'), 'i_layout', 'layout',
+        _('Interface Layout'),
+        'i_layout',
+        'layout',
         $user->profile->i_layout,
         'radio_group',
         [
@@ -478,7 +512,9 @@ function echo_proofreading_tab($user)
         ]
     );
     show_preference(
-        _('Show Status Bar'), 'i_statusbar', 'statusbar',
+        _('Show Status Bar'),
+        'i_statusbar',
+        'statusbar',
         $user->profile->i_statusbar,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
@@ -486,47 +522,64 @@ function echo_proofreading_tab($user)
     echo "</tr>\n";
 
     echo "<tr>\n";
-    th_label_long(2,
-        "<img src='tools/proofers/gfx/bt4.png'>" . _("Vertical Interface Preferences"));
+    th_label_long(
+        2,
+        "<img src='tools/proofers/gfx/bt4.png'>" . _("Vertical Interface Preferences")
+    );
     td_pophelp('vertprefs');
-    th_label_long(2,
-        "<img src='tools/proofers/gfx/bt5.png'>" . _("Horizontal Interface Preferences"));
+    th_label_long(
+        2,
+        "<img src='tools/proofers/gfx/bt5.png'>" . _("Horizontal Interface Preferences")
+    );
     td_pophelp('horzprefs');
     echo "</tr>\n";
 
     $proofreading_font_faces = get_available_proofreading_font_faces();
     echo "<tr>\n";
     show_preference(
-        _('Font Face'), 'v_fntf', 'v_fontface',
+        _('Font Face'),
+        'v_fntf',
+        'v_fontface',
         $user->profile->v_fntf,
         'fontface_selection',
         $user->profile->v_fntf_other
     );
     show_preference(
-        _('Font Face'), 'h_fntf', 'h_fontface',
+        _('Font Face'),
+        'h_fntf',
+        'h_fontface',
         $user->profile->h_fntf,
         'fontface_selection',
         $user->profile->h_fntf_other
     );
     echo "</tr>\n";
 
-    $font_sample = wordwrap(sprintf("
+    $font_sample = wordwrap(
+        sprintf(
+            "
         The lazy brown fox was puzzled by these commonly-confused
         characters: %s",
-        "O0o l1iI BE3 RK"), 40, "<br>"
+            "O0o l1iI BE3 RK"
+        ),
+        40,
+        "<br>"
     );
 
     $proofreading_font_sizes = get_available_proofreading_font_sizes();
     echo "<tr>\n";
     $proofreading_font_sizes[0] = BROWSER_DEFAULT_STR;
     show_preference(
-        _('Font Size'), 'v_fnts', 'v_fontsize',
+        _('Font Size'),
+        'v_fnts',
+        'v_fontsize',
         $user->profile->v_fnts,
         'dropdown',
         $proofreading_font_sizes
     );
     show_preference(
-        _('Font Size'), 'h_fnts', 'h_fontsize',
+        _('Font Size'),
+        'h_fnts',
+        'h_fontsize',
         $user->profile->h_fnts,
         'dropdown',
         $proofreading_font_sizes
@@ -547,14 +600,18 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Text Frame Size'), 'v_tframe', 'v_textsize',
+        _('Text Frame Size'),
+        'v_tframe',
+        'v_textsize',
         $user->profile->v_tframe,
         'numberfield',
         // xgettext:no-php-format
         ['5em', 'required', _("% of browser width")]
     );
     show_preference(
-        _('Text Frame Size'), 'h_tframe', 'h_textsize',
+        _('Text Frame Size'),
+        'h_tframe',
+        'h_textsize',
         $user->profile->h_tframe,
         'numberfield',
         // xgettext:no-php-format
@@ -564,13 +621,17 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Scroll Text Frame'), 'v_tscroll', 'v_scroll',
+        _('Scroll Text Frame'),
+        'v_tscroll',
+        'v_scroll',
         $user->profile->v_tscroll,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
     );
     show_preference(
-        _('Scroll Text Frame'), 'h_tscroll', 'h_scroll',
+        _('Scroll Text Frame'),
+        'h_tscroll',
+        'h_scroll',
         $user->profile->h_tscroll,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
@@ -579,13 +640,17 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Number of Text Lines'), 'v_tlines', 'v_textlines',
+        _('Number of Text Lines'),
+        'v_tlines',
+        'v_textlines',
         $user->profile->v_tlines,
         'numberfield',
         ['5em', 'required', ""]
     );
     show_preference(
-        _('Number of Text Lines'), 'h_tlines', 'h_textlines',
+        _('Number of Text Lines'),
+        'h_tlines',
+        'h_textlines',
         $user->profile->h_tlines,
         'numberfield',
         ['5em', 'required', ""]
@@ -594,13 +659,17 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Length of Text Lines'), 'v_tchars', 'v_textlength',
+        _('Length of Text Lines'),
+        'v_tchars',
+        'v_textlength',
         $user->profile->v_tchars,
         'numberfield',
         ['5em', 'required', " "._("characters")]
     );
     show_preference(
-        _('Length of Text Lines'), 'h_tchars', 'h_textlength',
+        _('Length of Text Lines'),
+        'h_tchars',
+        'h_textlength',
         $user->profile->h_tchars,
         'numberfield',
         ['5em', 'required', " "._("characters")]
@@ -609,13 +678,17 @@ function echo_proofreading_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Wrap Text'), 'v_twrap', 'v_wrap',
+        _('Wrap Text'),
+        'v_twrap',
+        'v_wrap',
         $user->profile->v_twrap,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
     );
     show_preference(
-        _('Wrap Text'), 'h_twrap', 'h_wrap',
+        _('Wrap Text'),
+        'h_twrap',
+        'h_wrap',
         $user->profile->h_twrap,
         'radio_group',
         [1 => _("Yes"), 0 => _("No")]
@@ -691,7 +764,9 @@ function echo_pm_tab($user)
     echo "<tr>\n";
     show_preference(
         // TRANSLATORS: PM = project manager
-        _('Default PM Page'), 'pm_view', 'pmdefault',
+        _('Default PM Page'),
+        'pm_view',
+        'pmdefault',
         $userSettings->get_value('pm_view', "user_all"),
         'dropdown',
         $pm_view_options
@@ -702,7 +777,9 @@ function echo_pm_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Automatically watch your project threads'), 'auto_proj_thread', 'auto_thread',
+        _('Automatically watch your project threads'),
+        'auto_proj_thread',
+        'auto_thread',
         ($auto_proj_thread ? 'yes' : 'no'),
         'dropdown',
         ['yes' => _('Yes'), 'no' => _('No')]
@@ -713,7 +790,9 @@ function echo_pm_tab($user)
 
     echo "<tr>\n";
     show_preference(
-        _('Automatically send your projects to the post-processing pool'), 'send_to_post', 'pmto_post',
+        _('Automatically send your projects to the post-processing pool'),
+        'send_to_post',
+        'pmto_post',
         ($send_to_post ? 'yes' : 'no'),
         'dropdown',
         ['yes' => _('Yes'), 'no' => _('No')]
@@ -756,11 +835,13 @@ function echo_bottom_button_row()
 // ---------------------------------------------------------
 
 function show_preference(
-    $label, $field_name, $pophelp_name,
+    $label,
+    $field_name,
+    $pophelp_name,
     $current_value,
     $type,
-    $extras)
-{
+    $extras
+) {
     th_label($label);
 
     echo "<td>";
@@ -940,8 +1021,8 @@ function show_link_as_if_preference(
     $label,
     $pophelp_name,
     $link_url,
-    $link_text)
-{
+    $link_text
+) {
     th_label($label);
     echo "<td>";
     echo "<a href='$link_url'>$link_text</a>";


### PR DESCRIPTION
Update the version of `php-cs-fixer` to v3. This PR has two commits, the first updates the package version in composer and the second is a run of the new version across the codebase. The new version is pickier about multi-line function signatures and calls (either they're all one one line, or every arg is on a separate line) which makes up most of the diff in this PR.

This is best reviewed by hiding whitespace as some of the changes were simple indents (or de-indents). I don't think this needs a crazy careful review -- I've looked at every change and it seems reasonable -- but I welcome any and all feedback.

This should not need testing as the changes are purely stylistic but here's one anyway: [update-phpcsfixer-3](https://www.pgdp.org/~cpeel/c.branch/update-phpcsfixer-3/).