### PR TITLE
Standardize SQL formatting

### DIFF
--- a/SETUP/MediaWiki_extensions/dpExtensions.php
+++ b/SETUP/MediaWiki_extensions/dpExtensions.php
@@ -53,12 +53,16 @@ function getPgFormats($input, $argv)
         return sprintf($err, "invalid etext number");
     }
 
-    $result = DPDatabase::query(sprintf("
+    $sql = sprintf(
+        "
         SELECT formats
         FROM pg_books
         WHERE etext_number = '%d'
         LIMIT 1
-    ", $etext));
+        ",
+        $etext
+    );
+    $result = DPDatabase::query($sql);
 
     $row = mysqli_fetch_assoc($result);
     if (!$row) {
@@ -101,12 +105,16 @@ function showProjectInfo($input, $argv, $parser)
     $err = "<strong style='color: red;'>[Error: showProjectInfo: %s]</strong>";
     $pid = $argv['id'];
 
-    $result = DPDatabase::query(sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM projects
         WHERE projectid = '%s'
         LIMIT 1
-    ", DPDatabase::escape($pid)));
+        ",
+        DPDatabase::escape($pid)
+    );
+    $result = DPDatabase::query($sql);
 
     $project = mysqli_fetch_assoc($result);
     if (!$project) {

--- a/SETUP/tests/SettingsTest.php
+++ b/SETUP/tests/SettingsTest.php
@@ -13,10 +13,14 @@ class SettingsTest extends PHPUnit\Framework\TestCase
         create_test_user($this->TEST_USERNAME);
 
         // Now create the usersettings record
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO usersettings
             SET username='%s', setting = '%ssetting', value = 'blah'
-        ", $this->TEST_USERNAME, $this->PREFIX);
+            ",
+            $this->TEST_USERNAME,
+            $this->PREFIX
+        );
         $result = DPDatabase::query($sql);
         if (!$result) {
             throw new Exception("Unable to create test usersetting");
@@ -25,10 +29,14 @@ class SettingsTest extends PHPUnit\Framework\TestCase
 
     protected function tearDown(): void
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             DELETE FROM usersettings
             WHERE username='%s' AND setting like '%s%%'
-        ", $this->TEST_USERNAME, $this->PREFIX);
+            ",
+            $this->TEST_USERNAME,
+            $this->PREFIX
+        );
         DPDatabase::query($sql);
 
         delete_test_user($this->TEST_USERNAME);

--- a/SETUP/tests/phpunit_test_helpers.inc
+++ b/SETUP/tests/phpunit_test_helpers.inc
@@ -4,14 +4,18 @@ function create_test_user($username, $age = 0)
 {
     // create a user who joined $age days ago
     // Attempt to load our test user, replace if it exists
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         REPLACE INTO users
         SET reg_token = '%1\$s',
             real_name = '%1\$s',
             username = '%1\$s',
             email = '%1\$s@localhost',
             date_created = %2\$d
-    ", DPDatabase::escape($username), time() - ($age * 86400));
+        ",
+        DPDatabase::escape($username),
+        time() - ($age * 86400)
+    );
     $result = DPDatabase::query($sql);
     if (!$result) {
         throw new Exception(sprintf("Unable to create test user %s", $username));
@@ -21,32 +25,32 @@ function create_test_user($username, $age = 0)
 function delete_test_user($username)
 {
     // Delete test user's page events
-    $sql = sprintf("
-        DELETE FROM page_events
-        WHERE username  = '%s'
-    ", DPDatabase::escape($username));
+    $sql = sprintf(
+        "DELETE FROM page_events WHERE username = '%s'",
+        DPDatabase::escape($username)
+    );
     DPDatabase::query($sql);
 
     // Delete from user_project_info
-    $sql = sprintf("
-        DELETE FROM user_project_info
-        WHERE username  = '%s'
-    ", DPDatabase::escape($username));
+    $sql = sprintf(
+        "DELETE FROM user_project_info WHERE username = '%s'",
+        DPDatabase::escape($username)
+    );
     DPDatabase::query($sql);
 
     // Delete Tally
     $user = new User($username);
-    $sql = sprintf("
-        DELETE FROM current_tallies
-        WHERE holder_id = %d
-    ", $user->u_id);
+    $sql = sprintf(
+        "DELETE FROM current_tallies WHERE holder_id = %d",
+        $user->u_id
+    );
     DPDatabase::query($sql);
 
     // remove the test user
-    $sql = sprintf("
-        DELETE FROM users
-        WHERE username = '%s'
-    ", DPDatabase::escape($username));
+    $sql = sprintf(
+        "DELETE FROM users WHERE username = '%s'",
+        DPDatabase::escape($username)
+    );
     $result = DPDatabase::query($sql);
     if (!$result) {
         throw new Exception(sprintf("Unable to delete test user %s", $username));
@@ -56,22 +60,28 @@ function delete_test_user($username)
 function create_test_image_source($image_source)
 {
     // Attempt to create the image source
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT code_name
         FROM image_sources
         WHERE code_name = '%s'
-    ", DPDatabase::escape($image_source));
+        ",
+        DPDatabase::escape($image_source)
+    );
     $result = DPDatabase::query($sql);
     $row = mysqli_fetch_assoc($result);
     if (!$row) {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO image_sources
             SET code_name = '%1\$s',
                 display_name = '%1\$s',
                 full_name = '%1\$s',
                 info_page_visibility = 1,
                 is_active = 1
-        ", DPDatabase::escape($image_source));
+            ",
+            DPDatabase::escape($image_source)
+        );
         $result = DPDatabase::query($sql);
         if (!$result) {
             throw new Exception(sprintf("Unable to create test image source %s", $image_source));
@@ -84,10 +94,10 @@ function create_test_image_source($image_source)
 function delete_test_image_source($image_source)
 {
     // remove the test image source
-    $sql = sprintf("
-        DELETE FROM image_sources
-        WHERE code_name = '%s'
-    ", DPDatabase::escape($image_source));
+    $sql = sprintf(
+        "DELETE FROM image_sources WHERE code_name = '%s'",
+        DPDatabase::escape($image_source)
+    );
     $result = DPDatabase::query($sql);
     if (!$result) {
         throw new Exception(sprintf("Unable to delete test image source %s", $image_source));
@@ -96,12 +106,15 @@ function delete_test_image_source($image_source)
 
 function load_project_events($project)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM project_events
         WHERE projectid = '%s'
         ORDER BY event_id
-    ", DPDatabase::escape($project->projectid));
+        ",
+        DPDatabase::escape($project->projectid)
+    );
     $res = DPDatabase::query($sql);
     $events = [];
     while ($event = mysqli_fetch_assoc($res)) {
@@ -131,23 +144,23 @@ function delete_test_project_remains($project)
     }
 
     // project_events
-    $sql = sprintf("
-        DELETE FROM project_events
-        WHERE projectid  = '%s'
-    ", DPDatabase::escape($projectid));
+    $sql = sprintf(
+        "DELETE FROM project_events WHERE projectid = '%s'",
+        DPDatabase::escape($projectid)
+    );
     DPDatabase::query($sql);
 
     // projects table
-    $sql = sprintf("
-        DELETE FROM projects
-        WHERE projectid  = '%s'
-    ", DPDatabase::escape($projectid));
+    $sql = sprintf(
+        "DELETE FROM projects WHERE projectid = '%s'",
+        DPDatabase::escape($projectid)
+    );
     DPDatabase::query($sql);
 
     // charsuites table
-    $sql = sprintf("
-        DELETE FROM project_charsuites
-        WHERE projectid  = '%s'
-    ", DPDatabase::escape($projectid));
+    $sql = sprintf(
+        "DELETE FROM project_charsuites WHERE projectid = '%s'",
+        DPDatabase::escape($projectid)
+    );
     DPDatabase::query($sql);
 }

--- a/SETUP/upgrade/15/20201229_replace_project_templates.php
+++ b/SETUP/upgrade/15/20201229_replace_project_templates.php
@@ -31,11 +31,15 @@ while ([$projectid, $comments] = mysqli_fetch_row($result)) {
 
     echo "Updating $projectid...\n";
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE projects
         SET comments = '%s'
         WHERE projectid = '%s'
-    ", DPDatabase::escape($comments), DPDatabase::escape($projectid));
+        ",
+        DPDatabase::escape($comments),
+        DPDatabase::escape($projectid)
+    );
 
     mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
 }

--- a/SETUP/upgrade/19/20230601_prune_user_project_info.php
+++ b/SETUP/upgrade/19/20230601_prune_user_project_info.php
@@ -25,7 +25,8 @@ $result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(D
 
 while ([$projectid] = mysqli_fetch_row($result)) {
     $project = new Project($projectid);
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT username
         FROM user_project_info
         WHERE projectid = '%s'
@@ -39,7 +40,9 @@ while ([$projectid] = mysqli_fetch_row($result)) {
             AND iste_posted = 0
             AND iste_sr_reported = 0
         ORDER BY username
-    ", DPDatabase::escape($projectid));
+        ",
+        DPDatabase::escape($projectid)
+    );
 
     $upi_result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
 
@@ -67,7 +70,7 @@ while ([$projectid] = mysqli_fetch_row($result)) {
         DELETE FROM user_project_info
         WHERE projectid = '%s'
             AND username in (%s)
-    ",
+        ",
         DPDatabase::escape($projectid),
         surround_and_join(array_map("DPDatabase::escape", $upi_users_to_delete), "'", "'", ",")
     );

--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -131,9 +131,7 @@ $profile->save();
 
 // add ref to profile
 $refString = sprintf(
-    "
-    UPDATE users SET u_profile=%d WHERE u_id=%d
-    ",
+    "UPDATE users SET u_profile=%d WHERE u_id=%d",
     DPDatabase::escape($profile->id),
     $u_id
 );

--- a/accounts/login.php
+++ b/accounts/login.php
@@ -58,9 +58,7 @@ if (!$success) {
 
 // Look for user in 'users' table.
 $q = sprintf(
-    "
-    SELECT * FROM users WHERE username='%s'
-    ",
+    "SELECT * FROM users WHERE username='%s'",
     DPDatabase::escape($userNM)
 );
 $u_res = DPDatabase::query($q);

--- a/activity_hub.php
+++ b/activity_hub.php
@@ -101,8 +101,8 @@ while ([$project_state, $count] = mysqli_fetch_row($result)) {
 $sql = "
     SELECT COUNT(*)
     FROM projects
-    WHERE state = '" . PROJ_POST_FIRST_CHECKED_OUT . "' AND
-        smoothread_deadline > UNIX_TIMESTAMP()
+    WHERE state = '" . PROJ_POST_FIRST_CHECKED_OUT . "'
+        AND smoothread_deadline > UNIX_TIMESTAMP()
 ";
 $result = DPDatabase::query($sql);
 [$n_projects_in_state_['SR']] = mysqli_fetch_row($result);

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -445,7 +445,7 @@ function api_v1_project_page_round($method, $data, $query_params)
             state
         FROM %s
         WHERE image = '%s'
-    ",
+        ",
         $text_column,
         $user_column,
         $data[":projectid"]->projectid,

--- a/api/v1_stats.inc
+++ b/api/v1_stats.inc
@@ -17,11 +17,15 @@ function api_v1_stats_site($method, $data, $query_params)
     ];
 
     foreach ([1, 7, 30] as $days_back) {
-        $res = DPDatabase::query(sprintf("
+        $sql = sprintf(
+            "
             SELECT COUNT(*)
             FROM users
             WHERE t_last_activity > UNIX_TIMESTAMP() - %d * 24*60*60
-        ", $days_back));
+            ",
+            $days_back
+        );
+        $res = DPDatabase::query($sql);
         [$num_users] = mysqli_fetch_row($res);
         $key = sprintf("active_users_%d_day", $days_back);
         $stats[$key] = (int)$num_users;

--- a/crontab/archive_projects.php
+++ b/crontab/archive_projects.php
@@ -19,7 +19,8 @@ if ($dry_run) {
     echo "This is a dry run.\n";
 }
 
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT *
     FROM projects
     WHERE
@@ -27,7 +28,9 @@ $sql = sprintf("
         AND archived = '0'
         AND state = '%s'
     ORDER BY modifieddate
-", DPDatabase::escape(PROJ_SUBMIT_PG_POSTED));
+    ",
+    DPDatabase::escape(PROJ_SUBMIT_PG_POSTED)
+);
 $result = DPDatabase::query($sql);
 
 echo "Archiving page-tables for ", mysqli_num_rows($result), " projects...\n";

--- a/crontab/del_teams.php
+++ b/crontab/del_teams.php
@@ -9,7 +9,8 @@ require_localhost_request();
 
 $old_date = time() - 7776000; // 90 days
 
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT id, teamname
     FROM user_teams
     WHERE
@@ -19,7 +20,9 @@ $sql = sprintf("
             FROM user_teams_membership
             WHERE t_id = user_teams.id
         ) = 0
-", $old_date);
+    ",
+    $old_date
+);
 $result = DPDatabase::query($sql);
 
 while ([$id, $teamname] = mysqli_fetch_row($result)) {

--- a/crontab/extend_site_tally_goals.php
+++ b/crontab/extend_site_tally_goals.php
@@ -17,11 +17,14 @@ if (is_null($current_max_date)) {
     exit;
 }
 
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT tally_name, goal
     FROM site_tally_goals
     WHERE date='%s'
-", DPDatabase::escape($current_max_date));
+    ",
+    DPDatabase::escape($current_max_date)
+);
 $res2 = DPDatabase::query($sql);
 
 $values_list = '';

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -20,14 +20,19 @@ if ($dry_run) {
 $from = -60 * 60;
 $to = 60 * 60;
 
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT *
     FROM projects
     WHERE
         smoothread_deadline >= (UNIX_TIMESTAMP() + %d)
         AND smoothread_deadline <= (UNIX_TIMESTAMP() + %d)
         AND state = '%s'
-", $from, $to, DPDatabase::escape(PROJ_POST_FIRST_CHECKED_OUT));
+    ",
+    $from,
+    $to,
+    DPDatabase::escape(PROJ_POST_FIRST_CHECKED_OUT)
+);
 $result = DPDatabase::query($sql);
 
 $output = "Checking " . mysqli_num_rows($result) . " projects...\n";

--- a/default.php
+++ b/default.php
@@ -135,11 +135,15 @@ echo "<br>\n";
 
 // Show the number of users that have been active over various recent timescales.
 foreach ([1, 7, 30] as $days_back) {
-    $res = DPDatabase::query(sprintf("
+    $sql = sprintf(
+        "
         SELECT COUNT(*)
         FROM users
         WHERE t_last_activity > UNIX_TIMESTAMP() - %d * 24*60*60
-    ", $days_back));
+        ",
+        $days_back
+    );
+    $res = DPDatabase::query($sql);
     [$num_users] = mysqli_fetch_row($res);
 
     $template = (

--- a/feeds/backend.php
+++ b/feeds/backend.php
@@ -58,7 +58,8 @@ if (!file_exists($xmlfile) || filemtime($xmlfile) < $refreshAge) {
                         e.details1 = 'text available' AND
                         e.timestamp > UNIX_TIMESTAMP() - (30*24*60*60)
                     ORDER BY e.timestamp DESC
-                    LIMIT $limit";
+                    LIMIT $limit
+                ";
                 $desc = sprintf(_("The latest releases available at %1\$s for Smooth Reading."), $site_name);
                 $link = "$code_url/tools/post_proofers/smooth_reading.php";
                 break;
@@ -71,7 +72,8 @@ if (!file_exists($xmlfile) || filemtime($xmlfile) < $refreshAge) {
                 FROM projects 
                 WHERE $condition 
                 ORDER BY modifieddate DESC 
-                LIMIT $limit";
+                LIMIT $limit
+            ";
         }
 
         $data = '';

--- a/pastnews.php
+++ b/pastnews.php
@@ -32,13 +32,15 @@ if ($num == 0) {
         . sprintf(_("Show All %s News"), $news_subject) . "</a>";
 }
 
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT * FROM news_items 
-    WHERE (news_page_id = '%s' OR news_page_id = 'GLOBAL') AND 
-        status = 'recent'
+    WHERE (news_page_id = '%s' OR news_page_id = 'GLOBAL') AND status = 'recent'
     ORDER BY id DESC
     $limit_clause
-", DPDatabase::escape($news_page_id));
+    ",
+    DPDatabase::escape($news_page_id)
+);
 $result = DPDatabase::query($sql);
 
 if (mysqli_num_rows($result) == 0) {

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -165,12 +165,15 @@ class CharSuites
         // Validate we have a valid charsuite
         $charsuite = CharSuites::get($name);
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO charsuites
             SET name='%s', enabled=1
             ON DUPLICATE KEY UPDATE
                 enabled=1
-        ", DPDatabase::escape($name));
+            ",
+            DPDatabase::escape($name)
+        );
 
         DPDatabase::query($sql);
     }
@@ -179,11 +182,14 @@ class CharSuites
     {
         // We don't validate the charsuite is installed in case it was
         // uninstalled before being disabled.
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE charsuites
             SET enabled=0
             WHERE name='%s'
-        ", DPDatabase::escape($name));
+            ",
+            DPDatabase::escape($name)
+        );
 
         DPDatabase::query($sql);
     }

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -123,11 +123,15 @@ final class DPDatabase
 
     private static function get_db_defaults()
     {
-        $result = self::query(sprintf("
+        $sql = sprintf(
+            "
             SELECT *
             FROM information_schema.schemata
             WHERE schema_name='%s';
-        ", self::$_db_name));
+            ",
+            self::$_db_name
+        );
+        $result = self::query($sql);
 
         $row = mysqli_fetch_assoc($result);
         self::$_default_db_charset = $row['DEFAULT_CHARACTER_SET_NAME'];
@@ -157,7 +161,8 @@ final class DPDatabase
             "
             SELECT TABLE_COLLATION
             FROM information_schema.tables
-            WHERE table_schema='%s' AND table_name='%s'",
+            WHERE table_schema='%s' AND table_name='%s'
+            ",
             self::$_db_name,
             self::escape($table_name)
         );
@@ -175,7 +180,8 @@ final class DPDatabase
             "
             SELECT TABLE_NAME
             FROM information_schema.tables
-            WHERE table_schema='%s' AND table_name='%s'",
+            WHERE table_schema='%s' AND table_name='%s'
+            ",
             self::$_db_name,
             self::escape($table_name)
         );

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -133,7 +133,7 @@ function project_add_page(
             $setters,
             master_text = $txt_expr,
             $columns_for_rounds
-            ";
+    ";
 
     // echo $sql, "\n";
     DPDatabase::query($sql);
@@ -201,11 +201,7 @@ function Page_delete($projectid, $image, $user)
     $res = DPDatabase::query($sql);
     [$page_was_available] = mysqli_fetch_row($res); // either 0 or 1
 
-    $sql = "
-        DELETE
-        FROM $projectid
-        $where_image
-    ";
+    $sql = "DELETE FROM $projectid $where_image";
     DPDatabase::query($sql);
 
     _log_page_event($projectid, $image, 'delete', $user, null);
@@ -774,7 +770,7 @@ function _log_page_event($projectid, $image, $event_type, $username, $round)
             event_type   = '%s',
             username     = '%s',
             round_id     = %s
-    ",
+        ",
         DPDatabase::escape($projectid),
         DPDatabase::escape($image),
         DPDatabase::escape($event_type),
@@ -793,7 +789,7 @@ function _project_set_t_last_page_done($projectid, $timestamp)
         UPDATE projects
         SET t_last_page_done = %d
         WHERE projectid = '%s'
-    ",
+        ",
         $timestamp,
         DPDatabase::escape($projectid)
     );
@@ -813,7 +809,7 @@ function _project_adjust_n_pages($projectid, $adjustment)
         UPDATE projects
         SET n_pages = %s
         WHERE projectid='%s'
-    ",
+        ",
         $expr,
         DPDatabase::escape($projectid)
     );
@@ -845,7 +841,7 @@ function _project_adjust_n_available_pages($projectid, $adjustment)
         UPDATE projects
         SET n_available_pages = %s
         WHERE projectid = '%s'
-    ",
+        ",
         $expr,
         DPDatabase::escape($projectid)
     );

--- a/pinc/NonactivatedUser.inc
+++ b/pinc/NonactivatedUser.inc
@@ -167,7 +167,7 @@ class NonactivatedUser
                 http_referrer = LEFT('%s', 256),
                 u_intlang = '%s',
                 user_password = '%s'
-        ",
+            ",
             $this->table_row["id"],
             DPDatabase::escape($this->username),
             DPDatabase::escape($this->real_name),
@@ -202,9 +202,7 @@ class NonactivatedUser
         }
 
         $sql = sprintf(
-            "
-            DELETE FROM non_activated_users
-            WHERE id = '%s'",
+            "DELETE FROM non_activated_users WHERE id = '%s'",
             DPDatabase::escape($this->id)
         );
         DPDatabase::query($sql);

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -210,7 +210,8 @@ class Project
             "
             SELECT *
             FROM projects
-            WHERE projectid = '%s'",
+            WHERE projectid = '%s'
+            ",
             DPDatabase::escape($projectid)
         );
         $res = DPDatabase::query($sql);
@@ -465,7 +466,8 @@ class Project
                 DPDatabase::escape($this->projectid)
             );
             $sql = "
-                UPDATE projects SET
+                UPDATE projects
+                SET
                     $project_settings
                     t_last_edit = UNIX_TIMESTAMP()
                     $where
@@ -773,7 +775,8 @@ class Project
             "
             SELECT projectid
             FROM project_charsuites
-            WHERE charsuite_name='%s'",
+            WHERE charsuite_name='%s'
+            ",
             DPDatabase::escape($charsuite->name)
         );
 
@@ -834,7 +837,8 @@ class Project
         $sql = sprintf(
             "
             INSERT INTO project_charsuites
-            SET projectid='%s', charsuite_name='%s'",
+            SET projectid='%s', charsuite_name='%s'
+            ",
             DPDatabase::escape($this->projectid),
             DPDatabase::escape($charsuite->name)
         );
@@ -852,7 +856,8 @@ class Project
         $sql = sprintf(
             "
             DELETE FROM project_charsuites
-            WHERE projectid='%s' AND charsuite_name='%s'",
+            WHERE projectid='%s' AND charsuite_name='%s'
+            ",
             DPDatabase::escape($this->projectid),
             DPDatabase::escape($charsuite->name)
         );
@@ -876,7 +881,8 @@ class Project
             "
             SELECT charsuite_name
             FROM project_charsuites
-            WHERE projectid='%s'",
+            WHERE projectid='%s'
+            ",
             DPDatabase::escape($this->projectid)
         );
         $result = DPDatabase::query($sql);
@@ -1075,11 +1081,14 @@ class Project
         $states = [];
 
         validate_projectID($this->projectid);
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT DISTINCT state
             FROM {$this->projectid}
             ORDER BY %s
-        ", sql_collater_for_page_state("state"));
+            ",
+            sql_collater_for_page_state("state")
+        );
         $res = DPDatabase::query($sql);
         while ($row = mysqli_fetch_assoc($res)) {
             $states[] = $row["state"];
@@ -1103,7 +1112,7 @@ class Project
             SELECT count($counter_sql)
             FROM {$this->projectid}
             WHERE $where
-            ";
+        ";
         $res = DPDatabase::query($sql);
         [$num_pages] = mysqli_fetch_row($res);
 
@@ -1312,7 +1321,8 @@ class Project
             "
             UPDATE projects
             SET topic_id=%d
-            WHERE projectid='%s'",
+            WHERE projectid='%s'
+            ",
             $topic_id,
             DPDatabase::escape($this->projectid)
         );
@@ -1361,7 +1371,7 @@ class Project
                 details1   = '%s',
                 details2   = '%s',
                 details3   = '%s'
-        ",
+            ",
             DPDatabase::escape($this->projectid),
             DPDatabase::escape($who),
             DPDatabase::escape($event_type),
@@ -1396,7 +1406,8 @@ class Project
             "
             SELECT state
             FROM project_holds
-            WHERE projectid='%s'",
+            WHERE projectid='%s'
+            ",
             DPDatabase::escape($this->projectid)
         );
         $res = DPDatabase::query($sql);
@@ -1456,12 +1467,16 @@ class Project
 
     public function get_hold_state_notify_time($state)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT notify_time
             FROM project_holds
             WHERE projectid = '%s'
                 AND state = '%s'
-        ", DPDatabase::escape($this->projectid), DPDatabase::escape($state));
+            ",
+            DPDatabase::escape($this->projectid),
+            DPDatabase::escape($state)
+        );
         $res = DPDatabase::query($sql);
         [$notify_time] = mysqli_fetch_row($res);
         return $notify_time;
@@ -1592,7 +1607,8 @@ class Project
             INSERT INTO marc_records
             SET
                 projectid      = '%s',
-                original_array = '%s'",
+                original_array = '%s'
+            ",
             DPDatabase::escape($this->projectid),
             base64_encode(serialize($original_marc_array))
         );
@@ -1609,7 +1625,8 @@ class Project
             UPDATE marc_records
             SET
                 updated_array = '%s'
-            WHERE projectid = '%s'",
+            WHERE projectid = '%s'
+            ",
             base64_encode(serialize($updated_marc_array)),
             DPDatabase::escape($this->projectid)
         );
@@ -1629,7 +1646,8 @@ class Project
             "
             SELECT updated_array
             FROM marc_records
-            WHERE projectid = '%s'",
+            WHERE projectid = '%s'
+            ",
             DPDatabase::escape($this->projectid)
         );
         $result = DPDatabase::query($sql);
@@ -1696,11 +1714,14 @@ class Project
     public function get_last_proofread_time($round)
     {
         validate_projectID($this->projectid);
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT max({$round->time_column_name})
             FROM $this->projectid
             WHERE state = '%s'
-        ", DPDatabase::escape($round->page_save_state));
+            ",
+            DPDatabase::escape($round->page_save_state)
+        );
         $res = DPDatabase::query($sql);
         [$last_proofread] = mysqli_fetch_row($res);
         return $last_proofread;
@@ -1771,7 +1792,8 @@ function project_has_a_hold_in_state($projectid, $state)
         SELECT *
         FROM project_holds
         WHERE projectid='%s'
-            AND state='%s'",
+            AND state='%s'
+        ",
         DPDatabase::escape($projectid),
         DPDatabase::escape($state)
     );

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -568,9 +568,7 @@ class ProjectSearchResults
             USING (projectid, state)
             WHERE $where_condition
             ORDER BY $this->sort_sql
-        " . sprintf("
-            LIMIT %d OFFSET %d
-        ", $this->page_size, $results_offset);
+            " . sprintf("LIMIT %d OFFSET %d", $this->page_size, $results_offset);
         if ($testing) {
             echo_html_comment($sql);
         }

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -78,7 +78,7 @@ class Quiz
                 AND quiz_page IN (%s)
                 AND result = 'pass'
             ORDER BY date
-        ",
+            ",
             DPDatabase::escape($username),
             surround_and_join(array_keys($this->pages), '"', '"', ",")
         );
@@ -277,11 +277,15 @@ function get_Quiz_containing_page($quiz_page_id)
 
 function record_quiz_attempt($username, $quiz_page_id, $result)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM quiz_passes
         WHERE username = '%s' AND quiz_page = '%s'
-    ", DPDatabase::escape($username), DPDatabase::escape($quiz_page_id));
+        ",
+        DPDatabase::escape($username),
+        DPDatabase::escape($quiz_page_id)
+    );
     $res = DPDatabase::query($sql);
 
     if (mysqli_num_rows($res) > 0) {
@@ -291,7 +295,7 @@ function record_quiz_attempt($username, $quiz_page_id, $result)
             UPDATE quiz_passes
             SET date = %d
             WHERE username = '%s' AND quiz_page = '%s'
-        ",
+            ",
             time(),
             DPDatabase::escape($username),
             DPDatabase::escape($quiz_page_id)
@@ -302,7 +306,7 @@ function record_quiz_attempt($username, $quiz_page_id, $result)
             "
             INSERT INTO quiz_passes
             VALUES ('%s', %d, '%s', '%s')
-        ",
+            ",
             DPDatabase::escape($username),
             time(),
             DPDatabase::escape($quiz_page_id),

--- a/pinc/RandomRule.inc
+++ b/pinc/RandomRule.inc
@@ -36,11 +36,14 @@ class RandomRule
      */
     public function load($id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT *
             FROM rules
             WHERE id = %d
-        ", $id);
+            ",
+            $id
+        );
 
         $result = DPDatabase::query($sql);
         $this->table_row = mysqli_fetch_assoc($result);
@@ -56,9 +59,10 @@ class RandomRule
             SELECT id
             FROM rules
             WHERE
-                document = '%s' AND
-                anchor = '%s' AND
-                langcode = '%s'",
+                document = '%s'
+                AND anchor = '%s'
+                AND langcode = '%s'
+            ",
             DPDatabase::escape($document),
             DPDatabase::escape($anchor),
             DPDatabase::escape($langcode)
@@ -83,10 +87,11 @@ class RandomRule
             SELECT id
             FROM rules
             WHERE
-                document = '%s' AND
-                langcode = '%s'
+                document = '%s'
+                AND langcode = '%s'
             ORDER BY RAND(NOW())
-            LIMIT 1",
+            LIMIT 1
+            ",
             DPDatabase::escape($document),
             DPDatabase::escape($langcode)
         );
@@ -109,9 +114,10 @@ class RandomRule
             SELECT id
             FROM rules
             WHERE
-                document = '%s' AND
-                langcode = '%s'
-            ORDER BY id",
+                document = '%s'
+                AND langcode = '%s'
+            ORDER BY id
+            ",
             DPDatabase::escape($document),
             DPDatabase::escape($langcode)
         );
@@ -163,8 +169,9 @@ class RandomRule
             DELETE
             FROM rules
             WHERE
-                document = '%s' AND
-                langcode = '%s'",
+                document = '%s'
+                AND langcode = '%s'
+            ",
             DPDatabase::escape($document),
             DPDatabase::escape($langcode)
         );
@@ -272,7 +279,8 @@ class RandomRule
                 langcode = '%s',
                 anchor = '%s',
                 subject = '%s',
-                rule = '%s'",
+                rule = '%s'
+            ",
             DPDatabase::escape($document),
             DPDatabase::escape($langcode),
             DPDatabase::escape($anchor),

--- a/pinc/SettingsClass.inc
+++ b/pinc/SettingsClass.inc
@@ -31,11 +31,14 @@ class Settings
 
         // Query the "usersettings" table and get all the rows for our user.
         // build an array with the settings, to use when somebody asks.
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT *
             FROM usersettings
             WHERE username = '%s'
-        ", DPDatabase::escape($this->username));
+            ",
+            DPDatabase::escape($this->username)
+        );
 
         $result = DPDatabase::query($sql);
         // To know whether we've populated fields from 'users' table yet:
@@ -106,9 +109,11 @@ class Settings
 
     private function _clear_setting($settingCode)
     {
-        $sql = "DELETE FROM usersettings 
-                WHERE username = '$this->username'
-                AND setting = '$settingCode'" ;
+        $sql = "
+            DELETE FROM usersettings 
+            WHERE username = '$this->username'
+                AND setting = '$settingCode'
+        " ;
         DPDatabase::query($sql);
     }
 
@@ -119,7 +124,7 @@ class Settings
             INSERT INTO usersettings
                 (username, setting, value)
             VALUES ('%s', '%s', '%s')
-        ",
+            ",
             DPDatabase::escape($this->username),
             DPDatabase::escape($settingCode),
             DPDatabase::escape($value)
@@ -135,7 +140,7 @@ class Settings
             WHERE username = '%s'
                 AND setting = '%s'
                 AND value = '%s'
-        ",
+            ",
             DPDatabase::escape($this->username),
             DPDatabase::escape($settingCode),
             DPDatabase::escape($value)
@@ -331,11 +336,14 @@ class Settings
     public static function get_users_with_setting($setting, $value = null)
     {
         $usernames = [];
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT DISTINCT username
             FROM usersettings
             WHERE setting = '%s'
-        ", DPDatabase::escape($setting));
+            ",
+            DPDatabase::escape($setting)
+        );
 
         if ($value) {
             $sql .= sprintf(

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -69,7 +69,8 @@ class TallyBoard
                 holder_id   = %d,
                 tally_value = %d
             ON DUPLICATE KEY UPDATE
-                tally_value = tally_value + %d",
+                tally_value = tally_value + %d
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             intval($holder_id),
@@ -120,7 +121,8 @@ class TallyBoard
                 $alias.tally_name      = '%s'
                 AND $alias.holder_type = '%s'
                 AND $alias.holder_id   = $holder_id_expr
-            )",
+            )
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type)
         );
@@ -138,7 +140,8 @@ class TallyBoard
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
-                AND tally_value > 0",
+                AND tally_value > 0
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type)
         );
