### PR TITLE
remove inline-block from no-wrap style

### DIFF
--- a/styles/preview.css
+++ b/styles/preview.css
@@ -121,5 +121,4 @@
 .no-wrap {
     margin-bottom: 0.4em;
     white-space: pre;
-    display: inline-block;
 }


### PR DESCRIPTION
consecutive no-wrap blocks would otherwise wrap onto the same line. This style was originally added to avoid an artifact where an uncoloured area would appear if long lines of no-wrap were scrolled into view but this is less serious.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/consec_nw
