### PR TITLE
add proofing api functions and tests

### DIFF
--- a/SETUP/tests/ApiTest.php
+++ b/SETUP/tests/ApiTest.php
@@ -4,6 +4,88 @@
 
 class ApiTest extends ProjectUtils
 {
+    //---------------------------------------------------------------------------
+    // helper functions
+
+    protected function checkout(string $projectid, string $project_state, int $npages = 1): array
+    {
+        $path = "v1/projects/$projectid/checkout";
+        $router = ApiRouter::get_router();
+        $_SERVER["REQUEST_METHOD"] = "PUT";
+        return $router->route($path, ['projstate' => $project_state, 'npage' => (string)$npages]);
+    }
+
+    protected function return_pages(string $projectid, string $project_state): void
+    {
+        $path = "v1/projects/$projectid/returnpages";
+        $router = ApiRouter::get_router();
+        $_SERVER["REQUEST_METHOD"] = "PUT";
+        $router->route($path, ['projstate' => $project_state]);
+    }
+
+    protected function get_next_outpage(string $projectid, string $project_state): array
+    {
+        $path = "v1/projects/$projectid/nextpage";
+        $router = ApiRouter::get_router();
+        $_SERVER["REQUEST_METHOD"] = "GET";
+        return $router->route($path, ['projstate' => $project_state]);
+    }
+
+    protected function get_data(string $projectid, string $project_state): array
+    {
+        $path = "v1/projects/$projectid/proofdata";
+        $router = ApiRouter::get_router();
+        $_SERVER["REQUEST_METHOD"] = "GET";
+        return $router->route($path, ['projstate' => "$project_state"]);
+    }
+
+    protected function resume(string $projectid, string $project_state, string $page_name, string $page_state): array
+    {
+        return $this->api_project_page($projectid, $project_state, $page_name, $page_state, [], "resumepage");
+    }
+
+    protected function return_to_round(string $projectid, string $project_state, string $page_name, string $page_state): void
+    {
+        $this->api_project_page($projectid, $project_state, $page_name, $page_state, [], "return");
+    }
+
+    protected function save_as_in_progress(string $projectid, string $project_state, string $page_name, string $page_state, string $text): array
+    {
+        return $this->api_project_page($projectid, $project_state, $page_name, $page_state, ["text" => $text], "savetemp");
+    }
+
+    protected function save_revert(string $projectid, string $project_state, string $page_name, string $page_state, string $text): array
+    {
+        return $this->api_project_page($projectid, $project_state, $page_name, $page_state, ["text" => $text], "saverevert");
+    }
+
+    protected function save_as_done(string $projectid, string $project_state, string $page_name, string $page_state, string $text): void
+    {
+        $this->api_project_page($projectid, $project_state, $page_name, $page_state, ["text" => $text], "saveasdone");
+    }
+
+    protected function get_text(string $projectid, string $project_state, string $page_name, string $page_state): array
+    {
+        $_SERVER["REQUEST_METHOD"] = "GET";
+        $path = "v1/projects/$projectid/pages/$page_name/text";
+        $router = ApiRouter::get_router();
+        return $router->route($path, ['projstate' => $project_state, 'pagestate' => $page_state]);
+    }
+
+    private function api_project_page(string $projectid, string $project_state, string $page_name, string $page_state, array $request_array = [], string $action)
+    {
+        global $request_body;
+
+        $_SERVER["REQUEST_METHOD"] = "PUT";
+        $request_body = $request_array;
+        $path = "v1/projects/$projectid/pages/$page_name/$action";
+        $router = ApiRouter::get_router();
+        return $router->route($path, ['projstate' => $project_state, 'pagestate' => $page_state]);
+    }
+
+    //---------------------------------------------------------------------------
+    // tests
+
     public function test_get_invalid_project_info()
     {
         $this->expectExceptionCode(101);
@@ -90,6 +172,482 @@ class ApiTest extends ProjectUtils
         $router = ApiRouter::get_router();
         $_SERVER["REQUEST_METHOD"] = "POST";
         $router->route($path, $query_params);
+    }
+
+    //---------------------------------------------------------------------------
+    // tests for proofreading
+
+    public function test_checkout_bad_projectid()
+    {
+        global $pguser;
+        $pguser = $this->TEST_USERNAME;
+
+        $this->expectExceptionCode(101);
+
+        $this->checkout("projectId", "P1.proj_avail");
+    }
+
+    public function test_checkout_invalid_proj_state()
+    {
+        global $pguser;
+        $pguser = $this->TEST_USERNAME;
+
+        $this->expectExceptionCode(121);
+
+        $project = $this->_create_project();
+        $this->checkout($project->projectid, "project_ne");
+    }
+
+    public function test_project_no_state_given()
+    {
+        global $pguser;
+
+        $this->expectExceptionCode(122);
+
+        $project = $this->_create_project();
+        $pguser = $this->TEST_USERNAME;
+
+        $path = "v1/projects/$project->projectid/returnpages";
+        $router = ApiRouter::get_router();
+        $_SERVER["REQUEST_METHOD"] = "PUT";
+        $router->route($path, []);
+    }
+
+    public function test_checkout_wrong_proj_state()
+    {
+        global $pguser;
+        $pguser = $this->TEST_USERNAME;
+
+        $this->expectExceptionCode(120);
+
+        $project = $this->_create_project();
+        $this->checkout($project->projectid, "P1.proj_bad");
+    }
+
+    public function test_project_not_in_round()
+    {
+        global $pguser;
+
+        $this->expectExceptionCode(110);
+
+        $project = $this->_create_project();
+        $pguser = $this->TEST_USERNAME;
+
+        $this->checkout($project->projectid, "project_new");
+    }
+
+    public function test_project_unavailable()
+    {
+        global $pguser;
+
+        $this->expectExceptionCode(112);
+
+        $project = $this->_create_project();
+        $pguser = $this->TEST_USERNAME;
+        $this->quiet_project_transition($project->projectid, PROJ_P1_UNAVAILABLE, $this->TEST_USERNAME_PM);
+
+        $this->checkout($project->projectid, "P1.proj_unavail");
+    }
+
+    public function test_user_not_qualified_for_round()
+    {
+        global $pguser;
+        $pguser = $this->TEST_USERNAME;
+        // see comment in SettingsClass.inc about calling by reference
+        $settings = & Settings::get_settings($this->TEST_USERNAME);
+        $settings->set_boolean("P2.access", false);
+
+        $this->expectExceptionCode(302);
+
+        $project = $this->_create_available_project();
+        $this->advance_to_round2($project->projectid);
+
+        $this->checkout($project->projectid, "P2.proj_avail");
+    }
+
+    public function test_project_checkout_available()
+    {
+        global $pguser;
+
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_USERNAME;
+
+        // verify there are no pages checked out
+        $this->assertEquals(0, $this->get_data($project->projectid, "P1.proj_avail")["outpages"]);
+
+        $response = $this->checkout($project->projectid, "P1.proj_avail");
+        $expected = [
+            'reason' => '',
+            'status' => 0,
+            'npages' => 1,
+        ];
+        $this->assertEquals($expected, $response);
+
+        // get page name and state
+        $response = $this->get_next_outpage($project->projectid, "P1.proj_avail");
+        $expected = [
+            'pagename' => '001.png',
+            'image_url' => "{$project->url}/001.png",
+            'text' => $this->TEST_TEXT,
+            'pagestate' => "P1.page_out",
+            'saved' => false,
+            'pageNum' => '001',
+            'roundInfoArray' => [],
+        ];
+        $this->assertEquals($expected, $response);
+
+        // try to checkout a page when there are already pages out
+        $this->expectExceptionCode(117);
+        $this->checkout($project->projectid, "P1.proj_avail");
+    }
+
+    public function test_project_checkout_pages()
+    {
+        global $pguser;
+
+        // new project, new user
+        $project = $this->_create_available_project(2);
+        $pguser = $this->TEST_USERNAME;
+
+        $response = $this->checkout($project->projectid, "P1.proj_avail", 5);
+        // insufficient pages
+        $this->assertEquals(113, $response['status']);
+        $this->assertEquals(2, $response['npages']);
+
+        $this->return_pages($project->projectid, "P1.proj_avail");
+        $this->assertEquals(0, $this->get_data($project->projectid, "P1.proj_avail")["outpages"]);
+
+        // try to get next out page
+        $this->expectExceptionCode(116);
+        $this->get_next_outpage($project->projectid, "P1.proj_avail");
+    }
+
+    public function test_many_pages_few_days()
+    {
+        // user done many pages but few days on site
+        // $page_tally_threshold 500 for new projects in reserve time
+
+        global $pguser;
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_USERNAME;
+        page_tallies_add("P1", $pguser, 501);
+        $response = $this->checkout($project->projectid, "P1.proj_avail");
+        $this->assertEquals(0, $response['status']);
+    }
+
+    public function test_few_pages_many_days()
+    {
+        global $pguser;
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_OLDUSERNAME;
+        $response = $this->checkout($project->projectid, "P1.proj_avail");
+        $this->assertEquals(0, $response['status']);
+    }
+
+    public function test_many_pages_many_days()
+    {
+        global $pguser;
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_OLDUSERNAME;
+        page_tallies_add("P1", $pguser, 501);
+
+        // reserved for new proofreaders
+        $this->expectExceptionCode(306);
+        $this->checkout($project->projectid, "P1.proj_avail");
+    }
+
+    public function test_beginner_project_checkout()
+    {
+        global $pguser;
+
+        $this->valid_project_data["difficulty"] = "beginner";
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_USERNAME;
+        // beginners limit is 40 in user_is.inc
+        page_tallies_add("P1", $pguser, 50);
+
+        $this->expectExceptionCode(303);
+        $this->checkout($project->projectid, "P1.proj_avail");
+    }
+
+    public function test_beginner_mentor_project_checkout()
+    {
+        global $pguser;
+
+        $this->expectExceptionCode(305);
+
+        $this->valid_project_data["difficulty"] = "beginner";
+        $project = $this->_create_available_project();
+        $this->advance_to_round2($project->projectid);
+        $pguser = $this->TEST_USERNAME;
+        $settings = & Settings::get_settings($this->TEST_USERNAME);
+        $settings->set_boolean("P2.access", true);
+
+        $this->checkout($project->projectid, "P2.proj_avail");
+    }
+
+    public function test_project_checkout_too_many_pages()
+    {
+        global $pguser;
+
+        // new project, new user
+        $project = $this->_create_available_project(2);
+        $pguser = $this->TEST_USERNAME;
+
+        $this->expectExceptionCode(118);
+        $response = $this->checkout($project->projectid, "P1.proj_avail", 20);
+    }
+
+    public function test_get_page_data()
+    {
+        global $pguser;
+
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_USERNAME;
+
+        $this->checkout($project->projectid, "P1.proj_avail");
+        $response = $this->resume($project->projectid, 'P1.proj_avail', '001.png', 'P1.page_out');
+        $expected =
+        [
+            'pagename' => '001.png',
+            'image_url' => "{$project->url}/001.png",
+            'text' => $this->TEST_TEXT,
+            'pagestate' => "P1.page_out",
+            'saved' => false,
+            'pageNum' => '001',
+            'roundInfoArray' => [],
+        ];
+
+        $this->assertEquals($expected, $response);
+    }
+
+    public function test_project_return_to_round()
+    {
+        global $pguser;
+
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_USERNAME;
+
+        // check out a page
+        $this->checkout($project->projectid, "P1.proj_avail");
+
+        // return it to round
+        $this->return_to_round($project->projectid, 'P1.proj_avail', '001.png', 'P1.page_out');
+        $this->assertEquals(0, $this->get_data($project->projectid, "P1.proj_avail")["outpages"]);
+    }
+
+    public function test_return_page_no_state()
+    {
+        global $pguser;
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project();
+
+        $this->expectExceptionCode(124);
+
+        $_SERVER["REQUEST_METHOD"] = "PUT";
+        $path = "v1/projects/$project->projectid/pages/001.png/return";
+        $router = ApiRouter::get_router();
+        $router->route($path, ['projstate' => "P1.proj_avail"]);
+    }
+
+    public function test_return_non_existent_page()
+    {
+        global $pguser;
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project();
+
+        $this->expectExceptionCode(104);
+        $this->return_to_round($project->projectid, "P1.proj_avail", "002.png", "P1.page_out");
+    }
+
+    public function test_return_invalid_page_state()
+    {
+        global $pguser;
+
+        $this->expectExceptionCode(123);
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project();
+
+        $this->return_to_round($project->projectid, "P1.proj_avail", "001.png", "P1.page_in");
+    }
+
+    public function test_return_page_state_not_as_in_project()
+    {
+        global $pguser;
+
+        $this->expectExceptionCode(119);
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project();
+
+        $this->return_to_round($project->projectid, "P1.proj_avail", "001.png", "P1.page_out");
+    }
+
+    public function test_return_page_state_not_allowed()
+    {
+        global $pguser;
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project();
+        $this->checkout($project->projectid, "P1.proj_avail");
+
+        $this->return_to_round($project->projectid, "P1.proj_avail", "001.png", "P1.page_out");
+
+        $this->expectExceptionCode(115);
+        // user still appears to own this page. Can't return from available.
+        $this->return_to_round($project->projectid, "P1.proj_avail", "001.png", "P1.page_avail");
+    }
+
+    public function test_return_page_not_owned()
+    {
+        global $pguser;
+
+        $this->expectExceptionCode(307);
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project();
+
+        // check out a page
+        $this->checkout($project->projectid, "P1.proj_avail");
+
+        // let another user return it to round
+        $pguser = $this->TEST_USERNAME_PM;
+        $this->return_to_round($project->projectid, "P1.proj_avail", "001.png", "P1.page_out");
+    }
+
+    public function test_save_as_in_progress()
+    {
+        global $pguser;
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project();
+
+        // check out a page
+        $this->checkout($project->projectid, "P1.proj_avail");
+
+        // save as in progress
+        $response = $this->save_as_in_progress($project->projectid, "P1.proj_avail", "001.png", "P1.page_out", $this->TEST_MODIFIED_TEXT);
+        $expected = [
+            "text" => $this->TEST_MODIFIED_TEXT,
+            'pagestate' => "P1.page_temp",
+            'saved' => true,
+            'good' => true,
+        ];
+
+        $this->assertEquals($expected, $response);
+
+        // get original text back
+        $response = $this->save_revert($project->projectid, "P1.proj_avail", "001.png", "P1.page_temp", $this->TEST_MODIFIED_TEXT);
+        $this->assertEquals($this->TEST_TEXT, $response["text"]);
+
+        // get last saved text
+        $response = $this->get_text($project->projectid, "P1.proj_avail", "001.png", "P1.page_temp");
+        $this->assertEquals(["text" => $this->TEST_MODIFIED_TEXT], $response);
+
+        // save bad text
+        $response = $this->save_as_in_progress($project->projectid, "P1.proj_avail", "001.png", "P1.page_temp", "This is a bĀd test file");
+        $expected = [
+            'good' => false,
+            'mark_array' => [["This is a b", 0], ["Ā", 1], ["d test file", 0]],
+        ];
+
+        $this->assertEquals($expected, $response);
+    }
+
+    public function test_save_as_done()
+    {
+        global $pguser;
+
+        $pguser = $this->TEST_USERNAME;
+        $project = $this->_create_available_project(2);
+
+        // check out a page
+        $this->checkout($project->projectid, "P1.proj_avail");
+
+        // get user's tally
+        $user = new User($pguser);
+        $user_tallyboard = new TallyBoard("P1", 'U');
+        $tally = $user_tallyboard->get_current_tally($user->u_id);
+
+        // save as done
+        $this->save_as_done($project->projectid, "P1.proj_avail", "001.png", "P1.page_out", $this->TEST_MODIFIED_TEXT);
+
+        // check tally has increased by one
+        $this->assertEquals(1, $user_tallyboard->get_current_tally($user->u_id) - $tally);
+
+        // reopen
+        $response = $this->resume($project->projectid, "P1.proj_avail", "001.png", "P1.page_saved");
+        $expected =
+        [
+            'pagename' => '001.png',
+            'image_url' => "{$project->url}/001.png",
+            'text' => $this->TEST_MODIFIED_TEXT,
+            'pagestate' => "P1.page_temp",
+            'saved' => true,
+            'pageNum' => '001',
+            'roundInfoArray' => [],
+        ];
+
+        $this->assertEquals($expected, $response);
+        // check tally back to original value
+        $this->assertEquals($user_tallyboard->get_current_tally($user->u_id), $tally);
+
+        // test daily limit
+        $round = get_Round_for_round_id("P1");
+        $old_limit = $round->daily_page_limit;
+        $round->daily_page_limit = 1;
+        // check reaching limit
+        try {
+            $this->save_as_done($project->projectid, "P1.proj_avail", '001.png', "P1.page_temp", $this->TEST_MODIFIED_TEXT);
+        } catch (ApiException $exception) {
+            $this->assertEquals(309, $exception->getCode());
+        }
+
+        // checkout another page
+        $this->checkout($project->projectid, "P1.proj_avail");
+        try {
+            $this->save_as_done($project->projectid, "P1.proj_avail", '002.png', "P1.page_out", $this->TEST_MODIFIED_TEXT);
+        } catch (ApiException $exception) {
+            $this->assertEquals(308, $exception->getCode());
+        }
+        // check that page has been saved as in progress,
+        // if saved as done this will fail with wrong state,
+        // if not saved at all the text will not be modified
+        $response = $this->resume($project->projectid, "P1.proj_avail", '002.png', "P1.page_temp");
+        $this->assertEquals($response["text"], $this->TEST_MODIFIED_TEXT);
+
+        // reset daily limit
+        $round->daily_page_limit = $old_limit;
+    }
+
+    public function test_info_for_previous_proofreaders()
+    {
+        global $pguser;
+
+        $project = $this->_create_available_project();
+        $pguser = $this->TEST_USERNAME;
+        $this->checkout($project->projectid, "P1.proj_avail");
+        $this->save_as_done($project->projectid, "P1.proj_avail", '001.png', "P1.page_out", $this->TEST_MODIFIED_TEXT);
+
+        $this->advance_to_round2($project->projectid);
+        $pguser = $this->TEST_OLDUSERNAME;
+        $settings = & Settings::get_settings($this->TEST_OLDUSERNAME);
+        $settings->set_boolean("P2.access", true);
+        $this->checkout($project->projectid, "P2.proj_avail");
+        $response = $this->get_next_outpage($project->projectid, "P2.proj_avail");
+        $this->assertEquals([['P1', $this->TEST_USERNAME]], $response['roundInfoArray']);
+        $this->save_as_done($project->projectid, "P2.proj_avail", '001.png', "P2.page_out", $this->TEST_MODIFIED_TEXT);
+
+        $this->advance_to_round3($project->projectid);
+        $pguser = $this->TEST_USERNAME_PM;
+        $settings = & Settings::get_settings($this->TEST_USERNAME_PM);
+        $settings->set_boolean("P3.access", true);
+        $this->checkout($project->projectid, "P3.proj_avail");
+        $response = $this->get_next_outpage($project->projectid, "P3.proj_avail");
+        $this->assertEquals([['P1', $this->TEST_USERNAME], ['P2', $this->TEST_OLDUSERNAME]], $response['roundInfoArray']);
     }
 }
 