@@ -164,7 +167,8 @@ class TallyBoard
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
-                AND holder_id   = %s",
+                AND holder_id   = %s
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             intval($holder_id)
@@ -197,7 +201,8 @@ class TallyBoard
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
-            ORDER BY tally_value DESC",
+            ORDER BY tally_value DESC
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type)
         );
@@ -261,7 +266,8 @@ class TallyBoard
                     AND holder_id   = $holder_id_expr
                 )
             WHERE tally_value > 0 OR $holder_id_expr='$target_holder_id'
-            ORDER BY tally_value DESC, holder_id ASC",
+            ORDER BY tally_value DESC, holder_id ASC
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type)
         );
@@ -350,7 +356,8 @@ class TallyBoard
                 WHERE
                     timestamp       = $prev_ascribe_time
                     AND tally_name  = '%s'
-                    AND holder_type = '%s'",
+                    AND holder_type = '%s'
+                ",
                 DPDatabase::escape($this->tally_name),
                 DPDatabase::escape($this->holder_type)
             );
@@ -366,7 +373,8 @@ class TallyBoard
                 FROM best_tally_rank
                 WHERE
                     tally_name      = '%s'
-                    AND holder_type = '%s'",
+                    AND holder_type = '%s'
+                ",
                 DPDatabase::escape($this->tally_name),
                 DPDatabase::escape($this->holder_type)
             );
