### PR TITLE
Format preview class

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -520,7 +520,7 @@ QUnit.module("Format preview test", function() {
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 1);
-        assert.strictEqual(preview.txtout, "<span style=\"background-color:#ceff09;\"title='unRecTag'>&lt;</span>i&amp;&gt;");
+        assert.strictEqual(preview.txtout, "<span class='hlt_color' title='unRecTag'>&lt;</span>i&amp;&gt;");
     });
 
     QUnit.test("Check html entity is encoded", function (assert) {
@@ -538,7 +538,7 @@ QUnit.module("Format preview test", function() {
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<span class='sc'  style=\"color:#009700;\">Ab</span>");
+        assert.strictEqual(preview.txtout, "<span class='sc_color sc'>Ab</span>");
     });
 
     QUnit.test("Small cap markup with all upper case", function (assert) {
@@ -547,7 +547,7 @@ QUnit.module("Format preview test", function() {
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<span class='sc'  style=\"color:#009700;\"><span class=\"tt\">AB</span></span>");
+        assert.strictEqual(preview.txtout, "<span class='sc_color sc'><span class=\"tt\">AB</span></span>");
     });
 
     QUnit.test("Small cap markup with all upper case with &", function (assert) {
@@ -556,7 +556,7 @@ QUnit.module("Format preview test", function() {
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<span class='sc'  style=\"color:#009700;\"><span class=\"tt\">A&amp;B</span></span>");
+        assert.strictEqual(preview.txtout, "<span class='sc_color sc'><span class=\"tt\">A&amp;B</span></span>");
     });
 
     QUnit.test("Rewrap continuation paragraph", function (assert) {

--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -566,7 +566,7 @@ QUnit.module("Format preview test", function() {
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<div style=\"margin-bottom: 0.4em; margin-left: 0em;\">abcd\n</div>");
+        assert.strictEqual(preview.txtout, "<div style='margin-left: 0em;' class='cont-para'>abcd\n</div>");
     });
 
     QUnit.test("Rewrap new paragraph", function (assert) {
@@ -577,7 +577,7 @@ abcd`;
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<div style=\"margin-bottom: 0.4em; margin-left: 0em; text-indent: 1em;\">abcd\n</div>");
+        assert.strictEqual(preview.txtout, "<div style='margin-left: 0em;' class='para'>abcd\n</div>");
     });
 
     QUnit.test("Rewrap no-wrap block with 4 blank lines", function (assert) {
@@ -593,7 +593,7 @@ EDIBLE FIGS
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<div style=\"margin-bottom: 0.4em; margin-left: 0em; white-space: pre;\">\n\n\n\nEDIBLE FIGS\n</div>");
+        assert.strictEqual(preview.txtout, "<div style='margin-left: 0em;' class='no-wrap nowrap_color'>\n\n\n\nEDIBLE FIGS\n</div>");
     });
 
     QUnit.test("Rewrap no-wrap block preceeded by 4 blank lines", function (assert) {
@@ -611,7 +611,7 @@ abc
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<div style=\"margin-bottom: 0.4em; margin-left: 0em; white-space: pre;\">FIG CULTURE.\n\nabc\n</div>");
+        assert.strictEqual(preview.txtout, "<div style='margin-left: 0em;' class='no-wrap nowrap_color'>FIG CULTURE.\n\nabc\n</div>");
     });
 
     QUnit.test("Rewrap continuation block quote", function (assert) {
@@ -623,7 +623,7 @@ abc
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<div style=\"margin-bottom: 0.4em; margin-left: 1em;\">abc\n</div>");
+        assert.strictEqual(preview.txtout, "<div style='margin-left: 1em;' class='cont-para blockquote_color'>abc\n</div>");
     });
 
     QUnit.test("Rewrap continuation block quote with new paragraph", function (assert) {
@@ -636,7 +636,7 @@ abc
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<div style=\"margin-bottom: 0.4em; margin-left: 1em; text-indent: 1em;\">abc\n</div>");
+        assert.strictEqual(preview.txtout, "<div style='margin-left: 1em;' class='para blockquote_color'>abc\n</div>");
     });
 
     QUnit.test("Rewrap new block quote with paragraph", function (assert) {
@@ -649,7 +649,7 @@ abc
         assert.strictEqual(preview.ok, true);
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
-        assert.strictEqual(preview.txtout, "<div style=\"margin-bottom: 0.4em; margin-left: 1em; text-indent: 1em;\">abc\n</div>");
+        assert.strictEqual(preview.txtout, "<div style='margin-left: 1em;' class='para blockquote_color'>abc\n</div>");
     });
 
     QUnit.test("Rewrap no-wrap in block quote with no blank line before no-wrap", function (assert) {
@@ -667,8 +667,8 @@ bq
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
         assert.strictEqual(preview.txtout,
-            `<div style="margin-bottom: 0.4em; margin-left: 1em; white-space: pre;">bqnw
-</div><div style="margin-bottom: 0.4em; margin-left: 1em; text-indent: 1em;">bq
+            `<div style='margin-left: 1em;' class='no-wrap nowrap_color'>bqnw
+</div><div style='margin-left: 1em;' class='para blockquote_color'>bq
 </div>`);
     });
 
@@ -688,8 +688,28 @@ bq
         assert.strictEqual(preview.issues, 0);
         assert.strictEqual(preview.possIss, 0);
         assert.strictEqual(preview.txtout,
-            `<div style="margin-bottom: 0.4em; margin-left: 1em; white-space: pre;">bqnw
-</div><div style="margin-bottom: 0.4em; margin-left: 1em; text-indent: 1em;">bq
+            `<div style='margin-left: 1em;' class='no-wrap nowrap_color'>bqnw
+</div><div style='margin-left: 1em;' class='para blockquote_color'>bq
+</div>`);
+    });
+
+    QUnit.test("Rewrap block quote in block quote", function (assert) {
+        let text =
+`
+/#
+bq
+
+/#
+bqbq
+#/
+#/`;
+        let preview = makePreview(text, false, true, defaultStyles, getMessage);
+        assert.strictEqual(preview.ok, true);
+        assert.strictEqual(preview.issues, 0);
+        assert.strictEqual(preview.possIss, 0);
+        assert.strictEqual(preview.txtout,
+            `<div style='margin-left: 1em;' class='para blockquote_color'>bq
+</div><div style='margin-left: 2em;' class='para blockquote_color'>bqbq
 </div>`);
     });
 });