--- a/SETUP/tests/ProjectUtils.inc
+++ b/SETUP/tests/ProjectUtils.inc
@@ -32,7 +32,7 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
         create_test_user($this->TEST_USERNAME);
         // give access to P1 in production
         // see comment in SettingsClass.inc about calling by reference
-        $settings =& Settings::get_settings($this->TEST_USERNAME);
+        $settings = & Settings::get_settings($this->TEST_USERNAME);
         $settings->set_boolean("P1.access", true);
 
 

--- a/SETUP/tests/ProjectUtils.inc
+++ b/SETUP/tests/ProjectUtils.inc
@@ -19,6 +19,7 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
     ];
     protected $created_projectids = [];
     protected $TEST_TEXT = "This is a test file";
+    protected $TEST_MODIFIED_TEXT = "This is a modified test file";
 
     protected function setUp(): void
     {
@@ -29,6 +30,11 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
         $settings->set_boolean("manager", true);
 
         create_test_user($this->TEST_USERNAME);
+        // give access to P1 in production
+        // see comment in SettingsClass.inc about calling by reference
+        $settings =& Settings::get_settings($this->TEST_USERNAME);
+        $settings->set_boolean("P1.access", true);
+
 
         // create an old user (new users $days_on_site_threshold = 21)
         create_test_user($this->TEST_OLDUSERNAME, 22);
@@ -92,6 +98,13 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
         $this->quiet_project_transition($projectid, PROJ_P1_COMPLETE, PT_AUTO);
         $this->quiet_project_transition($projectid, PROJ_P2_WAITING_FOR_RELEASE, PT_AUTO);
         $this->quiet_project_transition($projectid, PROJ_P2_AVAILABLE, PT_AUTO);
+    }
+
+    protected function advance_to_round3($projectid)
+    {
+        $this->quiet_project_transition($projectid, PROJ_P2_COMPLETE, PT_AUTO);
+        $this->quiet_project_transition($projectid, PROJ_P3_WAITING_FOR_RELEASE, PT_AUTO);
+        $this->quiet_project_transition($projectid, PROJ_P3_AVAILABLE, PT_AUTO);
     }
 
     protected function _create_project_with_pages($npage = 1)

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -678,6 +678,315 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/{projectid}/checkout:
+    put:
+      tags:
+      - project
+      description: Check out some pages for proofreading
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      - name: npage
+        in: query
+        description: number of pages to checkout
+        required: false
+        schema:
+          type: integer
+          default: 1
+      responses:
+        200:
+          description: result status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/checkout_status'
+              example:
+                status: 303
+                reason: You have reached your quota of pages from 'Beginners Only' projects in this round.
+                npages: 2
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/mentorcheckout:
+    put:
+      tags:
+      - project
+      description: Finds the 'oldest' mentee and checks out all his/her pages.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      responses:
+        200:
+          description: no content
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/returnpages:
+    put:
+      tags:
+      - project
+      description: Returns all the user's checked out pages to the round.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      responses:
+        200:
+          description: no content
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/nextpage:
+    get:
+      tags:
+      - project
+      description: Gets data for the next checked out page.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      responses:
+        200:
+          description: page data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/proof_page_data'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/proofdata:
+    get:
+      tags:
+      - project
+      description: Gets project data for proofreading.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      responses:
+        200:
+          description: mentor mode and number of checked out pages
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/proof_data'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/resumepage:
+    put:
+      tags:
+      - project
+      description: If the page is saved-as-done 'unsaves' it, gets data for the given page.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      - $ref: '#/components/parameters/pagename'
+      - $ref: '#/components/parameters/pagestate'
+      responses:
+        200:
+          description: page data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/proof_page_data'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/saveasdone:
+    put:
+      tags:
+      - project
+      description: Checks the page for invalid characters and if good, saves it as done. Else returns data indicating the bad characters.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      - $ref: '#/components/parameters/pagename'
+      - $ref: '#/components/parameters/pagestate'
+      requestBody:
+        $ref: '#/components/requestBodies/TextBody'
+      responses:
+        200:
+          description: page data
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/good_page_saved'
+                  - $ref: '#/components/schemas/bad_page'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/savetemp:
+    put:
+      tags:
+      - project
+      description: Checks the page for invalid characters and if good, saves it as in progress, returns page text and state. Else returns data indicating the bad characters.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      - $ref: '#/components/parameters/pagename'
+      - $ref: '#/components/parameters/pagestate'
+      requestBody:
+        $ref: '#/components/requestBodies/TextBody'
+      responses:
+        200:
+          description: page data
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/bad_page'
+                  - $ref: '#/components/schemas/good_page_temp'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/saverevert:
+    put:
+      tags:
+      - project
+      description: Checks the page for invalid characters and if good, saves it as in progress, returns original page text and current state.  Else returns data indicating the bad characters.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      - $ref: '#/components/parameters/pagename'
+      - $ref: '#/components/parameters/pagestate'
+      requestBody:
+        $ref: '#/components/requestBodies/TextBody'
+      responses:
+        200:
+          description: page data
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/good_page_temp'
+                  - $ref: '#/components/schemas/bad_page'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/return:
+    put:
+      tags:
+      - project
+      description: Returns the page to the round.
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      - $ref: '#/components/parameters/pagename'
+      - $ref: '#/components/parameters/pagestate'
+      responses:
+        200:
+          description: no content
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/text:
+    get:
+      tags:
+      - project
+      description: Gets the current (last saved) page text
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/projectstate'
+      - $ref: '#/components/parameters/pagename'
+      - $ref: '#/components/parameters/pagestate'
+      responses:
+        200:
+          description: page text
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/proof_page_text'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /stats/site:
     get:
       tags:
