### PR TITLE
Allow multiple aux languages for a given WC call

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -60,16 +60,16 @@ define('WC_PAGE', 4);
  * @param string $projectid
  *   ID of project, needed for project languages and to load the custom
  *   dictionaries
- * @param string $aux_languages
- *   Auxiliary language to check against.
+ * @param array $languages
+ *   Languages to check against.
  * @param array $adhoc_good_words
  *   Array of words to treat as good for this invocation only.
  *
  * @return array
  */
-function get_bad_word_freqs_for_project_text($text, $projectid, $aux_language = '', $adhoc_good_words = [])
+function get_bad_word_freqs_for_project_text($text, $projectid, $languages, $adhoc_good_words = [])
 {
-    return _get_bad_words_for_project_text('FREQS', $text, $projectid, $aux_language, $adhoc_good_words);
+    return _get_bad_words_for_project_text('FREQS', $text, $projectid, $languages, $adhoc_good_words);
 }
 
 /**
@@ -91,16 +91,16 @@ function get_bad_word_freqs_for_project_text($text, $projectid, $aux_language = 
  * @param string $projectid
  *   ID of project, needed for project languages and to load the custom
  *   dictionaries
- * @param string $aux_languages
- *   Auxiliary language to check against.
+ * @param array $languages
+ *   Languages to check against.
  * @param array $adhoc_good_words
  *   Array of words to treat as good for this invocation only.
  *
  * @return array
  */
-function get_bad_word_levels_for_project_text($text, $projectid, $aux_language = '', $adhoc_good_words = [])
+function get_bad_word_levels_for_project_text($text, $projectid, $languages, $adhoc_good_words = [])
 {
-    return _get_bad_words_for_project_text('LEVELS', $text, $projectid, $aux_language, $adhoc_good_words);
+    return _get_bad_words_for_project_text('LEVELS', $text, $projectid, $languages, $adhoc_good_words);
 }
 
 /**
@@ -127,20 +127,16 @@ function get_bad_word_levels_for_project_text($text, $projectid, $aux_language =
  * @param string $projectid
  *   ID of project, needed for project languages and to load the custom
  *   dictionaries
- * @param string $aux_languages
- *   Auxiliary language to check against.
+ * @param array $languages
+ *   Languages to check against.
  * @param array $adhoc_good_words
  *   Array of words to treat as good for this invocation only.
  *
  * @return array
  */
-function _get_bad_words_for_project_text($which_result_values, $text, $projectid, $aux_language, $adhoc_good_words)
+function _get_bad_words_for_project_text($which_result_values, $text, $projectid, $languages, $adhoc_good_words)
 {
     $messages = [];
-
-    // Get the list of languages that we'll use. This also ensures that
-    // $aux_language is a valid language and if not discards it.
-    $languages = array_values(get_project_languages($projectid, $aux_language));
 
     // And the langcode3s for those languages
     [$langcode3s, $new_messages] = get_langcode3s_for_languages($languages);
@@ -783,21 +779,21 @@ function load_project_good_word_suggestions($projectid, $start_time = 0)
 
 function load_site_good_words_given_project($projectid)
 {
-    $languages = array_values(get_project_languages($projectid));
+    $languages = get_project_languages($projectid);
     [$langcode3s, $messages] = get_langcode3s_for_languages($languages);
     return load_site_good_words($langcode3s);
 }
 
 function load_site_bad_words_given_project($projectid)
 {
-    $languages = array_values(get_project_languages($projectid));
+    $languages = get_project_languages($projectid);
     [$langcode3s, $messages] = get_langcode3s_for_languages($languages);
     return load_site_bad_words($langcode3s);
 }
 
 function load_site_possible_bad_words_given_project($projectid)
 {
-    $languages = array_values(get_project_languages($projectid));
+    $languages = get_project_languages($projectid);
     [$langcode3s, $messages] = get_langcode3s_for_languages($languages);
     return load_site_possible_bad_words($langcode3s);
 }
@@ -995,9 +991,17 @@ function save_word_list($path, $words)
 // -----------------------------------------------------------------------------
 
 /**
- * Returns an associative array of all languages for a project
+ * Returns an array of all languages for a project
+ *
+ * @param string $projectid
+ *   ID of project
+ * @param array $aux_languages
+ *   Any additional languages to append to the list of project languages.
+ *   This function will silently filter out any invalid values.
+ *
+ * @return array
  */
-function get_project_languages($projectid, $aux_language = null)
+function get_project_languages($projectid, $aux_languages = [])
 {
     $returnArray = [];
 
@@ -1006,15 +1010,13 @@ function get_project_languages($projectid, $aux_language = null)
     } catch (NonexistentProjectException $exception) {
         return $returnArray;
     }
-    $languages = $project->languages;
-    if ($aux_language) {
-        $languages[] = $aux_language;
-    }
 
+    // filter out unknown languages by removing those without langcode2s
+    $languages = array_merge($project->languages, $aux_languages);
     foreach ($languages as $language) {
         $langcode = langcode2_for_langname($language);
         if ($langcode) {
-            $returnArray[$langcode] = $language;
+            $returnArray[] = $language;
         }
     }
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -191,7 +191,7 @@ try {
             }
             // save what we have so far, just in case the spellchecker barfs
             $ppage->saveAsInProgress($text_data, $pguser);
-            $aux_language = '';
+            $languages = get_project_languages($projectid);
             $accepted_words = [];
             $text_data = $_POST["text_data"];
 
@@ -203,7 +203,7 @@ try {
             $is_changed = 0;
 
             slim_header(_("WordCheck"), get_wordcheck_page_header_args($user, $ppage));
-            output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $accepted_words, $aux_language);
+            output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $accepted_words, $languages);
             break;
 
         case 101:
@@ -311,7 +311,7 @@ try {
             // User wants to run the page through spellcheck for an another language
             // Apply current corrections to text (but don't save the progress)
             // and rerun through the spellcheck
-            $aux_language = $_POST["aux_language"];
+            $languages = get_project_languages($projectid, [$_POST["aux_language"]]);
             $accepted_words = explode(' ', $_POST["accepted_words"]);
             $_SESSION["is_header_visible"] = get_integer_param($_POST, 'is_header_visible', 0, 0, 1);
             [$text_data, $corrections] = spellcheck_apply_corrections();
@@ -326,7 +326,7 @@ try {
             $is_changed = get_integer_param($_POST, 'is_changed', 0, 0, 1);
 
             slim_header(_("WordCheck"), get_wordcheck_page_header_args($user, $ppage));
-            output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $accepted_words, $aux_language);
+            output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $accepted_words, $languages);
             break;
 
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -308,7 +308,7 @@ try {
             break;
 
         case 104:
-            // User wants to run the page through spellcheck for an another language
+            // User wants to run the page through spellcheck for another language
             // Apply current corrections to text (but don't save the progress)
             // and rerun through the spellcheck
             $languages = get_project_languages($projectid, [$_POST["aux_language"]]);

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -24,14 +24,14 @@ use voku\helper\UTF8;
  *   Id of projected, needed for temp filename and to load the custom dictionaries
  * @param text $imagefile
  *   Image filename, needed for temp filename
- * @param text $aux_language
- *   Auxiliary language to check against
+ * @param array $languages
+ *   Languages to check against
  * @param array $accepted_words
  *   Array of words that should not be considered misspelled
  *
  * @return array
  */
-function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $accepted_words)
+function spellcheck_text($orig_text, $projectid, $imagefile, $languages, $accepted_words)
 {
     global $puncCharacters;
 
@@ -51,13 +51,8 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $aux_language, $acc
     // prepare the text for checking, in this case change all EOLs to spaces
     $orig_text = str_replace('[lf]', ' ', $orig_text);
 
-    // Handle a UI-ism so that func only needs to handle ''.
-    if ($aux_language == _("Language")) {
-        $aux_language = '';
-    }
-
     [$badWordHash, $languages, $messages] =
-        get_bad_word_levels_for_project_text($orig_text, $projectid, $aux_language, $accepted_words);
+        get_bad_word_levels_for_project_text($orig_text, $projectid, $languages, $accepted_words);
 
     [$uncommonScriptWords, $uncommonScripts] =
         get_words_with_uncommon_scripts(array_keys(get_distinct_words_in_text($orig_text)));
@@ -393,7 +388,7 @@ $word_check_messages = [
     "rerun" => _("Check page against an additional language"),
 ];
 
-function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $accepted_words, $aux_language)
+function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $accepted_words, $languages)
 {
     global $code_url, $word_check_messages;
 
@@ -421,7 +416,7 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
 
     // run the text through the spellcheck - returns the form contents and a list of languages the page was checked against
     [$page_contents, $languages, $messages, $highlights] =
-        spellcheck_text($text_data, $ppage->projectid(), $ppage->imagefile(), $aux_language, $accepted_words);
+        spellcheck_text($text_data, $ppage->projectid(), $ppage->imagefile(), $languages, $accepted_words);
 
     // start the div containing the link to show/hide the WordCheck header
     echo "<div>";
@@ -450,9 +445,10 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
 
     // start the first line of the WordCheck header
     // printing any dictionaries used
+    $project_languages = get_project_languages($ppage->projectid());
     echo "<p>";
-    if (count($languages) > 0) {
-        echo sprintf(_("Dictionaries used: <b>%s</b>."), implode(', ', $languages));
+    if (count($project_languages) > 0) {
+        echo sprintf(_("Dictionaries used: <b>%s</b>."), implode(', ', $project_languages));
     } else {
         echo "<b>" . _("No check against a dictionary has been made.") . "</b>";
     }
@@ -471,15 +467,16 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     echo "<option value=''>" . _("Language") . "</option>\n";
 
     // get a list of languages with dictionaries installed on the system
+    $aux_languages = array_diff($languages, $project_languages);
     $dict_list = get_languages_with_dictionaries();
     asort($dict_list);
     foreach ($dict_list as $langcode => $language) {
-        // skip the languages that we just used.
-        if (in_array($language, $languages)) {
+        // skip the project-specific languages that we just used.
+        if (in_array($language, $project_languages)) {
             continue;
         }
         echo "<option value='" .  attr_safe($language) . "'";
-        if (strcmp($language, $aux_language) == 0) {
+        if (in_array($language, $aux_languages)) {
             echo " selected";
         }
         echo ">$language</option>\n";

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -445,10 +445,9 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
 
     // start the first line of the WordCheck header
     // printing any dictionaries used
-    $project_languages = get_project_languages($ppage->projectid());
     echo "<p>";
-    if (count($project_languages) > 0) {
-        echo sprintf(_("Dictionaries used: <b>%s</b>."), implode(', ', $project_languages));
+    if (count($languages) > 0) {
+        echo sprintf(_("Dictionaries used: <b>%s</b>."), implode(', ', $languages));
     } else {
         echo "<b>" . _("No check against a dictionary has been made.") . "</b>";
     }
@@ -467,19 +466,16 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     echo "<option value=''>" . _("Language") . "</option>\n";
 
     // get a list of languages with dictionaries installed on the system
-    $aux_languages = array_diff($languages, $project_languages);
     $dict_list = get_languages_with_dictionaries();
     asort($dict_list);
     foreach ($dict_list as $langcode => $language) {
-        // skip the project-specific languages that we just used.
-        if (in_array($language, $project_languages)) {
+        // skip the languages that we just used.
+        if (in_array($language, $languages)) {
             continue;
         }
-        echo "<option value='" .  attr_safe($language) . "'";
-        if (in_array($language, $aux_languages)) {
-            echo " selected";
-        }
-        echo ">$language</option>\n";
+        echo "<option value='" .  attr_safe($language) . "'>";
+        echo html_safe($language);
+        echo "</option>\n";
     }
     echo "</select>";
 


### PR DESCRIPTION
Rather than restrict to only one additional aux language when calling WordCheck, allow multiple of them. This is the backend changes for [Task 2062](https://www.pgdp.net/c/tasks.php?action=show&task_id=2062) -- the UI bits need to still be implemented. There should be no user-visible changes with this change.

Unfortunately none of these high-level functions have unit tests because of the overhead of setting up a new Project with page text, etc. The lower-level calls are covered, but not the changed functions.

Testable in https://www.pgdp.org/~cpeel/c.branch/allow-multiple-dictionaries/