--- a/styles/preview.css
+++ b/styles/preview.css
@@ -108,3 +108,18 @@
     font-weight: bold;
     text-align: center;
 }
+/* paragraph and block quote*/
+.para {
+    margin-bottom: 0.4em;
+    text-indent: 1em;
+}
+/* continuation paragraph */
+.cont-para {
+    margin-bottom: 0.4em;
+}
+/* no-wrap block */
+.no-wrap {
+    margin-bottom: 0.4em;
+    white-space: pre;
+    display: inline-block;
+}

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -982,8 +982,9 @@ const makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
             txt = txt.replace(/┌tb┐/g, function replacer(match) {
                 return `<span class="etc_color">${boxHtml(match)}</span>`;
             });
-            txt = txt.replace(/\/#|#\//g, "<span class='blockquote_color'>$&</span>");
-            txt = txt.replace(/\/\*|\*\//g, "<span class='nowrap_color'>$&</span>");
+            txt = txt.replace(/\/#/g, "<span class='blockquote_color'>$&");
+            txt = txt.replace(/\/\*/g, "<span class='nowrap_color'>$&");
+            txt = txt.replace(/#\/|\*\//g, "$&</span>");
         }
 
         // encode any unrecognised tags
@@ -1057,6 +1058,7 @@ const makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
         let indent = 0;
         let blockType = CONT;
         let blockQuote = false;
+        const noWrapColor = styler.color ? ' nowrap_color' : '';
 
         function terminate() {
             if(inBlock) {
@@ -1103,7 +1105,7 @@ const makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
                     indent -= 1;
                 } else if("/*" === line) {
                     // no wrap
-                    txtOut += `<div style="margin-bottom: 0.4em; margin-left: ${indent}em; white-space: pre;">`;
+                    txtOut += `<div style='margin-left: ${indent}em;' class='no-wrap${noWrapColor}'>`;
                     for(;;) {
                         line = getNextLine();
                         if(processTB()) {
@@ -1120,6 +1122,7 @@ const makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
                     continue;
                 } else {
                     // text line
+                    const paraColor = (styler.color && blockQuote) ? ' blockquote_color' : '';
                     if(!inBlock) {
                         inBlock = true;
                         switch(blockType) {
@@ -1129,16 +1132,16 @@ const makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
                         case HEAD2:
                             if(blockQuote) {
                                 // use paragraph style
-                                txtOut += '<div style="margin-bottom: 0.4em; margin-left: 1em; text-indent: 1em;">';
+                                txtOut += `<div style='margin-left: 1em;' class='para${paraColor}'>`;
                             } else {
                                 txtOut += '<div class="head2">';
                             }
                             break;
                         case PARA:
-                            txtOut += `<div style="margin-bottom: 0.4em; margin-left: ${indent}em; text-indent: 1em;">`;
+                            txtOut += `<div style='margin-left: ${indent}em;' class='para${paraColor}'>`;
                             break;
                         case CONT:
-                            txtOut += `<div style="margin-bottom: 0.4em; margin-left: ${indent}em;">`;
+                            txtOut += `<div style='margin-left: ${indent}em;' class='cont-para${paraColor}'>`;
                             break;
                         }
                     }

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, camelcase */
-/* exported previewControl, initPrev */
+/* exported previewControl */
 /* global $ makePreview, fontStyles fontFamilies MathJax validateText tagNames previewStrings
 previewMessages defaultStyles */
 /*
@@ -13,7 +13,6 @@ The configuration screen is handled in the same way.
 previewStrings are translated strings in header args
 */
 var previewControl;
-var previewColorStyle;
 
 window.addEventListener("DOMContentLoaded", () => {
     "use strict";
@@ -39,7 +38,7 @@ window.addEventListener("DOMContentLoaded", () => {
     let fontSelector = document.getElementById("id_font_sel");
     let previewStyles = defaultStyles;
 
-    previewColorStyle = document.createElement('style');
+    const previewColorStyle = document.createElement('style');
     document.head.appendChild(previewColorStyle);
 
     var suppCheckBox = [];

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -13,6 +13,7 @@ The configuration screen is handled in the same way.
 previewStrings are translated strings in header args
 */
 var previewControl;
+var previewColorStyle;
 
 window.addEventListener("DOMContentLoaded", () => {
     "use strict";
@@ -38,6 +39,9 @@ window.addEventListener("DOMContentLoaded", () => {
     let fontSelector = document.getElementById("id_font_sel");
     let previewStyles = defaultStyles;
 
+    previewColorStyle = document.createElement('style');
+    document.head.appendChild(previewColorStyle);
+
     var suppCheckBox = [];
 
     var viewMode;
@@ -56,6 +60,22 @@ window.addEventListener("DOMContentLoaded", () => {
 
     function getMessage(index) {
         return previewMessages[index];
+    }
+
+    function makeColorStyles(config) {
+        let styleString = '';
+        Object.keys(tagNames).forEach(function(tag) {
+            let tagStyle = config[tag];
+            let innerString = "";
+            if (tagStyle.fg !== "") {
+                innerString = `color:${tagStyle.fg};`;
+            }
+            if (tagStyle.bg !== "") {
+                innerString += `background-color:${tagStyle.bg};`;
+            }
+            styleString += `.${tag}_color {${innerString}} `;
+        });
+        previewColorStyle.innerHTML = styleString;
     }
 
     function writePreviewText() {
@@ -120,12 +140,15 @@ window.addEventListener("DOMContentLoaded", () => {
         return dest;
     }
 
+
+
     function initStyle() {
         var style0;
         if (localStorage.getItem('preview_data')) {
             style0 = JSON.parse(localStorage.preview_data);
             previewStyles = deepCopy(previewStyles, style0, true);
         }
+        makeColorStyles(previewStyles);
     }
 
     function setSelectedFont() {
@@ -219,6 +242,7 @@ window.addEventListener("DOMContentLoaded", () => {
     function testDraw() {
         testDiv.style.backgroundColor = tempStyle.t.bg;
         testDiv.style.color = tempStyle.t.fg;
+        makeColorStyles(tempStyle);
         preview = makePreview(previewStrings.previewDemo, 'no_tags', false, tempStyle, getMessage);
         testDiv.innerHTML = preview.txtout;
     }
@@ -353,7 +377,9 @@ window.addEventListener("DOMContentLoaded", () => {
             });
         },
 
-        cancelConfig: function () { // don't change anything
+        cancelConfig: function () {
+            // restore color style css
+            makeColorStyles(previewStyles);
             hideConfig();
         },
     };


### PR DESCRIPTION
This uses classes rather than styles to colour and style the format preview. This makes the tests less dependent on the details of the style.
Then colour no-wrap and block-quote blocks rather than just the tags. This addresses [task #2065](https://www.pgdp.net/c/tasks.php?action=show&task_id=2065)

Sandbox at: https://www.pgdp.org/~rp31/c.branch/format_preview_class