@@ -732,6 +1041,51 @@ components:
       type: apiKey
       in: header
       name: X-API-KEY
+
+  parameters:
+    projectid:
+      name: projectid
+      in: path
+      description: ID of project
+      required: true
+      schema:
+        type: string
+
+    projectstate:
+      name: projstate
+      in: query
+      description: Project state
+      required: true
+      schema:
+        type: string
+
+    pagename:
+      name: pagename
+      in: path
+      description: name of page
+      required: true
+      schema:
+        type: string
+
+    pagestate:
+      name: pagestate
+      in: query
+      description: page state
+      required: true
+      schema:
+        type: string
+
+  requestBodies:
+    TextBody:
+      description: Text to save
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              text:
+                type: string
 
   schemas:
     project:
@@ -1019,6 +1373,99 @@ components:
       type: array
       items:
         type: string
+
+    checkout_status:
+      description: npages is the number of pages actually checked out. status is 0 if the required number of pages is checked out, Otherwise the status code for the reason why fewer pages are available. If no pages are available throws an Error with the code and reason. In either case reasons are "No more pages are available", "Beginners Quota Reached", "Beginners Project Quota Reached".
+      type: object
+      properties:
+        status:
+          type: integer
+        reason:
+          type: string
+        npages:
+          type: integer
+
+    proof_page_text:
+      type: object
+      properties:
+        text:
+          description: the page text from current round.
+          type: string
+
+    proof_page_data:
+      type: object
+      properties:
+        text:
+          description: the page text. If page state is 'out' from OCR or previous round, else from current round
+          type: string
+        pagestate:
+          description: the page state, for checking continuity. Either out or temp
+          type: string
+        saved:
+          description: true if the page state is 'temp'
+          type: boolean
+        pagename:
+          description: the filename of the page with extension
+          type: string
+        image_url:
+          description: url of the image of the page
+          type: string
+        pageNum:
+          description: page "number" without extension
+          type: string
+        roundInfoArray:
+          description: array of names of proofreaders in earlier rounds
+          type: array
+          items:
+            type: string
+
+    proof_data:
+      type: object
+      properties:
+        outpages:
+          description: the number of pages checked out to the user.
+          type: integer
+        mentormode:
+          description: is a beginner's project in a mentor round.
+          type: boolean
+
+    good_page_saved:
+      type: object
+      properties:
+        good:
+          type: boolean
+          enum: [true]
+
+    good_page_temp:
+      type: object
+      properties:
+        good:
+          type: boolean
+          enum: [true]
+        text:
+          type: string
+        pagestate:
+          description: the page state, it is now temp
+          type: string
+        saved:
+          description: now true
+          type: boolean
+          enum: [true]
+
+    bad_page:
+      type: object
+      properties:
+        good:
+          type: boolean
+          enum: [false]
+        mark_array:
+          type: array
+          items:
+            type: array
+            items:
+              oneOf:
+                - type: string
+                - type: integer
 
     Error:
       required:

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -811,46 +811,21 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
-  /projects/{projectid}/pages/{pagename}/resumepage:
+  /projects/{projectid}/pages/{pagename}:
     put:
       tags:
       - project
