### PR TITLE
Add callouts on round pages to move up

### DIFF
--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -3,6 +3,7 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'forum_interface.inc');
+include_once($relPath.'graph_data.inc'); // get_round_backlog_stats()
 
 // This file deals with the gradual revelation of site features,
 // based on the number of pages proofread by the user.
@@ -55,7 +56,7 @@ function welcome_see_beginner_forum($pagesproofed, $page_id, $username = null)
         echo "</div>";
 
         echo "<p>";
-        echo sprintf(_('Before you can begin proofreading, you must:'));
+        echo sprintf(_('Before you can begin proofreading, you must have:'));
         echo "<ul>";
         foreach ($uao->minima_table as $row) {
             [$criterion_str, $minimum, $user_score, $satisfied] = $row;
@@ -231,5 +232,146 @@ function maybe_output_new_proofer_project_message($project)
         echo _("After a period of time, this message will no longer appear.");
         echo "</small></p>";
         echo "</div>";
+    }
+}
+
+/*
+ * Output a callout and encourage the user to work in the round with the
+ * highest backlog that they can work in.
+ */
+function encourage_highest_round($username, $round_id = null)
+{
+    global $code_url, $Round_for_round_id_, $ELR_round, $ACCESS_CRITERIA;
+
+    // This URL fragment gets used a lot in this file
+    $round_url = "$code_url/tools/proofers/round.php?round_id=";
+
+    // get the backlog stats for all rounds sorted largest first
+    $backlog_stats = get_round_backlog_stats(array_keys($Round_for_round_id_));
+    arsort($backlog_stats);
+
+    // get all the rounds a user can work
+    $rounds_can_work_in = array_keys(get_stages_user_can_work_in($username));
+
+    // loop through the needs, highest to lowest, and point them to the
+    // one where they can make the most impact with their current access
+    foreach (array_keys($backlog_stats) as $round_target) {
+        $round = get_Round_for_round_id($round_target);
+
+        // don't encourage people towards $ELR_round, as that isn't really
+        // helpful for most sites
+        if ($round->id == $ELR_round->id) {
+            continue;
+        }
+
+        // if $round_id is the current one, ignore $round_id because that means
+        // we're on that round's page already
+        if ($round_target == $round_id) {
+            return;
+        }
+
+        // prepare the common wordings between the callouts
+        $please_move_up = sprintf(
+            _("Please consider proofreading a project in $round_target. Having eligible users working in <a href='%s'>%s</a> helps significantly with our backlog."),
+            "$round_url$round_target",
+            $round_target
+        );
+
+        // They can work in the target round, encourage them to do so.
+        if (in_array($round_target, $rounds_can_work_in)) {
+            echo "<div class='callout'>";
+            echo "<div class='calloutheader'>";
+            echo sprintf(_("Consider working on projects in %s!"), $round_target);
+            echo "</div>";
+
+            echo "<p>$please_move_up</p>";
+            echo "</div>";
+            return;
+        }
+
+        // They're already eligible but have not requested access, tell them.
+        $uao = $round->user_access($username);
+        if ($uao->all_minima_satisfied) {
+            echo "<div class='callout'>";
+            echo "<div class='calloutheader'>";
+            echo sprintf(_("You are eligible to work in %s!"), $round_target);
+            echo "</div>";
+
+            echo "<p>";
+            echo _("You are eligible to work on projects in $round_target!") . " ";
+            if ($round->after_satisfying_minima == 'REQ-AUTO') {
+                echo sprintf(
+                    _("Simply go to the <a href='%s'>%s</a> page to be automatically granted access, find a project that interests you, and start proofreading."),
+                    "$round_url$round_target",
+                    $round_target
+                );
+            } else {
+                echo sprintf(
+                    _("View the round's <a href='%s'>entrance requirements</a> for further details."),
+                    "$round_url$round_target#Entrance_Requirements",
+                    $round_target
+                );
+            }
+            echo "</p>";
+            echo "<p>$please_move_up</p>";
+            echo "</div>";
+            return;
+        }
+
+        // They aren't yet eligible, but if they've satisfied all the criteria
+        // except the quizzes (eg number of days and pages done), nudge them along.
+        $ready_ignoring_quizzes = true;
+        $quiz_requirements = [];
+        $uao = $round->user_access($username);
+        foreach ($uao->minima_table as $criterion_code => $tuple) {
+            // skip checking any quiz criteria for pass
+            if (startswith($criterion_code, 'quiz/')) {
+                $quiz_requirements[] = $criterion_code;
+                continue;
+            }
+            // 4th entry in the tuple is a boolean for if the criteria is satisfied
+            if ($tuple[3] == false) {
+                $ready_ignoring_quizzes = false;
+            }
+        }
+        if ($ready_ignoring_quizzes && $quiz_requirements) {
+            echo "<div class='callout'>";
+            echo "<div class='calloutheader'>";
+            echo sprintf(
+                _("You are just a few quiz pages away from %s!"),
+                $round_target
+            );
+            echo "</div>";
+
+            echo "<p>";
+            echo sprintf(
+                _("You are almost eligible to work in the %s round! The only thing left is to have:"),
+                $round_target,
+            );
+            echo "</p>";
+            echo "<ul>";
+            foreach ($quiz_requirements as $quiz_type) {
+                echo "<li>" . $ACCESS_CRITERIA[$quiz_type] . "</li>";
+            }
+            echo "</ul>";
+            echo "<p>";
+            if ($round->after_satisfying_minima == 'REQ-AUTO') {
+                echo sprintf(
+                    _("After you pass them you can go to the <a href='%s'>%s</a> page to be automatically granted access, find a project that interests you, and start proofreading."),
+                    "$round_url$round_target",
+                    $round_target
+                );
+            } else {
+                echo sprintf(
+                    _("After you pass them, view the round's <a href='%s'>entrance requirements</a> for further details."),
+                    "$round_url$round_target#Entrance_Requirements",
+                    $round_target
+                );
+            }
+            echo "</p>";
+            echo "<p>$please_move_up</p>";
+            echo "</div>";
+            return;
+        }
     }
 }

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -279,13 +279,45 @@ function encourage_highest_round($username, $round_id = null)
 
         // They can work in the target round, encourage them to do so.
         if (in_array($round_target, $rounds_can_work_in)) {
-            echo "<div class='callout'>";
-            echo "<div class='calloutheader'>";
-            echo sprintf(_("Consider working on projects in %s!"), $round_target);
-            echo "</div>";
+            // To encourage, but not annoy, users we allow them to mute the
+            // message for this round for some number of days.
+            $mute_query_param = "mute-encourage";
+            $mute_days = 90;
 
-            echo "<p>$please_move_up</p>";
-            echo "</div>";
+            // check if they've muted the callout for this round
+            $user_settings = new Settings($username);
+            $mute_setting_key = "mute-encourage-$round_target-expire";
+            $mute_expire = $user_settings->get_value($mute_setting_key);
+
+            // if user has requested muting for this round, set the expire time
+            if (array_get($_GET, $mute_query_param, "") == $round_target) {
+                $mute_expire = time() + 60 * 60 * 24 * $mute_days;
+                $user_settings->set_value($mute_setting_key, $mute_expire);
+            }
+
+            // user does not have round muted
+            if ($mute_expire === null || $mute_expire < time()) {
+                if ($mute_expire) {
+                    $user_settings->remove_value($mute_setting_key, $mute_expire);
+                }
+                echo "<div class='callout'>";
+                echo "<div class='calloutheader'>";
+                echo sprintf(_("Consider working on projects in %s!"), $round_target);
+                echo "</div>";
+
+                echo "<p>$please_move_up</p>";
+
+                // build the URL to refer back to the same page
+                $url = "?$mute_query_param=$round_target";
+                if ($_SERVER["QUERY_STRING"]) {
+                    $url .= "&" . $_SERVER["QUERY_STRING"];
+                }
+                echo "<p><small><a href='" . attr_safe($url) . "'>";
+                echo sprintf(_("Mute this message for %s days."), $mute_days);
+                echo "</a></small></p>";
+
+                echo "</div>";
+            }
             return;
         }
 

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -38,6 +38,8 @@ if (!$uao->can_access) {
     show_user_access_object($uao, true /* will_autogrant */);
 }
 
