### PR TITLE
Correct cell bg color for striped rows

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1540,7 +1540,8 @@ li.spaced {
 /* Review Work */
 
 td.has-diff {
-    background-color: @table-cell-ok-lowc;
+    /* we use !important so this overrides the bg color in striped tables */
+    background-color: @table-cell-ok-lowc !important;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -2524,7 +2524,8 @@ li.spaced {
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 td.has-diff {
-  background-color: #009900;
+  /* we use !important so this overrides the bg color in striped tables */
+  background-color: #009900 !important;
 }
 /* ------------------------------------------------------------------------ */
 /* CharSuite Explorer */

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2524,7 +2524,8 @@ li.spaced {
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 td.has-diff {
-  background-color: #ccffcc;
+  /* we use !important so this overrides the bg color in striped tables */
+  background-color: #ccffcc !important;
 }
 /* ------------------------------------------------------------------------ */
 /* CharSuite Explorer */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2524,7 +2524,8 @@ li.spaced {
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 td.has-diff {
-  background-color: #ccffcc;
+  /* we use !important so this overrides the bg color in striped tables */
+  background-color: #ccffcc !important;
 }
 /* ------------------------------------------------------------------------ */
 /* CharSuite Explorer */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2524,7 +2524,8 @@ li.spaced {
 /* ------------------------------------------------------------------------ */
 /* Review Work */
 td.has-diff {
-  background-color: #ccffcc;
+  /* we use !important so this overrides the bg color in striped tables */
+  background-color: #ccffcc !important;
 }
 /* ------------------------------------------------------------------------ */
 /* CharSuite Explorer */


### PR DESCRIPTION
Fix setting the has-diff cell background color in Review Work for striped tables.

[Task 2067](https://www.pgdp.net/c/tasks.php?task_id=2067)

This is testable in: https://www.pgdp.org/~cpeel/c.branch/fix-review-work-style/

Specifically see srjfoo's diff [in the sandbox](https://www.pgdp.org/~cpeel/c.branch/fix-review-work-style/tools/proofers/review_work.php?username=srjfoo&use_eval_query=1&work_round_id=P1&review_round_id=P2&days=1200&sample_limit=0) vs the [main TEST code](https://www.pgdp.org/c/tools/proofers/review_work.php?username=srjfoo&use_eval_query=1&work_round_id=P1&review_round_id=P2&days=1200&sample_limit=0) -- you need to be a site admin or PF on TEST to see another user's diffs.