-      description: If the page is saved-as-done 'unsaves' it, gets data for the given page.
+      description: various operations on the page as determined by the 'pagefunction' parameter.<br><br>
+        resume If the page is saved-as-done 'unsaves' it, gets data for the given page.<br><br>
+        saveasdone Checks the page for invalid characters and if good, saves it as done. Else returns data indicating the bad characters.<br><br>
+        savetemp Checks the page for invalid characters and if good, saves it as in progress, returns page text and state. Else returns data indicating the bad characters.<br><br>
+        saverevert Checks the page for invalid characters and if good, saves it as in progress, returns original page text and current state.  Else returns data indicating the bad characters.<br><br>
+        return Returns the page to the round.
       parameters:
       - $ref: '#/components/parameters/projectid'
       - $ref: '#/components/parameters/projectstate'
       - $ref: '#/components/parameters/pagename'
       - $ref: '#/components/parameters/pagestate'
-      responses:
-        200:
-          description: page data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/proof_page_data'
-        '400':
-          $ref: '#/components/responses/InvalidValue'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '429':
-          $ref: '#/components/responses/RateLimitExceeded'
-        default:
-          $ref: '#/components/responses/UnexpectedError'
-
-  /projects/{projectid}/pages/{pagename}/saveasdone:
-    put:
-      tags:
-      - project
-      description: Checks the page for invalid characters and if good, saves it as done. Else returns data indicating the bad characters.
-      parameters:
-      - $ref: '#/components/parameters/projectid'
-      - $ref: '#/components/parameters/projectstate'
-      - $ref: '#/components/parameters/pagename'
-      - $ref: '#/components/parameters/pagestate'
-      requestBody:
-        $ref: '#/components/requestBodies/TextBody'
       responses:
         200:
           description: page data
@@ -858,39 +833,9 @@ paths:
             application/json:
               schema:
                 oneOf:
+                  - $ref: '#/components/schemas/proof_page_data'
                   - $ref: '#/components/schemas/good_page_saved'
                   - $ref: '#/components/schemas/bad_page'
-        '400':
-          $ref: '#/components/responses/InvalidValue'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '429':
-          $ref: '#/components/responses/RateLimitExceeded'
-        default:
-          $ref: '#/components/responses/UnexpectedError'
-
-  /projects/{projectid}/pages/{pagename}/savetemp:
-    put:
-      tags:
-      - project
-      description: Checks the page for invalid characters and if good, saves it as in progress, returns page text and state. Else returns data indicating the bad characters.
-      parameters:
-      - $ref: '#/components/parameters/projectid'
-      - $ref: '#/components/parameters/projectstate'
-      - $ref: '#/components/parameters/pagename'
-      - $ref: '#/components/parameters/pagestate'
-      requestBody:
-        $ref: '#/components/requestBodies/TextBody'
-      responses:
-        200:
-          description: page data
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/bad_page'
                   - $ref: '#/components/schemas/good_page_temp'
         '400':
           $ref: '#/components/responses/InvalidValue'
@@ -902,64 +847,6 @@ paths:
           $ref: '#/components/responses/RateLimitExceeded'
         default:
           $ref: '#/components/responses/UnexpectedError'