+encourage_highest_round($pguser, $round->id);
+
 show_news_for_page($round_id);
 
 


### PR DESCRIPTION
Add callouts to the round pages to encourage users to work in rounds with the largest backlog. This is a generalized, and improved, version of the 2b891bde0c009ba5642d2a1f1b4094e2da979287 commit in the `pgdp-production` branch which only applies to P1. This version will encourage users towards the round with the biggest backlog that they have access to or are eligible for except for quizzes.

We may want to consider updating the version of this that goes into `pgdp-production` to exclude the bits about applying for P3/F2 if they are otherwise eligible.

This is testable in https://www.pgdp.org/~cpeel/c.branch/encourage-higher-rounds/

The above sandbox has a hack applied to simulate the backlog order on PROD: P3, F2, F1, P1, P2 rather than what's on TEST which has the biggest backlog in P1:
```diff
--- /home/cpeel/u-cpeel-dp/pinc/gradual.inc	2023-12-24 02:52:17.764298935 +0000
+++ gradual.inc	2023-12-24 02:53:20.152555136 +0000
@@ -249,7 +249,8 @@

     // loop through the needs, highest to lowest, and point them to the
     // one where they can make the most impact with their current access
-    foreach (array_keys($backlog_stats) as $round_target) {
+    foreach (["P3", "F2", "F1", "P1", "P2"] as $round_target) {
         $round = get_Round_for_round_id($round_target);

         // don't encourage people towards $ELR_round, as that isn't really
```