### PR TITLE
Standardize new proofreader page thresholds

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -128,7 +128,7 @@ $show_filtering_links = true;
 
 // Proofreaders with fewer than 21 pages can't see the filter box on the Round
 // pages so prevent those users from selecting the filtered option.
-if ($pagesproofed <= 20) {
+if ($pagesproofed < 20) {
     $show_filtered_projects = false;
     $show_filtering_links = false;
 }

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -5,10 +5,18 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'forum_interface.inc');
 include_once($relPath.'graph_data.inc'); // get_round_backlog_stats()
 
-// This file deals with the gradual revelation of site features,
-// based on the number of pages proofread by the user.
-// (So far, it only has the code that is shared between multiple files.
-// Maybe it should include unshared stuff too, for completeness.)
+/*
+ * This file deals with the gradual revelation of site features,
+ * based on the number of pages proofread by the user.
+ * (So far, it only has the code that is shared between multiple files.
+ * Maybe it should include unshared stuff too, for completeness.)
+ *
+ * The following are common thresholds used in this and other files
+ * based on the number of pages proofread:
+ *   <  20 - newbie user, gets simplified information
+ *   < 100 - proofreader is guided through the site
+ *   < 300 - final guidance
+ */
 
 
 /**
@@ -69,7 +77,7 @@ function welcome_see_beginner_forum($pagesproofed, $page_id, $username = null)
         echo sprintf(_('After that you will be able to work in <a href="%1$s">%2$s</a>, the first proofreading round.'), "$code_url/{$ELR_round->relative_url}", $ELR_round->id);
         echo "</p>";
         echo "</div>";
-    } elseif ($pagesproofed <= 100) {
+    } elseif ($pagesproofed < 100) {
         echo "<div class='callout'>";
         echo "<div class='calloutheader'>";
         echo _("Welcome New Proofreader!");
@@ -109,7 +117,7 @@ function welcome_see_beginner_forum($pagesproofed, $page_id, $username = null)
 
 function thoughts_re_mentor_feedback($pagesproofed)
 {
-    if ($pagesproofed >= 15 && $pagesproofed < 200) {
+    if ($pagesproofed >= 20 && $pagesproofed < 300) {
         echo "<p>";
         echo sprintf(_("New Proofreaders: <a href='%s'>What did you think of the Mentor feedback you received?</a>"), get_url_to_view_topic(6651));
         echo "</p>";

--- a/tools/proofers/round.php
+++ b/tools/proofers/round.php
@@ -43,7 +43,7 @@ encourage_highest_round($pguser, $round->id);
 show_news_for_page($round_id);
 
 
-if ($pagesproofed <= 100 && $ELR_round->id == $round_id) {
+if ($pagesproofed < 100 && $ELR_round->id == $round_id) {
     if ($pagesproofed > 80) {
         echo "<p class='small italic'>";
         // TRANSLATORS: Simple Proofreading Rules are the strings listed in pinc/simple_proof_text.inc
@@ -98,7 +98,7 @@ if ($round->is_a_mentor_round()) {
     }
 }
 
-if ($pagesproofed > 20) {
+if ($pagesproofed >= 20) {
     // Link to queues.
     echo "<h2>", _('Release Queues'), "</h2>";
     $res = DPDatabase::query("
@@ -124,6 +124,6 @@ if ($pagesproofed > 20) {
 }
 
 // Don't display the filter block to newbies.
-$show_filter_block = ($pagesproofed > 20);
+$show_filter_block = ($pagesproofed >= 20);
 
 show_projects_for_round($round, $show_filter_block);


### PR DESCRIPTION
This provides some minor standardization for our new proofreader cutoffs so we have fewer of them. This is a minor improvement for issue #995 but is not a fix.

Not putting up a sandbox as this is a pretty simple review via PR.