-
-  /projects/{projectid}/pages/{pagename}/saverevert:
-    put:
-      tags:
-      - project
-      description: Checks the page for invalid characters and if good, saves it as in progress, returns original page text and current state.  Else returns data indicating the bad characters.
-      parameters:
-      - $ref: '#/components/parameters/projectid'
-      - $ref: '#/components/parameters/projectstate'
-      - $ref: '#/components/parameters/pagename'
-      - $ref: '#/components/parameters/pagestate'
-      requestBody:
-        $ref: '#/components/requestBodies/TextBody'
-      responses:
-        200:
-          description: page data
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/good_page_temp'
-                  - $ref: '#/components/schemas/bad_page'
-        '400':
-          $ref: '#/components/responses/InvalidValue'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '429':
-          $ref: '#/components/responses/RateLimitExceeded'
-        default:
-          $ref: '#/components/responses/UnexpectedError'
-
-  /projects/{projectid}/pages/{pagename}/return:
-    put:
-      tags:
-      - project
-      description: Returns the page to the round.
-      parameters:
-      - $ref: '#/components/parameters/projectid'
-      - $ref: '#/components/parameters/projectstate'
-      - $ref: '#/components/parameters/pagename'
-      - $ref: '#/components/parameters/pagestate'
-      responses:
-        200:
-          description: no content
-        '400':
-          $ref: '#/components/responses/InvalidValue'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '429':
-          $ref: '#/components/responses/RateLimitExceeded'
-        default:
-          $ref: '#/components/responses/UnexpectedError'
-
-  /projects/{projectid}/pages/{pagename}/text:
     get:
       tags:
       - project

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -42,12 +42,8 @@ $router->add_route("PUT", "v1/projects/:projectid/mentorcheckout", "api_v1_proje
 $router->add_route("PUT", "v1/projects/:projectid/returnpages", "api_v1_project_returnpages");
 $router->add_route("GET", "v1/projects/:projectid/nextpage", "api_v1_project_nextpage");
 $router->add_route("GET", "v1/projects/:projectid/proofdata", "api_v1_project_proofdata");
-$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/resumepage", "api_v1_project_page_resume");
-$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/saveasdone", "api_v1_project_page_saveasdone");
-$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/savetemp", "api_v1_project_page_savetemp");
-$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/saverevert", "api_v1_project_page_saverevert");
-$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/return", "api_v1_project_page_return");
-$router->add_route("GET", "v1/projects/:projectid/pages/:pagename/text", "api_v1_project_page_text");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
+$router->add_route("GET", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
 $router->add_route("GET", "v1/stats/site/rounds", "api_v1_stats_site_rounds");

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -37,6 +37,18 @@ $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages"
 $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
 
+$router->add_route("PUT", "v1/projects/:projectid/checkout", "api_v1_project_checkout");
+$router->add_route("PUT", "v1/projects/:projectid/mentorcheckout", "api_v1_project_mentorcheckout");
+$router->add_route("PUT", "v1/projects/:projectid/returnpages", "api_v1_project_returnpages");
+$router->add_route("GET", "v1/projects/:projectid/nextpage", "api_v1_project_nextpage");
+$router->add_route("GET", "v1/projects/:projectid/proofdata", "api_v1_project_proofdata");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/resumepage", "api_v1_project_page_resume");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/saveasdone", "api_v1_project_page_saveasdone");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/savetemp", "api_v1_project_page_savetemp");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/saverevert", "api_v1_project_page_saverevert");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/return", "api_v1_project_page_return");
+$router->add_route("GET", "v1/projects/:projectid/pages/:pagename/text", "api_v1_project_page_text");
+
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
 $router->add_route("GET", "v1/stats/site/rounds", "api_v1_stats_site_rounds");
 $router->add_route("GET", "v1/stats/site/rounds/:roundid", "api_v1_stats_site_round");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -692,38 +692,30 @@ function api_v1_project_proofdata($method, $data, $query_params)
     return $proof_project->get_data();
 }
 
-function api_v1_project_page_resume($method, $data, $query_params)
+function api_v1_project_page($method, $data, $query_params)
 {
     $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
-    return $proof_project_page->resume_page();
-}
-
-function api_v1_project_page_saveasdone($method, $data, $query_params)
-{
-    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
-    return $proof_project_page->attempt_save_as_done();
-}
-
-function api_v1_project_page_savetemp($method, $data, $query_params)
-{
-    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
-    return $proof_project_page->save_as_in_progress("current");
-}
-
-function api_v1_project_page_saverevert($method, $data, $query_params)
-{
-    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
-    return $proof_project_page->save_as_in_progress("original");
-}
-
-function api_v1_project_page_return($method, $data, $query_params)
-{
-    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
-    return $proof_project_page->return_to_round();
-}
-
-function api_v1_project_page_text($method, $data, $query_params)
-{
-    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
-    return $proof_project_page->render_page_text("current");
+    if ($method == "GET") {
+        return $proof_project_page->render_page_text("current");
+    }
+    // must be PUT
+    $page_function = $query_params['pagefunction'] ?? null;
+    if (null === $page_function) {
+        throw new BadRequest("No page function found in request.");
+    }
+    switch($page_function) {
+        case 'resume':
+            return $proof_project_page->resume_page();
+        case 'saveasdone':
+            return $proof_project_page->attempt_save_as_done();
+        case 'savetemp':
+            return $proof_project_page->save_as_in_progress("current");
+        case 'saverevert':
+            return $proof_project_page->save_as_in_progress("original");
+        case 'return':
+            return $proof_project_page->return_to_round();
+        default:
+            throw new BadRequest("$page_function is not a valid page function.");
+            break;
+    }
 }

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -656,3 +656,74 @@ function _get_enabled_filter($query_params)
         return $bool;
     }
 }
+
+//---------------------------------------------------------------------------
+// Proofreading functions
+
+// checkout some pages
+function api_v1_project_checkout($method, $data, array $query_params)
+{
+    $proof_project = new ProofProject($data[":projectid"], $query_params);
+    $requested_pages = get_integer_param($query_params, "npage", 1, null, null);
+    return $proof_project->checkout_pages($requested_pages);
+}
+
+function api_v1_project_mentorcheckout($method, $data, array $query_params)
+{
+    $proof_project = new ProofProject($data[":projectid"], $query_params);
+    $proof_project->mentor_checkout();
+}
+
+function api_v1_project_returnpages($method, $data, array $query_params)
+{
+    $proof_project = new ProofProject($data[":projectid"], $query_params);
+    $proof_project->return_pages();
+}
+
+function api_v1_project_nextpage($method, $data, array $query_params)
+{
+    $proof_project = new ProofProject($data[":projectid"], $query_params);
+    return $proof_project->get_outpage();
+}
+
+function api_v1_project_proofdata($method, $data, $query_params)
+{
+    $proof_project = new ProofProject($data[":projectid"], $query_params);
+    return $proof_project->get_data();
+}
+
+function api_v1_project_page_resume($method, $data, $query_params)
+{
+    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
+    return $proof_project_page->resume_page();
+}
+
+function api_v1_project_page_saveasdone($method, $data, $query_params)
+{
+    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
+    return $proof_project_page->attempt_save_as_done();
+}
+
+function api_v1_project_page_savetemp($method, $data, $query_params)
+{
+    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
+    return $proof_project_page->save_as_in_progress("current");
+}
+
+function api_v1_project_page_saverevert($method, $data, $query_params)
+{
+    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
+    return $proof_project_page->save_as_in_progress("original");
+}
+
+function api_v1_project_page_return($method, $data, $query_params)
+{
+    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
+    return $proof_project_page->return_to_round();
+}
+
+function api_v1_project_page_text($method, $data, $query_params)
+{
+    $proof_project_page = new ProofProjectPage($data[":projectid"], $data[":pagename"], $query_params);
+    return $proof_project_page->render_page_text("current");
+}

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -12,6 +12,7 @@ include_once($relPath.'special_colors.inc');
 include_once($relPath.'wordcheck_engine.inc'); // delete_project_wordcheck_events()
 include_once($relPath.'DPage.inc'); // project_allow_pages()
 include_once($relPath.'send_mail.inc');
