### PR TITLE
Fix non-resumable upload

### DIFF
--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -108,7 +108,7 @@ function show_upload_form($form_content, $submit_label)
     echo "<div id='old_uploader'>
     <p class='warning'>", sprintf(_('Maximum file size is %s.'), humanize_bytes(get_max_upload_size())), "</p>
     <p>", get_big_upload_blurb(), "</p>",
-    _("File to upload"), ": <input type='file' id='old_browse' accept='.zip' name='uploaded_file'>
+    _("File to upload"), ": <span id='file_name'></span><input type='file' id='old_browse' accept='.zip' name='uploaded_file'>
     <input type='submit' id='old_submit' value='", attr_safe($submit_label), "'>",
     "<p>", sprintf(_("After you click the '%s' button, the browser will appear to be slow getting to the next page. This is because it is uploading the file."), $submit_label), "</p>",
     "</div>";

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -123,15 +123,13 @@ function show_upload_form($form_content, $submit_label)
         <span id='resumable_browse' class='button'>", _("Choose File"), "</span>
         <span id='resumable_submit' class='button'>", html_safe($submit_label), "</span></p>
     ";
-
-    echo "<p>", _("Upload progress"), ":&nbsp;<span id='upload_progress'></span></p>";
-
     echo "<p>", sprintf(
         _("Your browser supports uploading large files (up to %s) via javascript. If the upload fails, or you navigate away from this page before it finishes, uploading the file again will pick up where it left off."),
         humanize_bytes(RESUMABLE_UPLOAD_SIZE)
     ), "</p>";
     echo "</div>";
 
+    echo "<p>", _("Upload progress"), ":&nbsp;<span id='upload_progress'></span></p>";
     echo "</form>\n";
 }
 

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -49,6 +49,11 @@ window.addEventListener("DOMContentLoaded", function() {
     // Before we start the upload, prevent the user from hitting upload again.
     document.getElementById("old_submit").addEventListener("click", function(ev) {
         let file = document.getElementById("old_browse").files[0];
+        if(!file) {
+            alert(uploadMessages.noFile);
+            ev.preventDefault();
+            return false;
+        }
         if(file.size >= maxNormSize) {
             alert(uploadMessages.fileTooBig);
             ev.preventDefault();

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -60,8 +60,11 @@ window.addEventListener("DOMContentLoaded", function() {
             return false;
         }
         if(validate(file.name)) {
-            // won't work if we disable browse button so hide it
+            // won't work if we disable the buttons so hide them
+            // and show the file name instead
             document.getElementById("old_browse").style.display = "none";
+            document.getElementById("old_submit").style.display = "none";
+            document.getElementById("file_name").innerText = file.name;
             showProgress(uploadMessages.working);
         } else {
             ev.preventDefault();

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -57,7 +57,6 @@ window.addEventListener("DOMContentLoaded", function() {
         if(validate(file.name)) {
             // won't work if we disable browse button so hide it
             document.getElementById("old_browse").style.display = "none";
-            document.getElementById("old_browse").disabled = true;
             showProgress(uploadMessages.working);
         } else {
             ev.preventDefault();


### PR DESCRIPTION
While looking into uploading files, I found that the non-resumable upload did not work. The first commit enables it to work. The others tidy up other features.

It is probably not possible to test this without hacking the code to make it appear that the resumable upload is not available. I suppose two sandboxes are needed: one to make sure this does not break the resumable upload and another hacked sandbox to test this. I can make these if anyone wishes.