@@ -384,7 +392,8 @@ class TallyBoard
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
-            ORDER BY tally_value DESC",
+            ORDER BY tally_value DESC
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type)
         );
@@ -404,7 +413,8 @@ class TallyBoard
                     holder_type = '%s',
                     holder_id   = %d,
                     tally_delta = $tally_delta,
-                    tally_value = $current_tally",
+                    tally_value = $current_tally
+                ",
                 DPDatabase::escape($this->tally_name),
                 DPDatabase::escape($this->holder_type),
                 intval($holder_id)
@@ -426,7 +436,8 @@ class TallyBoard
                         holder_type = '%s',
                         holder_id   = %d,
                         best_rank   = $rank,
-                        best_rank_timestamp = $ascribe_time",
+                        best_rank_timestamp = $ascribe_time
+                    ",
                     DPDatabase::escape($this->tally_name),
                     DPDatabase::escape($this->holder_type),
                     intval($holder_id)
@@ -456,7 +467,8 @@ class TallyBoard
             FROM past_tallies
             WHERE
                 tally_name      = '%s'
-                AND holder_type = '%s'",
+                AND holder_type = '%s'
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type)
         );
@@ -495,7 +507,8 @@ class TallyBoard
                 AND holder_type = '%s'
                 AND holder_id   = %d
             ORDER BY timestamp DESC
-            LIMIT 1",
+            LIMIT 1
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             intval($holder_id)
@@ -541,7 +554,8 @@ class TallyBoard
                 AND holder_type = '%s'
                 AND holder_id   = %d
             ORDER BY tally_delta DESC, timestamp ASC
-            LIMIT 1",
+            LIMIT 1
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             intval($holder_id)
@@ -576,7 +590,8 @@ class TallyBoard
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
-                AND holder_id   = %d",
+                AND holder_id   = %d
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             intval($holder_id)
@@ -615,7 +630,8 @@ class TallyBoard
                 AND holder_type = '%s'
                 AND holder_id   = %d
                 AND timestamp  >= $min_timestamp
-            ORDER BY timestamp ASC",
+            ORDER BY timestamp ASC
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             intval($holder_id)
@@ -654,7 +670,8 @@ class TallyBoard
                 AND holder_type = '%s'
                 AND holder_id   = %d
                 AND $start_timestamp < timestamp
-                AND timestamp <= $end_timestamp",
+                AND timestamp <= $end_timestamp
+            ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             intval($holder_id)

--- a/pinc/Team.inc
+++ b/pinc/Team.inc
@@ -9,22 +9,29 @@ class Team
 
     public static function log_recent_join($tid, $uid)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE user_teams
             SET latestUser = %d, member_count = member_count+1
             WHERE id = %d
-        ", $uid, $tid);
+            ",
+            $uid,
+            $tid
+        );
 
         DPDatabase::query($sql);
     }
 
     public static function active_member_count($tid)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT count(*)
             FROM user_teams_membership
             WHERE t_id = %d
-        ", $tid);
+            ",
+            $tid
+        );
 
         $result = DPDatabase::query($sql);
         [$count] = mysqli_fetch_row($result);

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -130,11 +130,15 @@ class User
                 $this->current_profile = $value;
 
                 // persist the current profile ID to the database
-                $sql = sprintf("
+                $sql = sprintf(
+                    "
                     UPDATE users
                     SET u_profile = %d
                     WHERE u_id = %d
-                ", $this->current_profile->id, $this->u_id);
+                    ",
+                    $this->current_profile->id,
+                    $this->u_id
+                );
                 DPDatabase::query($sql);
 
                 // now set the profile cookie if this is for the current user
@@ -257,11 +261,14 @@ class User
 
     public function load_teams()
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT t_id
             FROM user_teams_membership
             WHERE u_id = %d
-        ", $this->u_id);
+            ",
+            $this->u_id
+        );
         $result = DPDatabase::query($sql);
         $teams = [];
         while ($row = mysqli_fetch_assoc($result)) {
@@ -277,10 +284,14 @@ class User
             return;
         }
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             INSERT INTO user_teams_membership
             SET u_id = %d, t_id = %d
-        ", $this->u_id, $team_id);
+            ",
+            $this->u_id,
+            $team_id
+        );
         DPDatabase::query($sql);
 
         Team::log_recent_join($team_id, $this->u_id);
@@ -288,10 +299,14 @@ class User
 
     public function remove_team($team_id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             DELETE FROM user_teams_membership
             WHERE u_id = %d AND t_id = %d
-        ", $this->u_id, $team_id);
+            ",
+            $this->u_id,
+            $team_id
+        );
         DPDatabase::query($sql);
     }
 
@@ -460,11 +475,14 @@ class User
      */
     public static function is_valid_user($username, $strict = true)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT username
             FROM users
             WHERE username='%s'
-        ", DPDatabase::escape($username));
+            ",
+            DPDatabase::escape($username)
+        );
         $result = DPDatabase::query($sql);
         if (mysqli_num_rows($result) == 0) {
             $is_valid = false;

--- a/pinc/UserProfile.inc
+++ b/pinc/UserProfile.inc
@@ -58,11 +58,14 @@ class UserProfile
 
     private function load($id)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT *
             FROM user_profiles
             WHERE id = %d
-        ", $id);
+            ",
+            $id
+        );
 
         $result = DPDatabase::query($sql);
         if (mysqli_num_rows($result) == 0) {
@@ -101,11 +104,14 @@ class UserProfile
             }
 
             $set_string = create_mysql_update_string($update_data, $this->string_fields);
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE user_profiles
                 SET $set_string
                 WHERE id = %d
-            ", $this->id);
+                ",
+                $this->id
+            );
         }
         DPDatabase::query($sql);
 
@@ -122,22 +128,28 @@ class UserProfile
             );
         }
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             DELETE FROM user_profiles
             WHERE id = %d
-        ", $this->id);
+            ",
+            $this->id
+        );
         DPDatabase::query($sql);
     }
 
     // static functions
     public static function load_user_profiles($u_ref)
     {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT id
             FROM user_profiles
             WHERE u_ref = %d
             ORDER BY id
-        ", $u_ref);
+            ",
+            $u_ref
+        );
 
         $profiles = [];
         $result = DPDatabase::query($sql);

--- a/pinc/access_log.inc
+++ b/pinc/access_log.inc
@@ -12,7 +12,8 @@ function log_access_change($subject_username, $modifier_username, $activity_id, 
     ]);
     $sql = "
         INSERT INTO access_log
-        SET $setters";
+        SET $setters
+    ";
     return DPDatabase::query($sql);
 }
 
@@ -26,7 +27,8 @@ function get_first_granted_date($username, $stage)
             AND activity = '%s'
             AND action = 'grant'
         ORDER BY timestamp ASC
-        LIMIT 1",
+        LIMIT 1
+        ",
         DPDatabase::escape($username),
         DPDatabase::escape($stage)
     );
@@ -50,7 +52,8 @@ function get_latest_access_change_entry($username, $activity_id)
         WHERE subject_username = '%s'
             AND activity = '%s'
         ORDER BY timestamp DESC
-        LIMIT 1",
+        LIMIT 1
+        ",
         DPDatabase::escape($username),
         DPDatabase::escape($activity_id)
     );

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -74,11 +74,14 @@ function archive_project($project, $dry_run)
     if ($dry_run) {
         echo "    Mark project as archived.\n";
     } else {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE projects
             SET archived = '1'
             WHERE projectid = '%s'
-        ", DPDatabase::escape($projectid));
+            ",
+            DPDatabase::escape($projectid)
+        );
         DPDatabase::query($sql);
 
         $project->log_project_event('[archiver]', 'archive');
@@ -129,9 +132,9 @@ function archive_ancillary_data_for_project_etc($project, $indent, $dry_run)
         SELECT projectid, modifieddate, state
         FROM projects
         WHERE state = '%s'
-        AND deletion_reason = '%s'
+            AND deletion_reason = '%s'
         ORDER BY modifieddate
-    ",
+        ",
         DPDatabase::escape(PROJ_DELETE),
         DPDatabase::escape("merged into $project->projectid")
     );
@@ -190,12 +193,15 @@ function move_project_rows_to_archive_db($projectid, $table_name, $indent, $dry_
     $watch = new Stopwatch();
     $watch->start();
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO $archive_db_name.$table_name
         SELECT *
         FROM $table_name
         WHERE projectid = '%s'
-    ", DPDatabase::escape($projectid));
+        ",
+        DPDatabase::escape($projectid)
+    );
     DPDatabase::query($sql);
     $n_copied = DPDatabase::affected_rows();
     echo sprintf("%4d rows copied", $n_copied);
@@ -205,11 +211,14 @@ function move_project_rows_to_archive_db($projectid, $table_name, $indent, $dry_
         return;
     }
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         DELETE 
         FROM $table_name
         WHERE projectid = '%s'
-    ", DPDatabase::escape($projectid));
+        ",
+        DPDatabase::escape($projectid)
+    );
     DPDatabase::query($sql);
     $n_deleted = DPDatabase::affected_rows();
     if ($n_deleted == $n_copied) {

--- a/pinc/authors.inc
+++ b/pinc/authors.inc
@@ -2,11 +2,14 @@
 
 function get_biography($id)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT bio, bio_format
         FROM biographies
         WHERE bio_id = %d
-    ", $id);
+        ",
+        $id
+    );
     $result = DPDatabase::query($sql);
     $row = mysqli_fetch_assoc($result);
     if (!$row) {

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -119,11 +119,14 @@ function _update_user_activity_time($update_login_time_too)
         $additional_where = "";
     }
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE users
         SET $settings
         WHERE username='%s' $additional_where
-    ", DPDatabase::escape($pguser));
+        ",
+        DPDatabase::escape($pguser)
+    );
     DPDatabase::query($sql);
 }
 
@@ -185,7 +188,8 @@ function mysql_session_write($sid, $value)
             ('%s', %d, '%s')
         ON DUPLICATE KEY UPDATE
             expiration = %d,
