### PR TITLE
Fix phpunit tests that use temp files

### DIFF
--- a/SETUP/tests/ProjectUtils.inc
+++ b/SETUP/tests/ProjectUtils.inc
@@ -110,19 +110,14 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
 
     protected function add_page($project, $base)
     {
-        $source_project_dir = sys_get_temp_dir();
         $txt_file_name = "$base.txt";
-        $txt_file_path = "$source_project_dir/$txt_file_name";
-        $fp = fopen($txt_file_path, 'w');
-        fwrite($fp, $this->TEST_TEXT);
-        fclose($fp);
+        $txt_file_path = "$project->dir/$txt_file_name";
+        file_put_contents($txt_file_path, $this->TEST_TEXT);
 
         $image_file_name = "$base.png";
-        $img_file_path = "{$project->dir}/$image_file_name";
-        $fp = fopen($img_file_path, 'w');
+        $img_file_path = "$project->dir/$image_file_name";
         // write some data so file is not too short
-        fwrite($fp, str_repeat("This is a test image file", 10));
-        fclose($fp);
+        file_put_contents($img_file_path, str_repeat("This is a test image file", 10));
 
         project_add_page($project->projectid, $base, $image_file_name, $txt_file_path, $this->TEST_USERNAME_PM, time());
     }

--- a/SETUP/tests/phpunit_bootstrap.php
+++ b/SETUP/tests/phpunit_bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-global $relPath, $forum_type;
+global $relPath, $forum_type, $projects_dir, $aspell_temp_dir;
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'misc.inc');
@@ -9,3 +9,6 @@ include_once($relPath.'../api/v1.inc');
 
 include_once("phpunit_test_helpers.inc");
 include_once("ProjectUtils.inc");
+
+// Define top-level temporary directories
+$projects_dir = $aspell_temp_dir = "/tmp";


### PR DESCRIPTION
This fixes two problems with running phpunit tests locally:
* WordCheck tests failed with permission errors
* ApiTest left a `/tmp/001.txt` file that was owned by the last test runner which can cause tests to fail when run by a different user later.

To understand how this fix works we need to understand how modern Linux systems handle temp files. In Old School Unix, `/tmp` is just a global, common shared directory on the filesystem. But this poses some potential security issues as other processes might be able to see these temp files. Modern unix systems using systemd address this by giving each process its own `/tmp` (see the `PrivateTmp` systemd setting) transparent to the process. So if a reads or writes to `/tmp` it's actually some other subdirectory. Bonus is that systemd will clean up this temp subdirectory for us when the process ends (or some time after)

Now PHP on the other hand doesn't know anything about these process-local subdirectories. When the WordCheck code calls `tempnam()` with `$aspell_temp_dir` undefined it falls back to using `sys_get_temp_dir()` which returns `/tmp` **but** that is [not the systemd-provided tempdir](https://www.php.net/manual/en/function.sys-get-temp-dir.php#121073) (confusing, right!?).

This fix is to set variables in the test framework such that files they write go to `/tmp` which will use the systemd-provided subdirectory.

No sandbox but you can confirm this works on the TEST server by checking out the code and running the tests with:
```bash
# from within the checkout, run
cd SETUP/tests
../../vendor/bin/phpunit
```

For further reading on temp directories with systemd see https://systemd.io/TEMPORARY_DIRECTORIES/