### PR TITLE
Add round param validation

### DIFF
--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -594,12 +594,13 @@ function get_round_param($arr, $key, $default = null, $allownull = false)
         }
         // Trim whitespace from both ends of the string.
         $s = trim($s);
+        if ($s == '' && $allownull) {
+            return null;
+        }
+
         $round = $Round_for_round_id_[$s] ?? null;
         if ($round) {
             return $round;
-        }
-        if ($round === null && $allownull) {
-            return null;
         } else {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' ('%2\$s') is not a valid round ID"),

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -563,3 +563,60 @@ function is_formatting_round($round)
 {
     return startswith($round->id, 'F');
 }
+
+/**
+ * From an array & key, get a Round object matching the ID
+ *
+ * @param array $arr
+ * @param string $key
+ * @param mixed $default
+ * @param bool $allownull
+ *
+ * @throws InvalidArgumentException
+ */
+function get_round_param($arr, $key, $default = null, $allownull = false)
+{
+    global $Round_for_round_id_;
+    // sanity checks on the args
+    assert(is_array($arr));
+    assert(!is_array($key));
+    assert(is_null($default) || is_string($default));
+    if (!is_null($default)) {
+        assert(!$allownull);
+    }
+    if (isset($arr[$key])) {
+        $s = $arr[$key];
+        if (!is_string($s)) {
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' is not a valid type"),
+                $key
+            ));
+        }
+        // Trim whitespace from both ends of the string.
+        $s = trim($s);
+        $round = $Round_for_round_id_[$s] ?? null;
+        if ($round) {
+            return $round;
+        }
+        if ($round === null && $allownull) {
+            return null;
+        } else {
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' ('%2\$s') is not a valid round ID"),
+                $key,
+                $s
+            ));
+        }
+    } else {
+        // parameter not set, use default
+        if (is_null($default) && !$allownull) {
+            // There is no default. The parameter is required.
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' is required"),
+                $key
+            ));
+        } else {
+            return $default;
+        }
+    }
+}

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -73,7 +73,7 @@ function get_rounds_to_display($project)
  * }
  * ```
  */
-function fetch_page_table_data($project, $page_selector = null, $proofed_in_round = null)
+function fetch_page_table_data($project, $page_selector = null, $work_round = null)
 {
     if (!$project->pages_table_exists) {
         throw new NoProjectPageTable(_("Project page table does not exist."));
@@ -133,8 +133,7 @@ function fetch_page_table_data($project, $page_selector = null, $proofed_in_roun
         $username_for_selecting_pages = $page_selector;
 
         $where_condition = "0";
-        $work_round = get_Round_for_round_id($proofed_in_round);
-        if (is_null($proofed_in_round) || is_null($work_round)) {
+        if (is_null($work_round)) {
             // want pages that the specified user did in any round
             foreach ($rounds_to_display as $round) {
                 $where_condition .= sprintf("

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -382,7 +382,6 @@ function headerbar_text_array($entries)
 function html_statsbar($nameofpage)
 {
     global $code_url, $PG_home_url;
-    global $Round_for_round_id_;
     maybe_show_language_selector();
 
     // For logged-in users, show links to key help documents:
@@ -401,8 +400,8 @@ function html_statsbar($nameofpage)
 
     // If tally_name is unspecfied, try to see if round_id is set.
     if (!isset($tally_name)) {
-        $rounds = array_keys($Round_for_round_id_);
-        $tally_name = get_enumerated_param($_REQUEST, 'round_id', null, $rounds, true);
+        $round = get_round_param($_REQUEST, 'round_id', null, true);
+        $tally_name = $round->id ?? null;
     }
 
     if (!isset($tally_name)) {

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -25,7 +25,7 @@ $listing_view_modes = [
     ],
 ];
 
-$round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_), true);
+$round = get_round_param($_GET, 'round_id', null, true);
 $name = @$_GET['name'];
 $listing_view_mode = get_enumerated_param($_GET, "show", "populated", array_keys($listing_view_modes));
 $unheld_only = get_integer_param($_GET, 'unheld_only', 0, 0, 1);
@@ -34,11 +34,9 @@ $title = _("Release Queues");
 output_header($title, NO_STATSBAR);
 echo "<h1>" . html_safe($title) . "</h1>\n";
 
-if (is_null($round_id)) {
+if (is_null($round)) {
     _show_available_rounds();
 } else {
-    $round = get_Round_for_round_id($round_id);
-
     if (isset($name)) {
         _show_queue_details($round, $name, $unheld_only);
     } else {

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -9,7 +9,7 @@ require_login();
 
 $projectid = get_projectID_param($_GET, 'project');
 $show_image_size = get_integer_param($_GET, 'show_image_size', 0, 0, 1);
-$round_for_page_selection = get_enumerated_param($_GET, 'select_by_round', null, array_keys($Round_for_round_id_), true);
+$round_for_page_selection = get_round_param($_GET, 'select_by_round', null, true);
 
 // select_by_user can have three possible values:
 //    NULL = show all users
@@ -71,7 +71,7 @@ if ($project->check_pages_table_exists($warn_message)) {
             echo sprintf(
                 _("Showing only the pages of user '%1\$s' in round %2\$s."),
                 html_safe($username_for_page_selection),
-                html_safe($round_for_page_selection)
+                html_safe($round_for_page_selection->id)
             );
         }
         $blurb = _("Show all pages instead.");

--- a/tools/proofers/ctrl_frame.php
+++ b/tools/proofers/ctrl_frame.php
@@ -6,8 +6,7 @@ include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc'); // validate_projectID()
 include_once($relPath.'ProofreadingToolbox.inc');
 
-$round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_));
-$round = get_Round_for_round_id($round_id);
+$round = get_round_param($_GET, 'round_id');
 // if this is used in a quiz there will not be a real projectid, 'quiz' will be
 // used for the MRU local storage prefix and the character selector will
 // provide the quiz pickers

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -26,10 +26,8 @@ echo "<h1>$title</h1>";
 
 // Decide which mentoring-round we're dealing with.
 
-$round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_), true);
-if ($round_id != '') {
-    $mentoring_round = get_Round_for_round_id($round_id);
-} else {
+$mentoring_round = get_round_param($_GET, 'round_id', null, true);
+if (!$mentoring_round) {
     // Consider the page they came from.
     $referer = @$_SERVER['HTTP_REFERER'];
 

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -15,8 +15,8 @@ include_once($relPath.'faq.inc');
 
 require_login();
 
-$round_id = get_enumerated_param($_GET, 'round_id', null, array_keys($Round_for_round_id_));
-$round = get_Round_for_round_id($round_id);
+$round = get_round_param($_GET, 'round_id');
+$round_id = $round->id;
 $header_args = ["js_files" => ["$code_url/scripts/filter_project.js"]];
 
 output_header("$round->id: $round->name", SHOW_STATSBAR, $header_args);


### PR DESCRIPTION
Create and use a new function for validating a round ID and return the round object if found. This mirrors our other `get_[name]_param()` functions in `misc.inc`.

Testable in https://www.pgdp.org/~cpeel/c.branch/create-round-param-validator/

Specifically the following pages:
* [round page](https://www.pgdp.org/~cpeel/c.branch/create-round-param-validator/tools/proofers/round.php?round_id=P1)
* [Review Work](https://www.pgdp.org/~cpeel/c.branch/create-round-param-validator/tools/proofers/review_work.php)
* [release queues](https://www.pgdp.org/~cpeel/c.branch/create-round-param-validator/stats/release_queue.php?round_id=P1)
* [for mentors](https://www.pgdp.org/~cpeel/c.branch/create-round-param-validator/tools/proofers/for_mentors.php?round_id=P2)
* [page details without round param](https://www.pgdp.org/~cpeel/c.branch/create-round-param-validator/tools/project_manager/page_detail.php?project=projectID4c49f39aa829c&show_image_size=0)
* [page details with round param](https://www.pgdp.org/~cpeel/c.branch/create-round-param-validator/tools/project_manager/page_detail.php?project=projectID4c49f39aa829c&show_image_size=0&select_by_user=srjfoo&select_by_round=F1)