### PR TITLE
Allow users more control over WC dictionaries

### DIFF
--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -209,14 +209,39 @@
 
     #wc_header {
         input, select {
-            background-color: white;
-            color: black;
-            .solid-border;
+            .page-interface .text-pane;
         }
         button, input[type=submit], input[type=button] {
             .button;
         }
+        .dict-selection {
+            margin: 5px;
+            .dict-section {
+                margin: 5px;
+                .dict-section-title {
+                    padding: 3px 4px;
+                    display: inline;
+                }
+                .remove-language {
+                    .page-interface .text-pane;
+                    .solid-border;
+                    border-radius: 5px;
+                    font-size: 0.9em;
+                    display: inline;
+                    padding: 3px 4px 3px 0;
+                    margin: 2px;
+                    input {
+                        border: none;
+                        background: none;
+                        outline: none;
+                        box-shadow: none;
+                        color: red;
+                    }
+                }
+            }
+        }
     }
+
 }
 
 .preWC {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -547,9 +547,8 @@
 }
 #wordcheck_interface #wc_header input,
 #wordcheck_interface #wc_header select {
-  background-color: white;
+  background-color: #FFF8DC;
   color: black;
-  border: thin solid #565656;
 }
 #wordcheck_interface #wc_header button,
 #wordcheck_interface #wc_header input[type=submit],
@@ -564,6 +563,33 @@
   cursor: default;
   font-family: Verdana, Helvetica, sans-serif;
   border: thin solid #565656;
+}
+#wordcheck_interface #wc_header .dict-selection {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .dict-section-title {
+  padding: 3px 4px;
+  display: inline;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language {
+  background-color: #FFF8DC;
+  color: black;
+  border: thin solid #565656;
+  border-radius: 5px;
+  font-size: 0.9em;
+  display: inline;
+  padding: 3px 4px 3px 0;
+  margin: 2px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language input {
+  border: none;
+  background: none;
+  outline: none;
+  box-shadow: none;
+  color: red;
 }
 .preWC {
   background-color: #c2c2c2;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -547,9 +547,8 @@
 }
 #wordcheck_interface #wc_header input,
 #wordcheck_interface #wc_header select {
-  background-color: white;
+  background-color: #FFF8DC;
   color: black;
-  border: thin solid #000000;
 }
 #wordcheck_interface #wc_header button,
 #wordcheck_interface #wc_header input[type=submit],
@@ -564,6 +563,33 @@
   cursor: default;
   font-family: Verdana, Helvetica, sans-serif;
   border: thin solid #000000;
+}
+#wordcheck_interface #wc_header .dict-selection {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .dict-section-title {
+  padding: 3px 4px;
+  display: inline;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language {
+  background-color: #FFF8DC;
+  color: black;
+  border: thin solid #000000;
+  border-radius: 5px;
+  font-size: 0.9em;
+  display: inline;
+  padding: 3px 4px 3px 0;
+  margin: 2px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language input {
+  border: none;
+  background: none;
+  outline: none;
+  box-shadow: none;
+  color: red;
 }
 .preWC {
   background-color: #c2c2c2;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -547,9 +547,8 @@
 }
 #wordcheck_interface #wc_header input,
 #wordcheck_interface #wc_header select {
-  background-color: white;
+  background-color: #FFF8DC;
   color: black;
-  border: thin solid #000000;
 }
 #wordcheck_interface #wc_header button,
 #wordcheck_interface #wc_header input[type=submit],
@@ -564,6 +563,33 @@
   cursor: default;
   font-family: Verdana, Helvetica, sans-serif;
   border: thin solid #000000;
+}
+#wordcheck_interface #wc_header .dict-selection {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .dict-section-title {
+  padding: 3px 4px;
+  display: inline;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language {
+  background-color: #FFF8DC;
+  color: black;
+  border: thin solid #000000;
+  border-radius: 5px;
+  font-size: 0.9em;
+  display: inline;
+  padding: 3px 4px 3px 0;
+  margin: 2px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language input {
+  border: none;
+  background: none;
+  outline: none;
+  box-shadow: none;
+  color: red;
 }
 .preWC {
   background-color: #c2c2c2;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -547,9 +547,8 @@
 }
 #wordcheck_interface #wc_header input,
 #wordcheck_interface #wc_header select {
-  background-color: white;
+  background-color: #FFF8DC;
   color: black;
-  border: thin solid #000000;
 }
 #wordcheck_interface #wc_header button,
 #wordcheck_interface #wc_header input[type=submit],