-            value = '%s'",
+            value = '%s'
+        ",
         substr(DPDatabase::escape($sid), 0, 32), // truncate to column size
         $expiration,
         DPDatabase::escape($value),

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -86,7 +86,8 @@ class GenreElement extends ProjectFilterElement
         $query = "
             SELECT distinct projects.genre, genre_translations.trans_genre
             FROM projects NATURAL JOIN genre_translations
-            WHERE ($this->state_sql) ORDER BY trans_genre";
+            WHERE ($this->state_sql) ORDER BY trans_genre
+        ";
         $options = [];
         $result = DPDatabase::query($query);
         while ($cols = mysqli_fetch_row($result)) {
@@ -103,7 +104,9 @@ class SpecialDayElement extends ProjectFilterElement
         $query = "
             SELECT DISTINCT special_code, display_name
             FROM projects, special_days
-            WHERE projects.special_code = special_days.spec_code AND ($this->state_sql) ORDER BY display_name";
+            WHERE projects.special_code = special_days.spec_code AND ($this->state_sql)
+            ORDER BY display_name
+        ";
         $options = [];
         $result = DPDatabase::query($query);
         while ($cols = mysqli_fetch_row($result)) {
@@ -368,7 +371,8 @@ function save_raw_data($pguser, $data_name, $data)
         "
         REPLACE INTO user_filters
         (username, filtertype, value)
-        VALUES ('%s', '%s', '%s')",
+        VALUES ('%s', '%s', '%s')
+        ",
         DPDatabase::escape($pguser),
         DPDatabase::escape($data_name),
         DPDatabase::escape($data)
@@ -393,7 +397,8 @@ function get_raw_saved_data($pguser, $data_name)
         SELECT value
         FROM user_filters
         WHERE username = '%s'
-            AND filtertype = '%s'",
+            AND filtertype = '%s'
+        ",
         DPDatabase::escape($pguser),
         DPDatabase::escape($data_name)
     );

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -74,7 +74,8 @@ function phpbb_lang($locale = false)
                 "
                 SELECT *
                 FROM %s
-                WHERE lang_iso='%s'",
+                WHERE lang_iso='%s'
+                ",
                 phpbb_table("lang"),
                 DPDatabase::escape($lang)
             );
@@ -145,7 +146,8 @@ function create_forum_user($username, $password, $email, $password_is_digested =
                 "
                 UPDATE %s
                 SET user_password='%s'
-                WHERE user_id=%d",
+                WHERE user_id=%d
+                ",
                 phpbb_table("users"),
                 DPDatabase::escape($password),
                 $user_id
@@ -351,7 +353,8 @@ function get_forum_user_details($username)
         "
         SELECT *
         FROM %s
-        WHERE username='%s'",
+        WHERE username='%s'
+        ",
         phpbb_table("users"),
         DPDatabase::escape($username)
     );
@@ -380,7 +383,8 @@ function get_forum_user_details($username)
         "
         SELECT *
         FROM %s
-        WHERE user_id = %d",
+        WHERE user_id = %d
+        ",
         phpbb_table("profile_fields_data"),
         $row["user_id"]
     );
@@ -417,7 +421,8 @@ function get_forum_user_id($username)
         "
         SELECT user_id
         FROM %s
-        WHERE username = '%s'",
+        WHERE username = '%s'
+        ",
         phpbb_table("users"),
         DPDatabase::escape($username)
     );
@@ -445,7 +450,8 @@ function get_forum_rank_title($rank)
         "
         SELECT rank_title
         FROM %s
-        WHERE rank_id = %d",
+        WHERE rank_id = %d
+        ",
         phpbb_table("ranks"),
         $rank
     );
@@ -606,7 +612,8 @@ function get_number_of_unread_messages($username)
             "
             SELECT SUM(pm_unread)
             FROM %s
-            WHERE user_id = %d",
+            WHERE user_id = %d
+            ",
             phpbb_table("privmsgs_to"),
             $forum_userid
         );
@@ -631,7 +638,8 @@ function does_topic_exist($topic_id)
         "
         SELECT 1
         FROM %s
-        WHERE topic_id = %d",
+        WHERE topic_id = %d
+        ",
         phpbb_table("topics"),
         $topic_id
     );
@@ -660,7 +668,8 @@ function get_last_post_time_in_topic($topic_id)
         "
         SELECT MAX(post_time) as max_post_time
         FROM %s
-        WHERE topic_id = %d",
+        WHERE topic_id = %d
+        ",
         phpbb_table("posts"),
         $topic_id
     );

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -31,11 +31,16 @@ function cumulative_total_proj_summary_graph()
         $psd = get_project_status_descriptor($which);
 
         //query db and put results into arrays
