### PR TITLE
revise sending SR notifications assuming whole hour deadlines

### DIFF
--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -4,7 +4,7 @@
 
 # hourly:
 03 * * * * URL=<<CODE_URL>>/crontab/update_user_counts.php; <<URL_DUMP_PROGRAM>> $URL
-55 * * * * URL=<<CODE_URL>>/crontab/finish_smoothreading.php; <<URL_DUMP_PROGRAM>> $URL
+05 * * * * URL=<<CODE_URL>>/crontab/finish_smoothreading.php; <<URL_DUMP_PROGRAM>> $URL
 
 # daily:
 01  0 * * * URL=<<CODE_URL>>/crontab/take_tally_snapshots.php; <<URL_DUMP_PROGRAM>> $URL

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -14,55 +14,38 @@ if ($dry_run) {
     echo "This is a dry run.\n";
 }
 
-// Interval relative to current time
-//   Select all projects whose smooth reading deadline is within this interval.
+// This should run at 5 minutes past each hour
+// Assume smooth read deadlines are at exact hours
+// Select all projects whose smooth reading deadline is within the past hour.
 $from = -60 * 60;
-$to = 60 * 60;
-
 $sql = sprintf(
     "
     SELECT *
     FROM projects
     WHERE
         smoothread_deadline >= (UNIX_TIMESTAMP() + %d)
-        AND smoothread_deadline <= (UNIX_TIMESTAMP() + %d)
+        AND smoothread_deadline <= UNIX_TIMESTAMP()
         AND state = '%s'
     ",
     $from,
-    $to,
     DPDatabase::escape(PROJ_POST_FIRST_CHECKED_OUT)
 );
 $result = DPDatabase::query($sql);
 
-$output = "Checking " . mysqli_num_rows($result) . " projects...\n";
-$any_work_done = false;
+$number_of_projects = mysqli_num_rows($result);
 
-// Used for checking smoothread_deadline within the loop
-$curr_time = date('Y-m-d H');
-
-while ($row = mysqli_fetch_assoc($result)) {
-    $project = new Project($row);
-
-    // Check if the time is right, with precision of an hour
-    $deadline = date('Y-m-d H', $project->smoothread_deadline);
-
-    if ($curr_time == $deadline) {
-        $output .= "$project->nameofwork\n";
-        $any_work_done = true;
-
+if($number_of_projects > 0) {
+    echo "Found $number_of_projects projects...\n";
+    while ($row = mysqli_fetch_assoc($result)) {
+        $project = new Project($row);
+        echo "$project->nameofwork\n";
         if ($dry_run) {
-            $output .= "  Since this is a dry run, we won't send an email and log an event\n";
+            echo "  Since this is a dry run, we won't send an email and log an event\n";
         } else {
-            $output .= "  Sending email and logging event...\n";
+            echo "  Sending email and logging event...\n";
             $project->log_project_event('[AUTO]', 'smooth-reading', 'finished');
             notify_project_event_subscribers($project, 'sr_complete');
         }
     }
-}
-
-$output .= "finish_smoothreading.php executed.\n";
-
-// Don't output anything if no work was done
-if ($any_work_done) {
-    echo $output;
+    echo "finish_smoothreading.php executed.\n";
 }

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -34,7 +34,7 @@ $result = DPDatabase::query($sql);
 
 $number_of_projects = mysqli_num_rows($result);
 
-if($number_of_projects > 0) {
+if ($number_of_projects > 0) {
     echo "Found $number_of_projects projects...\n";
     while ($row = mysqli_fetch_assoc($result)) {
         $project = new Project($row);


### PR DESCRIPTION
This is the second stage of the revised method of sending SR end notifications. It should not be merged until at least 42 days after #987 or SR periods that have not been rounded up may fail to send notifications.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/improve_sr_notify