@@ -564,6 +563,33 @@
   cursor: default;
   font-family: Verdana, Helvetica, sans-serif;
   border: thin solid #000000;
+}
+#wordcheck_interface #wc_header .dict-selection {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section {
+  margin: 5px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .dict-section-title {
+  padding: 3px 4px;
+  display: inline;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language {
+  background-color: #FFF8DC;
+  color: black;
+  border: thin solid #000000;
+  border-radius: 5px;
+  font-size: 0.9em;
+  display: inline;
+  padding: 3px 4px 3px 0;
+  margin: 2px;
+}
+#wordcheck_interface #wc_header .dict-selection .dict-section .remove-language input {
+  border: none;
+  background: none;
+  outline: none;
+  box-shadow: none;
+  color: red;
 }
 .preWC {
   background-color: #c2c2c2;

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -84,7 +84,7 @@ if (isset($_POST['spsaveandnext'])) {
     $tbutton = 103;
 }
 // Spellcheck against another language
-if (isset($_POST['rerunauxlanguage'])) {
+if (isset($_POST['rerunauxlanguage']) || isset($_POST["remove_language"])) {
     $tbutton = 104;
 }
 
@@ -311,7 +311,13 @@ try {
             // User wants to run the page through spellcheck for another language
             // Apply current corrections to text (but don't save the progress)
             // and rerun through the spellcheck
-            $languages = get_project_languages($projectid, [$_POST["aux_language"]]);
+            $languages = $_POST["languages"] ?? [];
+            if ($_POST["aux_language"] ?? null) {
+                $languages[] = $_POST["aux_language"];
+            }
+            if (isset($_POST["remove_language"])) {
+                $languages = array_diff($languages, array_keys($_POST["remove_language"] ?? []));
+            }
             $accepted_words = explode(' ', $_POST["accepted_words"]);
             $_SESSION["is_header_visible"] = get_integer_param($_POST, 'is_header_visible', 0, 0, 1);
             [$text_data, $corrections] = spellcheck_apply_corrections();

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -471,8 +471,6 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     }
 
     // limit the total number of dictionaries to 5
-    // Note: if a user de-selects the project languages, and then adds 5
-    // this code will allow them to select the project languages too for >5.
     if (count($languages) < 5) {
         // output the code allowing the user to select another language
         echo "<select name='aux_language'>";

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -418,6 +418,10 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     [$page_contents, $languages, $messages, $highlights] =
         spellcheck_text($text_data, $ppage->projectid(), $ppage->imagefile(), $languages, $accepted_words);
 
+    if (!$languages) {
+        $messages[] = _("No check against a dictionary has been made.");
+    }
+
     // start the div containing the link to show/hide the WordCheck header
     echo "<div>";
     echo "<a id='wc_header_link' href='#' onClick='return toggleWCHeader();'>";
@@ -443,48 +447,59 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
         echo "</p>";
     }
 
-    // start the first line of the WordCheck header
-    // printing any dictionaries used
-    echo "<p>";
-    if (count($languages) > 0) {
-        echo sprintf(_("Dictionaries used: <b>%s</b>."), implode(', ', $languages));
-    } else {
-        echo "<b>" . _("No check against a dictionary has been made.") . "</b>";
+    // for the vertical layout, use line breaks between pieces
+    // for the horizontal one, use two spaces instead
+    $spacer = $user->profile->i_layout == 1 ? "<br>" : "&nbsp; ";
+
+    // Handle dictionary selection
+    echo "<div class='dict-selection'>";
+    $project_languages = get_project_languages($ppage->projectid());
+    $used_project_languages = array_intersect($languages, $project_languages);
+    if (count($used_project_languages) > 0) {
+        echo "<div class='dict-section'>";
+        echo "<div class='dict-section-title'>" . _("Project-based dictionaries:") . "</div>$spacer";
+        output_wordcheck_language_buttons($used_project_languages);
+        echo "</div>";
     }
 
-    // for the vertical layout, stick in a line break
-    // for the horizontal one, stick in a space
-    if ($user->profile->i_layout == 1) {
-        echo "<br>";
-    } else {
-        echo " ";
+    $aux_languages = array_diff($languages, $project_languages);
+    if (count($aux_languages) > 0) {
+        echo "<div class='dict-section'>";
+        echo "<div class='dict-section-title'>" . _("Additional dictionaries: ") . "</div>$spacer";
+        output_wordcheck_language_buttons($aux_languages);
+        echo "</div>";
     }
 
-    // output the code allowing the user to select another language
-    echo _("Use additional: ");
-    echo "<select name='aux_language'>";
-    echo "<option value=''>" . _("Language") . "</option>\n";
+    // limit the total number of dictionaries to 5
+    // Note: if a user de-selects the project languages, and then adds 5
+    // this code will allow them to select the project languages too for >5.
+    if (count($languages) < 5) {
+        // output the code allowing the user to select another language
+        echo "<select name='aux_language'>";
+        echo "<option value=''>" . _("Select additional language...") . "</option>\n";
 
-    // get a list of languages with dictionaries installed on the system
-    $dict_list = get_languages_with_dictionaries();
-    asort($dict_list);
-    foreach ($dict_list as $langcode => $language) {
-        // skip the languages that we just used.
-        if (in_array($language, $languages)) {
-            continue;
+        // get a list of languages with dictionaries installed on the system
+        $dict_list = get_languages_with_dictionaries();
+        asort($dict_list);
+        foreach ($dict_list as $langcode => $language) {
+            // skip the languages that we just used.
+            if (in_array($language, $languages)) {
+                continue;
+            }
+            echo "<option value='" .  attr_safe($language) . "'>";
+            echo html_safe($language);
+            echo "</option>\n";
         }
-        echo "<option value='" .  attr_safe($language) . "'>";
-        echo html_safe($language);
-        echo "</option>\n";
-    }
-    echo "</select>";
+        echo "</select>";
 
-    $value = attr_safe(_("Check"));
-    $title = attr_safe($word_check_messages["rerun"]);
-    echo "<input type='submit' name='rerunauxlanguage' id='rerunauxlanguage' value='$value' title='$title'>";
-    echo "<br>";
+        $value = attr_safe(_("Check"));
+        $title = attr_safe($word_check_messages["rerun"]);
+        echo "<input type='submit' name='rerunauxlanguage' id='rerunauxlanguage' value='$value' title='$title'>";
+    }
+    echo "</div>";
 
     // show help blurb on the UA&S icon
+    echo "<p>";
     echo sprintf(
         _("The %s icon accepts the word for this page and suggests it for the dictionary."),
         "<img src=\"$code_url/graphics/Book-Plus-Small.gif\" border=\"0\">"
@@ -494,9 +509,9 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     // text highlight legend
     if ($highlights) {
         echo "<p>";
-        echo _("The following highlights have been used:") . "<br>";
+        echo _("The following highlights have been used:") . $spacer;
         foreach ($highlights as $hl_class => $message) {
-            echo "<span class='$hl_class'>$message</span><br>";
+            echo "<span class='$hl_class'>$message</span>" . $spacer;
         }
         echo "</p>";
     }
@@ -540,6 +555,19 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     echo '</table>';
     echo '</form>';
     echo '</div>';
+}
+
+function output_wordcheck_language_buttons($languages)
+{
+    foreach ($languages as $language) {
+        $name = attr_safe("remove_language[$language]");
+        $alt = attr_safe(_("Remove language"));
+        $value = attr_safe($language);
+        echo "<div class='remove-language'>";
+        echo "<input type='hidden' name='languages[]' value='$value'>";
+        echo "<input type='submit' name='$name' value='☒' title='$alt'>" . html_safe($language);
+        echo "</div>";
+    }
 }
 
 function get_page_js($interface_type_init_value)


### PR DESCRIPTION
Allow users to de-select project dictionaries and add more than one non-project-defined dictionary. [Task 2062](https://www.pgdp.net/c/tasks.php?action=show&task_id=2062)

This is the feature that is out for discussion/review in the [Updates to how languages are selected (and de-selected) in WordCheck](https://www.pgdp.net/phpBB3/viewtopic.php?f=4&t=80775) topic.

Testable in https://www.pgdp.org/~cpeel/c.branch/multi-dict-ui/