### PR TITLE
Move misc.inc include to bootstrap

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -94,3 +94,5 @@ jobs:
         run: cd SETUP && make lint_charsuites && cd ..
       - name: Run less/CSS checks
         run: cd SETUP && make lint_css && cd ..
+      - name: Run best practice checks
+        run: cd SETUP && make best_practice_checks && cd ..

--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -1,14 +1,19 @@
-.PHONY: all less security_checks lint_charsuites lint_css lint_code lint tests
+.PHONY: all less security_checks best_practice_checks lint_charsuites lint_css lint_code lint tests
 
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-all: less security_checks lint
+all: less security_checks best_practice_checks lint
 
 #----------------------------------------------------------------------------
 # Security checks
 security_checks:
 	$(SELF_DIR)check_security.sh $(SELF_DIR)..
 	$(SELF_DIR)check_require_login.php
+
+#----------------------------------------------------------------------------
+# Best Practice checks
+best_practice_checks:
+	$(SELF_DIR)check_includes_base.php
 
 #----------------------------------------------------------------------------
 # File linting

--- a/SETUP/check_includes_base.php
+++ b/SETUP/check_includes_base.php
@@ -1,0 +1,86 @@
+#!/usr/bin/env php
+<?php
+/*
+ * All .php files should include pinc/base.inc to ensure common files
+ * are included and variables are defined.
+ */
+
+$relPath = "../pinc/";
+include_once($relPath."misc.inc");
+
+// List of files that don't need to contain base.inc
+$ok_files = [
+    // Settings files
+    "pinc/site_vars.php",
+    "pinc/udb_user.php",
+    // Simple redirects
+    "stats/default.php",
+    "faq/default.php",
+    // API loads bootstrap directly
+    "api/index.php",
+    // Privacy is a dual-mode include page and the UI version has base.inc
+    "faq/privacy.php",
+    // Dev tools
+    ".php-cs-fixer.dist.php",
+];
+
+$files = get_all_php_files("../");
+foreach ($files as $file) {
+    // If it's in the SETUP directory, skip it
+    if (startswith($file, "SETUP/")) {
+        continue;
+    }
+
+    // If it's in the vendor directory, skip it
+    if (startswith($file, "vendor/")) {
+        continue;
+    }
+
+    // If it's in the node_modules directory, skip it
+    if (startswith($file, "node_modules/")) {
+        continue;
+    }
+
+    // If it's a 3rdparty file, skip it
+    if (startswith($file, "pinc/3rdparty/mediawiki/")) {
+        continue;
+    }
+
+    echo "$file\n";
+
+    // If it requires authentication, skip it
+    if (file_includes_base("../$file")) {
+        continue;
+    }
+
+    // If it's on the OK list, skip it
+    if (in_array($file, $ok_files)) {
+        continue;
+    }
+
+    echo "ERROR: file does not include base.inc or api.inc\n";
+    exit(1);
+}
+
+function get_all_php_files($basedir)
+{
+    $php_files = [];
+
+    $dir_iter = new RecursiveDirectoryIterator($basedir);
+    $files = new RecursiveIteratorIterator($dir_iter);
+    foreach ($files as $file_info) {
+        $file = $file_info->getPathname();
+        if (!endswith($file, ".php")) {
+            continue;
+        }
+        $php_files[] = str_replace($basedir, "", $file);
+    }
+    return $php_files;
+}
+
+function file_includes_base($filename)
+{
+    $contents = file_get_contents($filename);
+
+    return preg_match("/^\w+_once\(.*['\"]base.inc['\"]\);$/m", $contents);
+}

--- a/SETUP/document_database.php
+++ b/SETUP/document_database.php
@@ -3,7 +3,6 @@
 
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'TableDocumentation.inc');
 include_once($relPath.'DPage.inc'); // project_allow_pages()
 

--- a/SETUP/tests/manual_web/page_compare/manual_page_compare_test.php
+++ b/SETUP/tests/manual_web/page_compare/manual_page_compare_test.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "../../../../pinc/";
 include_once($relPath.'base.inc'); // require_login()
-include_once($relPath.'misc.inc'); // array_get()
 include_once($relPath.'theme.inc'); // output_header()
 include_once($relPath."PageUnformatter.inc"); // PageUnformatter()
 

--- a/SETUP/tests/phpunit_bootstrap.php
+++ b/SETUP/tests/phpunit_bootstrap.php
@@ -2,7 +2,6 @@
 global $relPath, $forum_type, $projects_dir, $aspell_temp_dir;
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'TableDocumentation.inc');
 include_once($relPath.'../api/v1.inc');

--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -5,7 +5,6 @@ include_once($relPath.'new_user_mails.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'forum_interface.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'User.inc');
 
 // The current param value is "reg_token" but the prior value was "id"

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -7,7 +7,6 @@ include_once($relPath.'email_address.inc');
 include_once($relPath.'new_user_mails.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'User.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
 
 $real_name = array_get($_POST, 'real_name', '');
 $username = array_get($_POST, 'userNM', '');

--- a/accounts/logout.php
+++ b/accounts/logout.php
@@ -2,7 +2,6 @@
 //clear cookie if one is already set
 $relPath = './../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'forum_interface.inc');
 

--- a/activity_hub.php
+++ b/activity_hub.php
@@ -10,7 +10,6 @@
 
 $relPath = "./pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_states.inc');

--- a/api/ApiRouter.inc
+++ b/api/ApiRouter.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath."misc.inc"); // startswith()
 include_once("exceptions.inc");
 
 // Raise exceptions on assert failures