+include_once($relPath.'../api/exceptions.inc');
 
 class UTF8ConversionException extends Exception
 {
@@ -22,7 +23,7 @@ class UTF8ConversionException extends Exception
  *
  * These exception codes range from 100 to 199
  */
-class ProjectException extends Exception
+class ProjectException extends BadRequest
 {
     public function __construct($message, $code = 100)
     {
@@ -118,7 +119,88 @@ class ProjectNotAvailableException extends ProjectException
 
 class ProjectNoMorePagesException extends ProjectException
 {
-    public function __construct($message, $code = 113)
+    public function __construct($message = null, $code = 113)
+    {
+        $message ??= _("The project has no more pages available for proofreading");
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectPageStateException extends ProjectException
+{
+    public function __construct($message, $code = 115)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectNoMoreOutPagesException extends ProjectException
+{
+    public function __construct($message, $code = 116)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectThereAreOutPagesException extends ProjectException
+{
+    public function __construct($message, $code = 117)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectTooManyPagesRequested extends ProjectException
+{
+    public function __construct($message, $code = 118)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectPageInconsistentStateException extends ProjectException
+{
+    public function __construct($message, $code = 119)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectNotInRequiredStateException extends ProjectException
+{
+    public function __construct($message, $code = 120)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectInvalidStateException extends ProjectException
+{
+    public function __construct($message, $code = 121)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectNoStateGivenException extends ProjectException
+{
+    public function __construct($message, $code = 122)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectInvalidPageStateException extends ProjectException
+{
+    public function __construct($message, $code = 123)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class ProjectNoPageStateGivenException extends ProjectException
+{
+    public function __construct($message, $code = 124)
     {
         parent::__construct($message, $code);
     }

--- a/pinc/ProofProject.inc
+++ b/pinc/ProofProject.inc
@@ -1,0 +1,598 @@
+<?php
+declare(strict_types=1);
+
+const MAX_REQUESTED_PAGES = 10;
+
+trait ProofPage
+{
+    private function render_page_data(): array
+    {
+        $round_info_array = [];
+        foreach ($this->round->other_rounds_with_visible_usernames as $other_round_id) {
+            $other_round = get_Round_for_round_id($other_round_id);
+            $username = $this->get_username_for_round($other_round);
+            $round_info_array[] = [$other_round->id, $username];
+        }
+        $page_option = ($this->page_state == $this->round->page_out_state) ? "previous" : "current";
+        return
+            $this->get_page_text_array($page_option) +
+            $this->get_page_state_array() +
+            [
+                "pageNum" => pathinfo($this->page_name, PATHINFO_FILENAME),
+                "roundInfoArray" => $round_info_array,
+                "pagename" => $this->page_name,
+                "image_url" => "{$this->project->url}/{$this->page_name}",
+            ];
+    }
+
+    private function get_username_for_round($round)
+    {
+        $res = DPDatabase::query("
+            SELECT {$round->user_column_name}
+            FROM {$this->projectid}
+            WHERE image = '{$this->page_name}'
+        ");
+        $row = mysqli_fetch_assoc($res);
+        return $row[$round->user_column_name];
+    }
+
+    private function get_page_text_array(string $page_option): array
+    {
+        if ($page_option == "current") {
+            $desired_column_name = $this->round->text_column_name;
+        } else {
+            $desired_column_name = $this->round->prevtext_column_name;
+        }
+
+        $sql = "
+            SELECT $desired_column_name
+            FROM $this->projectid
+            WHERE image='$this->page_name'
+        ";
+        $res = DPDatabase::query($sql);
+        $text = mysqli_fetch_row($res)[0];
+
+        return ["text" => $text];
+    }
+
+    private function get_page_state_array()
+    {
+        return [
+            "pagestate" => $this->page_state,
+            "saved" => ($this->page_state == $this->round->page_temp_state),
+        ];
+    }
+
+    private function _return_to_round(): void
+    {
+        global $pguser;
+
+        $setters = join(", ", [
+            set_col_str("state", $this->round->page_avail_state),
+            set_col_num($this->round->time_column_name, time()),
+        ]);
+        _Page_UPDATE($this->projectid, $this->page_name, $setters);
+        _log_page_event($this->projectid, $this->page_name, 'returnToRound', $pguser, $this->round);
+        _project_adjust_n_available_pages($this->projectid, +1);
+    }
+}
+
+class ProofProject
+{
+    use ProofPage;
+
+    public function __construct(object $project, array $query_params = [])
+    {
+        global $pguser, $PROJECT_STATES_IN_ORDER;
+
+        $expected_state = $query_params["projstate"] ?? null;
+        if (null === $expected_state) {
+            throw new ProjectNoStateGivenException("No expected state found in request.");
+        }
+        if (!in_array($expected_state, $PROJECT_STATES_IN_ORDER)) {
+            throw new ProjectInvalidStateException(sprintf("%s is not a valid project state", $expected_state));
+        }
+        if ($expected_state != $project->state) {
+            $err = sprintf(
+                _('Warning: Project "%1$s" is not in state "%2$s"; it is now in state "%3$s".'),
+                $project->nameofwork,
+                project_states_text($expected_state),
+                project_states_text($project->state)
+            );
+            throw new ProjectNotInRequiredStateException($err);
+        }
+
+        $project_round = $project->get_project_available_round();
+        $project_round->validate_user_can_access($pguser);
+
+        $this->project = $project;
+        $this->projectid = $project->projectid;
+        $this->round = $project_round;
+    }
+
+    public function checkout_pages(int $requested_pages): array
+    {
+        global $pguser;
+        if ($requested_pages < 1) {
+            throw new InvalidValue("requested pages must be at least 1");
+        }
+        if ($requested_pages > MAX_REQUESTED_PAGES) {
+            throw new ProjectTooManyPagesRequested(sprintf("requested pages must not be more than %d", MAX_REQUESTED_PAGES));
+        }
+        // get some pages. If not enough available return a reason
+        $reason = "";
+        $status_code = 0;
+        $this->validate_no_outpages();
+        $out_pages = 0;
+        validate_user_can_get_pages_in_project($pguser, $this->project, $this->round);
+        while ($out_pages < $requested_pages) {
+            try {
+                $this->checkout_available_proof_page();
+                $out_pages += 1;
+            } catch (ProjectNoMorePagesException | BeginnersQuotaReachedException | BeginnersProjectQuotaReachedException $exception) {
+                if ($out_pages == 0) {
+                    throw $exception;
+                }
+                $reason = $exception->getMessage();
+                $status_code = $exception->getCode();
+                break;
+            }
+        }
+
+        // find the pages we have checked out and log page events
+        $this->log_checkout_events();
+
+        return [
+            "reason" => $reason,
+            "status" => $status_code,
+            "npages" => $out_pages,
+        ];
+    }
+
+    private function checkout_available_proof_page(): void
+    {
+        global $preceding_proofer_restriction;
+
+        // If the global setting is to not serve the immediately preceding page,
+        // first see if we can serve them a page they haven't at all seen before,
+        // then fall back to not the immediately preceding page.
+        if ($preceding_proofer_restriction == 'not_immediately_preceding') {
+            $pages = $this->get_available_restricted_page('not_previously_proofed');
+        }
+
+        // If that failed, try again with the global setting. This is also the
+        // common case if $preceding_proofer_restriction != not_immediately_preceding
+        if (0 == $pages) {
+            $pages = $this->get_available_restricted_page($preceding_proofer_restriction);
+        }
+        if (0 == $pages) {
+            throw new ProjectNoMorePagesException();
+        }
+    }
+
+    private function get_available_restricted_page(string $preceding_proofer_restriction): int
+    // Returns the best page entry for the user given the specified preceding
+    // project restriction. If successful, it returns [ $imagename, $state ],
+    // on failure it returns NULL;
+    {
+        global $pguser;
+
+        // The page to be retrieved must be an available page, of course.
+        $restrictions = "state='{$this->round->page_avail_state}'";
+
+        // Are there any other restrictions that the page must satisfy?
+        // (This should maybe be a property of $round.)
+        if (empty($preceding_proofer_restriction)) {
+            // Nope, no other restrictions.
+        } elseif ($preceding_proofer_restriction == 'not_immediately_preceding') {
+            // Don't give this user a page that they worked on in the preceding round.
+            // (Where "preceding" takes into account skipped rounds.)
+            if ($this->round->round_number > 1) {
+                // We need an SQL expression for the preceding proofreader.
+                $preceding_proofer = "CASE";
+                for ($rn = $this->round->round_number - 1; $rn > 0; $rn--) {
+                    $earlier_round = get_Round_for_round_number($rn);
+                    $ucn = $earlier_round->user_column_name;
+                    $preceding_proofer .= " WHEN LENGTH($ucn) THEN $ucn";
+                }
+                // What if all of the earlier rounds were skipped?
+                // (It's pretty unlikely, but we should allow for it.)
+                // All of the WHEN LENGTH(...) clauses will fail.
+                //
+                // If the CASE expr doesn't have an ELSE clause, it will yield NULL,
+                // so we'll end up requiring that
+                //     NULL != '$pguser'
+                // which is always NULL (effectively false), so no pages will
+                // satisfy the restriction, which is not what we want.
+                //
+                // Instead, add an ELSE clause saying that the preceding proofreader's
+                // name was the empty string. So we'll end up requiring that
+                //     '' != '$pguser'
+                // which is always true, so any (available) page will satisfy the
+                // restriction, which is what we want.
+                $preceding_proofer .= " ELSE ''";
+                $preceding_proofer .= " END";
+
+                $restrictions .= " AND $preceding_proofer != '$pguser'";
+            }
+        } elseif ($preceding_proofer_restriction == 'not_previously_proofed') {
+            // Don't give this user a page that they have worked on before.
+            for ($rn = 1; $rn < $this->round->round_number; $rn++) {
+                $earlier_round = get_Round_for_round_number($rn);
+                $restrictions .= " AND {$earlier_round->user_column_name} != '$pguser'";
+            }
+        } else {
+            // The empty/null (i.e., no restriction) case has already been dealt with.
+            throw new ValueError("Bad value for 'preceding_proofer_restriction': '$preceding_proofer_restriction'.");
+        }
+
+        // Update a page
+        return $this->checkout_block($restrictions, 1);
+    }
+
+    public function mentor_checkout(): void
+    {
+        global $pguser;
+
+        $this->validate_no_outpages();
+        if(!$this->mentor_mode()) {
+            throw new BadRequest("This is not a Mentor Project");
+        }
+        // in available projects
+        // find proofreader in previous round with earliest time stamp
+        $mentee_column = $this->round->mentee_round->user_column_name;
+        $mentee_time_column = $this->round->mentee_round->time_column_name;
+        $dbQuery = "
+            SELECT $mentee_column, $mentee_time_column
+            FROM $this->projectid
+            WHERE state='{$this->round->page_avail_state}'
+            ORDER BY $mentee_time_column ASC
+            LIMIT 1
+        ";
+        $result = DPDatabase::query($dbQuery);
+        $row = $result->fetch_assoc();
+        if(!$row) {
+            throw new ProjectNoMorePagesException();
+        }
+        $mentee = $row[$mentee_column];
+        // checkout all mentee's pages
+        $restrictions = "state='{$this->round->page_avail_state}' AND $mentee_column='$mentee'";
+        if(0 == $this->checkout_block($restrictions, 9999)) {
+            // can only happen if another mentor has intervened
+            throw new ProjectNoMorePagesException();
+        }
+        $this->log_checkout_events();
+    }
+
+    private function checkout_block(string $restrictions, int $limit): int
+    {
+        global $pguser;
+
+        $settings = sprintf(
+            "
+            state = '{$this->round->page_out_state}',
+            {$this->round->time_column_name} = UNIX_TIMESTAMP(),
+            {$this->round->user_column_name} = '%s'
+        ",
+            DPDatabase::escape($pguser)
+        );
+
+        $dbQuery = "
+            UPDATE $this->projectid
+            SET $settings
+            WHERE $restrictions
+            ORDER BY image ASC
+            LIMIT $limit
+        ";
+        DPDatabase::query($dbQuery);
+        // return the number of rows checked out
+        return DPDatabase::affected_rows();
+    }
+
+    public function return_pages(): void
+    {
+        $page_array = $this->gather_pages();
+        foreach ($page_array as $page_name) {
+            $this->page_name = $page_name;
+            $this->_return_to_round();
+        }
+    }
+
+    public function get_outpage(): array
+    {
+        $page_array = $this->gather_pages();
+        if (0 == count($page_array)) {
+            throw new ProjectNoMoreOutPagesException(_("You have no more pages checked out."));
+        }
+        $this->page_name = $page_array[0];
+        $this->page_state = $this->round->page_out_state;
+
+        return $this->render_page_data();
+    }
+
+    public function get_data(): array
+    {
+        return [
+            "outpages" => count($this->gather_pages()),
+            "mentormode" => $this->mentor_mode(),
+        ];
+    }
+
+    private function mentor_mode(): bool
+    {
+        return ($this->project->difficulty == 'beginner') && $this->round->is_a_mentor_round();
+    }
+
+    private function log_checkout_events(): void
+    {
+        global $pguser;
+
+        // find the pages we have checked out and log page events
+        $page_array = $this->gather_pages();
+        _project_adjust_n_available_pages($this->projectid, -count($page_array));
+        foreach ($page_array as $page_name) {
+            _log_page_event($this->projectid, $page_name, 'checkout', $pguser, $this->round);
+        }
+    }
+
+    private function validate_no_outpages(): void
+    {
+        $out_pages = count($this->gather_pages());
+        if ($out_pages > 0) {
+            throw new ProjectThereAreOutPagesException(sprintf(_("You already have %d pages checked out"), $out_pages));
+        }
+    }
+
+    private function gather_pages(): array
+    {
+        global $pguser;
+
+        $page_array = [];
+        $sql = sprintf(
+            "
+            SELECT image
+            FROM $this->projectid
+            WHERE state = '{$this->round->page_out_state}'
+            AND {$this->round->user_column_name} = '%s'
+            ORDER BY image ASC
+        ",
+            DPDatabase::escape($pguser)
+        );
+        $result = DPDatabase::query($sql);
+        while ([$page_name] = mysqli_fetch_row($result)) {
+            $page_array[] = $page_name;
+        }
+        return $page_array;
+    }
+}
+
+class ProofProjectPage extends ProofProject
+{
+    use ProofPage;
+
+    public function __construct(object $project, string $page_name, array $query_params = [])
+    {
+        global $pguser, $PAGE_STATES_IN_ORDER;
+
+        parent::__construct($project, $query_params);
+
+        $expected_page_state = $query_params['pagestate'] ?? null;
+        if (null === $expected_page_state) {
+            throw new ProjectNoPageStateGivenException("No expected page state found in request.");
+        }
+        if (!in_array($expected_page_state, $PAGE_STATES_IN_ORDER)) {
+            throw new ProjectInvalidPageStateException(sprintf("%s is not a valid page state", $expected_page_state));
+        }
+
+        $user_column = $this->round->user_column_name;
+        $sql = "
+            SELECT state, $user_column
+            FROM $this->projectid
+            WHERE image = '$page_name'
+        ";
+        $res = DPDatabase::query($sql);
+        $row = mysqli_fetch_assoc($res);
+
+        $current_page_state = $row["state"];
+        if ($expected_page_state != $current_page_state) {
+            $err = sprintf(
+                _('Warning: Page  "%1$s" is no longer in state "%2$s"; it is now in state "%3$s".'),
+                $page_name,
+                $expected_page_state,
+                $current_page_state
+            );
+            throw new ProjectPageInconsistentStateException($err);
+        }
+
+        if ($row[$user_column] != $pguser) {
+            throw new PageNotOwnedException(_("You do not own this page."));
+        }
+
+        $this->page_name = $page_name;
+        $this->page_state = $current_page_state;
+    }
+
+    public function return_to_round(): void
+    {
+        global $pguser;
+
+        $this->validate_page(false, "returnToRound");
+        $this->_return_to_round();
+    }
+
+    public function attempt_save_as_done(): array
+    {
+        global $pguser;
+
+        $this->validate_page(false, "saveAsDone");
+        $analysis = $this->receive_text();
+        if(!$analysis["good"]) {
+            return $analysis;
+        }
+        if ($this->round->has_a_daily_page_limit()) {
+            $pre_save_dpl_count = get_dpl_count_for_user_in_round($pguser, $this->round);
+            if ($pre_save_dpl_count >= $this->round->daily_page_limit) {
+                // The user has already reached their limit of this kind of page.
+                $this->_save_as_in_progress();
+                $sentence = sprintf(
+                    _("Your page was saved as 'In Progress' rather than 'Done', because you have already reached the daily page limit for %s."),
+                    $this->round->id
+                );
+                throw new DailyLimitExceededException($sentence);
+            } else {
+                $this->save_as_done();
+                if ($pre_save_dpl_count + 1 >= $this->round->daily_page_limit) {
+                    $sentence = sprintf(
+                        _("Your page has been saved as 'Done'. However, you have now reached the daily page limit for %s."),
+                        $this->round->id
+                    );
+                    throw new DailyLimitReachedException($sentence);
+                }
+            }
+        } else {
+            $this->save_as_done();
+        }
+        return ["good" => true];
+    }
+
+    private function save_as_done(): void
+    {
+        global $pguser;
+
+        $timestamp = time();
+        $setters = join(", ", [
+            set_col_str("state", $this->round->page_save_state),
+            set_col_num($this->round->time_column_name, $timestamp),
+            set_col_str($this->round->text_column_name, $this->page_text),
+        ]);
+        _Page_UPDATE($this->projectid, $this->page_name, $setters);
+        _log_page_event($this->projectid, $this->page_name, 'saveAsDone', $pguser, $this->round);
+        upi_set_t_latest_page_event($pguser, $this->projectid, $timestamp);
+        _project_set_t_last_page_done($this->projectid, $timestamp);
+        page_tallies_add($this->round->id, $pguser, +1);
+    }
+
+    public function save_as_in_progress(string $option = "current"): array
+    {
+        $this->validate_page(false, "saveAsInProgress");
+        $analysis = $this->receive_text();
+        if(!$analysis["good"]) {
+            return $analysis;
+        }
+        $this->_save_as_in_progress();
+        return $this->get_page_text_array($option) + $this->get_page_state_array() + ["good" => true];
+    }
+
+    private function _save_as_in_progress(): void
+    {
+        global $pguser;
+
+        $this->page_state = $this->round->page_temp_state;
+        $setters = join(", ", [
+            set_col_str("state", $this->page_state),
+            set_col_num($this->round->time_column_name, time()),
+            set_col_str($this->round->text_column_name, $this->page_text),
+        ]);
+        _Page_UPDATE($this->projectid, $this->page_name, $setters);
+        _log_page_event($this->projectid, $this->page_name, 'saveAsInProgress', $pguser, $this->round);
+        upi_set_t_latest_page_event($pguser, $this->projectid, time());
+    }
+
+    private function receive_text(): array
+    {
+        $request_data = api_get_request_body();
+        $text = $request_data["text"] ?? null;
+        if(null === $text) {
+            throw new ProjectNoTextException();
+        }
+        $text_checker = new TextChecker();
+        $result = $text_checker->analyse($text, $this->project);
+        if($result["good"]) {
+            $this->page_text = _normalize_page_text($text, $this->projectid);
+        }
+        return $result;
+    }
+
+    public function resume_page(): array
+    {
+        global $pguser;
+
+        // page could be in out, temp or saved state
+        $this->validate_page(true, "reopen");
+        if ($this->page_state == $this->round->page_save_state) {
+            // Page comes from DONE.
+            // no need to update text, just record state change
+            $this->page_state = $this->round->page_temp_state;
+            $setters = join(", ", [
+                set_col_str("state", $this->page_state),
+                set_col_num($this->round->time_column_name, time()),
+            ]);
+            _Page_UPDATE($this->projectid, $this->page_name, $setters);
+            _log_page_event($this->projectid, $this->page_name, 'reopen', $pguser, $this->round);
+
+            // When it was saved, the user's page-count was incremented.
+            // Now they are 'unsaving' it, so decrement their page-count.
+            // They'll get it back if/when they save-as-done again.
+            page_tallies_add($this->round->id, $pguser, -1);
+        }
+        // otherwise it is in temp or out state: do nothing
+        return $this->render_page_data();
+    }
+
+    public function render_page_text($page_option)
+    {
+        // page should be in out or temp state only
+        $this->validate_page(false, "getText");
+        return $this->get_page_text_array($page_option);
+    }
+
+    private function validate_page(bool $can_be_in_saved_state, string $op_name): void
+    {
+        $allowed_states = [$this->round->page_out_state, $this->round->page_temp_state];
+        if ($can_be_in_saved_state) {
+            $allowed_states[] = $this->round->page_save_state;
+        }
+        if (!in_array($this->page_state, $allowed_states)) {
+            $err = sprintf(_("The page state %1s is not allowed for this operation (%2s)."), $this->page_state, $op_name);
+            throw new ProjectPageStateException($err);
+        }
+    }
+}
+
+class TextChecker
+{
+    public const GOOD_TEXT = 0;
+    public const BAD_TEXT = 1;
+
+    private $text_array = [];
+    private $good_text_block = "";
+
+    private function append_good()
+    {
+        if ($this->good_text_block != "") {
+            $this->text_array[] = [$this->good_text_block, self::GOOD_TEXT];
+            $this->good_text_block = "";
+        }
+    }
+
+    public function analyse($string, $project)
+    {
+        $all_good = true;
+        $pattern_string = build_character_regex_filter($project->get_valid_codepoints());
+        foreach (split_graphemes($string) as $grapheme) {
+            if (1 === preg_match("/$pattern_string/u", $grapheme)) {
+                $this->good_text_block .= $grapheme;
+            } else {
+                $all_good = false;
+                $this->append_good();
+                $this->text_array[] = [$grapheme, self::BAD_TEXT];
+            }
+        }
+        // append any remaining good text
+        $this->append_good();
+        return [
+            "mark_array" => $this->text_array,
+            "good" => $all_good,
+        ];
+    }
+}

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -2,6 +2,7 @@
 include_once($relPath.'misc.inc');
 include_once($relPath.'access_log.inc');
 include_once($relPath.'SettingsClass.inc');
+include_once($relPath.'../api/exceptions.inc');
 
 class NonexistentUserException extends Exception
 {
@@ -16,7 +17,7 @@ class NonuniqueUserException extends Exception
  *
  * These exception codes range from 300 to 399
  */
-class UserAccessException extends Exception
+class UserAccessException extends BadRequest
 {
     public function __construct($message = "", $code = 300)
     {
@@ -67,6 +68,30 @@ class NoAccessToMentorsOnlyException extends UserAccessException
 class ReservedForNewProofreadersException extends UserAccessException
 {
     public function __construct($message = "", $code = 306)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class PageNotOwnedException extends UserAccessException
+{
+    public function __construct($message = "", $code = 307)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class DailyLimitExceededException extends UserAccessException
+{
+    public function __construct($message = "", $code = 308)
+    {
+        parent::__construct($message, $code);
+    }
+}
+
+class DailyLimitReachedException extends UserAccessException
+{
+    public function __construct($message = "", $code = 309)
     {
         parent::__construct($message, $code);
     }

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -24,6 +24,8 @@ include_once($relPath.'site_vars.php');
   (Actually, the naming convention is in transition.)
 */
 
+global $PROJECT_STATES_IN_ORDER;
+
 $PROJECT_STATES_IN_ORDER = [];
 $project_state_medium_label_ = [];
 $project_state_long_label_ = [];


### PR DESCRIPTION
The checkout procedures are intended to be used with a revised meaning for save as done and proofread next -- the next already-checked-out page. (It can be used in a way compatible with the present procedure).

The exceptions are all derived from BadRequest so they already have a response code. The code may not be entirely appropriate but so far as our client ajax function (which uses fetch()) is concerned it does not make any difference: Response.ok is true if the response code is in the range 200-299 and false otherwise. This can easily be changed if appropriate.

This generally follows the pattern that if what you want to do does not succeed it throws an exception and returns a response code 400, otherwise 200. Deviations from this pattern:

Checkout a number of pages: If none are available, returns 400. If the number requested can be checked out, returns 200 with status 0. If some can be checked out but not as many as requested, returns 200 with status 1 and a reason string and the corresponding code and the number actually checked out.

When saving, if the text contains invalid characters, does not save the text but returns 200 with data indicating what the problems are. This could be changed to return a not-ok response code together with changing the client ajax function to be able to handle this. Or alternatively add another endpoint to validate the text which can be invoked if the save fails with bad characters. This would need an extra trip to the server but doesn't matter much since this will probably happen rarely.

If the daily limit for saving is reached the text is saved but returns response 400 with a message. Perhaps it would be better to return 200 with a status code and message since the request has succeeded but the user needs to be warned.

If the daily limit for saving is exceeded the text is saved as in progress but returns response 400 with a message.
