### PR TITLE
Factor out user project reserve validation

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -444,21 +444,21 @@ class ProjectTest extends ProjectUtils
         $round = get_Round_for_round_id("P1");
 
         // user done no pages and few days on site
-        validate_user_can_get_pages_in_project($pguser, $project, $round);
+        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
 
         // user done many pages
         // $page_tally_threshold 500 for new projects in reserve time
         page_tallies_add("P1", $pguser, 501);
-        validate_user_can_get_pages_in_project($pguser, $project, $round);
+        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
 
         // few pages, many days on site
         $pguser = $this->TEST_OLDUSERNAME;
-        validate_user_can_get_pages_in_project($pguser, $project, $round);
+        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
 
         // many pages, many days on site
         page_tallies_add("P1", $pguser, 501);
         $this->expectExceptionCode(306);
-        validate_user_can_get_pages_in_project($pguser, $project, $round);
+        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
     }
 
     public function test_beginner_project_checkout()
@@ -471,7 +471,7 @@ class ProjectTest extends ProjectUtils
         page_tallies_add("P1", $pguser, 50);
         $round = get_Round_for_round_id("P1");
         $this->expectExceptionCode(303);
-        validate_user_can_get_pages_in_project($pguser, $project, $round);
+        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
     }
 
     public function test_beginner_mentor_project_checkout()
@@ -485,7 +485,7 @@ class ProjectTest extends ProjectUtils
         $user->grant_access("P2", $pguser);
         $round = get_Round_for_round_id("P2");
         $this->expectExceptionCode(305);
-        validate_user_can_get_pages_in_project($pguser, $project, $round);
+        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
     }
 
     public function test_project_checkout_no_more_pages()

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -164,7 +164,7 @@ function get_available_proof_page_array($project, $round, $pguser)
 {
     global $preceding_proofer_restriction;
 
-    validate_user_can_get_pages_in_project($pguser, $project, $round);
+    validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
 
     // If the global setting is to not serve the immediately preceding page,
     // first see if we can serve them a page they haven't at all seen before,

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -278,7 +278,7 @@ $ELR_round = get_Round_for_round_number(1);
  * It also doesn't need to check whether any of the project's pages
  * are actually available.
  */
-function validate_user_can_get_pages_in_project($username, $project, $round)
+function validate_user_can_get_pages_in_project($user, $project, $round)
 {
     // Projects with difficulty='beginner' are treated differently in
     // various ways.
@@ -300,11 +300,15 @@ function validate_user_can_get_pages_in_project($username, $project, $round)
                 // Then we reduced it to 6 for English beginner projects.)
                 $max_n_pages_per_project = ($project->language == 'English' ? 6 : 11);
 
-                $result = DPDatabase::query("
+                $sql = sprintf(
+                    "
                     SELECT COUNT(*) as pagesdone
                     FROM {$project->projectid}
-                    WHERE {$round->user_column_name} = '$username'
-                ");
+                    WHERE {$round->user_column_name} = '%s'
+                    ",
+                    DPDatabase::escape($user->username)
+                );
+                $result = DPDatabase::query($sql);
                 $row = mysqli_fetch_assoc($result);
                 if ($row["pagesdone"] >= $max_n_pages_per_project) {
                     throw new BeginnersProjectQuotaReachedException(_("You have reached your quota of pages from this 'Beginners Only' project,
@@ -320,6 +324,13 @@ function validate_user_can_get_pages_in_project($username, $project, $round)
         }
     }
 
+    validate_user_against_project_reserve($user, $project, $round);
+
+    // None of the above restrictions apply.
+}
+
+function validate_user_against_project_reserve($user, $project, $round)
+{
     // Allow projects to be reserved for newcomers based on
     // criteria defined in get_reserve_length().
     $n_days_of_reserve = get_reserve_length($project, $round);
@@ -339,20 +350,19 @@ function validate_user_can_get_pages_in_project($username, $project, $round)
             // The project is still in its "reserved" period.
             // It is available only to inexperienced users plus a few others.
 
-            if ($project->can_be_managed_by_user($username)) {
+            if ($project->can_be_managed_by_user($user->username)) {
                 // The current user is an SA, PF, or the project's PM,
                 // and is not subject to this restriction.
             } else {
                 // Is this user an inexperienced user?
 
-                $user = new User($username);
                 $days_on_site = ($t_now - $user->date_created) / 86400;
                 // echo "days_on_site = $days_on_site<br>\n";
 
-                $P1_page_tally = user_get_ELR_page_tally($username);
-                // echo "P1_page_tally = $P1_page_tally<br>\n";
+                $ELR_page_tally = user_get_ELR_page_tally($user->username);
+                // echo "ELR_page_tally = $ELR_page_tally<br>\n";
 
-                if ($days_on_site < $days_on_site_threshold or $P1_page_tally < $page_tally_threshold) {
+                if ($days_on_site < $days_on_site_threshold or $ELR_page_tally < $page_tally_threshold) {
                     // Yes, inexperienced.
                     // So not subject to this restriction
                     // (and so, allowed to proofread, unless there's some other problem).
@@ -360,9 +370,10 @@ function validate_user_can_get_pages_in_project($username, $project, $round)
                     // No, experienced.
                     // So cannot proofread this project yet.
                     $message = sprintf(
-                        _('This project is currently reserved for proofreaders who joined less than %1$d days ago or have done less than %2$s P1 pages. It will become generally available %3$s.'),
+                        _('This project is currently reserved for proofreaders who joined less than %1$d days ago or have done less than %2$s %3$s pages. It will become generally available %4$s.'),
                         $days_on_site_threshold,
                         $page_tally_threshold,
+                        $round->id,
                         icu_date_template("long+time", $t_generally_available)
                     );
                     throw new ReservedForNewProofreadersException($message);
@@ -373,6 +384,7 @@ function validate_user_can_get_pages_in_project($username, $project, $round)
             // It is available to all (subject to other restrictions).
         }
     }
+
     // None of the above restrictions apply.
 }
 

--- a/project.php
+++ b/project.php
@@ -229,7 +229,7 @@ function decide_blurbs()
     }
 
     try {
-        validate_user_can_get_pages_in_project($pguser, $project, $round);
+        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
     } catch (UserAccessException $exception) {
         $blurb = $exception->getMessage();
         return [$blurb, $blurb];


### PR DESCRIPTION
Factor out the logic used to determine if a user is able to work on a project that might be restricted to a round reserve. Require a User object to be passed in so we don't have to recreate it (with the DB hit) on every call -- which with the current interface is just once per page load, but won't be when I re-use this in the My Recommendations page. There is no functional change.

Testable in https://www.pgdp.org/~cpeel/c.branch/abstract-out-reserve-calculations/

Testing this is a bit hairy because you have to have a user with a certain time on site and a certain number of pages done in P1. I managed to do so on TEST but more importantly we have automated tests! Thanks to @70ray for the `validate_user_can_get_pages_in_project()` tests which caught a bug in my initial implementation!