### PR TITLE
Explicitly include misc.inc in MW extensions

### DIFF
--- a/SETUP/MediaWiki_extensions/dpExtensions.php
+++ b/SETUP/MediaWiki_extensions/dpExtensions.php
@@ -97,6 +97,7 @@ function showProjectInfo($input, $argv, $parser)
 {
     global $relPath, $code_url;
     include($relPath.'site_vars.php');
+    include_once($relPath.'misc.inc'); // needed for project_states.inc
     include_once($relPath.'DPDatabase.inc');
     include_once($relPath.'project_states.inc');
 

--- a/SETUP/MediaWiki_extensions/hospitalExtensions.php
+++ b/SETUP/MediaWiki_extensions/hospitalExtensions.php
@@ -41,6 +41,7 @@ function listHospitalProjects($input, $argv)
 {
     global $relPath, $code_url;
     include_once($relPath.'site_vars.php');
+    include_once($relPath.'misc.inc'); // needed for project_states.inc
     include_once($relPath.'DPDatabase.inc');
     include_once($relPath.'project_states.inc');
 


### PR DESCRIPTION
The 2 MediaWiki extensions are Special Snowflakes that do not pull in `base.inc`. They do, however, use `project_states.inc` which depends on the now-not-explicitly-included `misc.inc` (because it is included in `base.inc`) so we include it in the extensions instead.

This code was hotfixed on TEST and PROD.