-        $sql = sprintf("SELECT date, SUM(num_projects)
+        $sql = sprintf(
+            "
+            SELECT date, SUM(num_projects)
             FROM project_state_stats
             WHERE %s
             GROUP BY DATE
-            ORDER BY date ASC", $psd->state_selector);
+            ORDER BY date ASC
+            ",
+            $psd->state_selector
+        );
         $result = DPDatabase::query($sql);
 
         [$datax, $datay] = dpsql_fetch_columns($result);
@@ -109,10 +114,12 @@ function user_logging_on($past, $preceding)
     //query db and put results into arrays
 
     $sql = sprintf(
-        "SELECT DATE_FORMAT(FROM_UNIXTIME(time_stamp), '%s'), $column_name
+        "
+        SELECT DATE_FORMAT(FROM_UNIXTIME(time_stamp), '%s'), $column_name
         FROM user_active_log
         WHERE time_stamp >= %d
-        ORDER BY time_stamp",
+        ORDER BY time_stamp
+        ",
         DPDatabase::escape($date_format),
         $min_timestamp
     );
@@ -189,10 +196,15 @@ function new_users($time_interval)
     $date_format = $time_interval_options[$time_interval]['format'];
     $title = $time_interval_options[$time_interval]['title'];
 
-    $sql = sprintf("SELECT FROM_UNIXTIME(date_created, '%s'), COUNT(*)
+    $sql = sprintf(
+        "
+        SELECT FROM_UNIXTIME(date_created, '%s'), COUNT(*)
         FROM users
         GROUP BY 1
-        ORDER BY date_created", DPDatabase::escape($date_format));
+        ORDER BY date_created
+        ",
+        DPDatabase::escape($date_format)
+    );
     $res = DPDatabase::query($sql);
 
     [$datax, $datay] = dpsql_fetch_columns($res);
@@ -215,10 +227,12 @@ function average_hour_users_logging_on()
     //Numbers of users logging on in each hour of the day, since the start of stats
 
     //query db and put results into arrays
-    $sql = "SELECT hour, AVG(L_hour)
+    $sql = "
+        SELECT hour, AVG(L_hour)
         FROM user_active_log
         GROUP BY hour
-        ORDER BY hour";
+        ORDER BY hour
+    ";
     $result = DPDatabase::query($sql);
 
     [$datax, $datay] = dpsql_fetch_columns($result);
@@ -236,11 +250,12 @@ function average_hour_users_logging_on()
 
 function users_by_language()
 {
-    $res = DPDatabase::query("SELECT IFNULL(LEFT(u_intlang, 2), '') AS intlang, COUNT(*) AS num
+    $res = DPDatabase::query("
+        SELECT IFNULL(LEFT(u_intlang, 2), '') AS intlang, COUNT(*) AS num
         FROM users
         GROUP BY intlang
-        ORDER BY num DESC");
-
+        ORDER BY num DESC
+    ");
     $x = [];
     $y = [];
 
@@ -271,13 +286,13 @@ function users_by_language()
 
 function users_by_country()
 {
-    $res = DPDatabase::query("SELECT SUBSTRING_INDEX(email, '.' ,-1) AS domain,
-        COUNT(*) AS num
+    $res = DPDatabase::query("
+        SELECT SUBSTRING_INDEX(email, '.' ,-1) AS domain, COUNT(*) AS num
         FROM users
         WHERE email LIKE '%@%.%'
         GROUP BY domain
-        ORDER BY num DESC");
-
+        ORDER BY num DESC
+    ");
     $x = [];
     $y = [];
 
@@ -341,11 +356,13 @@ function curr_month_proj($which)
 
     //query db and put results into arrays
     $sql = sprintf(
-        "SELECT DAYOFMONTH(date) as day, SUM(num_projects)
+        "
+        SELECT DAYOFMONTH(date) as day, SUM(num_projects)
         FROM project_state_stats
         WHERE MONTH(date) = %d AND YEAR(date) = %d AND (%s)
         GROUP BY DAYOFMONTH(date)
-        ORDER BY date",
+        ORDER BY date
+        ",
         DPDatabase::escape($month),
         DPDatabase::escape($year),
         $psd->state_selector
@@ -405,11 +422,13 @@ function cumulative_month_proj($which)
 
     //query db and put results into arrays
     $sql = sprintf(
-        "SELECT DAYOFMONTH(date) as day, SUM(num_projects)
+        "
+        SELECT DAYOFMONTH(date) as day, SUM(num_projects)
         FROM project_state_stats
         WHERE MONTH(date) = %s AND YEAR(date) = %s AND (%s)
         GROUP BY DAYOFMONTH(date)
-        ORDER BY date",
+        ORDER BY date
+        ",
         DPDatabase::escape($month),
         DPDatabase::escape($year),
         $psd->state_selector
@@ -452,12 +471,13 @@ function total_proj_graph($which)
 
 
     //query db and put results into arrays
-    $result = DPDatabase::query("SELECT date, SUM(num_projects)
+    $result = DPDatabase::query("
+        SELECT date, SUM(num_projects)
         FROM project_state_stats
         WHERE $psd->state_selector
         GROUP BY date
-        ORDER BY date");
-
+        ORDER BY date
+    ");
     [$datax, $y_cumulative] = dpsql_fetch_columns($result);
 
     $datay1 = array_successive_differences($y_cumulative);
@@ -485,12 +505,13 @@ function cumulative_total_proj_graph($which)
     $timeframe = _('since stats began');
 
     //query db and put results into arrays
-    $result = DPDatabase::query("SELECT date, SUM(num_projects)
+    $result = DPDatabase::query("
+        SELECT date, SUM(num_projects)
         FROM project_state_stats
         WHERE $psd->state_selector
         GROUP BY date
-        ORDER BY date ASC");
-
+        ORDER BY date ASC
+    ");
     [$datax, $datay1] = dpsql_fetch_columns($result);
 
     if (empty($datay1)) {
@@ -662,20 +683,20 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
         }
 
         $sql = "
-        SELECT t1.timestamp,
-            (SELECT round(sum(t2.tally_delta)/count(t2.tally_delta))
-            FROM past_tallies as t2
-            WHERE t2.holder_type = 'S'
-                AND t2.holder_id = '1'
-                AND t2.tally_name = '$tally_name'
-                AND datediff(from_unixtime(t1.timestamp), from_unixtime(t2.timestamp)) between 0 and $days_to_average )
-            as 'sma'
-        FROM past_tallies as t1
-        WHERE t1.holder_type = 'S'
-            AND t1.tally_name = '$tally_name'
-            AND t1.holder_id = '1'
-            AND t1.timestamp > $where_start_timestamp
-        ORDER BY t1.timestamp asc
+            SELECT t1.timestamp,
+                (SELECT round(sum(t2.tally_delta)/count(t2.tally_delta))
+                FROM past_tallies as t2
+                WHERE t2.holder_type = 'S'
+                    AND t2.holder_id = '1'
+                    AND t2.tally_name = '$tally_name'
+                    AND datediff(from_unixtime(t1.timestamp), from_unixtime(t2.timestamp)) between 0 and $days_to_average )
+                as 'sma'
+            FROM past_tallies as t1
+            WHERE t1.holder_type = 'S'
+                AND t1.tally_name = '$tally_name'
+                AND t1.holder_id = '1'
+                AND t1.timestamp > $where_start_timestamp
+            ORDER BY t1.timestamp asc
         ";
         $res = DPDatabase::query($sql);
 
@@ -820,9 +841,11 @@ function get_round_backlog_stats($interested_phases)
     $stats = [];
     foreach ($interested_phases as $phase) {
         $where_state = _get_project_state_selector($phase, ["available", "waiting"]);
-        $sql = "SELECT SUM(n_pages) as num_pages
-                FROM projects
-                WHERE $where_state";
+        $sql = "
+            SELECT SUM(n_pages) as num_pages
+            FROM projects
+            WHERE $where_state
+        ";
         $res = DPDatabase::query($sql);
         while ($result = mysqli_fetch_assoc($res)) {
             $stats[$phase] = $result["num_pages"];

--- a/pinc/job_log.inc
+++ b/pinc/job_log.inc
@@ -10,7 +10,7 @@ function insert_job_log_entry($filename, $event, $comments, $tracetime = null)
         "
         INSERT INTO job_logs (filename, tracetime, event, comments)
         VALUES ('%s', %d, '%s', '%s')
-    ",
+        ",
         DPDatabase::escape($filename),
         $tracetime,
         DPDatabase::escape($event),

--- a/pinc/mentorbanner.inc
+++ b/pinc/mentorbanner.inc
@@ -16,11 +16,11 @@ function mentor_banner($round)
     $sql = sprintf(
         "
         SELECT max(round((unix_timestamp() - modifieddate)/(24 * 60 * 60)))
-            FROM projects
-            WHERE
-                difficulty = 'beginner'
-                AND state = '%s'
-                AND language = '%s'",
+        FROM projects
+        WHERE difficulty = 'beginner'
+            AND state = '%s'
+            AND language = '%s'
+        ",
         DPDatabase::escape($r_avail_state),
         DPDatabase::escape($eng_lang_name)
     );

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -105,7 +105,7 @@ function fetch_page_table_data($project, $page_selector = null, $proofed_in_roun
                         username = $round->user_column_name AND
                         round_id = '%s'
                 ) as wordcheck_status$rn
-            ",
+                ",
                 DPDatabase::escape($project->projectid),
                 DPDatabase::escape($round->id)
             );

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -106,7 +106,8 @@ function user_get_ELR_page_tally($username)
         "
         SELECT $user_ELR_page_tally_column
         FROM users $joined_with_user_ELR_page_tallies
-        WHERE username='%s'",
+        WHERE username='%s'
+        ",
         DPDatabase::escape($username)
     );
     $res = DPDatabase::query($sql);
@@ -331,7 +332,8 @@ function get_site_tally_goal_summed($tally_name, $date_condition)
         "
         SELECT SUM(goal)
         FROM site_tally_goals
-        WHERE tally_name = '%s' AND ($date_condition)",
+        WHERE tally_name = '%s' AND ($date_condition)
+        ",
         DPDatabase::escape($tally_name)
     );
     $res = DPDatabase::query($sql);

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -65,9 +65,10 @@ function phpbb3_create_user(
 
     // get the group_id for the REGISTERED user group
     global $db;
-    $sql = "SELECT group_id
-            FROM {$forums_phpbb_table_prefix}_groups
-            WHERE group_name = 'REGISTERED'
+    $sql = "
+        SELECT group_id
+        FROM {$forums_phpbb_table_prefix}_groups
+        WHERE group_name = 'REGISTERED'
     ";
     $result = $db->sql_query($sql);
     $group_id = (int) $db->sql_fetchfield('group_id');
@@ -193,11 +194,14 @@ function _insert_post(
     } else {
         $username = "Anonymous";
     }
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM {$forums_phpbb_table_prefix}_users
         WHERE username='%s'
-    ", $db->sql_escape($username));
+        ",
+        $db->sql_escape($username)
+    );
     $result = $db->sql_query($sql);
     $row = $db->sql_fetchrow($result);
     if (!$row) {

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -112,7 +112,7 @@ function show_projects_for_smooth_reading()
             projectid NOT IN (
                 SELECT projectid FROM smoothread WHERE smoothread.user = '$pguser'
             )
-         ";
+        ";
     }
 
     $title = _('Projects Available for Smooth Reading');

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -26,11 +26,14 @@ function get_news_subject($news_page_id)
 
 function get_news_page_last_modified_date($news_page_id)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT t_last_change
         FROM news_pages
         WHERE news_page_id = '%s'
-    ", DPDatabase::escape($news_page_id));
+        ",
+        DPDatabase::escape($news_page_id)
+    );
     $res = DPDatabase::query($sql);
 
     $row = mysqli_fetch_assoc($res);
@@ -74,7 +77,7 @@ function show_news_for_page($news_page_id)
             AND (news_page_id = '%s' OR news_page_id = 'GLOBAL')
             AND (locale = '' OR locale = '%s')
         ORDER BY ORDERING DESC
-    ",
+        ",
         DPDatabase::escape($news_page_id),
         DPDatabase::escape($user_locale)
     );
@@ -90,7 +93,7 @@ function show_news_for_page($news_page_id)
             AND (news_page_id = '%s' OR news_page_id = 'GLOBAL')
             AND (locale = '' OR locale = '%s')
         ORDER BY RAND() LIMIT 1
-    ",
+        ",
         DPDatabase::escape($news_page_id),
         DPDatabase::escape($user_locale)
     );

--- a/pinc/smoothread.inc
+++ b/pinc/smoothread.inc
@@ -26,13 +26,17 @@ include_once($relPath.'user_project_info.inc'); // notify_project_event_subscrib
  */
 function sr_user_is_committed($projectid, $username)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT count(*)
         FROM smoothread
         WHERE projectid = '%s'
             AND user = '%s'
             AND committed > 0
-        ", DPDatabase::escape($projectid), DPDatabase::escape($username));
+        ",
+        DPDatabase::escape($projectid),
+        DPDatabase::escape($username)
+    );
     $res = DPDatabase::query($sql);
     [$count] = mysqli_fetch_row($res);
 
@@ -53,12 +57,16 @@ function sr_user_is_committed($projectid, $username)
  */
 function sr_commit($projectid, $username)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         INSERT INTO smoothread
         SET projectid='%s', user='%s', committed=1
         ON DUPLICATE KEY UPDATE
             committed=1
-        ", DPDatabase::escape($projectid), DPDatabase::escape($username));
+        ",
+        DPDatabase::escape($projectid),
+        DPDatabase::escape($username)
+    );
     DPDatabase::query($sql);
 }
 
@@ -72,11 +80,15 @@ function sr_commit($projectid, $username)
  */
 function sr_withdraw_commitment($projectid, $username)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         DELETE FROM smoothread
         WHERE projectid = '%s'
             AND user = '%s'
-        ", DPDatabase::escape($projectid), DPDatabase::escape($username));
+        ",
+        DPDatabase::escape($projectid),
+        DPDatabase::escape($username)
+    );
     DPDatabase::query($sql);
 }
 
@@ -89,13 +101,16 @@ function sr_withdraw_commitment($projectid, $username)
  */
 function sr_get_committed_users($projectid)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT user
         FROM smoothread
         WHERE projectid = '%s'
             AND committed > 0
         ORDER BY user
-        ", DPDatabase::escape($projectid));
+        ",
+        DPDatabase::escape($projectid)
+    );
     $res = DPDatabase::query($sql);
 
     $list = [];
@@ -195,12 +210,16 @@ function handle_smooth_reading_change($project, $postcomments, $days, $extend)
         $project->log_project_event($pguser, 'smooth-reading', 'text replaced');
     }
 
-    $qstring = sprintf("
+    $qstring = sprintf(
+        "
         UPDATE projects
         SET $smoothread_deadline_sql
             postcomments = CONCAT(postcomments, '%s')
         WHERE projectid = '%s'
-    ", DPDatabase::escape($postcomments), DPDatabase::escape($projectid));
+        ",
+        DPDatabase::escape($postcomments),
+        DPDatabase::escape($projectid)
+    );
     DPDatabase::query($qstring);
 
     notify_project_event_subscribers($project, 'sr_available');

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -154,9 +154,10 @@ function echo_special_legend($projects_where_clause)
     $legend_text = _("Legend for Special Day Colors");
 
     $currspecs_result = DPDatabase::query("
-            SELECT distinct special_code as spec FROM projects
-            WHERE $projects_where_clause
-        ");
+        SELECT distinct special_code as spec
+        FROM projects
+        WHERE $projects_where_clause
+    ");
 
     $specials_array = load_special_days(true);
     $day_array = [];

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -731,12 +731,15 @@ function show_user_teams()
     echo "<ul>\n";
     $user_teams = $user->load_teams();
     if ($user_teams) {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT id, teamname
             FROM user_teams
             WHERE id IN (%s)
             ORDER BY teamname
-        ", implode(",", $user_teams));
+            ",
+            implode(",", $user_teams)
+        );
         $result = DPDatabase::query($sql);
         while ([$tid, $teamname] = mysqli_fetch_row($result)) {
             echo "<li>";
@@ -777,7 +780,8 @@ function show_birthdays()
     // We exclude users whose privacy preference is set to anonymous.
     // Birthdays are only shown on the activity hub which requires a login
     // so users with a privacy preference of 'private' are ok to be included.
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT username, date_created
         FROM users
         WHERE
@@ -786,8 +790,12 @@ function show_birthdays()
             AND date_created < %s
             AND u_privacy != %d
         ORDER BY date_created ASC
-    ", date("m-d"), $oldest_activity, $timestamp_at_midnight, PRIVACY_ANONYMOUS);
-
+        ",
+        date("m-d"),
+        $oldest_activity,
+        $timestamp_at_midnight,
+        PRIVACY_ANONYMOUS
+    );
     $result = DPDatabase::query($sql);
 
     if (mysqli_num_rows($result) == 0) {

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -134,12 +134,15 @@ function that_user_is_over_PP_checked_out_limit($username)
     $actual_limit = intval($limit);
 
     // now see how many they have checked out
-    $query = sprintf("
+    $query = sprintf(
+        "
         SELECT COUNT(*)
         FROM projects
         WHERE checkedoutby LIKE '%s'
             AND state = 'proj_post_first_checked_out'
-    ", DPDatabase::escape($username));
+        ",
+        DPDatabase::escape($username)
+    );
     $result = DPDatabase::query($query);
     $row = mysqli_fetch_row($result);
     $number_out = $row[0];

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -32,7 +32,8 @@ function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_
                 projectid           = '%s',
                 t_latest_home_visit = %d
             ON DUPLICATE KEY UPDATE
-                t_latest_home_visit = %d",
+                t_latest_home_visit = %d
+            ",
             DPDatabase::escape($username),
             DPDatabase::escape($projectid),
             $timestamp,
@@ -43,7 +44,8 @@ function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_
             "
             UPDATE user_project_info
             SET t_latest_home_visit = %d
-            WHERE username = '%s' AND projectid = '%s'",
+            WHERE username = '%s' AND projectid = '%s'
+            ",
             $timestamp,
             DPDatabase::escape($username),
             DPDatabase::escape($projectid)
@@ -62,7 +64,8 @@ function upi_set_t_latest_page_event($username, $projectid, $timestamp)
             projectid           = '%s',
             t_latest_page_event = %d
         ON DUPLICATE KEY UPDATE
-            t_latest_page_event = %d",
+            t_latest_page_event = %d
+        ",
         DPDatabase::escape($username),
         DPDatabase::escape($projectid),
         $timestamp,
@@ -128,7 +131,8 @@ function set_user_project_event_subscription($username, $projectid, $event, $bit
             projectid   = '%s',
             iste_$event = %d
         ON DUPLICATE KEY UPDATE
-            iste_$event = %d",
+            iste_$event = %d
+        ",
         DPDatabase::escape($username),
         DPDatabase::escape($projectid),
         $bit,
@@ -147,7 +151,8 @@ function user_is_subscribed_to_project_event($username, $projectid, $event)
         SELECT iste_$event
         FROM user_project_info
         WHERE username    = '%s'
-            AND projectid = '%s'",
+            AND projectid = '%s'
+        ",
         DPDatabase::escape($username),
         DPDatabase::escape($projectid)
     );
@@ -186,7 +191,8 @@ function notify_project_event_subscribers($project, $event, $extras = [])
         SELECT username
         FROM user_project_info
         WHERE projectid = '%s'
-            AND iste_$event = 1",
+            AND iste_$event = 1
+        ",
         DPDatabase::escape($projectid)
     );
     $res1 = DPDatabase::query($sql1);
@@ -265,7 +271,8 @@ function notify_project_event_subscribers($project, $event, $extras = [])
             "
             UPDATE projects
             SET int_level = %d
-            WHERE projectid = '%s'",
+            WHERE projectid = '%s'
+            ",
             $n_subscribers,
             DPDatabase::escape($projectid)
         );
@@ -292,7 +299,8 @@ function get_n_users_subscribed_to_events_for_project($projectid)
         "
         SELECT $selects
         FROM user_project_info
-        WHERE projectid='%s'",
+        WHERE projectid='%s'
+        ",
         DPDatabase::escape($projectid)
     );
     $res = DPDatabase::query($sql);

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -605,7 +605,8 @@ function delete_project_wordcheck_events($projectid)
     $sql = sprintf(
         "
         DELETE FROM wordcheck_events
-        WHERE projectid='%s'",
+        WHERE projectid='%s'
+        ",
         DPDatabase::escape($projectid)
     );
     DPDatabase::query($sql);
@@ -647,7 +648,8 @@ function copy_project_wordcheck_events($from_projectid, $to_projectid)
             (projectid, timestamp, image, round_id, username, suggestions, corrections)
         SELECT '%s', timestamp, image, round_id, username, suggestions, corrections
         FROM wordcheck_events
-        WHERE projectid = '%s'",
+        WHERE projectid = '%s'
+        ",
         DPDatabase::escape($to_projectid),
         DPDatabase::escape($from_projectid)
     );
@@ -674,8 +676,10 @@ function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions,
         set_col_str("suggestions", join("\n", $suggestions)),
         set_col_str("corrections", join("\n", $correction_list)),
     ]);
-    $sql = "INSERT INTO wordcheck_events
-            SET $setters";
+    $sql = "
+        INSERT INTO wordcheck_events
+            SET $setters
+    ";
     DPDatabase::query($sql);
 }
 
@@ -693,8 +697,8 @@ function count_wordcheck_suggestion_events($projectid, $start_time = 0)
     $sql = sprintf(
         "
         SELECT count(*) AS numevents FROM wordcheck_events
-        WHERE projectid='%s'
-        AND timestamp>%d AND suggestions<>''",
+        WHERE projectid='%s' AND timestamp>%d AND suggestions<>''
+        ",
         DPDatabase::escape($projectid),
         $start_time
     );
@@ -713,8 +717,8 @@ function load_wordcheck_events($projectid, $start_time = 0)
     $sql = sprintf(
         "
         SELECT * FROM wordcheck_events
-        WHERE projectid='%s'
-        AND timestamp>%d",
+        WHERE projectid='%s' AND timestamp>%d
+        ",
         DPDatabase::escape($projectid),
         $start_time
     );

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -561,12 +561,15 @@ function showMbrTeams($user)
         _("Active Members")
     );
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT id, teamname
         FROM user_teams
         WHERE id IN (%s)
         ORDER BY teamname
-    ", implode(",", $user_teams));
+        ",
+        implode(",", $user_teams)
+    );
     $result = DPDatabase::query($sql);
 
     while ([$tid, $teamname] = mysqli_fetch_row($result)) {

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -362,7 +362,8 @@ function showTeamMbrs($curTeam, $tally_name)
     [$joined_with_user_tallies, $user_tally_column] =
         $users_tallyboard->get_sql_joinery_for_current_tallies('u_id');
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *, $user_tally_column AS current_tally
         FROM users $joined_with_user_tallies
         WHERE u_id IN (
@@ -371,7 +372,9 @@ function showTeamMbrs($curTeam, $tally_name)
             WHERE t_id = %d
         )
         ORDER BY $orderby $direction
-    ", $req_team_id);
+        ",
+        $req_team_id
+    );
     $mbrQuery = DPDatabase::query($sql);
 
     $totalAnonUsers = 0;
@@ -519,12 +522,15 @@ function showEdit($tname, $ttext, $twebpage, $tedit, $tsid)
     if ($tedit == 1 && count($user_teams) >= MAX_USER_TEAM_MEMBERSHIP) {
         echo "<tr><td style='text-align: center;' colspan='2'>"._("You must join the team to create it, which team space would you like to use?")."<br>";
         echo "<select name='otid' title='".attr_safe(_("Team List"))."'>";
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT id, teamname
             FROM user_teams
             WHERE id IN (%s)
             ORDER BY teamname
-        ", implode(",", $user_teams));
+            ",
+            implode(",", $user_teams)
+        );
         $result = DPDatabase::query($sql);
         while ([$id, $teamname] = mysqli_fetch_row($result)) {
             echo "<option value='$id'>" . html_safe($teamname) . "</option>";

--- a/stats/members/jointeam.php
+++ b/stats/members/jointeam.php
@@ -33,12 +33,15 @@ if (count($user_teams) >= MAX_USER_TEAM_MEMBERSHIP) {
     echo "<h1>" . html_safe($title) . "</h1>\n";
     echo "<p>" . sprintf(_("You have already joined the maximum of %d teams. Which team would you like to replace?"), MAX_USER_TEAM_MEMBERSHIP) . "</p>";
     echo "<ul>";
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT id, teamname
         FROM user_teams
         WHERE id IN (%s)
         ORDER BY teamname
-    ", implode(",", $user_teams));
+        ",
+        implode(",", $user_teams)
+    );
     $result = DPDatabase::query($sql);
     while ([$old_team_id, $teamname] = mysqli_fetch_row($result)) {
         echo "<li><a href='jointeam.php?tid=$tid&otid=$old_team_id'>" . html_safe($teamname) . "</a></li>";

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -53,12 +53,15 @@ if ($uname) {
         metarefresh(0, "mdetail.php?id=".$row["u_id"]);
     }
 } else {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT u_id, username, date_created, u_privacy
         FROM users
         ORDER BY $order $direction
         LIMIT %d,20
-    ", $mstart);
+        ",
+        $mstart
+    );
     $mResult = DPDatabase::query($sql);
     $mRows = mysqli_num_rows($mResult);
 }

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -22,13 +22,15 @@ $site_stats = get_site_page_tally_summary($round_before_PP);
 $pp_page_goal = $site_stats->curr_month_actual + $page_offset;
 
 // Get the total pages for projects that have posted