--- a/api/index.php
+++ b/api/index.php
@@ -2,7 +2,6 @@
 $relPath = "../pinc/";
 include_once($relPath.'bootstrap.inc');
 include_once($relPath.'User.inc');
-include_once($relPath.'misc.inc');
 include_once('ApiRouter.inc');
 include_once('exceptions.inc');
 include_once('v1.inc');

--- a/crontab/archive_projects.php
+++ b/crontab/archive_projects.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'archiving.inc');
 

--- a/crontab/clean_tmp.php
+++ b/crontab/clean_tmp.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 
 require_localhost_request();
 

--- a/crontab/clean_uploads_trash.php
+++ b/crontab/clean_uploads_trash.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // requester_is_localhost()
 
 require_localhost_request();
 

--- a/crontab/del_teams.php
+++ b/crontab/del_teams.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 
 require_localhost_request();
 

--- a/crontab/extend_site_tally_goals.php
+++ b/crontab/extend_site_tally_goals.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = './../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 
 require_localhost_request();
 

--- a/crontab/finish_smoothreading.php
+++ b/crontab/finish_smoothreading.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'user_project_info.inc');
 include_once($relPath.'Project.inc');

--- a/crontab/import_pg_catalog.php
+++ b/crontab/import_pg_catalog.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'Stopwatch.inc');
 include_once($relPath.'pg.inc');
 

--- a/crontab/log_project_states.php
+++ b/crontab/log_project_states.php
@@ -2,7 +2,6 @@
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
-include_once($relPath.'misc.inc');
 
 require_localhost_request();
 

--- a/crontab/notify_old_pp.php
+++ b/crontab/notify_old_pp.php
@@ -3,7 +3,6 @@ $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'send_mail.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'post_processing.inc'); // get_pp_projects_past_threshold
 

--- a/crontab/onoff_special_event_queues.php
+++ b/crontab/onoff_special_event_queues.php
@@ -12,7 +12,6 @@
 
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 
 require_localhost_request();
 

--- a/crontab/take_tally_snapshots.php
+++ b/crontab/take_tally_snapshots.php
@@ -5,7 +5,6 @@
 
 $relPath = './../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'TallyBoard.inc');
 include_once($relPath.'job_log.inc');
 

--- a/crontab/update_user_counts.php
+++ b/crontab/update_user_counts.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = './../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 
 require_localhost_request();
 

--- a/faq/font_sample.php
+++ b/faq/font_sample.php
@@ -3,7 +3,6 @@ $relPath = '../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'prefs_options.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 
 // Note: The text used for font sample images is stored in font_sample.txt
 

--- a/feeds/backend.php
+++ b/feeds/backend.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // xmlencode()
 
 $content = get_enumerated_param($_GET, 'content', 'posted', ['posted', 'postprocessing', 'proofing', 'smoothreading']); // Which feed the user wants
 // Time in seconds for how often the feeds get refreshed

--- a/list_etexts.php
+++ b/list_etexts.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'list_projects.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param(), get_integer_param(), surround_and_join()
 
 $x = get_enumerated_param($_GET, 'x', 'g', ['g', 's', 'b']);
 $sort = get_integer_param($_GET, 'sort', 0, 0, 5);

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -2,7 +2,6 @@
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'POFile.inc');

--- a/pastnews.php
+++ b/pastnews.php
@@ -3,7 +3,6 @@ $relPath = "./pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'site_news.inc');
-include_once($relPath.'misc.inc'); // get_integer_param()
 
 require_login();
 

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -3,7 +3,6 @@
 include_once($relPath.'TallyBoard.inc');
 include_once($relPath.'SettingsClass.inc');
 include_once($relPath.'quizzes.inc'); // get_Quiz_with_id
-include_once($relPath.'misc.inc'); // startswith
 include_once($relPath.'User.inc');
 
 // $ACCESS_CRITERIA and $Activity_for_id_ are extended as activities are defined.

--- a/pinc/BBDiffFormatter.inc
+++ b/pinc/BBDiffFormatter.inc
@@ -3,7 +3,6 @@
 // MediaWiki difference formatter base class
 //
 // See 3rdparty/mediawiki/README.md for which MediaWiki version this maps to.
-include_once($relPath."misc.inc"); // html_safe()
 include_once($relPath."3rdparty/mediawiki/DiffFormatter.php");
 
 class BBDiffFormatter extends DiffFormatter

--- a/pinc/BrowseUtility.inc
+++ b/pinc/BrowseUtility.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc'); // attr_safe()
 
 // Handles HTTP-arguments 'start' and 'count'
 // specifying where in a db-query-result to start and

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc');
 include_once($relPath.'site_vars.php');
 include_once($relPath.'stages.inc');
 include_once($relPath.'user_project_info.inc');

--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -17,7 +17,6 @@
 // and see if they need updating in the DifferenceEngineWrapper class.
 //
 // See 3rdparty/mediawiki/README.md for which MediaWiki version this maps to.
-include_once($relPath."misc.inc"); // html_safe() in following includes
 include_once($relPath."3rdparty/mediawiki/ComplexityException.php");
 include_once($relPath."3rdparty/mediawiki/WordAccumulator.php");
 include_once($relPath."3rdparty/mediawiki/DairikiDiff.php");

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -1,6 +1,5 @@
 <?php
 
-include_once($relPath.'misc.inc');
 include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath.'user_is.inc');
 include_once($relPath.'project_states.inc');
