### PR TITLE
redefine task_status_array after unsetting keys

### DIFF
--- a/tasks.php
+++ b/tasks.php
@@ -1169,14 +1169,14 @@ function TaskForm($task)
     global $task_assignees_array;
     global $priority_array, $tasks_url;
 
-    // Don't want to permit setting status to "Closed" or "Reopened" when creating/editing a task
-    unset($tasks_status_array[get_property_key("Closed", $tasks_status_array)]);
-    unset($tasks_status_array[get_property_key("Reopened", $tasks_status_array)]);
-
     // Non-managers can only set the task status to New.
     if (!user_is_a_sitemanager() && !user_is_taskcenter_mgr()) {
         $tasks_status_array = [get_property_key("New", $tasks_status_array) => "New"];
     }
+
+    // Don't want to permit setting status to "Closed" or "Reopened" when creating/editing a task
+    unset($tasks_status_array[get_property_key("Closed", $tasks_status_array)]);
+    unset($tasks_status_array[get_property_key("Reopened", $tasks_status_array)]);
 
     $task_summary_enc = attr_safe($task->task_summary);
     $task_details_enc = html_safe($task->task_details);

--- a/tasks.php
+++ b/tasks.php
@@ -1169,14 +1169,14 @@ function TaskForm($task)
     global $task_assignees_array;
     global $priority_array, $tasks_url;
 
+    // Don't want to permit setting status to "Closed" or "Reopened" when creating/editing a task
+    unset($tasks_status_array[get_property_key("Closed", $tasks_status_array)]);
+    unset($tasks_status_array[get_property_key("Reopened", $tasks_status_array)]);
+
     // Non-managers can only set the task status to New.
     if (!user_is_a_sitemanager() && !user_is_taskcenter_mgr()) {
         $tasks_status_array = [get_property_key("New", $tasks_status_array) => "New"];
     }
-
-    // Don't want to permit setting status to "Closed" or "Reopened" when creating/editing a task
-    unset($tasks_status_array[get_property_key("Closed", $tasks_status_array)]);
-    unset($tasks_status_array[get_property_key("Reopened", $tasks_status_array)]);
 
     $task_summary_enc = attr_safe($task->task_summary);
     $task_details_enc = html_safe($task->task_details);

--- a/tasks.php
+++ b/tasks.php
@@ -1172,11 +1172,11 @@ function TaskForm($task)
     // Non-managers can only set the task status to New.
     if (!user_is_a_sitemanager() && !user_is_taskcenter_mgr()) {
         $tasks_status_array = [get_property_key("New", $tasks_status_array) => "New"];
+    } else {
+        // Don't want to permit setting status to "Closed" or "Reopened" when creating/editing a task
+        unset($tasks_status_array[get_property_key("Closed", $tasks_status_array)]);
+        unset($tasks_status_array[get_property_key("Reopened", $tasks_status_array)]);
     }
-
-    // Don't want to permit setting status to "Closed" or "Reopened" when creating/editing a task
-    unset($tasks_status_array[get_property_key("Closed", $tasks_status_array)]);
-    unset($tasks_status_array[get_property_key("Reopened", $tasks_status_array)]);
 
     $task_summary_enc = attr_safe($task->task_summary);
     $task_details_enc = html_safe($task->task_details);


### PR DESCRIPTION
This enables ordinary users to create tasks.

Perhaps not an entirely satisfactory solution to the problem. Probably better to avoid redefining the task_status_array somehow, but seems to fix the problem for now.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/task_fix