### PR TITLE
Validate requested user's access to project, not pguser

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -438,54 +438,50 @@ class ProjectTest extends ProjectUtils
 
     public function test_can_user_get_pages_reserved_for_new_proofreaders()
     {
-        global $pguser;
-        $pguser = $this->TEST_USERNAME;
+        $user = new User($this->TEST_USERNAME);
         $project = $this->_create_available_project();
         $round = get_Round_for_round_id("P1");
 
         // user done no pages and few days on site
-        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
+        validate_user_can_get_pages_in_project($user, $project, $round);
 
         // user done many pages
         // $page_tally_threshold 500 for new projects in reserve time
-        page_tallies_add("P1", $pguser, 501);
-        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
+        page_tallies_add("P1", $user->username, 501);
+        validate_user_can_get_pages_in_project($user, $project, $round);
 
         // few pages, many days on site
-        $pguser = $this->TEST_OLDUSERNAME;
-        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
+        $user = new User($this->TEST_OLDUSERNAME);
+        validate_user_can_get_pages_in_project($user, $project, $round);
 
         // many pages, many days on site
-        page_tallies_add("P1", $pguser, 501);
+        page_tallies_add("P1", $user->username, 501);
         $this->expectExceptionCode(306);
-        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
+        validate_user_can_get_pages_in_project($user, $project, $round);
     }
 
     public function test_beginner_project_checkout()
     {
-        global $pguser;
-        $pguser = $this->TEST_USERNAME;
+        $user = new User($this->TEST_USERNAME);
         $this->valid_project_data["difficulty"] = "beginner";
         $project = $this->_create_available_project();
         // beginners limit is 40 in user_is.inc
-        page_tallies_add("P1", $pguser, 50);
+        page_tallies_add("P1", $user->username, 50);
         $round = get_Round_for_round_id("P1");
         $this->expectExceptionCode(303);
-        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
+        validate_user_can_get_pages_in_project($user, $project, $round);
     }
 
     public function test_beginner_mentor_project_checkout()
     {
-        global $pguser;
-        $pguser = $this->TEST_USERNAME;
         $this->valid_project_data["difficulty"] = "beginner";
         $project = $this->_create_available_project();
         $this->advance_to_round2($project->projectid);
-        $user = new User($pguser);
-        $user->grant_access("P2", $pguser);
+        $user = new User($this->TEST_USERNAME);
+        $user->grant_access("P2", $this->TEST_USERNAME);
         $round = get_Round_for_round_id("P2");
         $this->expectExceptionCode(305);
-        validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
+        validate_user_can_get_pages_in_project($user, $project, $round);
     }
 
     public function test_project_checkout_no_more_pages()

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -284,12 +284,13 @@ function validate_user_can_get_pages_in_project($user, $project, $round)
     // various ways.
     if ($project->difficulty == 'beginner') {
         if ($round->is_a_mentee_round()) {
-            if (!user_can_work_on_beginner_pages_in_round($round)) {
+            if (!that_user_can_work_on_beginner_pages_in_round($user->username, $round)) {
                 throw new BeginnersQuotaReachedException(_("You have reached your quota of pages from 'Beginners Only' projects in this round.
                     Perhaps you could try working on an EASY project."));
             }
 
-            if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
+            if (that_user_is_a_sitemanager($user->username) ||
+                that_user_is_proj_facilitator($user->username)) {
                 // User is exempt from N-pages-per-beginner-project restriction.
             } else {
                 // When a beginner project is in a mentored round,
@@ -316,7 +317,7 @@ function validate_user_can_get_pages_in_project($user, $project, $round)
                 }
             }
         } elseif ($round->is_a_mentor_round()) {
-            if (!user_can_work_on_beginner_pages_in_round($round)) {
+            if (!that_user_can_work_on_beginner_pages_in_round($user->username, $round)) {
                 throw new NoAccessToMentorsOnlyException(_("You do not have access to difficulty='beginner' (Mentors Only) projects in this round."));
             }
         } else {

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -196,20 +196,19 @@ function user_can_mentor_in_round($round)
             || $userSettings->get_boolean("{$round->id}_mentor.access");
 }
 
-function user_can_work_on_beginner_pages_in_round($round)
+function that_user_can_work_on_beginner_pages_in_round($username, $round)
 {
+    $userSettings = & Settings::get_settings($username);
     $round_number = $round->round_number;
-    $userSettings = & get_pguser_settings();
-    if (user_is_a_sitemanager()
-            || user_is_proj_facilitator()
+    if (that_user_is_a_sitemanager($username)
+            || that_user_is_proj_facilitator($username)
             || $userSettings->get_boolean("see_BEGIN_R".$round_number)
             || $userSettings->get_boolean("{$round->id}_mentor.access")
     ) {
         return true;
     }
 
-    global $pguser;
-    $n_pages = user_get_ELR_page_tally($pguser);
+    $n_pages = user_get_ELR_page_tally($username);
     if ($round_number == 1) {
         return $n_pages <= 40;
     } elseif ($round_number == 2) {
@@ -219,6 +218,12 @@ function user_can_work_on_beginner_pages_in_round($round)
         return true;
     }
     // The round-restriction is sufficient.
+}
+
+function user_can_work_on_beginner_pages_in_round($round)
+{
+    global $pguser;
+    return that_user_can_work_on_beginner_pages_in_round($pguser, $round);
 }
 
 function user_is_authors_db_manager()


### PR DESCRIPTION
Fix functions that `validate_user_can_get_pages_in_project()` depend on to operate against the specified user and not assume `$pguser`. This makes the function more generally useful and more consistent.

Testable in https://www.pgdp.org/~cpeel/c.branch/dont-assume-pguser-in-checks/

The only place that the function is called right now is in `project.php` and `LPage.inc` during the proofreading process which all takes place only for the logged-in user so testing this just confirming its enforcing the reserve in the branch just like it does in `master`. The new recommendation page will optionally use this as another user.