### PR TITLE
Improve performance for neighbor stats

### DIFF
--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -240,60 +240,53 @@ class TallyBoard
      * Parameters after `$radius` are an optimization for extracting
      * other info from the database at the same time.
      */
-    public function get_neighborhood(
-        $target_holder_id,
-        $radius,
-        $other_table,
-        $holder_id_expr,
-        $other_select_exprs,
-        $tally_alias,
-        $rank_alias
-    ) {
+    public function get_neighborhood($target_holder_id, $radius)
+    {
         assert($radius >= 0);
 
         $sql = sprintf(
             "
             SELECT
-                $holder_id_expr AS _holder_id,
-                IFNULL(tally_value,0) AS $tally_alias,
-                $other_select_exprs
+                IFNULL(tally_value, 0) AS current_tally,
+                u_id, username, u_privacy, date_created
             FROM
-                $other_table
-                LEFT OUTER JOIN current_tallies
-                ON (
-                    tally_name      = '%s'
-                    AND holder_type = '%s'
-                    AND holder_id   = $holder_id_expr
-                )
-            WHERE tally_value > 0 OR $holder_id_expr='$target_holder_id'
-            ORDER BY tally_value DESC, holder_id ASC
+                current_tallies
+                RIGHT OUTER JOIN users ON u_id = holder_id
+            WHERE
+                tally_name = '%s'
+                AND holder_type = '%s'
+                AND tally_value > 0
+            ORDER BY tally_value DESC, u_id ASC
             ",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type)
+            DPDatabase::escape($this->holder_type),
+            $target_holder_id
         );
         $result = DPDatabase::query($sql);
         // Note that for the purposes of this function,
-        // we pretend that holders with tally_value <= 0 don't exist,
-        // with the possible exception of the target holder.
+        // we pretend that holders with tally_value <= 0 don't exist.
 
         // First, run through the results,
         // looking for the row that contains the target holder.
         $target_holder_r = null;
         $r = 1;
         while ($row = mysqli_fetch_assoc($result)) {
-            if ($row['_holder_id'] == $target_holder_id) {
+            if ($row['u_id'] == $target_holder_id) {
                 $target_holder_r = $r;
                 break;
             }
             $r += 1;
         }
 
+        // if the user wasn't in the results, they have a de facto
+        // current_tally of 0; fill in the neighbors above them and then
+        // populate their row
         if (is_null($target_holder_r)) {
-            die("Holder '$target_holder_id' does not appear in $other_table.$holder_id_expr.");
+            $target_holder_r = $r;
+            $fill_zero_entry = true;
+        } else {
+            $fill_zero_entry = false;
         }
-        // Note that it's *not* a problem if $target_holder_id doesn't appear
-        // in current_tallies.holder_id. That's handled by the LEFT OUTER JOIN
-        // and the IFNULL(tally_value,0).
 
         // Now, go through the results again (calculating rank as you go),
         // and when you're in the neighborhood of the target holder,
@@ -305,17 +298,39 @@ class TallyBoard
         $r = 1;
         $ranker = new Ranker(false);
         while ($row = mysqli_fetch_assoc($result)) {
-            $rank = $ranker->next($row[$tally_alias]);
+            $rank = $ranker->next($row["current_tally"]);
 
             $rel_posn = $r - $target_holder_r;
             if (abs($rel_posn) <= $radius) {
                 // We're in the neighborhood of the target holder.
 
-                $row[$rank_alias] = $rank;
+                $row["current_rank"] = $rank;
                 $neighbors[$rel_posn] = $row;
             }
 
             $r++;
+        }
+        mysqli_free_result($result);
+
+        // we need to pull the same data from the users table but with a
+        // current_tally of 0 to populate $neighbors
+        if ($fill_zero_entry) {
+            $sql = sprintf(
+                "
+                SELECT
+                    0 AS current_tally,
+                    u_id, username, u_privacy, date_created
+                FROM users
+                WHERE u_id = %d
+                ",
+                $target_holder_id
+            );
+            $result = DPDatabase::query($sql);
+            $row = mysqli_fetch_assoc($result);
+            mysqli_free_result($result);
+            $rank = $ranker->next($row["current_tally"]);
+            $row["current_rank"] = $rank;
+            $neighbors[0] = $row;
         }
 
         return $neighbors;

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -259,8 +259,7 @@ class TallyBoard
             ORDER BY tally_value DESC, u_id ASC
             ",
             DPDatabase::escape($this->tally_name),
-            DPDatabase::escape($this->holder_type),
-            $target_holder_id
+            DPDatabase::escape($this->holder_type)
         );
         $result = DPDatabase::query($sql);
         // Note that for the purposes of this function,

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -145,15 +145,7 @@ function user_get_page_tally_neighborhood($tally_name, $username, $radius)
 
     $tallyboard = new TallyBoard($tally_name, 'U');
     $nb =
-        $tallyboard->get_neighborhood(
-            $user->u_id,
-            $radius,
-            'users',
-            'u_id',
-            'username, u_privacy, date_created, u_id',
-            'current_tally',
-            'current_rank'
-        );
+        $tallyboard->get_neighborhood($user->u_id, $radius);
 
     $neighbors = [];
     foreach ($nb as $rel_posn => $row) {


### PR DESCRIPTION
Currently on PROD, the round pages take ~2.5 seconds each to load. >2 seconds of this time is coming from the logic to calculate a user's neighbors for the stats bar.

Not all users proof in all rounds, so the size of the users table is always going to be bigger than the number of tallies in a round. So instead of generating tallies in a round for all users and trimming out those who aren't present, only get users with tallies and special-case when the current user isn't in the tally round. Performance is now based on how many users have proofread in a round rather than the number of entries in the user table.

I've simplified the function which makes it specific to this one use-case, but it's only used in one place so the extensibility isn't necessary.

Here are the timings of the SQL for the 5 round pages on PROD:
| Round        | Current   | PR        |
|--------------|-----------|-----------|
| P1           | 2.07 sec  | 1.12 sec  |
| P2           | 1.75 sec  | 0.13 sec  |
| P3           | 1.90 sec  | 0.02 sec  |
| F1           | 1.77 sec  | 0.10 sec  |
| F2           | 1.82 sec  | 0.00 sec  |

Testable in https://www.pgdp.org/~cpeel/c.branch/improve-neighbor-performance/

Results should be identical to what is live on TEST now, although the performance difference will be negligible there. Be sure to look at a round page for a user who hasn't proofread anything in that round and confirm user's 0-entry is present and last.