-$page_res = DPDatabase::query(sprintf("
-    SELECT 
-    SUM(n_pages)
+$page_res = DPDatabase::query(sprintf(
+    "
+    SELECT SUM(n_pages)
     FROM projects
     WHERE state='proj_submit_pgposted'
-    AND modifieddate >= %d
-", $m_start));
+        AND modifieddate >= %d
+    ",
+    $m_start
+));
 
 $row = mysqli_fetch_row($page_res);
 $pp_pages_total = $row[0];

--- a/stats/proof_stats.php
+++ b/stats/proof_stats.php
@@ -38,7 +38,7 @@ $sql = sprintf(
     WHERE $user_page_tally_column > 0
     ORDER BY 2 DESC, 1 ASC
     LIMIT 100
-",
+    ",
     PRIVACY_ANONYMOUS,
     DPDatabase::escape(_("Anonymous")),
     DPDatabase::escape(_("Proofreader")),

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -127,7 +127,8 @@ function _show_round_queues($round, $listing_view_mode)
         SELECT *
         FROM queue_defns
         WHERE round_id='%s' AND ((%s) OR (SUBSTR(name, 1, 1) = '*'))
-        ORDER BY ordering",
+        ORDER BY ordering
+        ",
         DPDatabase::escape($round->id),
         in_array($listing_view_mode, ["enabled", "populated"]) ? "enabled = 1" : "1"
     );
@@ -218,7 +219,8 @@ function _show_queue_details($round, $name, $unheld_only)
         "
         SELECT *
         FROM queue_defns
-        WHERE round_id='%s' AND name='%s'",
+        WHERE round_id='%s' AND name='%s'
+        ",
         DPDatabase::escape($round->id),
         DPDatabase::escape($name)
     );
@@ -322,18 +324,24 @@ function _show_queue_details($round, $name, $unheld_only)
 
 function _get_num_projects_and_pages_released_in_last($name, $seconds_ago, $waiting_state)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT count(*)
         FROM project_events
         WHERE event_type = 'transition'
             AND details1 = '%s'
             AND details3 = 'via_q: %s'
             AND timestamp >= %d
-    ", DPDatabase::escape($waiting_state), DPDatabase::escape($name), $seconds_ago);
+        ",
+        DPDatabase::escape($waiting_state),
+        DPDatabase::escape($name),
+        $seconds_ago
+    );
     $result = DPDatabase::query($sql);
     $projects_released = mysqli_fetch_row($result)[0];
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT sum(n_pages)
         FROM projects
         WHERE projectid in (
@@ -344,7 +352,11 @@ function _get_num_projects_and_pages_released_in_last($name, $seconds_ago, $wait
                 AND details3 = 'via_q: %s'
                 AND timestamp >= %d
         )
-    ", DPDatabase::escape($waiting_state), DPDatabase::escape($name), $seconds_ago);
+        ",
+        DPDatabase::escape($waiting_state),
+        DPDatabase::escape($name),
+        $seconds_ago
+    );
     $result = DPDatabase::query($sql);
     $pages_released = mysqli_fetch_row($result)[0] ?? 0;
 
@@ -353,7 +365,8 @@ function _get_num_projects_and_pages_released_in_last($name, $seconds_ago, $wait
 
 function _get_num_projects_and_pages_available_from_queue($name, $seconds_ago, $waiting_state, $round)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT count(*)
         FROM projects
         WHERE projectid in (
@@ -364,11 +377,17 @@ function _get_num_projects_and_pages_available_from_queue($name, $seconds_ago, $
                 AND details3 = 'via_q: %s'
                 AND timestamp >= %d
             ) AND state = '%s'
-    ", DPDatabase::escape($waiting_state), DPDatabase::escape($name), $seconds_ago, $round->project_available_state);
+        ",
+        DPDatabase::escape($waiting_state),
+        DPDatabase::escape($name),
+        $seconds_ago,
+        $round->project_available_state
+    );
     $result = DPDatabase::query($sql);
     $projects_available = mysqli_fetch_row($result)[0] ?? 0;
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT sum(n_available_pages)
         FROM projects
         WHERE projectid in (
@@ -379,7 +398,12 @@ function _get_num_projects_and_pages_available_from_queue($name, $seconds_ago, $
                 AND details3 = 'via_q: %s'
                 AND timestamp >= %d
             ) AND state = '%s'
-    ", DPDatabase::escape($waiting_state), DPDatabase::escape($name), $seconds_ago, $round->project_available_state);
+        ",
+        DPDatabase::escape($waiting_state),
+        DPDatabase::escape($name),
+        $seconds_ago,
+        $round->project_available_state
+    );
     $result = DPDatabase::query($sql);
     $pages_available = mysqli_fetch_row($result)[0] ?? 0;
 
@@ -388,19 +412,25 @@ function _get_num_projects_and_pages_available_from_queue($name, $seconds_ago, $
 
 function _get_num_projects_and_pages_available($round)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT count(*)
         FROM projects
         WHERE state = '%s'
-    ", DPDatabase::escape($round->project_available_state));
+        ",
+        DPDatabase::escape($round->project_available_state)
+    );
     $result = DPDatabase::query($sql);
     $projects_available = mysqli_fetch_row($result)[0] ?? 0;
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT sum(n_available_pages)
         FROM projects
         WHERE state = '%s'
-    ", DPDatabase::escape($round->project_available_state));
+        ",
+        DPDatabase::escape($round->project_available_state)
+    );
     $result = DPDatabase::query($sql);
     $pages_available = mysqli_fetch_row($result)[0] ?? 0;
 

--- a/stats/requested_books.php
+++ b/stats/requested_books.php
@@ -37,7 +37,8 @@ for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
         OR state='{$round->project_available_state}'
     ";
 }