-include_once($relPath.'misc.inc'); // html_safe(), xmlencode(), startswith()
 include_once($relPath.'forum_interface.inc'); // topic_create
 include_once($relPath.'SettingsClass.inc');
 include_once($relPath.'User.inc');

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath.'iso_lang_list.inc');
-include_once($relPath."misc.inc"); // attr_safe, array_get
 include_once($relPath.'genres.inc'); // load_genre_translation_array
 
 class ProjectSearchWidget

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -5,7 +5,6 @@ include_once($relPath.'forum_interface.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'ProjectSearchResultsConfig.inc');
 include_once($relPath.'forum_interface.inc'); // get_url_to_view_topic()
-include_once($relPath.'misc.inc'); // array_get(), html_safe()
 include_once($relPath.'pg.inc'); // get_pg_catalog_url_for_etext
 include_once($relPath.'genres.inc');  // maybe_create_temporary_genre_translation_table()
 

--- a/pinc/ProofreadingToolbox.inc
+++ b/pinc/ProofreadingToolbox.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'faq.inc'); // get_faq_url()
 include_once($relPath.'CharacterSelector.inc');
 

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath."Stage.inc");
 include_once($relPath."stages.inc");
-include_once($relPath.'misc.inc'); // get_enumerated_param
 include_once($relPath.'CharSuites.inc'); // CharSuiteSet
 
 // for groups of quizzes that go together

--- a/pinc/RandomRule.inc
+++ b/pinc/RandomRule.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath."misc.inc"); // startswith()
 
 class RandomRule
 {

--- a/pinc/RoundDescriptor.inc
+++ b/pinc/RoundDescriptor.inc
@@ -2,7 +2,6 @@
 
 // $Id$
 
-include_once($relPath.'misc.inc');
 include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -9,7 +9,6 @@
 // and a specialization of the concept of 'Activity'.
 
 include_once($relPath.'Activity.inc');
-include_once($relPath.'misc.inc'); // attr_safe
 
 $Stage_for_id_ = [];
 

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -16,8 +16,6 @@
 
 // -----------------------------------------------------------------------------
 
-include_once($relPath.'misc.inc');
-
 // A TallyBoard maintains all tally data (past and present)
 // for a particular combination of tally_name and holder_type.
 

--- a/pinc/Team.inc
+++ b/pinc/Team.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc');
 
 // This is an incomplete abstration around the Teams
 

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc');
 include_once($relPath.'access_log.inc');
 include_once($relPath.'SettingsClass.inc');
 

--- a/pinc/UserProfile.inc
+++ b/pinc/UserProfile.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath."misc.inc"); // create_mysql_update_string()
 
 class NonexistentUserProfileException extends Exception
 {

--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'slim_header.inc'); // html_safe()
-include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'links.inc');
 
 function abort($error_message)

--- a/pinc/access_log.inc
+++ b/pinc/access_log.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc');
 
 function log_access_change($subject_username, $modifier_username, $activity_id, $action_type)
 {

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -6,8 +6,6 @@
 //     string_to_hex()
 // Other globally-declared identifiers are prefixed with an underscore.
 
-include_once($relPath.'misc.inc'); // startswith
-
 use voku\helper\UTF8;
 
 $_character_data = [

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -57,6 +57,10 @@ try {
 // the start/resume.
 include_once($relPath.'dpsession.inc');
 
+// Include misc.inc which contains useful functions that almost 90% of
+// the pages use in some way.
+include_once($relPath.'misc.inc');
+
 //----------------------------------------------------------------------------
 
 // Autoloading functions for DP classes in pinc/

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath.'site_vars.php');  // $charset for javascript_safe()
-include_once($relPath.'misc.inc');  // attr_safe(), javascript_safe()
 
 define('CHANGE_LAYOUT', 'A');
 define('QUIT', 'B');

--- a/pinc/faq.inc
+++ b/pinc/faq.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'metarefresh.inc');
 
 // This include holds information about DP people in charge of various things,

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc'); // attr_safe()
 include_once($relPath.'iso_lang_list.inc');
 include_once($relPath.'Project.inc'); // get_project_difficulties()
 

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath."misc.inc"); // array_get()
 
 // forum_interface_phpbb3.inc
 

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -3,7 +3,6 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc'); // get_integer_param()
 
 // This file deals with the gradual revelation of site features,
 // based on the number of pages proofread by the user.

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -3,7 +3,6 @@
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'page_tally.inc');
-include_once($relPath.'misc.inc'); // memoize_function()
 
 function get_graph_js_files()
 {

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath."languages.inc"); // html_lang_header();
-include_once($relPath."misc.inc"); // html_safe(), ends_with()
 
 define('NO_STATSBAR', false);
 define('SHOW_STATSBAR', true);

