### PR TITLE
Squirrels delete illos from images index

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -600,6 +600,8 @@ class Project
                 return $this->image_source_name;
             case "can_be_managed_by_current_user":
                 return $this->can_be_managed_by_user($pguser);
+            case "user_can_delete_nonpage_images":
+                return $this->user_can_delete_nonpage_images($pguser);
             case "names_can_be_seen_by_current_user":
                 return $this->names_can_be_seen_by_user($pguser);
             case "PPer":
@@ -977,6 +979,27 @@ class Project
             ($username == $this->username
             || that_user_is_a_sitemanager($username)
             || that_user_is_proj_facilitator($username));
+    }
+
+    public function user_can_delete_nonpage_images($username)
+    {
+        if (is_null($username)) {
+            return false;
+        }
+        // SAs can always delete nonpage images
+        if (that_user_is_a_sitemanager($username)) {
+            return true;
+        }
+
+        // PMs/PFs can only delete nonpage images in New
+        // or P1 Unavailable stages
+        if ($this->can_be_managed_by_user($username)) {
+            return $this->state == PROJ_NEW || $this->state == PROJ_P1_UNAVAILABLE;
+        } else {
+            return false;
+        }
+        // Nobody else can delete images
+        return false;
     }
 
     // -------------------------------------------------------------------------

--- a/tools/project_manager/update_illos.php
+++ b/tools/project_manager/update_illos.php
@@ -62,7 +62,9 @@ if (!$project->can_be_managed_by_current_user) {
     exit;
 }
 
-if (($is_delete_all_operation || $operation == 'delete') && $project->state != PROJ_NEW && $project->state != PROJ_P1_UNAVAILABLE) {
+if (($is_delete_all_operation || $operation == 'delete') && !$project->user_can_delete_nonpage_images) {
+    // Allow squirrels to delete illustrations in any stage
+    // and PMs to do so in project_new or P1.proj_unavail
     echo "<p>", _('You can only delete illustrations for a project in the new or P1 unavailable states.'), "</p>\n";
     provide_escape_links();
     exit;

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -110,7 +110,8 @@ function list_images($project, $image_names, $these_are_page_images)
     echo "<h4 class='center-align'>$header</h4>";
 
     $show_replace_links = $project->can_be_managed_by_current_user;
-    $show_delete_links = $project->can_be_managed_by_current_user && !$these_are_page_images && ($project->state == PROJ_NEW || $project->state == PROJ_P1_UNAVAILABLE);
+    // If user is allowed to delete nonpage images, show links
+    $show_delete_links = $project->user_can_delete_nonpage_images && !$these_are_page_images;
 
     echo "<table>\n";
 
@@ -196,7 +197,7 @@ function show_delete_all_link($project, $image_names)
 {
     global $code_url;
 
-    if ($project->can_be_managed_by_current_user && ($project->state == PROJ_NEW || $project->state == PROJ_P1_UNAVAILABLE) && !empty($image_names)) {
+    if ($project->user_can_delete_nonpage_images && !empty($image_names)) {
         $form_target = "$code_url/tools/project_manager/update_illos.php";
         $submit_label = _("Delete Illustrations");
         echo "<form action='$form_target' method='POST' style='display: inline'>\n";


### PR DESCRIPTION
This extends the ability to delete illustrations from the images index to all rounds/pools for squirrels. All others should still be limited to the new project state or P1 Waiting.

Testable in the [image-index-squirrel-delete-illos/](https://www.pgdp.org/~srjfoo/c.branch/image-index-squirrel-delete-illos/) sandbox.