### PR TITLE
Generalize function caching code

### DIFF
--- a/SETUP/API.md
+++ b/SETUP/API.md
@@ -54,8 +54,10 @@ ensure that 3rd parties don't obtain API keys from the requests.
 ## Rate Limiting
 
 API requests can be rate limited to help prevent the site from being
-overwhelemed. To use Rate Limiting, you must have the PHP memcached module
+overwhelmed. To use Rate Limiting, you must have the PHP memcached module
 installed and a local memcached process running and accessible via localhost.
+If rate limiting is enabled and memcached is not accessible, API requests will
+fail and an error will be logged to `php_errors`.
 
 Three settings in `configuration.sh` control limiting:
 

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -23,7 +23,7 @@ The following PHP extensions are required. They are listed below with their
 Ubuntu system package names.
 * Internationalization - php-intl
 * mbstring - php-mbstring
-* memcached - php-memcached (to enable API rate limiting)
+* memcached - php-memcached (for API rate limiting and stats caching)
 * MySQL - php-mysql
 * xml - php-xml (used by packages installed with composer)
 * zip - php-zip
@@ -124,6 +124,18 @@ aspell 0.60 or later is required.
 ### Install optional components
 
 The following components are optional and provide additional functionality.
+
+#### Memcached
+If a memcached instance is available on localhost, the code can use it in
+two ways:
+* Implementing API rate limiting (enabled with `_API_RATE_LIMIT` in
+  `configuration.sh`). If `_API_RATE_LIMIT` is set to `TRUE` and memcached
+  is not available, API calls will fail and an error will be logged.
+* Caching some statistics data (automatic, no configuration necessary). If
+  memcached is not available everything still functions but no caching is done.
+
+The default memcached memory limit of 64MB is more than adequate for all
+current memcached uses in the code.
 
 #### Anti-Virus Scanner (ClamAV)
 If an anti-virus scanner is installed and configured, the code will use it to

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -3,6 +3,7 @@
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'page_tally.inc');
+include_once($relPath.'misc.inc'); // memoize_function()
 
 function get_graph_js_files()
 {
@@ -871,29 +872,12 @@ function get_round_backlog_stats($interested_phases)
 
 /**
  * Given a function and arguments that will generate graph data, attempt
- * to load the data from memcached first and fall back to the function and
- * cache the response.
+ * to cache the value.
  *
  * Note that the graph function might include _() so it's important that we
  * include the user's language in the key.
  */
 function query_graph_cache($function, $args = [], $expire_from_now = 3600)
 {
-    $memcache = new Memcached();
-    $memcache->addServer('localhost', 11211);
-
-    $key = md5($function . join($args) . get_desired_language());
-
-    // if the key exists, just return the data uncompressed
-    $data = $memcache->get($key);
-    if ($data !== false) {
-        return json_decode(gzuncompress($data));
-    }
-
-    // if not, call the function to return the data
-    $data = call_user_func_array($function, $args);
-
-    $memcache->set($key, gzcompress(json_encode($data)), time() + $expire_from_now);
-
-    return $data;
+    return memoize_function($function, $args, $expire_from_now, get_desired_language());
 }

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1272,6 +1272,38 @@ function factor_strings($strings)
     return [$left_common, $middles, $right_common];
 }
 
+//--------------------------------------------------------------------------
+
+/**
+ * Given a function and arguments that will generate data, attempt
+ * to load the data from memcached first and fall back to the function and
+ * cache the response. If memcache is not running, this will call the requested
+ * function and return its data without generating a notice/warning/error.
+ *
+ * If the requested function returns data that has localized strings, it's
+ * important that $key_salt = get_desired_language();
+ */
+function memoize_function($function, $args = [], $expire_from_now = 3600, $key_salt = "")
+{
+    $memcache = new Memcached();
+    $memcache->addServer('localhost', 11211);
+
+    $key = hash("sha256", $function . serialize($args) . $key_salt);
+
+    // if the key exists, just return the data uncompressed
+    $data = $memcache->get($key);
+    if ($data !== false) {
+        return unserialize(gzuncompress($data));
+    }
+
+    // if not, call the function to return the data
+    $data = call_user_func_array($function, $args);
+
+    $memcache->set($key, gzcompress(serialize($data)), time() + $expire_from_now);
+
+    return $data;
+}
+
 // -----------------------------------------------------------------------------
 
 /**

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1285,8 +1285,12 @@ function factor_strings($strings)
  */
 function memoize_function($function, $args = [], $expire_from_now = 3600, $key_salt = "")
 {
-    $memcache = new Memcached();
-    $memcache->addServer('localhost', 11211);
+    // cache this connection for possible re-use during this page load
+    static $memcache = null;
+    if (!$memcache) {
+        $memcache = new Memcached();
+        $memcache->addServer('localhost', 11211);
+    }
 
     $key = hash("sha256", $function . serialize($args) . $key_salt);
 

--- a/stats/round_backlog.php
+++ b/stats/round_backlog.php
@@ -18,12 +18,20 @@ include_once($relPath.'slim_header.inc');
 $width = 300;
 $height = 200;
 
-// Pull all interested phases, primarily all the rounds and PP
-$interested_phases = array_keys($Round_for_round_id_);
-$interested_phases[] = "PP";
+function _get_round_backlog_data()
+{
+    global $Round_for_round_id_;
 
-// Pull the stats data out of the database
-$stats = get_round_backlog_stats($interested_phases);
+    // Pull all interested phases, primarily all the rounds and PP
+    $interested_phases = array_keys($Round_for_round_id_);
+    $interested_phases[] = "PP";
+
+    // Pull the stats data out of the database
+    return get_round_backlog_stats($interested_phases);
+}
+
+// cache backlog data for 1 day
+$stats = query_graph_cache("_get_round_backlog_data", [], 60 * 60 * 24);
 
 // get the total of all phases
 $stats_total = array_sum($stats);


### PR DESCRIPTION
Introduce a generalized version of `query_graph_cache()` that can be used for any data-collecting function. As for the name, see the [Memoization](https://en.wikipedia.org/wiki/Memoization) wikipedia article if you're not familiar with it. The updated graph pages are best viewed ignoring whitespace as the code was just indented when added to a function.

Testable in https://www.pgdp.org/~cpeel/c.branch/memoize-function/

I've added a new `memcache-stats` feature to the Squirrel Workbench on TEST that shows the memcache statistics. This can be used to confirm the new code is hitting memcache to get the cached data.