### PR TITLE
Validate chunk size in resumable uploads

### DIFF
--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -59,6 +59,7 @@ window.addEventListener("DOMContentLoaded", function() {
         testTarget: uploadTarget,
         forceChunkSize: false,
         maxFiles: 1,
+        maxChunkRetries: 10,
         fileType: ['zip'], // use extension not mime type since zips have many
         maxFileSize: maxResumeSize,
     });

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -57,7 +57,7 @@ window.addEventListener("DOMContentLoaded", function() {
     var resumable = new Resumable({
         target: uploadTarget,
         testTarget: uploadTarget,
-        forceChunkSize: true,
+        forceChunkSize: false,
         maxFiles: 1,
         fileType: ['zip'], // use extension not mime type since zips have many
         maxFileSize: maxResumeSize,

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -58,8 +58,9 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (!move_uploaded_file($file['tmp_name'], $chunk_filename)) {
             report_error("Error saving chunk $chunk_filename for $filename");
             exit;
-        } elseif (filesize($chunk_filename) < $chunk_size) {
-            // if the filesizes don't match, unlink the file and report an error
+        } elseif (filesize($chunk_filename) < $chunk_size && $total_size > $chunk_size) {
+            // if the filesize is smaller than expected, unlink the file
+            // and report an error
             report_error("Error saving chunk $chunk_filename for $filename, uploaded size did not match $chunk_size");
             unlink($chunk_filename);
             exit;

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -11,10 +11,11 @@ require_login();
 $root_staging_dir = "/tmp/resumable_uploads";
 
 $identifier = array_get($_REQUEST, "resumableIdentifier", "");
-$filename = array_get($_REQUEST, "resumableFilename", "");
-// create a sanitised file name
+// create a sanitized file name from the identifier
 $hashed_filename = md5($identifier);
+$filename = array_get($_REQUEST, "resumableFilename", "");
 $chunk_number = array_get($_REQUEST, "resumableChunkNumber", "");
+$chunk_size = array_get($_REQUEST, "resumableChunkSize", "");
 $total_chunks = array_get($_REQUEST, "resumableTotalChunks", 0);
 $total_size = array_get($_REQUEST, "resumableTotalSize", 0);
 
@@ -23,79 +24,107 @@ $total_size = array_get($_REQUEST, "resumableTotalSize", 0);
 $staging_dir = "$root_staging_dir/{$hashed_filename}dir";
 $chunk_filename = "$staging_dir/$hashed_filename.part.$chunk_number";
 
-// handle testChunks request, this allows uploads to be restarted by
+// Handle testChunks (GET) requests, this allows uploads to be restarted by
 // allowing the browser to query for which parts have been uploaded
 // successfully
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-    if (file_exists($chunk_filename)) {
-        header("HTTP/1.0 200 Ok");
-        // continue to try to reassemble
+    if (file_exists($chunk_filename) && filesize($chunk_filename) >= $chunk_size) {
+        if ($chunk_number == $total_chunks) {
+            // try to reassemble, see note in reassemble()
+            reassemble();
+        } else {
+            http_response_code(204);
+        }
     } else {
-        header("HTTP/1.0 204 No Content");
-        exit;
+        // uploaded file didn't exist or filesize didn't match, request a re-upload
+        http_response_code(204);
     }
 }
-
-// handle a file upload request
-foreach ($_FILES as $file) {
-    if ($file["error"] != UPLOAD_ERR_OK) {
-        report_error(get_upload_err_msg($file['error']), false);
-        exit;
-    }
-
-    if (!is_dir($staging_dir)) {
-        // Suppress warning by mkdir because despite the check above
-        // race conditions from other processes can result in the
-        // directory existing when we try to create it here.
-        @mkdir($staging_dir, 0777, true);
-    }
-
-    if (!move_uploaded_file($file['tmp_name'], $chunk_filename)) {
-        report_error("Error saving chunk $chunk_filename for $filename");
-        exit;
-    }
-}
-// attempt to assemble any completed files; this needs to run both for
-// testChunks and uploads to handle edge failure cases where all of the
-// parts have been uploaded but not reassembled
-// move_uploaded_file() should be 'atomic'
-// but check anyway that file sizes add up correctly
-// Ensure we have every chunk we're looking for.
-// Chunks are uploaded sequentially, so start at the top
-// and work our way down to fail early.
-// To prevent multiple instances from trying to do the reassembly
-// concurrently, lock the output file first. Other instances will
-// wait to get the lock and if the previous one assembled the file
-// the chunks will be gone.
-
-// mode 'c' opens for writing but does not truncate
-if (($fp = fopen("$root_staging_dir/$hashed_filename", "c")) !== false) {
-    if (flock($fp, LOCK_EX)) { // acquire an exclusive lock
-        $size_on_server = 0;
-        $got_chunks = true;
-        for ($i = $total_chunks; $i >= 1; $i--) {
-            $chunk_name = "$staging_dir/$hashed_filename.part.$i";
-            if (!is_file($chunk_name)) {
-                $got_chunks = false;
-                break;
-            }
-            $size_on_server = $size_on_server + filesize($chunk_name);
+// Handle a file upload request
+elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    foreach ($_FILES as $file) {
+        if ($file["error"] != UPLOAD_ERR_OK) {
+            report_error(get_upload_err_msg($file['error']), false);
+            exit;
         }
-        if ($got_chunks && ($size_on_server >= $total_size)) {
-            for ($i = 1; $i <= $total_chunks; $i++) {
-                $chunk_name = "$staging_dir/$hashed_filename.part.$i";
-                fwrite($fp, file_get_contents($chunk_name));
-                unlink($chunk_name);
-            }
-            rmdir($staging_dir);
+
+        if (!is_dir($staging_dir)) {
+            // Suppress warning by mkdir because despite the check above
+            // race conditions from other processes can result in the
+            // directory existing when we try to create it here.
+            @mkdir($staging_dir, 0777, true);
         }
-        flock($fp, LOCK_UN); // release the lock
-    } else {
-        report_error("Unable to lock $root_staging_dir/$hashed_filename");
+
+        if (!move_uploaded_file($file['tmp_name'], $chunk_filename)) {
+            report_error("Error saving chunk $chunk_filename for $filename");
+            exit;
+        } elseif (filesize($chunk_filename) < $chunk_size) {
+            // if the filesizes don't match, unlink the file and report an error
+            report_error("Error saving chunk $chunk_filename for $filename, uploaded size did not match $chunk_size");
+            unlink($chunk_filename);
+            exit;
+        }
     }
-    fclose($fp);
+
+    // Attempt reassemble
+    reassemble();
 } else {
-    report_error("Unable to create $root_staging_dir/$hashed_filename");
+    // something besides a GET or POST
+    http_response_code(400);
+}
+
+/*
+ * Attempt to reassemble a resumable-uploaded file.
+ *
+ * This needs to run both for testChunks (GETs) and uploads (POSTs) to handle
+ * edge failure cases where all of the parts have been uploaded in a prior
+ * attempt but not yet reassembled.
+ */
+function reassemble()
+{
+    global $root_staging_dir, $staging_dir, $hashed_filename;
+    global $total_chunks, $total_size;
+
+    // To prevent multiple instances from trying to do the reassembly
+    // concurrently, lock the output file first. Other instances will
+    // wait to get the lock and if the previous one assembled the file
+    // the chunks will be gone.
+    // mode 'c' opens for writing but does not truncate
+    if (($fp = fopen("$root_staging_dir/$hashed_filename", "c")) !== false) {
+        if (flock($fp, LOCK_EX)) { // acquire an exclusive lock
+            $size_on_server = 0;
+
+            // Ensure we have every chunk we're looking for. Chunks are
+            // uploaded sequentially, so start at the top and work our way
+            // down to fail early.
+            $got_chunks = true;
+            for ($i = $total_chunks; $i >= 1; $i--) {
+                $chunk_name = "$staging_dir/$hashed_filename.part.$i";
+                if (!is_file($chunk_name)) {
+                    $got_chunks = false;
+                    break;
+                }
+                $size_on_server = $size_on_server + filesize($chunk_name);
+            }
+
+            // move_uploaded_file() should be 'atomic' but check anyway that
+            // file sizes add up correctly before doing the reassembly.
+            if ($got_chunks && ($size_on_server >= $total_size)) {
+                for ($i = 1; $i <= $total_chunks; $i++) {
+                    $chunk_name = "$staging_dir/$hashed_filename.part.$i";
+                    fwrite($fp, file_get_contents($chunk_name));
+                    unlink($chunk_name);
+                }
+                rmdir($staging_dir);
+            }
+            flock($fp, LOCK_UN); // release the lock
+        } else {
+            report_error("Unable to lock $root_staging_dir/$hashed_filename");
+        }
+        fclose($fp);
+    } else {
+        report_error("Unable to create $root_staging_dir/$hashed_filename");
+    }
 }
 
 function report_error($error, $log_error = true)

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -58,10 +58,12 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (!move_uploaded_file($file['tmp_name'], $chunk_filename)) {
             report_error("Error saving chunk $chunk_filename for $filename");
             exit;
-        } elseif (filesize($chunk_filename) < $chunk_size && $total_size > $chunk_size) {
-            // if the filesize is smaller than expected, unlink the file
+        } elseif (filesize($chunk_filename) < $chunk_size && $chunk_number != $total_chunks) {
+            // if the filesize is smaller than expected and this isn't the last
+            // chunk (because it could be bigger or smaller), unlink the file
             // and report an error
-            report_error("Error saving chunk $chunk_filename for $filename, uploaded size did not match $chunk_size");
+            $actual_size = filesize($chunk_filename);
+            report_error("Error saving chunk $chunk_filename for $filename, uploaded size $actual_size did not match $chunk_size");
             unlink($chunk_filename);
             exit;
         }


### PR DESCRIPTION
This addresses two edgcases in an attempt to fix the upload problems we're seeing:
* Only ever return a single HTTP response code in GET requests
* Validate every chunk upload against its expected size.

To handle the edgecase where a file is fully uploaded but not reassembled, we attempt reassembly both on testChunks (GETs) as well as the uploads (POSTs). The original code responded with a 200 that the chunk exists but the reassembly could have failed and not reported a 5xx code. Now the code sets one and only one return code, or falls through to the script completion which is an implicit 200.

Also validate that every chunk is at least chunkSize to attempt and detect cases where the client didn't successfully uploading an entire chunk.

This PR is best reviewed ignoring whitespace as I moved some code into a function which increased its indent.

Testable in https://www.pgdp.org/~cpeel/c.branch/more-resumable-upload-checks/

I don't have confidence that this addresses the problems that we're seeing, but these were the two corner cases I found from code inspection.