-dpsql_dump_themed_query("
+dpsql_dump_themed_query(
+    "
     SELECT
         CONCAT('$comments_url1',projects.projectid,'$comments_url2', nameofwork, '$comments_url3') AS '" . DPDatabase::escape(_("Title")) . "',
         authorsname AS '" . DPDatabase::escape(_("Author")) . "',
@@ -49,14 +50,18 @@ dpsql_dump_themed_query("
         AND ($state_condition)
     ORDER BY 5 DESC
     LIMIT 50
-", 1, DPSQL_SHOW_RANK);
+    ",
+    1,
+    DPSQL_SHOW_RANK
+);
 
 echo "<br>\n";
 echo "<h2>" . _("Most Requested Books In Post-Processing") . "</h2>\n";
 
 //        $post_url1 = DPDatabase::escape("<a href='$code_url/project.php?id=");
 
-dpsql_dump_themed_query("
+dpsql_dump_themed_query(
+    "
     SELECT
         CONCAT('$comments_url1',projects.projectid,'$comments_url2', nameofwork, '$comments_url3') AS '" . DPDatabase::escape(_("Title")) . "',
         authorsname AS '" . DPDatabase::escape(_("Author")) . "',
@@ -68,13 +73,17 @@ dpsql_dump_themed_query("
         AND ".SQL_CONDITION_SILVER."
     ORDER BY 5 DESC
     LIMIT 50
-", 1, DPSQL_SHOW_RANK);
+    ",
+    1,
+    DPSQL_SHOW_RANK
+);
 
 echo "<br>\n";
 echo "<h2>" . _("Most Requested Books Posted to Project Gutenberg") . "</h2>\n";
 
 $pg_url1 = DPDatabase::escape(sprintf("<a href='%s", get_pg_catalog_url_for_etext('')));
-dpsql_dump_themed_query("
+dpsql_dump_themed_query(
+    "
     SELECT
         CONCAT('$pg_url1', postednum, '$comments_url2', nameofwork, '$comments_url3') AS '" . DPDatabase::escape(_("Title")) . "',
         authorsname AS '" . DPDatabase::escape(_("Author")) . "',
@@ -86,4 +95,7 @@ dpsql_dump_themed_query("
         AND int_level !=0
     ORDER BY 5 DESC
     LIMIT 50
-", 1, DPSQL_SHOW_RANK);
+    ",
+    1,
+    DPSQL_SHOW_RANK
+);

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -66,7 +66,8 @@ function count_books_in_state($state, $clauses = "")
         SELECT COUNT(*) AS numbooks
         FROM projects
         WHERE state = '%s'
-        %s",
+            %s
+        ",
         DPDatabase::escape($state),
         $clauses
     );
@@ -84,8 +85,10 @@ $table->set_column_alignments('left', 'right');
 
 //get total users active in the last 7 days
 $begin_time = time() - 604800; // in seconds
-$users = DPDatabase::query("SELECT count(*) AS numusers FROM users
-                          WHERE t_last_activity > $begin_time");
+$users = DPDatabase::query("
+    SELECT count(*) AS numusers FROM users
+    WHERE t_last_activity > $begin_time
+");
 $row = mysqli_fetch_assoc($users);
 $totalusers = $row["numusers"];
 

--- a/stats/teams/new_team.php
+++ b/stats/teams/new_team.php
@@ -43,7 +43,8 @@ if (isset($_POST['mkPreview'])) {
         "
         SELECT id
         FROM user_teams
-        WHERE teamname = '%s'",
+        WHERE teamname = '%s'
+        ",
         DPDatabase::escape($teamname)
     );
     $result = DPDatabase::query($sql);
@@ -81,7 +82,8 @@ if (isset($_POST['mkPreview'])) {
                 "
                 UPDATE user_teams
                 SET avatar='%s'
-                WHERE id = %d",
+                WHERE id = %d
+                ",
                 DPDatabase::escape($tavatar),
                 $tid
             );
@@ -94,7 +96,8 @@ if (isset($_POST['mkPreview'])) {
                 "
                 UPDATE user_teams
                 SET icon='%s'
-                WHERE id = %d",
+                WHERE id = %d
+                ",
                 DPDatabase::escape($ticon),
                 $tid
             );

--- a/stats/teams/team_topic.php
+++ b/stats/teams/team_topic.php
@@ -13,10 +13,14 @@ $team_id = get_integer_param($_GET, 'team', null, 0, null);
 
 // Get info about team
 
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT teamname, team_info, webpage, createdby, owner, topic_id
     FROM user_teams
-    WHERE id=%d", $team_id);
+    WHERE id=%d
+    ",
+    $team_id
+);
 $team_result = DPDatabase::query($sql);
 
 $row = mysqli_fetch_array($team_result);

--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -79,7 +79,8 @@ $data .= "
 
 //Team members portion of $data
 $data .= "<teammembers>";
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT username, date_created, u_id, u_privacy
     FROM users
     WHERE u_id IN (
@@ -88,7 +89,9 @@ $sql = sprintf("
         WHERE t_id = %d
     )
     ORDER BY username ASC
-", $team_id);
+    ",
+    $team_id
+);
 $mbrQuery = DPDatabase::query($sql);
 while ($curMbr = mysqli_fetch_assoc($mbrQuery)) {
     if ($curMbr['u_privacy'] == PRIVACY_PRIVATE) {

--- a/stats/teams/tedit.php
+++ b/stats/teams/tedit.php
@@ -66,7 +66,8 @@ if (isset($_GET['tid'])) {
         SELECT id
         FROM user_teams
         WHERE id != %d
-            AND teamname = '%s'",
+            AND teamname = '%s'
+        ",
         $tid,
         DPDatabase::escape($teamname)
     );
@@ -90,7 +91,8 @@ if (isset($_GET['tid'])) {
                 "
                 UPDATE user_teams
                 SET avatar='%s'
-                WHERE id = %d",
+                WHERE id = %d
+                ",
                 $tid,
                 DPDatabase::escape($tavatar)
             );
@@ -103,7 +105,8 @@ if (isset($_GET['tid'])) {
                 "
                 UPDATE user_teams
                 SET icon='%s'
-                WHERE id = %d",
+                WHERE id = %d
+                ",
                 $tid,
                 DPDatabase::escape($ticon)
             );
@@ -119,7 +122,8 @@ if (isset($_GET['tid'])) {
                 teamname = LEFT('%s', 50),
                 team_info = '%s',
                 webpage = LEFT('%s', 255)
-            WHERE id = %d",
+            WHERE id = %d
+            ",
             DPDatabase::escape($teamname),
             DPDatabase::escape($text_data),
             DPDatabase::escape($teamwebpage),

--- a/tasks.php
+++ b/tasks.php
@@ -501,7 +501,8 @@ function create_task_from_form_submission($formsub)
             date_edited      = %d,
             edited_by        = %d,
             percent_complete = 0,
-            related_postings = '%s'",
+            related_postings = '%s'
+        ",
         DPDatabase::escape($task_summary),
         $newt_type,
         $newt_category,
@@ -687,7 +688,8 @@ function handle_action_on_a_specified_task()
                 date_closed = 0,
                 closed_by = 0,
                 closed_reason = 0
-            WHERE task_id = %d",
+            WHERE task_id = %d
+            ",
             get_property_key("Reopened", $tasks_status_array),
             $requester_u_id,
             $now_sse,
@@ -733,7 +735,7 @@ function handle_action_on_a_specified_task()
                     edited_by        = %d,
                     percent_complete = %d
                 WHERE task_id = %d
-            ",
+                ",
                 DPDatabase::escape($task_summary),
                 $edit_type,
                 $edit_category,
@@ -771,7 +773,7 @@ function handle_action_on_a_specified_task()
                     date_edited = %d,
                     edited_by = %d
                 WHERE task_id = %d
-            ",
+                ",
                 get_property_key("100%", $percent_complete_array),
                 get_property_key("Closed", $tasks_status_array),
                 $now_sse,
@@ -794,7 +796,8 @@ function handle_action_on_a_specified_task()
             $sql = sprintf(
                 "
                 INSERT INTO tasks_comments (task_id, u_id, comment_date, comment)
-                VALUES (%d, %d, %d, '%s')",
+                VALUES (%d, %d, %d, '%s')
+                ",
                 $task_id,
                 $requester_u_id,
                 $now_sse,
@@ -806,7 +809,8 @@ function handle_action_on_a_specified_task()
                 "
                 UPDATE tasks
                 SET date_edited = %d, edited_by = %d
-                WHERE task_id = %d",
+                WHERE task_id = %d
+                ",
                 $now_sse,
                 $requester_u_id,
                 $task_id
@@ -847,7 +851,8 @@ function handle_action_on_a_specified_task()
             $sql = sprintf(
                 "
                 INSERT INTO tasks_votes (task_id, u_id, vote_os, vote_browser)
-                VALUES (%d, %d, %d, %d)",
+                VALUES (%d, %d, %d, %d)
+                ",
                 $task_id,
                 $requester_u_id,
                 $vote_os,
@@ -866,7 +871,8 @@ function handle_action_on_a_specified_task()
             $sql = sprintf(
                 "
                 UPDATE tasks_comments SET comment='%s'
-                WHERE task_id = %d AND u_id = %d AND comment_date = %d",
+                WHERE task_id = %d AND u_id = %d AND comment_date = %d
+                ",
                 DPDatabase::escape($comment),
                 $task_id,
                 $u_id,
@@ -959,7 +965,8 @@ function process_related_topic($pre_task, $action, $related_topic_id)
         "
         UPDATE tasks
         SET related_postings = '%s'
-        WHERE task_id = %d",
+        WHERE task_id = %d
+        ",
         DPDatabase::escape(encode_array($related_topics)),
         $pre_task_id
     );
@@ -1261,7 +1268,8 @@ function load_task($tid, $is_assoc = true)
         "
         SELECT *
         FROM tasks
-        WHERE task_id = %d",
+        WHERE task_id = %d
+        ",
         $tid
     );
     $result = DPDatabase::query($sql);
@@ -1389,7 +1397,8 @@ function get_me_too_count($task_id, $requester_u_id)
         "
         SELECT count(*)
         FROM tasks_votes
-        WHERE task_id = %d AND u_id = %d",
+        WHERE task_id = %d AND u_id = %d
+        ",
         $task_id,
         $requester_u_id
     );
@@ -1463,7 +1472,8 @@ function TaskComments($tid, $action)
         SELECT *
         FROM tasks_comments
         WHERE task_id = %d
-        ORDER BY comment_date ASC",
+        ORDER BY comment_date ASC
+        ",
         $tid
     );
     $result = DPDatabase::query($sql);
@@ -1591,7 +1601,8 @@ function load_related_tasks($task_id)
         SELECT task_id_1, task_id_2
         FROM tasks_related_tasks
         WHERE task_id_1 = %d
-            OR task_id_2 = %d",
+            OR task_id_2 = %d
+        ",
         $task_id,
         $task_id
     );
@@ -1622,7 +1633,8 @@ function insert_related_task($task1, $task2)
         SELECT COUNT(*) AS count
         FROM tasks_related_tasks
         WHERE task_id_1 = %d
-            AND task_id_2 = %d",
+            AND task_id_2 = %d
+        ",
         $task_id_1,
         $task_id_2
     );
@@ -1637,7 +1649,8 @@ function insert_related_task($task1, $task2)
     $sql = sprintf(
         "
         INSERT INTO tasks_related_tasks
-        SET task_id_1 = %d, task_id_2 = %d",
+        SET task_id_1 = %d, task_id_2 = %d
+        ",
         $task_id_1,
         $task_id_2
     );
@@ -1654,7 +1667,8 @@ function remove_related_task($task1, $task2)
         "
         DELETE FROM tasks_related_tasks
         WHERE task_id_1 = %d
-            AND task_id_2 = %d",
+            AND task_id_2 = %d
+        ",
         $task_id_1,
         $task_id_2
     );
@@ -1861,7 +1875,8 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
                     "
                     SELECT count(*) AS count
                     FROM tasks_votes
-                    WHERE task_id = %d",
+                    WHERE task_id = %d
+                    ",
                     $task_a['task_id']
                 );
                 $result = DPDatabase::query($sql);
@@ -1881,7 +1896,8 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
                 "
                 SELECT DISTINCT vote_os
                 FROM tasks_votes
-                WHERE task_id = %d",
+                WHERE task_id = %d
+                ",
                 $task_a['task_id']
             );
             $result = DPDatabase::query($sql);
@@ -1905,7 +1921,8 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
                 "
                 SELECT DISTINCT vote_browser
                 FROM tasks_votes
-                WHERE task_id = %d",
+                WHERE task_id = %d
+                ",
                 $task_a['task_id']
             );
             $result = DPDatabase::query($sql);

--- a/tools/authors/add.php
+++ b/tools/authors/add.php
@@ -66,7 +66,8 @@ if (isset($last_name)) {
                 SET last_name='%s', other_names='%s',
                     byear=%d, bmonth=%d, bday=%d, bcomments='%s',
                     dyear=%d, dmonth=%d, dday=%d, dcomments='%s'
-                WHERE author_id = $author_id",
+                WHERE author_id = $author_id
+                ",
                 DPDatabase::escape($last_name),
                 DPDatabase::escape($other_names),
                 $byear,
@@ -91,7 +92,8 @@ if (isset($last_name)) {
                 VALUES
                     ('%s', '%s',
                         %d, %d, %d, '%s',
-                        %d, %d, %d, '%s', 'yes')",
+                        %d, %d, %d, '%s', 'yes')
+                ",
                 DPDatabase::escape($last_name),
                 DPDatabase::escape($other_names),
                 $byear,

--- a/tools/authors/addbio.php
+++ b/tools/authors/addbio.php
@@ -38,11 +38,15 @@ if (isset($_GET['author_id'])) {
         if (isset($_POST['bio_id'])) {
             // edit existing bio
             $bio_id = get_integer_param($_POST, 'bio_id', null, null, null, true);
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 UPDATE biographies
                 SET bio = '%s'
                 WHERE bio_id = %d
-            ", DPDatabase::escape($bio), $bio_id);
+                ",
+                DPDatabase::escape($bio),
+                $bio_id
+            );
             $result = DPDatabase::query($sql);
             $msg = _('The biography was successfully updated in the database!');
         } else {
@@ -51,7 +55,8 @@ if (isset($_GET['author_id'])) {
                 "
                 INSERT INTO biographies
                     (author_id, bio)
-                VALUES(%d, '%s')",
+                VALUES(%d, '%s')
+                ",
                 $author_id,
                 DPDatabase::escape($bio)
             );

--- a/tools/post_proofers/postcomments.php
+++ b/tools/post_proofers/postcomments.php
@@ -18,11 +18,15 @@ if (! $project->PPer_is_current_user || $project->state != PROJ_POST_FIRST_CHECK
     exit;
 }
 
-$sql = sprintf("
-  UPDATE projects
-  SET postcomments = '%s'
-  WHERE projectid = '%s'
-", DPDatabase::escape($postcomments), DPDatabase::escape($projectid));
+$sql = sprintf(
+    "
+    UPDATE projects
+    SET postcomments = '%s'
+    WHERE projectid = '%s'
+    ",
+    DPDatabase::escape($postcomments),
+    DPDatabase::escape($projectid)
+);
 $qry = DPDatabase::query($sql);
 
 $msg = _("Comments added.");

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -81,12 +81,16 @@ $subdate = date('jS \o\f F, Y');
 
 // number of already-posted books post-processed by this PPer.
 $psd = get_project_status_descriptor('posted');
-$sql = sprintf("
+$sql = sprintf(
+    "
     SELECT COUNT(*) AS num_post_processed
     FROM projects
     WHERE %s
-    AND postproofer = LEFT('%s', 25)
-", $psd->state_selector, DPDatabase::escape($project->postproofer));
+        AND postproofer = LEFT('%s', 25)
+    ",
+    $psd->state_selector,
+    DPDatabase::escape($project->postproofer)
+);
 $result = DPDatabase::query($sql);
 $row = mysqli_fetch_assoc($result);
 $number_post_processed = $row["num_post_processed"];
@@ -109,13 +113,15 @@ $pp_date = "";
 
 // earliest transition from PPV.avail to PPV.checked out
 $sql = sprintf(
-    "SELECT timestamp FROM project_events
+    "
+    SELECT timestamp FROM project_events
     WHERE projectid = '%s'
       AND event_type = 'transition'
       AND details1 = '%s'
       AND details2 = '%s'
     ORDER BY timestamp ASC
-    LIMIT 1",
+    LIMIT 1
+    ",
     DPDatabase::escape($projectid),
     DPDatabase::escape(PROJ_POST_SECOND_AVAILABLE),
     DPDatabase::escape(PROJ_POST_SECOND_CHECKED_OUT)
@@ -128,14 +134,16 @@ if ($row) {
 
     // latest transition from PP.checked out to PPV.avail
     $sql = sprintf(
-        "SELECT timestamp FROM project_events
+        "
+        SELECT timestamp FROM project_events
         WHERE projectid = '%s'
           AND event_type = 'transition'
           AND details1 = '%s'
           AND details2 = '%s'
           AND timestamp < %d
         ORDER BY timestamp DESC
-        LIMIT 1",
+        LIMIT 1
+        ",
         DPDatabase::escape($projectid),
         DPDatabase::escape(PROJ_POST_FIRST_CHECKED_OUT),
         DPDatabase::escape(PROJ_POST_SECOND_AVAILABLE),

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -322,7 +322,8 @@ class Loader
         $sql = "
             SELECT image
             FROM $this->projectid
-            LIMIT 0";
+            LIMIT 0
+        ";
         $res = DPDatabase::query($sql);
         $field_data = mysqli_fetch_field_direct($res, 0);
         $this->image_field_len = $field_data->length;

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -84,7 +84,8 @@ if ($one_project) {
             "
             OR state = '%s'
             OR state = '%s'
-            OR state = '%s'",
+            OR state = '%s'
+            ",
             DPDatabase::escape($round->project_available_state),
             DPDatabase::escape($round->project_complete_state),
             DPDatabase::escape($round->project_bad_state)
@@ -101,7 +102,8 @@ $sql = "
     SELECT projectid
     FROM projects
     WHERE $condition
-    ORDER BY projectid";
+    ORDER BY projectid
+";
 $allprojects = DPDatabase::query($sql);
 // The "ORDER BY" ensures consistency of order.
 
@@ -179,7 +181,8 @@ while ([$projectid] = mysqli_fetch_row($allprojects)) {
             FROM $projectid
             WHERE state IN ('%s','%s')
                 AND $round->time_column_name <= %d
-            ORDER BY image ASC",
+            ORDER BY image ASC
+            ",
             $round->page_out_state,
             $round->page_temp_state,
             $max_reclaimable_time

--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -68,7 +68,8 @@ function autorelease_for_round($round)
         SELECT *
         FROM queue_defns
         WHERE round_id='%s'
-        ORDER BY ordering",
+        ORDER BY ordering
+        ",
         DPDatabase::escape($round->id)
     );
     $q_res = DPDatabase::query($sql);
@@ -111,7 +112,8 @@ function autorelease_for_round($round)
         SELECT *
         FROM queue_defns
         WHERE enabled AND round_id='%s'
-        ORDER BY ordering",
+        ORDER BY ordering
+        ",
         DPDatabase::escape($round->id)
     );
     $q_res = DPDatabase::query($sql);
@@ -356,10 +358,11 @@ class ReleaseRestrictor
         $this->this_round_authors = [];
         $sql = sprintf(
             "
-                SELECT authorsname
-                FROM projects
-                WHERE state = '%s'
-                ORDER BY authorsname",
+            SELECT authorsname
+            FROM projects
+            WHERE state = '%s'
+            ORDER BY authorsname
+            ",
             DPDatabase::escape($round->project_available_state)
         );
         $author_res = DPDatabase::query($sql);
@@ -378,10 +381,11 @@ class ReleaseRestrictor
         $this->this_round_pms = [];
         $sql = sprintf(
             "
-                SELECT username
-                FROM projects
-                WHERE state = '%s'
-                ORDER BY username",
+            SELECT username
+            FROM projects
+            WHERE state = '%s'
+            ORDER BY username
+            ",
             DPDatabase::escape($round->project_available_state)
         );
         $pm_res = DPDatabase::query($sql);
@@ -534,7 +538,8 @@ function AP_setup($round)
         "
         SELECT projectid
         FROM projects
-        WHERE state = '%s'",
+        WHERE state = '%s'
+        ",
         DPDatabase::escape($round->project_available_state)
     );
     $projects_res = DPDatabase::query($sql);
@@ -560,7 +565,8 @@ function AP_add_project($round, $projectid)
         SELECT
             '$projectid',
             SUM( state != '%s' ) as pages
-        FROM $projectid",
+        FROM $projectid
+        ",
         DPDatabase::escape($round->page_save_state)
     );
     DPDatabase::query($sql);

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -85,7 +85,8 @@ $query = sprintf(
     SELECT $L_text_column_name, $R_text_column_name,
         $L_user_column_name, $R_user_column_name
     FROM $projectid
-    WHERE image='%s'",
+    WHERE image='%s'
+    ",
     DPDatabase::escape($image)
 );
 
@@ -233,7 +234,8 @@ function do_navigation(
             $L_user_column_name,
             ($L_text_column_name = $R_text_column_name) AS is_empty_diff
         FROM $projectid
-        ORDER BY image ASC";
+        ORDER BY image ASC
+    ";
     $res = DPDatabase::query($query);
     $prev_image = "";
     $next_image = "";
@@ -329,8 +331,7 @@ function can_see_names_for_page($projectid, $image)
 
         validate_projectID($projectid);
         $query = sprintf(
-            "
-            SELECT $fields from $projectid WHERE image = '%s'",
+            "SELECT $fields from $projectid WHERE image = '%s'",
             DPDatabase::escape($image)
         );
         $res = DPDatabase::query($query);

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -155,7 +155,7 @@ class ImageSource
                 SELECT *
                 FROM image_sources
                 WHERE code_name = '%s'
-            ", DPDatabase::escape($code_name));
+                ", DPDatabase::escape($code_name));
             $result = DPDatabase::query($sql);
             $source_fields = mysqli_fetch_assoc($result);
 
@@ -419,7 +419,8 @@ class ImageSource
                 info_page_visibility = %d,
                 public_comment = LEFT('%s', 255),
                 internal_comment = '%s',
-                is_active = %d",
+                is_active = %d
+            ",
             DPDatabase::escape($this->code_name),
             DPDatabase::escape($this->display_name),
             DPDatabase::escape($this->full_name),
@@ -480,7 +481,8 @@ class ImageSource
             "
             UPDATE image_sources
             SET $field = '%s'
-            WHERE code_name = '%s'",
+            WHERE code_name = '%s'
+            ",
             DPDatabase::escape($value),
             DPDatabase::escape($this->code_name)
         );

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -114,7 +114,8 @@ class Comparator
             SELECT image, $L_text_column_name, $R_text_column_name
             FROM $this->projectid
             WHERE $condition
-            ORDER BY image ASC";
+            ORDER BY image ASC
+        ";
         $res = DPDatabase::query($sql);
 
         $num_rows = mysqli_num_rows($res);

--- a/tools/project_manager/page_operations.inc
+++ b/tools/project_manager/page_operations.inc
@@ -15,7 +15,8 @@ function page_del($projectid, $image)
         "
         SELECT image
         FROM $projectid
-        WHERE image = '%s'",
+        WHERE image = '%s'
+        ",
         DPDatabase::escape($image)
     );
     $result = DPDatabase::query($sql);
@@ -54,7 +55,8 @@ function page_clear($projectid, $image)
         "
         SELECT state, %s
         FROM $projectid
-        WHERE image = '%s'",
+        WHERE image = '%s'
+        ",
         $round->user_column_name,
         DPDatabase::escape($image)
     );

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -278,7 +278,7 @@ function _get_projects_for_pm($pm)
         FROM projects
         WHERE username='%s' AND $where
         ORDER BY $collator, nameofwork
-    ", DPDatabase::escape($pm));
+        ", DPDatabase::escape($pm));
 
     $res = DPDatabase::query($query);
     while ($ar = mysqli_fetch_array($res)) {

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -206,7 +206,8 @@ function get_beginner_projects_in_state($state, $mentored_round)
             AND projects.state = '%s'
         GROUP BY projects.projectid
         ORDER BY
-            project_events.timestamp ASC",
+            project_events.timestamp ASC
+        ",
         DPDatabase::escape($mentored_round_detail),
         DPDatabase::escape($state)
     );
@@ -247,7 +248,8 @@ function page_summary_sql($mentored_round, $projectid)
         FROM $projectid  AS p
             INNER JOIN users AS u ON p.{$mentored_round->user_column_name} = u.username
             $joined_with_user_page_tallies
-        GROUP BY p.{$mentored_round->user_column_name}";
+        GROUP BY p.{$mentored_round->user_column_name}
+    ";
 }
 
 // -------------------------------------------------------------------
@@ -285,5 +287,6 @@ function page_list_sql($mentored_round, $projectid)
             ) AS '$wc_events'
         FROM $projectid AS p
             INNER JOIN users AS u ON p.{$mentored_round->user_column_name} = u.username
-        ORDER BY $order" ;
+        ORDER BY $order
+    ";
 }

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -582,8 +582,7 @@ function get_round_query_result($round_view, $round_sort, $round_column_specs, $
 
     if ($round_view == "available") {
         $avail_state_clause = sprintf(
-            "
-            AND projects.state in (%s)",
+            "AND projects.state in (%s)",
             surround_and_join($avail_states, "'", "'", ',')
         );
         $t_latest_page_event = 0;

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -163,7 +163,7 @@ if ($use_eval_query) {
               timestamp > %d
         GROUP BY page_events.projectid
         ORDER BY time_of_latest_save DESC
-    ",
+        ",
         DPDatabase::escape($work_round->id),
         DPDatabase::escape($username),
         $time_limit
@@ -182,7 +182,7 @@ if ($use_eval_query) {
               t_latest_page_event > %d
         GROUP BY user_project_info.projectid
         ORDER BY t_latest_page_event DESC
-    ",
+        ",
         DPDatabase::escape($username),
         $time_limit
     );
@@ -338,7 +338,7 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
         FROM project_events
         WHERE projectid = '%s' AND
               details2 = '%s'
-       ",
+        ",
         DPDatabase::escape($projectid),
         DPDatabase::escape($work_round->project_complete_state)
     );
@@ -364,7 +364,7 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
         WHERE projectid = '%s' AND
               details2 ='%s' AND
               timestamp >= %d
-       ",
+        ",
         DPDatabase::escape($projectid),
         DPDatabase::escape($review_round->project_available_state),
         $max_done_timestamp
@@ -394,7 +394,7 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
             IFNULL( SUM($has_been_saved_in_review_round AND $there_is_a_diff), 0 )
         FROM $projectid
         WHERE {$work_round->user_column_name} = '%s'
-    ", DPDatabase::escape($username));
+        ", DPDatabase::escape($username));
     $res3 = DPDatabase::query($query);
     [$n_saved, $n_latered, $n_with_diff] = mysqli_fetch_row($res3);
     mysqli_free_result($res3);
@@ -427,14 +427,14 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
         validate_projectID($projectid);
         $query = sprintf(
             "
-           SELECT image 
-           FROM $projectid AS proj 
-           WHERE $has_been_saved_in_review_round AND 
-                 $there_is_a_diff AND
-                 {$work_round->user_column_name} = '%s'
-           ORDER BY {$work_round->time_column_name} DESC, image 
-           LIMIT %d
-        ",
+            SELECT image 
+            FROM $projectid AS proj 
+            WHERE $has_been_saved_in_review_round AND 
+                  $there_is_a_diff AND
+                  {$work_round->user_column_name} = '%s'
+            ORDER BY {$work_round->time_column_name} DESC, image 
+            LIMIT %d
+            ",
             DPDatabase::escape($username),
             $sampleLimit
         );

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -328,7 +328,8 @@ function do_stuff(
         $sql = "
             SELECT image, fileid
             FROM {$project->projectid}
-            ORDER BY image";
+            ORDER BY image
+        ";
         $res = DPDatabase::query($sql);
 
         $n_pages = mysqli_num_rows($res);
@@ -654,7 +655,8 @@ function do_stuff(
         $query = sprintf(
             "
             %s
-            WHERE image = '%s'",
+            WHERE image = '%s'
+            ",
             $insert,
             DPDatabase::escape($c_src_image)
         );
@@ -698,7 +700,8 @@ function do_stuff(
                 "
                 SELECT username FROM user_project_info
                 WHERE projectid = '%s' AND
-                    iste_$event = 1",
+                    iste_$event = 1
+                ",
                 $projectid_['from'] // validated input
             );
             $res1 = DPDatabase::query($query);
@@ -719,9 +722,10 @@ function do_stuff(
         echo "<p>" . _("Adding deletion reason to source project.") . "</p>\n";
         $query = sprintf(
             "
-              UPDATE projects
-              SET deletion_reason = 'merged into %s'
-              WHERE projectid = '%s'",
+            UPDATE projects
+            SET deletion_reason = 'merged into %s'
+            WHERE projectid = '%s'
+            ",
             $projectid_['to'], // validated input
             $projectid_['from'] // validated input
         );

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -93,7 +93,8 @@ if ($action == 'show_specials') {
     $sql = "
         SELECT spec_code
         FROM special_days
-        ORDER BY open_month, open_day";
+        ORDER BY open_month, open_day
+    ";
     $result = DPDatabase::query($sql);
     echo "<br>\n\n";
     echo "<table class='list_special_days'>\n";
@@ -136,7 +137,8 @@ class SpecialDay
                 "
                 SELECT *
                 FROM special_days
-                WHERE spec_code = '%s'",
+                WHERE spec_code = '%s'
+                ",
                 DPDatabase::escape($spec_code)
             );
             $result = DPDatabase::query($sql);
@@ -362,7 +364,8 @@ class SpecialDay
             "
             UPDATE special_days
             SET $field = '%s'
-            WHERE spec_code = '%s'",
+            WHERE spec_code = '%s'
+            ",
             DPDatabase::escape($value),
             DPDatabase::escape($this->spec_code)
         );

--- a/tools/site_admin/project_jump.php
+++ b/tools/site_admin/project_jump.php
@@ -117,11 +117,15 @@ function do_stuff($projectid, $new_state, $just_checking)
 
     // ----------------------------------------------------
 
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE projects
         SET state = '%s', modifieddate = UNIX_TIMESTAMP()
         WHERE projectid = '%s'
-    ", DPDatabase::escape($new_state), DPDatabase::escape($projectid));
+        ",
+        DPDatabase::escape($new_state),
+        DPDatabase::escape($projectid)
+    );
     DPDatabase::query($sql);
     echo "    jumped to : $new_state\n";
     $project->log_project_event(

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -127,7 +127,7 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
                     item_type    = LEFT('%s', 16),
                     header       = LEFT('%s', 256),
                     content      = '%s'
-            ",
+                ",
                 DPDatabase::escape($news_page_id),
                 time(),
                 DPDatabase::escape($item_status),
@@ -139,7 +139,9 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
             DPDatabase::query($sql);
             // by default, new items go at the top
             $sql = "
-                UPDATE news_items SET ordering = id WHERE id = LAST_INSERT_ID()
+                UPDATE news_items
+                SET ordering = id
+                WHERE id = LAST_INSERT_ID()
             ";
             DPDatabase::query($sql);
             news_change_made($news_page_id);
@@ -147,10 +149,10 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
 
         case 'delete':
             // Delete a specific site news item
-            $sql = sprintf("
-                DELETE FROM news_items
-                WHERE id = %d
-            ", $item_id);
+            $sql = sprintf(
+                "DELETE FROM news_items WHERE id = %d",
+                $item_id
+            );
             DPDatabase::query($sql);
             break;
 
@@ -201,7 +203,7 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
                     header    = LEFT('%s', 256),
                     content   = '%s'
                 WHERE id = %d
-            ",
+                ",
                 DPDatabase::escape($item_status),
                 DPDatabase::escape($locale),
                 DPDatabase::escape($item_type),
@@ -211,11 +213,14 @@ function handle_any_requested_db_updates($news_page_id, $action, $item_id, $head
             );
             DPDatabase::query($sql);
 
-            $sql = sprintf("
+            $sql = sprintf(
+                "
                 SELECT status
                 FROM news_items
                 WHERE id = %d
-            ", $item_id);
+                ",
+                $item_id
+            );
             $result = DPDatabase::query($sql);
             $row = mysqli_fetch_assoc($result);
             $visible_change_made = ($row['status'] == 'current');
@@ -238,11 +243,14 @@ function show_item_editor($news_page_id, $action, $item_id)
     global $item_type_options;
 
     if (isset($action) && $action == "edit") {
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             SELECT header, content, status, locale, item_type
             FROM news_items
             WHERE id = %d
-        ", $item_id);
+            ",
+            $item_id
+        );
         $result = DPDatabase::query($sql);
         $row = mysqli_fetch_assoc($result);
         $header = $row["header"];
@@ -357,7 +365,7 @@ function show_all_news_items_for_page($news_page_id)
             FROM news_items
             WHERE news_page_id = '%s' AND status = '%s'
             ORDER BY {$category['order_by']}
-        ",
+            ",
             DPDatabase::escape($news_page_id),
             DPDatabase::escape($status)
         );
@@ -414,11 +422,15 @@ function show_all_news_items_for_page($news_page_id)
 
 function update_news_item_status($item_id, $status)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         UPDATE news_items
         SET status = '%s'
         WHERE id = %d
-    ", DPDatabase::escape($status), $item_id);
+        ",
+        DPDatabase::escape($status),
+        $item_id
+    );
     DPDatabase::query($sql);
 }
 
@@ -430,7 +442,7 @@ function news_change_made($news_page_id)
         "
         REPLACE INTO news_pages
         SET news_page_id = '%s', t_last_change = %d
-    ",
+        ",
         DPDatabase::escape($news_page_id),
         time()
     );
@@ -441,22 +453,29 @@ function news_change_made($news_page_id)
 
 function move_news_item($news_page_id, $id_of_item_to_move, $direction)
 {
-    $sql = sprintf("
+    $sql = sprintf(
+        "
         SELECT *
         FROM news_items
         WHERE news_page_id = '%s' AND status = 'current'
         ORDER BY ordering
-    ", DPDatabase::escape($news_page_id));
+        ",
+        DPDatabase::escape($news_page_id)
+    );
     $result = DPDatabase::query($sql);
 
     $i = 1 ;
     while ($news_item = mysqli_fetch_assoc($result)) {
         $curr_id = $news_item['id'];
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE news_items
             SET ordering = %d
             WHERE id = %d
-        ", $i, $curr_id);
+            ",
+            $i,
+            $curr_id
+        );
         DPDatabase::query($sql);
         if (intval($curr_id) == intval($id_of_item_to_move)) {
             $old_pos = $i;
@@ -471,18 +490,27 @@ function move_news_item($news_page_id, $id_of_item_to_move, $direction)
             $new_pos = $old_pos - 1;
         }
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE news_items
             SET ordering = %d
             WHERE news_page_id = '%s' AND status = 'current' AND ordering = $new_pos
-        ", $old_pos, DPDatabase::escape($news_page_id), $new_pos);
+            ",
+            $old_pos,
+            DPDatabase::escape($news_page_id),
+            $new_pos
+        );
         DPDatabase::query($sql);
 
-        $sql = sprintf("
+        $sql = sprintf(
+            "
             UPDATE news_items
             SET ordering = %d
             WHERE id = %d
-        ", $new_pos, $id_of_item_to_move);
+            ",
+            $new_pos,
+            $id_of_item_to_move
+        );
         DPDatabase::query($sql);
     }
 }

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -263,7 +263,7 @@ if (!isset($action)) {
                 UPDATE projects
                 SET postcomments = CONCAT(postcomments, '%s')
                 WHERE projectid = '%s'
-            ",
+                ",
                 DPDatabase::escape($postcomments),
                 DPDatabase::escape($projectid)
             );


### PR DESCRIPTION
This standardizes the whitespace around our SQL to one of three formats:
* `sprintf()` with single-line SQL
   ```php
   $sql = sprintf(
       "SELECT * FROM table WHERE x = %d",
       $some_variable
   );
   ```
* `sprintf()` with multi-line SQL
   ```php
   $sql = sprintf(
       "
       SELECT *
       FROM table
       WHERE x = %d
       ",
       $some_variable
   );
   ```
* non-`sprintf()` with multi-line SQL
   ```php
   $sql = "
      SELECT *
      FROM table
      WHERE x = 1
   ";
   ```

This establishes the pattern where multi-line SQL statements do not contain quotes.

An alternative which was considered was the following formats which seemed less readable:
```php
$sql = sprintf(
    "SELECT *
    FROM table
    WHERE x = %d",
    $some_variable
);

$sql = "SELECT *
   FROM table
   WHERE x = 1";
```

Thoughts & discussion on the above formats are welcome in this PR.

---

The PR has only whitespace changes (including newlines) except for the following 3 files which had `DPDatabase::query(sprintf("")))` calls broken out into two separate calls:
* `api/v1_stats.inc`
* `pinc/DPDatabase.inc`
* `default.php`
* `SETUP/MediaWiki_extensions/dpExtensions.php`

Whitespace-only changes were confirmed via the following (courtesy of [this StackExchange answer](https://stackoverflow.com/questions/33159394/ignore-all-whitespace-changes-with-git-diff-between-commits)):
```
git -c core.whitespace=-trailing-space,-indent-with-non-tab,-tab-in-indent diff -U0 --word-diff-regex='[^[:space:]]'
```

A sandbox is available at [standardize-sql-formatting](https://www.pgdp.org/~cpeel/c.branch/standardize-sql-formatting/) although the whitespace-only changes should not need testing.