### PR TITLE
Upload check

### DIFF
--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -104,6 +104,7 @@ function show_upload_form($form_content, $submit_label)
     echo $form_content;
 
     echo "<p>$standard_blurb</p>";
+    echo "<input type='hidden' name='hash_code' id='hash_code' value=''>";
     // these are the form elements for non-resumable upload
     echo "<div id='old_uploader'>
     <p class='warning'>", sprintf(_('Maximum file size is %s.'), humanize_bytes(get_max_upload_size())), "</p>
@@ -209,6 +210,13 @@ function validate_uploaded_file($verbose)
         if (!is_valid_filename($file_info["name"])) {
             throw new FileUploadException(_("Invalid filename"));
         }
+
+        $hash_code = $_POST["hash_code"] ?? "no_hash";
+        $up_hash_code = hash('sha256', file_get_contents($file_path));
+        if(0 != strcmp($hash_code, $up_hash_code)) {
+            throw new FileUploadException(_("The file is corrupted"));
+        }
+        show_upload_message($verbose, _("Checksum validated"));
 
         virus_check($file_path, $verbose);
     } catch (FileUploadException $e) {

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -211,12 +211,15 @@ function validate_uploaded_file($verbose)
         }
 
         $hash_code = $_POST["hash_code"] ?? "no_hash";
-        $up_hash_code = hash('sha256', file_get_contents($file_path));
-        if(0 != strcmp($hash_code, $up_hash_code)) {
-            throw new FileUploadException(_("The file is corrupted"));
+        if($hash_code === "") {
+            show_upload_message($verbose, _("No checksum provided"));
+        } else {
+            $up_hash_code = hash('sha256', file_get_contents($file_path));
+            if(0 != strcmp($hash_code, $up_hash_code)) {
+                throw new FileUploadException(_("The file is corrupted"));
+            }
+            show_upload_message($verbose, _("Checksum validated"));
         }
-        show_upload_message($verbose, _("Checksum validated"));
-
         virus_check($file_path, $verbose);
     } catch (FileUploadException $e) {
         if (is_file($file_path)) {

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -125,14 +125,13 @@ function show_upload_form($form_content, $submit_label)
         <span id='resumable_submit' class='button'>", html_safe($submit_label), "</span></p>
     ";
 
-    echo "<p>", _("Upload progress"), ":&nbsp;<span id='upload_progress'></span></p>";
-
     echo "<p>", sprintf(
         _("Your browser supports uploading large files (up to %s) via javascript. If the upload fails, or you navigate away from this page before it finishes, uploading the file again will pick up where it left off."),
         humanize_bytes(RESUMABLE_UPLOAD_SIZE)
     ), "</p>";
     echo "</div>";
 
+    echo "<p>", _("Upload progress"), ":&nbsp;<span id='upload_progress'></span></p>";
     echo "</form>\n";
 }
 

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -72,6 +72,11 @@ window.addEventListener("DOMContentLoaded", function() {
         document.getElementById("upload_progress").innerHTML = text;
     }
 
+    function submitWithHash(hashString) {
+        document.getElementById("hash_code").value = hashString;
+        document.getElementById("upload_form").submit();
+    }
+
     if(resumable.support) {
         resumable.assignBrowse([document.getElementById("resumable_browse")]);
         resumable.assignDrop([document.getElementById("upload_form")]);
@@ -91,10 +96,13 @@ window.addEventListener("DOMContentLoaded", function() {
             return false;
         }
         if(validate(file.name)) {
-            // won't work if we disable browse button so hide it
+            // won't work if we disable the buttons so hide them
             document.getElementById("old_browse").style.display = "none";
-            document.getElementById("old_browse").disabled = true;
+            document.getElementById("old_submit").style.display = "none";
             showProgress(uploadMessages.working);
+            ev.preventDefault();
+            fileHash(file)
+                .then(submitWithHash);
         } else {
             ev.preventDefault();
         }
@@ -131,13 +139,7 @@ window.addEventListener("DOMContentLoaded", function() {
         document.querySelector('input[name="mode"]').value = "resumable";
         showProgress(uploadMessages.finalizingUpload);
         fileHash(file.file)
-            .then(function (hashString) {
-                document.getElementById("hash_code").value = hashString;
-                document.getElementById("upload_form").submit();
-            })
-            .catch( function () {
-                alert("Failed to create checksum");
-            });
+            .then(submitWithHash);
     });
 
     // If an error occurred, re-enable the upload form and show a message

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -67,9 +67,19 @@ window.addEventListener("DOMContentLoaded", function() {
         document.getElementById("upload_progress").innerHTML = text;
     }
 
-    function submitWithHash(hashString) {
-        document.getElementById("hash_code").value = hashString;
-        document.getElementById("upload_form").submit();
+    function submitWithHash(file) {
+        const hashInput = document.getElementById("hash_code");
+        const uploadForm = document.getElementById("upload_form");
+        fileHash(file)
+            .then (function (hashString) {
+                hashInput.value = hashString;
+                uploadForm.submit();
+            })
+            .catch( function () {
+                // send an empty string
+                hashInput.value = "";
+                uploadForm.submit();
+            });
     }
 
     if(resumable.support) {
@@ -96,8 +106,7 @@ window.addEventListener("DOMContentLoaded", function() {
             document.getElementById("old_submit").style.display = "none";
             showProgress(uploadMessages.working);
             ev.preventDefault();
-            fileHash(file)
-                .then(submitWithHash);
+            submitWithHash(file);
         } else {
             ev.preventDefault();
         }
@@ -133,8 +142,7 @@ window.addEventListener("DOMContentLoaded", function() {
         document.querySelector('input[name="resumable_identifier"]').value = file.uniqueIdentifier;
         document.querySelector('input[name="mode"]').value = "resumable";
         showProgress(uploadMessages.finalizingUpload);
-        fileHash(file.file)
-            .then(submitWithHash);
+        submitWithHash(file.file);
     });
 
     // If an error occurred, re-enable the upload form and show a message

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -40,11 +40,6 @@ window.addEventListener("DOMContentLoaded", function() {
         });
     }
 
-    // polyfill for String.padStart(2, "0")
-    function pad2(s) {
-        return (s.length < 2) ? `0${s}` : s;
-    }
-
     function fileHash(file) {
         return fileToArrayBuffer(file)
             .then(function (arrayBuffer) {
@@ -53,7 +48,7 @@ window.addEventListener("DOMContentLoaded", function() {
             .then(function(hashAsArrayBuffer) {
                 const uint8ViewOfHash = new Uint8Array(hashAsArrayBuffer);
                 const hashAsString = Array.from(uint8ViewOfHash)
-                    .map((b) => pad2(b.toString(16)))
+                    .map((b) => b.toString(16).padStart(2, "0"))
                     .join("");
                 return hashAsString;
             });

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -32,7 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         header("HTTP/1.0 200 Ok");
         // continue to try to reassemble
     } else {
-        header("HTTP/1.0 404 Not Found");
+        header("HTTP/1.0 204 No Content");
         exit;
     }
 }


### PR DESCRIPTION
This makes a checksum for the uploaded file, uploads it and checks it with the file received by the server.
The javascript function is based on the example in [this mozilla document](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API/Non-cryptographic_uses_of_subtle_crypto) reworked for the browsers we support which cannot use async, await, File.arrayBuffer() or String.padStart().
This checking should not really be necessary because lower levels of the internet protocol should already validate data but two users have encountered errors given by the zip validator so this is intended to discover if the problem is caused by data corruption or something else.
The change to upload_resumable_file.php is recommended in the resumable docs to avoid unnecessary error messages in the console.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/upload_check
