### PR TITLE
Allow image to scroll beyond edges

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -257,7 +257,6 @@ function makeControlDiv(container, content, controls) {
 
 function makeImageWidget(container, align = "C") {
     const content = document.createElement("div");
-    content.style.scrollbarWidth = 'none';
     const grabCursor = "grab";
     // use plain js image so width or style.width is clearly differentiated
     const image = document.createElement("img");
@@ -351,6 +350,11 @@ function makeImageWidget(container, align = "C") {
         yOffset += vertOffset;
         // image rotates about centre. Offset moves it to correct position
         image.style.transform = `matrix(${cosine}, ${-sine}, ${sine}, ${cosine}, ${xOffset}, ${yOffset})`;
+
+        // show scrollbar only if image is bigger than window
+        content.style.overflowX = (imageWidth > contentWidth) ? "auto" : "hidden";
+        // seems to need +1 to hide bar when fitting to height
+        content.style.overflowY = (imageHeight > contentHeight + 1) ? "auto" : "hidden";
     }
 
     function initScroll() {

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -346,8 +346,6 @@ function makeImageWidget(container, align = "C") {
         image.style.transform = `matrix(${cosine}, ${-sine}, ${sine}, ${cosine}, ${xOffset}, ${-yOffset})`;
     }
 
-    image.addEventListener("load", setImageStyle);
-
     function initScroll() {
         // assuming width is 2*contentWidth
         if(align == "C") {
@@ -359,6 +357,13 @@ function makeImageWidget(container, align = "C") {
         }
         content.scrollTop = 0;
     }
+
+    function initAll() {
+        setImageStyle();
+        initScroll();
+    }
+
+    image.addEventListener("load", initAll);
 
     function setZoom() {
         if(percent < minPercent) {
@@ -434,16 +439,14 @@ function makeImageWidget(container, align = "C") {
         .append($("<i>", {class: 'fas fa-redo-alt'}))
         .click( function () {
             [sine, cosine] = [-cosine, sine];
-            setImageStyle();
-            initScroll();
+            initAll();
         });
 
     const counterclockRotateInput = $("<button>", {title: texts.counterclockRotate})
         .append($("<i>", {class: 'fas fa-undo-alt'}))
         .click( function () {
             [sine, cosine] = [cosine, -sine];
-            setImageStyle();
-            initScroll();
+            initAll();
         });
 
     const controls = [
@@ -461,8 +464,7 @@ function makeImageWidget(container, align = "C") {
     const controlDiv = makeControlDiv(container, $(content), controls);
     // content width can change when moving controls
     controlDiv.onChange.add(function () {
-        setImageStyle();
-        initScroll();
+        initAll();
     });
 
     return {
@@ -483,7 +485,6 @@ function makeImageWidget(container, align = "C") {
             sine = 0;
             cosine = 1;
             image.src = src;
-            initScroll();
         },
 
         reScroll: reScroll,

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -358,8 +358,8 @@ function makeImageWidget(container, align = "C") {
         // (2 * windowWidth): half left to half right,
         // (2 * windowWidth + imageWidth): scroll to far edges,
         // similarly for vertical
-        contentWidth = parseFloat(getComputedStyle(content).width);
-        contentHeight = parseFloat(getComputedStyle(content).height);
+        contentWidth = content.clientWidth;
+        contentHeight = content.clientHeight;
         image.style.width = `${10 * percent}px`;
         image.style.height = "auto";
         let imageHeight, xOffset, yOffset, imDivHeight;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -391,7 +391,7 @@ function makeImageWidget(container, align = "C") {
 
     function reScroll () {
         // keep same scroll proportion when contentWidth changes
-        let oldScroll = content.scrollLeft / contentWidth;
+        let oldScroll = (contentWidth > 20) ? content.scrollLeft / contentWidth : 0.5;
         setImageStyle();
         content.scrollLeft = oldScroll * contentWidth;
     }

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -332,7 +332,7 @@ function makeImageWidget(container, align = "C") {
     let cosine = 1;
 
     const percentInput = $("<input>", {type: 'number', value: percent, title: texts.zoomPercent});
-    let contentWidth, imageWidth, imDivWidth, vertOffset;
+    let contentWidth, contentHeight, imageWidth, imDivWidth, vertOffset;
 
     function setImageStyle() {
         // To allow scrolling when image does not overflow the window
@@ -343,7 +343,7 @@ function makeImageWidget(container, align = "C") {
         // (2 * windowWidth + imageWidth): scroll to far edges,
         // similarly for vertical
         contentWidth = parseFloat(getComputedStyle(content).width);
-        const contentHeight = parseFloat(getComputedStyle(content).height);
+        contentHeight = parseFloat(getComputedStyle(content).height);
         image.style.width = `${10 * percent}px`;
         image.style.height = "auto";
         let imageHeight, xOffset, yOffset, imDivHeight;
@@ -402,19 +402,23 @@ function makeImageWidget(container, align = "C") {
             percent = maxPercent;
         }
         percentInput.val(Math.round(percent));
-        setImageStyle();
     }
 
     function setDrawSave() {
         setZoom();
+        setImageStyle();
         localStorage.setItem(imageKey, JSON.stringify({zoom: percent}));
     }
 
     function reScroll () {
-        // keep same scroll proportion when contentWidth changes
-        let oldScroll = (contentWidth > 20) ? content.scrollLeft / contentWidth : 0.5;
+        // keep image stationary when window changes size
+        // x is distance of left edge of image to left of window etc.
+        let x = contentWidth - content.scrollLeft;
+        let y = contentHeight - content.scrollTop;
         setImageStyle();
-        content.scrollLeft = oldScroll * contentWidth;
+        // contentWidth and height have changed
+        content.scrollLeft = contentWidth - x;
+        content.scrollTop = contentHeight - y;
     }
 
     percentInput.change(function() {
@@ -510,6 +514,8 @@ function makeImageWidget(container, align = "C") {
             setZoom();
             controlDiv.setupControls(imageWidgetKey);
         },
+
+        initAll,
 
         setImage: function (src) {
             sine = 0;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -274,25 +274,44 @@ function makeImageWidget(container, align = "C") {
 
     let scrollDiffX = 0;
     let scrollDiffY = 0;
-    function mousemove(event) {
+    function dragMove(event) {
         content.scrollTop = scrollDiffY - event.pageY;
         content.scrollLeft = scrollDiffX - event.pageX;
     }
 
-    function mouseup() {
-        document.removeEventListener("mousemove", mousemove);
-        document.removeEventListener("mouseup", mouseup);
+    function mouseUp() {
+        document.removeEventListener("mousemove", dragMove);
+        document.removeEventListener("mouseup", mouseUp);
         imageDiv.style.cursor = grabCursor;
+    }
+
+    function dragStart(event) {
+        scrollDiffX = event.pageX + content.scrollLeft;
+        scrollDiffY = event.pageY + content.scrollTop;
     }
 
     imageDiv.addEventListener("mousedown", function(event) {
         event.preventDefault();
-
         imageDiv.style.cursor = "grabbing";
-        scrollDiffX = event.pageX + content.scrollLeft;
-        scrollDiffY = event.pageY + content.scrollTop;
-        document.addEventListener("mousemove", mousemove);
-        document.addEventListener("mouseup", mouseup);
+        dragStart(event);
+        document.addEventListener("mousemove", dragMove);
+        document.addEventListener("mouseup", mouseUp);
+    });
+
+    function dragTouchMove(event) {
+        dragMove(event.touches[0]);
+    }
+
+    function dragTouchEnd() {
+        document.removeEventListener("touchmove", dragTouchMove);
+        document.removeEventListener("touchend", dragTouchEnd);
+    }
+
+    imageDiv.addEventListener("touchstart", function(event) {
+        event.preventDefault();
+        dragStart(event.touches[0]);
+        document.addEventListener("touchmove", dragTouchMove);
+        document.addEventListener("touchend", dragTouchEnd);
     });
 
     let imageKey;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -323,7 +323,7 @@ function makeImageWidget(container, align = "C") {
         // make imageDiv bigger than image, different options are:
         // windowWidth: no extra scrolling,
         // (2 * windowWidth - imageWidth): scroll to edges,
-        // (2 * windowWidth): half left to half right, (using this)
+        // (2 * windowWidth): half left to half right,
         // (2 * windowWidth + imageWidth): scroll to far edges,
         // similarly for vertical
         contentWidth = parseFloat(getComputedStyle(content).width);
@@ -344,9 +344,9 @@ function makeImageWidget(container, align = "C") {
         }
         // center aligned so:
         xOffset = 0;
-        imDivWidth = Math.max(2 * contentWidth, imageWidth);
+        imDivWidth = Math.max(2 * (contentWidth - 60) + imageWidth, imageWidth);
         imageDiv.style.width = `${imDivWidth}px`;
-        imDivHeight = Math.max(2 * contentHeight, imageHeight);
+        imDivHeight = Math.max(2 * (contentHeight - 60) + imageHeight, imageHeight);
         imageDiv.style.height = `${imDivHeight}px`;
         // adjust yOffset to be able to scroll downwards
         vertOffset = Math.max(0.5 * (imDivHeight - imageHeight), 0);

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -289,8 +289,6 @@ function makeImageWidget(container, align = "C") {
     imageDiv.addEventListener("mousedown", function(event) {
         event.preventDefault();
 
-        // so image can be moved with arrow keys
-        content.focus();
         imageDiv.style.cursor = "grabbing";
         scrollDiffX = event.pageX + content.scrollLeft;
         scrollDiffY = event.pageY + content.scrollTop;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -257,19 +257,19 @@ function makeControlDiv(container, content, controls) {
 
 function makeImageWidget(container, align = "C") {
     const content = document.createElement("div");
-    const imageCursor = "grab";
+    content.style.scrollbarWidth = 'none';
+    const grabCursor = "grab";
     // use plain js image so width or style.width is clearly differentiated
     const image = document.createElement("img");
     image.classList.add("middle-align");
-    image.style.cursor = imageCursor;
 
     // When the image is rotated it has width and height as if it were not
     // rotated. To make scroll work correctly, enclose it in a div with the
     //actual width and height.
     const imageDiv = document.createElement("div");
     imageDiv.classList.add("middle-align", "center-align");
-    imageDiv.style.overflow = "hidden";
     imageDiv.style.display = "inline-block";
+    imageDiv.style.cursor = grabCursor;
     content.append(imageDiv);
     imageDiv.appendChild(image);
 
@@ -283,15 +283,15 @@ function makeImageWidget(container, align = "C") {
     function mouseup() {
         document.removeEventListener("mousemove", mousemove);
         document.removeEventListener("mouseup", mouseup);
-        image.style.cursor = imageCursor;
+        imageDiv.style.cursor = grabCursor;
     }
 
-    image.addEventListener("mousedown", function(event) {
+    imageDiv.addEventListener("mousedown", function(event) {
         event.preventDefault();
 
         // so image can be moved with arrow keys
         content.focus();
-        image.style.cursor = "grabbing";
+        imageDiv.style.cursor = "grabbing";
         scrollDiffX = event.pageX + content.scrollLeft;
         scrollDiffY = event.pageY + content.scrollTop;
         document.addEventListener("mousemove", mousemove);

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -429,8 +429,7 @@ function makeImageWidget(container, align = "C") {
             // imDivWidth could have changed
             leftScroll += (imDivWidth / 2) - id2;
         } else {
-            // the +1 fixes a problem with iPad for some unknown reason
-            leftScroll = content.scrollLeft + 1;
+            leftScroll = content.scrollLeft;
             setImageStyle();
         }
         content.scrollLeft = leftScroll;

--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -173,12 +173,12 @@ function makeControlDiv(container, content, controls) {
         menu.hide();
     });
 
-    let onChange = new Set();
+    let onChangeCompassPoint = new Set();
     function newPoint(newP) {
         compassPoint = newP;
         saveLocation();
         setCompassPoint();
-        onChange.forEach(function (onChangeCallback) {
+        onChangeCompassPoint.forEach(function (onChangeCallback) {
             onChangeCallback();
         });
         menu.hide();
@@ -251,7 +251,7 @@ function makeControlDiv(container, content, controls) {
             setCompassPoint();
             setBegMidEnd();
         },
-        onChange: onChange,
+        onChange: onChangeCompassPoint,
     };
 }
 

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -234,7 +234,8 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                                 textWidget = makeTextWidget(textDiv);
                             }
                             theSplitter.mainSplit.onResize.add(imageWidget.reScroll);
-                            theSplitter.setSplitDirCallback.push(imageWidget.setup, textWidget.setup);
+                            theSplitter.preSetSplitDirCallback.push(imageWidget.setup, textWidget.setup);
+                            theSplitter.postSetSplitDirCallback.add(imageWidget.initAll);
                             controlSpan.append(imageButton, textButton, pageControls, roundControls, theSplitter.button);
                             theSplitter.fireSetSplitDir();
                             break;

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -204,6 +204,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                     const imageDiv = $("<div>");
                     imageWidget = makeImageWidget(imageDiv);
                     imageWidget.setup(storageKey);
+                    window.addEventListener("resize", imageWidget.reScroll);
                     stretchDiv.append(imageDiv);
                     showImageText();
                 } else {
@@ -232,6 +233,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                             } else {
                                 textWidget = makeTextWidget(textDiv);
                             }
+                            theSplitter.mainSplit.onResize.add(imageWidget.reScroll);
                             theSplitter.setSplitDirCallback.push(imageWidget.setup, textWidget.setup);
                             controlSpan.append(imageButton, textButton, pageControls, roundControls, theSplitter.button);
                             theSplitter.fireSetSplitDir();

--- a/scripts/view_splitter.js
+++ b/scripts/view_splitter.js
@@ -18,8 +18,10 @@ var viewSplitter = function(container, storageKey) {
     splitButton.type = 'button';
     splitButton.innerHTML = "&nbsp;";
     let splitKey;
-    const setSplitDirCallback = [];
-    setSplitDirCallback.push(function(storageKey) {
+    const preSetSplitDirCallback = [];
+    const postSetSplitDirCallback = new Set();
+
+    preSetSplitDirCallback.push(function(storageKey) {
         // get the split percent for vertical or horizontal
         splitKey = storageKey + "-split";
         let directionData = JSON.parse(localStorage.getItem(splitKey));
@@ -39,10 +41,13 @@ var viewSplitter = function(container, storageKey) {
     }
 
     function fireSetSplitDir() {
-        setSplitDirCallback.forEach(function (setSplitDirCallbackFunction) {
-            setSplitDirCallbackFunction(storageKey + "-" + layout.splitDirection);
+        preSetSplitDirCallback.forEach(function (preSetSplitDirCallbackFunction) {
+            preSetSplitDirCallbackFunction(storageKey + "-" + layout.splitDirection);
         });
         mainSplit.reLayout();
+        postSetSplitDirCallback.forEach(function (postSetSplitDirCallbackFunction) {
+            postSetSplitDirCallbackFunction();
+        });
     }
 
     splitButton.addEventListener("click", function () {
@@ -63,7 +68,8 @@ var viewSplitter = function(container, storageKey) {
     return {
         mainSplit,
         button: splitButton,
-        setSplitDirCallback,
+        preSetSplitDirCallback,
+        postSetSplitDirCallback,
         fireSetSplitDir,
     };
 };

--- a/tools/proofers/proof_image.js
+++ b/tools/proofers/proof_image.js
@@ -6,4 +6,5 @@ window.addEventListener('DOMContentLoaded', function() {
     let imageWidget = makeImageWidget(imageDiv, imageData.align);
     imageWidget.setup(imageData.storageKey);
     imageWidget.setImage(imageData.imageUrl);
+    window.addEventListener("resize", imageWidget.reScroll);
 });


### PR DESCRIPTION
This allows the image to scroll to halfway across the image to left and right and 80% of the way upwards.
These amounts could be changed and it could be made to work differently for vertical and horizontal layouts.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/image_overscroll
