### PR TITLE
Refer new users to My Suggestions page

### DIFF
--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -143,14 +143,25 @@ class Quiz
                 // if the user can't currently access it but they have satisfied
                 // all of the requirements to do so, point them in the right direction
                 if (!$uao->can_access && $uao->all_minima_satisfied) {
+                    // first see if we can auto-grant them access
+                    grant_user_access_if_sat($uao);
+                    if (!$uao->can_access) {
+                        // must be some other manual step required so point
+                        // them to the Entrance Requirements on the round page
+                        $next_steps = sprintf(_("Continue to the <a href='%1\$s'>%2\$s page</a> to learn about other access requirements."), "$code_url/$stage->relative_url#Entrance_Requirements", $stage_id);
+                    } else {
+                        // point them to the My Suggestions and stage page
+                        $next_steps = sprintf(_('To start proofreading in this round, see the list of projects on the <a href="%1$s">My Suggestions</a> page or the <a href="%2$s">%3$s</a> round page.'), "$code_url/tools/proofers/my_suggestions.php", "$code_url/{$stage->relative_url}", $stage_id);
+                    }
                     echo "<div class='callout'>";
+                    echo "<div class='calloutheader'>";
+                    echo _("Congratulations!");
+                    echo "</div>";
                     echo "<p>";
                     echo sprintf(_("You've completed the quiz requirements to work in %s!"), $stage_id);
-
-                    echo " ";
-
-                    echo sprintf(_("Continue to the <a href='%1\$s'>%2\$s page</a>."), "$code_url/$stage->relative_url#Entrance_Requirements", $stage_id);
                     echo "</p>";
+
+                    echo "<p>$next_steps</p>";
                     echo "</div>";
                     echo "<br>";
                 }

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -76,7 +76,7 @@ function welcome_see_beginner_forum($pagesproofed, $page_id, $username = null)
         echo "</div>";
 
         // If the user is not on the entry level round page, direct
-        // them to that page.
+        // them to My Suggestions or that round's page.
         if ($page_id != $ELR_round->id) {
             echo "<p>";
             echo sprintf(_('To start proofreading, see the list of projects on the <a href="%1$s">My Suggestions</a> page or the <a href="%2$s">%3$s</a> round page.'), "$code_url/tools/proofers/my_suggestions.php", "$code_url/{$ELR_round->relative_url}", $ELR_round->id);
@@ -152,7 +152,7 @@ function maybe_output_new_proofer_message()
         echo _("Looking for projects to proofread?");
         echo "</div>";
 
-        echo "<p>" . sprintf(_("If you're looking for projects to proofread, consider using the list on the <a href='%1\$s'>%2\$s</a> round page."), "$code_url/{$ELR_round->relative_url}#{$ELR_round->id}", $ELR_round->id) . "</p>";
+        echo "<p>" . sprintf(_('If you\'re looking for projects to proofread, see the list of projects on the <a href="%1$s">My Suggestions</a> page or the <a href="%2$s">%3$s</a> round page.'), "$code_url/tools/proofers/my_suggestions.php", "$code_url/{$ELR_round->relative_url}", $ELR_round->id) . "</p>";
 
         echo "<p><small>";
         echo _("After a period of time, this message will no longer appear.");


### PR DESCRIPTION
This does 2 things:
* Update the new proofreader message (<100 pages proofread) that gets shown on the Search page to point them to the My Suggestions page.
* Update the post-quiz pass logic to automatically grant them access to the round if they are eligible for auto-grant -- this is what already happens if they pass the quiz and then go to the round page. Doing this here allows us to refer them to the My Suggestions page in addition to the round page and ensure they can work in both when they get there.

Sandbox at https://www.pgdp.org/~cpeel/c.branch/finesse-new-proofreader-messages/

Note: The sandbox has the `pgdp-production` commit that requires passed quizzes to work in P1 so that this can be tested easily.