--- a/pinc/links.inc
+++ b/pinc/links.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
 
 /**
  * Returns a string containing a snippet of HTML

--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc'); // startswith()
 
 /**
  * Redirect the browser to a new URL

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1,5 +1,12 @@
 <?php
-// Miscellaneous little (non-DP-specific) functions
+/*
+ * Miscellaneous little (non-DP-specific) functions
+ *
+ * This file is included in bootstrap.inc and is therefore available to all
+ * DP .php and .inc pages without being explicitly included.
+ *
+ * This file MUST NOT include any other files or define any global variables.
+ */
 
 use voku\helper\UTF8;
 

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -5,7 +5,6 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'project_states.inc'); // get_phase_containing_project_state
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'../tools/proofers/PPage.inc'); // url_for_pi_do_particular_page
-include_once($relPath.'misc.inc'); // surround_and_join, attr_safe
 include_once($relPath.'links.inc'); // private_message_link
 
 /**

--- a/pinc/post_processing.inc
+++ b/pinc/post_processing.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath."project_states.inc"); // PROJ_POST_FIRST_CHECKED_OUT
-include_once($relPath."misc.inc"); // array_get
 
 // Global variable that specifies when we alert PPers about their
 // outstanding projects. Time is calculated as this many days prior

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath."misc.inc"); // array_get()
 
 define('BROWSER_DEFAULT_STR', _("Browser default"));
 

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc'); // array_get, html_safe()
 include_once($relPath.'site_vars.php');
 
 /*

--- a/pinc/send_mail.inc
+++ b/pinc/send_mail.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath.'site_vars.php');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'Project.inc');
 include_once($relPath.'User.inc');
 

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath.'stages.inc');
-include_once($relPath.'misc.inc');
 
 $NEWS_PAGES = [
     'GLOBAL' => _('Global'),

--- a/pinc/smoothread.inc
+++ b/pinc/smoothread.inc
@@ -1,6 +1,5 @@
 <?php
 include_once($relPath.'site_vars.php');
-include_once($relPath.'misc.inc');  // attr_safe()
 include_once($relPath.'user_project_info.inc'); // notify_project_event_subscribers()
 
 /***************************************************************************************

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc');
 
 /**
  * Return a set of hard-coded special days keyed by spec_code

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -10,7 +10,6 @@ include_once($relPath.'RoundDescriptor.inc');
 include_once($relPath.'Pool.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
-include_once($relPath.'misc.inc'); // str_contains startswith
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -12,7 +12,6 @@ include_once($relPath.'gradual.inc');
 include_once($relPath.'forum_interface.inc');
 include_once($relPath.'languages.inc');
 include_once($relPath.'post_processing.inc'); // count_pp_projects_past_threshold()
-include_once($relPath.'misc.inc'); // endswith(), get_enumerated_param(), attr_safe(), endswith()
 include_once($relPath.'faq.inc');
 
 /**

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -1,6 +1,4 @@
 <?php
-include_once($relPath.'misc.inc'); // get_upload_err_msg(), attr_safe(), return_bytes(), endswith()
-
 // This contains functions for uploading files using a resumable process if
 // supported by the browser. The process takes place in two stages: Showing
 // an upload form, then processing the uploaded data.

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -2,7 +2,6 @@
 include_once($relPath.'site_vars.php');
 include_once($relPath.'Project.inc');
 include_once($relPath.'iso_lang_list.inc'); // langcode3_for_langname, langcode2_for_langname
-include_once($relPath.'misc.inc'); // str_contains, array_get
 include_once($relPath.'unicode.inc');
 
 use voku\helper\UTF8;

--- a/pophelp.php
+++ b/pophelp.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'slim_header.inc');
 include_once('faq/pophelp/prefs/prefs_pophelp.inc');
 include_once('faq/pophelp/teams/teams_pophelp.inc');

--- a/project.php
+++ b/project.php
@@ -19,7 +19,6 @@ include_once($relPath.'wordcheck_engine.inc'); // get_project_word_file
 include_once($relPath.'links.inc'); // new_window_link
 include_once($relPath.'project_edit.inc'); // check_user_can_load_projects
 include_once($relPath.'forum_interface.inc'); // get_last_post_time_in_topic & get_url_*()
-include_once($relPath.'misc.inc'); // html_safe(), get_enumerated_param(), get_integer_param(), array_get(), humanize_bytes()
 include_once($relPath.'faq.inc');
 include_once($relPath.'daily_page_limit.inc'); // get_dpl_count_for_user_in_round
 include_once($relPath.'special_colors.inc'); // load_special_days

--- a/quiz/generic/hints.php
+++ b/quiz/generic/hints.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param
 include_once($relPath.'quizzes.inc'); // get_quiz_page_id_param
 include_once('../small_theme.inc'); // output_small_header
 

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -2,7 +2,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'quizzes.inc'); // get_quiz_page_id_param
 include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 include_once($relPath.'codepoint_validator.inc');

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -11,7 +11,6 @@
 // (2) Include this file.
 // (3) Call functions that it declares.
 
-include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'faq.inc');
 include_once($relPath.'Quiz.inc');
 include_once('./quiz_defaults.inc');

--- a/quiz/generic/returnfeed.php
+++ b/quiz/generic/returnfeed.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // array_get()
 include_once($relPath.'quizzes.inc'); // get_quiz_page_id_param
 include_once('../small_theme.inc'); // output_small_header
 

--- a/quiz/generic/wizard/messages.php
+++ b/quiz/generic/wizard/messages.php
@@ -2,7 +2,6 @@
 $relPath = '../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once('../quiz_defaults.inc'); // $default_*
 
 require_login();

--- a/quiz/generic/wizard/output.php
+++ b/quiz/generic/wizard/output.php
@@ -2,7 +2,6 @@
 $relPath = '../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once('../quiz_defaults.inc'); // ?
 
 require_login();

--- a/quiz/generic/wizard/output_quiz.php
+++ b/quiz/generic/wizard/output_quiz.php
@@ -2,7 +2,6 @@
 $relPath = '../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 
 require_login();
 

--- a/quiz/generic/wizard/quiz_pages.php
+++ b/quiz/generic/wizard/quiz_pages.php
@@ -2,7 +2,6 @@
 $relPath = '../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 
 require_login();
 

--- a/stats/PP_unknown.php
+++ b/stats/PP_unknown.php
@@ -3,7 +3,6 @@ $relPath = "../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 

--- a/stats/equilibria.php
+++ b/stats/equilibria.php
@@ -2,7 +2,6 @@
 $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'page_tally.inc');

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -10,7 +10,6 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'../stats/includes/common.inc');
 include_once($relPath.'forum_interface.inc');
 include_once($relPath.'SettingsClass.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), get_integer_param()
 include_once($relPath.'graph_data.inc');
 
 function showMbrInformation($user, $tally_name)

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -6,7 +6,6 @@ include_once($relPath.'site_vars.php');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'ThemedTable.inc');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param(), get_integer_param(), attr_safe(), get_filelist()
 include_once($relPath.'../stats/includes/common.inc');
 include_once($relPath.'graph_data.inc');
 

--- a/stats/members/jointeam.php
+++ b/stats/members/jointeam.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'theme.inc');
 include_once('../includes/team.inc');

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'privacy.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'metarefresh.inc');

--- a/stats/members/mbr_xml.php
+++ b/stats/members/mbr_xml.php
@@ -2,7 +2,6 @@
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'prefs_options.inc'); // PRIVACY_*
-include_once($relPath.'misc.inc'); // xmlencode()
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'forum_interface.inc');
 include_once($relPath.'User.inc');

--- a/stats/members/mdetail.php
+++ b/stats/members/mdetail.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'privacy.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'page_tally.inc'); // get_page_tally_names()
-include_once($relPath.'misc.inc'); // array_get(), get_integer_param()
 include_once($relPath.'User.inc');
 include_once($relPath.'graph_data.inc');
 include_once('../includes/team.inc');

--- a/stats/members/quitteam.php
+++ b/stats/members/quitteam.php
@@ -2,7 +2,6 @@
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc'); // get_integer_param()
 include_once('../includes/team.inc');
 
 require_login();

--- a/stats/misc_stats1.php
+++ b/stats/misc_stats1.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'page_tally.inc'); // get_page_tally_names()
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 include_once($relPath.'graph_data.inc');
 
 require_login();

--- a/stats/pages_proofed_graphs.php
+++ b/stats/pages_proofed_graphs.php
@@ -2,7 +2,6 @@
 $relPath = './../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 include_once($relPath.'graph_data.inc');
 
 require_login();

--- a/stats/projects_Xed_graphs.php
+++ b/stats/projects_Xed_graphs.php
@@ -3,7 +3,6 @@ $relPath = './../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 include_once($relPath.'graph_data.inc');
 
 require_login();

--- a/stats/proof_stats.php
+++ b/stats/proof_stats.php
@@ -6,7 +6,6 @@ include_once($relPath.'prefs_options.inc'); // PRIVACY_*
 include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'page_tally.inc'); // get_page_tally_names()
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 
 require_login();
 

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -2,7 +2,6 @@
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'dpsql.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'project_states.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'user_is.inc');

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -5,7 +5,6 @@ include_once($relPath.'project_states.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'ThemedTable.inc');
 include_once($relPath.'site_news.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'graph_data.inc');
 
 require_login();

--- a/stats/teams/tdetail.php
+++ b/stats/teams/tdetail.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'http_headers.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'graph_data.inc');

--- a/stats/teams/team_topic.php
+++ b/stats/teams/team_topic.php
@@ -4,7 +4,6 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'forum_interface.inc'); // topic_create & get_url_to_view_topic
-include_once($relPath.'misc.inc'); // get_integer_param()
 
 require_login();
 

--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -2,10 +2,8 @@
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'prefs_options.inc');
-include_once($relPath.'misc.inc'); // xmlencode()
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'forum_interface.inc'); // get_url_to_view_topic
-include_once($relPath.'misc.inc'); // get_integer_param()
 include_once('../includes/team.inc');
 include_once('../includes/member.inc');
 

--- a/stats/teams/tedit.php
+++ b/stats/teams/tedit.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'js_newpophelp.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc'); // get_integer_param()
 include_once('../includes/team.inc');
 
 require_login();

--- a/stats/teams/tlist.php
+++ b/stats/teams/tlist.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'metarefresh.inc');
 include_once('../includes/team.inc');

--- a/tasks.php
+++ b/tasks.php
@@ -6,11 +6,9 @@ include_once($relPath.'project_states.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'send_mail.inc');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe(), array_get()
 include_once($relPath.'SettingsClass.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'links.inc'); // private_message_link()
-include_once($relPath.'misc.inc'); // get_enumerated_param(), str_contains(), echo_html_comment()
 include_once($relPath.'metarefresh.inc');
 
 require_login();

--- a/tools/authors/add.php
+++ b/tools/authors/add.php
@@ -2,7 +2,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), attr_safe(), html_safe()
 include_once("authors.inc");
 include_once("menu.inc");
 

--- a/tools/authors/addbio.php
+++ b/tools/authors/addbio.php
@@ -2,7 +2,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once("authors.inc");
 include_once("menu.inc");
 

--- a/tools/authors/authors.inc
+++ b/tools/authors/authors.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath."misc.inc"); // html_safe()
 
 $months = [_('Unknown'),
     _('January'), _('February'), _('March'),

--- a/tools/authors/authorxml.php
+++ b/tools/authors/authorxml.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // xmlencode()
 
 require_login();
 

--- a/tools/authors/bio.php
+++ b/tools/authors/bio.php
@@ -3,7 +3,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), html_safe()
 include_once('authors.inc');
 include_once('menu.inc');
 

--- a/tools/authors/bioxml.php
+++ b/tools/authors/bioxml.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 
 require_login();
 

--- a/tools/authors/listing.php
+++ b/tools/authors/listing.php
@@ -2,7 +2,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once('authors.inc');
 include_once($relPath.'SortUtility.inc');
 include_once($relPath.'BrowseUtility.inc');

--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -2,11 +2,9 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'user_is.inc');
 include_once($relPath.'SortUtility.inc');
 include_once($relPath.'BrowseUtility.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 include_once('authors.inc');
 include_once('search.inc');
 include_once('menu.inc');

--- a/tools/authors/search.inc
+++ b/tools/authors/search.inc
@@ -1,6 +1,4 @@
 <?php
-include_once($relPath."misc.inc"); // get_enumerated_param(), attr_safe(), html_safe()
-
 // Functions to search authors, display search fields.
 
 // At creation, used by listing.php and manage.php .

--- a/tools/change_sr_commitment.php
+++ b/tools/change_sr_commitment.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'smoothread.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 
 require_login();
 

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -8,7 +8,6 @@ include_once($relPath.'metarefresh.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'ProjectTransition.inc');
 include_once($relPath.'project_quick_check.inc'); // needed for gate_on_pqc() callable
-include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -6,7 +6,6 @@ include_once($relPath."unicode.inc");
 include_once($relPath."CharSuites.inc");
 include_once($relPath."prefs_options.inc");
 include_once($relPath."Project.inc"); // get_projectID_param()
-include_once($relPath."misc.inc"); // array_get()
 
 require_login();
 

--- a/tools/download_images.php
+++ b/tools/download_images.php
@@ -5,7 +5,6 @@
 
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'Project.inc');
 
 require_login();

--- a/tools/pool.php
+++ b/tools/pool.php
@@ -7,7 +7,6 @@ include_once($relPath.'special_colors.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'site_news.inc');
 include_once($relPath.'showavailablebooks.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 
 require_login();
 

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -7,7 +7,6 @@ include_once($relPath.'Project.inc'); // get_projectID_param()
 include_once($relPath.'Stage.inc'); //user_can_work_in_stage()
 include_once($relPath.'User.inc');
 include_once($relPath.'project_states.inc'); // get_project_status_descriptor()
-include_once($relPath.'misc.inc');  // array_get() startswith() attr_safe()
 include_once($relPath.'faq.inc');
 include_once($relPath.'pg.inc');
 include_once($relPath.'links.inc');

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'project_edit.inc');
 include_once($relPath.'DPage.inc');

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -15,7 +15,6 @@ include_once($relPath.'DPage.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'Project.inc'); // project_get_auto_PPer
 include_once($relPath.'job_log.inc');
-include_once($relPath.'misc.inc'); // requester_is_localhost(), html_safe()
 include_once('autorelease.inc');
 
 $one_project = get_projectID_param($_GET, 'project', true);

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -2,7 +2,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // startswith str_contains
 include_once($relPath.'bad_bytes.inc'); // $_bad_byte_sequences
 include_once($relPath.'project_quick_check.inc'); // $css_for_bad_bytes_tables tds_for_bad_bytes
 

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -5,7 +5,6 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'links.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), attr_safe()
 include_once($relPath."DifferenceEngineWrapperTable.inc");
 include_once($relPath."DifferenceEngineWrapperBB.inc");
 include_once($relPath."PageUnformatter.inc"); // PageUnformatter()

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -4,7 +4,6 @@ include_once($relPath.'genres.inc'); // load_genre_translation_array
 include_once($relPath.'wordcheck_engine.inc'); // get_project_word_file
 include_once($relPath.'links.inc'); // new_window_link, new_help_window_link
 include_once($relPath.'user_is.inc'); // user_is_a_sitemanager
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe(), endswith()
 include_once($relPath.'special_colors.inc'); // load_special_days()
 include_once($relPath.'User.inc');
 include_once($relPath.'CharSuites.inc');

--- a/tools/project_manager/edit_pages.php
+++ b/tools/project_manager/edit_pages.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_edit.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc');  // attr_safe()
 include_once($relPath.'page_table.inc');
 include_once('page_operations.inc');
 

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -7,7 +7,6 @@ include_once('edit_common.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc');  // attr_safe(), html_safe()
 include_once($relPath.'faq.inc');
 
 require_login();

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -2,7 +2,6 @@
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'MARCRecord.inc');
 include_once($relPath.'project_states.inc');

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -6,7 +6,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
 include_once($relPath.'MARCRecord.inc');
 
 require_login();

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -5,7 +5,6 @@ include_once($relPath.'project_states.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param(), html_safe()
 include_once('./post_files.inc');
 
 require_login();

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -7,7 +7,6 @@ include_once($relPath.'DPage.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe(), get_enumerated_param()
 include_once($relPath.'codepoint_validator.inc');
 include_once($relPath.'page_table.inc');  // page_state_is_a_bad_state()
 

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -6,10 +6,8 @@ include_once($relPath.'project_states.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'send_mail.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'SettingsClass.inc');
 include_once($relPath.'User.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 
 require_login();
 

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'links.inc');
 include_once($relPath.'Project.inc');

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'page_table.inc');

--- a/tools/project_manager/post_files.inc
+++ b/tools/project_manager/post_files.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc');
 include_once($relPath.'site_vars.php');
 include_once($relPath.'comment_inclusions.inc');
 include_once($relPath.'stages.inc');

--- a/tools/project_manager/project_quick_check.php
+++ b/tools/project_manager/project_quick_check.php
@@ -4,7 +4,6 @@
 $relPath = "../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // array_get(), get_enumerated_param(), html_safe()
 include_once($relPath.'Project.inc'); // Project::Project
 include_once($relPath.'project_quick_check.inc');
 

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc'); // array_get()
 include_once($relPath.'SettingsClass.inc');
 include_once($relPath.'special_colors.inc');
 include_once($relPath.'gradual.inc');

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'user_is.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe(), startswith()
 include_once($relPath.'upload_file.inc'); // show_upload_form(), detect_too_large(), validate_uploaded_file()
 include_once($relPath.'slim_header.inc');
 

--- a/tools/project_manager/show_adhoc_word_details.php
+++ b/tools/project_manager/show_adhoc_word_details.php
@@ -2,10 +2,8 @@
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param(), attr_safe()
 include_once('./post_files.inc');
 include_once('./word_freq_table.inc');
 

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -3,9 +3,7 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
 include_once($relPath.'Stopwatch.inc');
-include_once($relPath.'misc.inc'); // array_get(), get_integer_param(), surround_and_join()
 include_once('./post_files.inc'); // page_info_query()
 include_once("./word_freq_table.inc"); // echo_cutoff_text(), printTableFrequencies(), decode_word()
 

--- a/tools/project_manager/show_current_flagged_words.php
+++ b/tools/project_manager/show_current_flagged_words.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param()
 include_once('./post_files.inc');
 include_once('./word_freq_table.inc');
 

--- a/tools/project_manager/show_good_word_suggestions.php
+++ b/tools/project_manager/show_good_word_suggestions.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param()
 include_once('./post_files.inc');
 include_once("./word_freq_table.inc");
 

--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -7,9 +7,7 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'LPage.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc'); // array_get(), attr_safe(), html_safe()
 include_once($relPath.'Stopwatch.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param()
 include_once($relPath.'page_controls.inc');
 include_once($relPath.'control_bar.inc'); // get_control_bar_texts()
 include_once('./post_files.inc');

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -6,7 +6,6 @@ $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'project_states.inc');
-include_once($relPath.'misc.inc'); // array_get(), html_safe()
 include_once($relPath.'pg.inc');
 include_once($relPath.'Project.inc'); // load_image_sources()
 

--- a/tools/project_manager/show_project_possible_bad_words.php
+++ b/tools/project_manager/show_project_possible_bad_words.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
-include_once($relPath.'misc.inc'); // get_integer_param(), get_enumerated_param()
 include_once('./post_files.inc');
 include_once('./word_freq_table.inc');
 

--- a/tools/project_manager/show_project_stealth_scannos.php
+++ b/tools/project_manager/show_project_stealth_scannos.php
@@ -6,7 +6,6 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 include_once('./post_files.inc');
 include_once('./word_freq_table.inc');
 

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -4,11 +4,9 @@ include_once($relPath.'base.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'stages.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'LPage.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc'); // array_get(), get_integer_param()
 include_once($relPath.'page_controls.inc'); // get_proofreading_interface_data_js()
 include_once($relPath.'control_bar.inc'); // get_control_bar_texts()
 include_once('./post_files.inc'); // page_info_query()

--- a/tools/project_manager/update_illos.php
+++ b/tools/project_manager/update_illos.php
@@ -5,7 +5,6 @@ $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc'); // get_upload_err_msg, get_enumerated_param, attr_safe
 include_once($relPath.'project_states.inc'); // PROJ_NEW
 include_once($relPath.'abort.inc'); // provide_escape_links
 

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -2,7 +2,6 @@
 include_once($relPath.'links.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'faq.inc');
 include_once($relPath.'unicode.inc');
 

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -5,10 +5,8 @@ include_once($relPath.'RoundDescriptor.inc'); // $PAGE_STATES_IN_ORDER
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 include_once($relPath.'LPage.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 include_once($relPath.'links.inc');
 include_once($relPath.'forum_interface.inc'); // get_forum_user_id()
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 
 // Page-related code that's common to the standard and enhanced interfaces.
 

--- a/tools/proofers/ctrl_frame.php
+++ b/tools/proofers/ctrl_frame.php
@@ -3,7 +3,6 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'stages.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param()
 include_once($relPath.'Project.inc'); // validate_projectID()
 include_once($relPath.'ProofreadingToolbox.inc');
 

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -13,7 +13,6 @@ include_once($relPath.'theme.inc');          // for page marginalia
 include_once($relPath.'project_states.inc'); // for PROJ_ declarations
 include_once($relPath.'TallyBoard.inc');     // for TallyBoard
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 
 require_login();
 

--- a/tools/proofers/greek2ascii.php
+++ b/tools/proofers/greek2ascii.php
@@ -3,7 +3,6 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'faq.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
 
 require_login();
 

--- a/tools/proofers/hiero/index.php
+++ b/tools/proofers/hiero/index.php
@@ -2,7 +2,6 @@
 $relPath = "./../../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc'); // html_safe()
 
 require_login();
 

--- a/tools/proofers/image_block_enh.inc
+++ b/tools/proofers/image_block_enh.inc
@@ -1,5 +1,4 @@
 <?php
-include_once($relPath.'misc.inc');
 
 // "ibe" for "image block enhanced"
 

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -3,7 +3,6 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'misc.inc'); // get_enumerated_param(), html_safe()
 include_once($relPath.'project_states.inc'); // PROJ_NEW, PROJ_P1_UNAVAILABLE
 include_once($relPath.'links.inc');
 

--- a/tools/proofers/mktable.php
+++ b/tools/proofers/mktable.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "../../pinc/";
 include_once($relPath."base.inc");
-include_once($relPath."misc.inc");
 
 require_login();
 

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // array_get(), surround_and_join(), html_safe()
 include_once($relPath.'theme.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -1,6 +1,5 @@
 <?php
 $relPath = "./../../pinc/";
-include_once($relPath.'misc.inc');
 
 function get_preview_messages()
 {

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -3,7 +3,6 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'metarefresh.inc');
-include_once($relPath.'misc.inc'); // array_get()
 include_once($relPath.'abort.inc');
 include_once($relPath.'Project.inc'); // $PROJECT_STATES_IN_ORDER
 include_once('PPage.inc');

--- a/tools/proofers/report_bad_page.php
+++ b/tools/proofers/report_bad_page.php
@@ -5,7 +5,6 @@ include_once($relPath.'project_states.inc');
 include_once($relPath.'project_trans.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'abort.inc');

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -2,7 +2,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'project_states.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'Project.inc'); // does_project_page_table_exist()

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -4,7 +4,6 @@
 
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'stages.inc');
 include_once($relPath.'showavailablebooks.inc');
 include_once($relPath.'theme.inc');

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -2,7 +2,6 @@
 include_once($relPath.'site_vars.php');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
-include_once($relPath.'misc.inc');  // attr_safe(), javascript_safe()
 include_once($relPath.'unicode.inc');
 include_once($relPath.'links.inc'); // new_window_link
 include_once($relPath.'faq.inc');

--- a/tools/proofers/srchrep.php
+++ b/tools/proofers/srchrep.php
@@ -2,7 +2,6 @@
 $relPath = './../../pinc/';
 include_once($relPath."base.inc");
 include_once($relPath."slim_header.inc");
-include_once($relPath."misc.inc");
 
 require_login();
 

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -1,7 +1,6 @@
 <?php
 include_once($relPath.'button_defs.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'codepoint_validator.inc');
 include_once('preview.inc');
 

--- a/tools/setlangcookie.php
+++ b/tools/setlangcookie.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "../pinc/";
 include_once($relPath."base.inc");
-include_once($relPath."misc.inc");
 include_once($relPath."metarefresh.inc");
 
 // These should always be set if the user got here correctly.

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -1,10 +1,8 @@
 <?php
 $relPath = './../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'DPage.inc'); // project_recalculate_page_counts
 include_once($relPath.'Project.inc');
 include_once($relPath.'user_project_info.inc');

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = './../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'new_user_mails.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'User.inc');
 include_once($relPath.'email_address.inc');
 

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'User.inc');
-include_once($relPath.'misc.inc'); // attr_safe()
 include_once($relPath.'access_log.inc');
 
 require_login();

--- a/tools/site_admin/manage_site_word_lists.php
+++ b/tools/site_admin/manage_site_word_lists.php
@@ -3,10 +3,8 @@ $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'links.inc');
-include_once($relPath.'misc.inc'); // array_get()
 
 require_login();
 

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -3,7 +3,6 @@ $relPath = './../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc'); // attr_safe(), html_safe()
 include_once($relPath.'user_is.inc');
 include_once($relPath.'special_colors.inc');
 

--- a/tools/site_admin/project_jump.php
+++ b/tools/site_admin/project_jump.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'links.inc');

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -3,7 +3,6 @@ $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'user_is.inc');
 
 require_login();

--- a/tools/site_admin/shared_postednums.php
+++ b/tools/site_admin/shared_postednums.php
@@ -2,7 +2,6 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'misc.inc');
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'user_is.inc');
 

--- a/tools/site_admin/show_common_words_from_project_word_lists.php
+++ b/tools/site_admin/show_common_words_from_project_word_lists.php
@@ -5,7 +5,6 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'links.inc');
-include_once($relPath.'misc.inc'); // array_get()
 
 require_login();
 

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -4,7 +4,6 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'site_news.inc');
-include_once($relPath.'misc.inc'); // html_safe(), get_integer_param(), get_enumerated_param()
 
 require_login();
 

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -1,7 +1,6 @@
 <?php
 $relPath = "../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'misc.inc'); // array_get()
 
 require_login();
 

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -8,7 +8,6 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'forum_interface.inc');
-include_once($relPath.'misc.inc'); // html_safe(), extract_zip_to(), return_bytes(), remove_common_basedir_from_zip()
 include_once($relPath.'smoothread.inc'); // handle_smooth_reading_change()
 include_once($relPath.'upload_file.inc'); // show_upload_form(), detect_too_large(), validate_uploaded_file, zip_check()
 include_once($relPath.'links.inc');

--- a/userprefs.php
+++ b/userprefs.php
@@ -8,9 +8,7 @@ include_once($relPath.'languages.inc'); // bilingual_name()
 include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'SettingsClass.inc');
-include_once($relPath.'misc.inc'); // startswith(...), attr_safe(), html_safe()
 include_once($relPath.'js_newpophelp.inc');
-include_once($relPath.'misc.inc'); // get_integer_param()
 include_once($relPath.'forum_interface.inc'); // get_forum_user_details(), get_url_to_edit_profile()
 include_once($relPath.'User.inc');
 


### PR DESCRIPTION
A _vast_ majority of files use functions in `misc.inc`, just include that in `bootstrap.inc` so we can assume functions in there are available everywhere and remove other includes.

This also adds a CI/CD check to make sure `base.inc` (which pulls in `bootstrap.inc`) is correctly being included in all `.php` files per our [best practices](https://www.pgdp.net/wiki/DP_Code_Best_Practices#Every_PHP_file_must_include_base.inc).

I've spun up a sandbox as a sanity check but due to the new CI/CD check we can confirm that all pages are pulling in `base.inc` which pulls in `bootstrap.inc` which pulls in `misc.inc` so there is no need for extensive testing.

https://www.pgdp.org/~cpeel/c.branch/move-misc-to-bootstrap/