### PR TITLE
Enable filtering page details API by round

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -620,6 +620,13 @@ paths:
         required: true
         schema:
           type: string
+      - name: pageroundid
+        in: query
+        description: Page round IDs to return, if not set all page rounds are
+          returned. To request multiple page rounds, append with [] and pass
+          one per desired page round (e.g. pageroundid[]=OCR&pageroundid[]=P3).
+        schema:
+          type: string
       responses:
         200:
           description: Page details

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -403,8 +403,26 @@ function api_v1_project_pages($method, $data, $query_params)
 
 function api_v1_project_pagedetails($method, $data, $query_params)
 {
+    // optional page round IDs (one or more) to filter down to
+    $only_rounds = null;
+    $pageroundids = array_get($query_params, "pageroundid", null);
+    if ($pageroundids) {
+        $only_rounds = [];
+        if (!is_array($pageroundids)) {
+            $pageroundids = [$pageroundids];
+        }
+        foreach ($pageroundids as $pageroundid) {
+            validate_page_round($pageroundid, null);
+            if ($pageroundid === "OCR") {
+                $only_rounds[] = "OCR";
+            } else {
+                $only_rounds[] = get_Round_for_round_id($pageroundid);
+            }
+        }
+    }
+
     $return_data = [];
-    foreach (fetch_page_table_data($data[":projectid"]) as $image) {
+    foreach (fetch_page_table_data($data[":projectid"], null, null, $only_rounds) as $image) {
         $page_rounds_data = [];
         // Remove proofer names and adjust timestamp format
         foreach ($image["pagerounds"] as $round_id => $round_data) {

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -99,6 +99,11 @@ class Activity
         $Activity_for_id_[$id] = & $this;
     }
 
+    public function __toString()
+    {
+        return $this->id;
+    }
+
     /**
      * Return a User Access object
      *

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -102,7 +102,7 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         $rounds_to_display = get_rounds_to_display($project);
         $include_ocr = true;
     } else {
-        $rounds_to_display = array_diff($only_rounds, ["OCR"]);
+        $rounds_to_display = array_unique(array_diff($only_rounds, ["OCR"]));
         $include_ocr = in_array("OCR", $only_rounds);
     }
 

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -106,14 +106,21 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         $include_ocr = in_array("OCR", $only_rounds);
     }
 
+    $rounds_with_data = get_rounds_with_data($project->projectid);
+
     $fields_to_get = "{$project->projectid}.image AS image, length(master_text), state";
     $tables = $project->projectid;
     foreach ($rounds_to_display as $round) {
         $rn = $round->round_number;
-        if ($rn == 1) {
+
+        // find the previous round with data to use as the diff column
+        $rounds_with_data_index = array_search($round, $rounds_with_data);
+        if ($rounds_with_data_index === 0 || $rn == 1) {
             $prev_text_column_name = 'master_text';
-        } else {
+        } elseif ($rounds_with_data_index === false) {
             $prev_text_column_name = get_Round_for_round_number($rn - 1)->text_column_name;
+        } else {
+            $prev_text_column_name = $rounds_with_data[$rounds_with_data_index - 1]->text_column_name;
         }
 
         $tallyboard = new TallyBoard($round->id, 'U');

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -72,20 +72,49 @@ function get_rounds_to_display($project)
  *     }
  * }
  * ```
+ *
+ * @param string $projectid
+ *   ID of project
+ * @param string|array $page_selector
+ *   Select which pages to return in the query, possible values are:
+ *   * null - all pages are returned
+ *   * string - this user's pages from all rounds are returned
+ *   * array - array of specific image names
+ * @param object $work_round
+ *   Round to limit a user's pages -- must be used with $page_selector set
+ *   to a username.
+ * @param array $only_rounds
+ *   Only return page details for a specific round, possible values are:
+ *   * null - all rounds with data are returned
+ *   * array of round objects and/or "OCR" - only these rounds are returned
+ *
+ * @return array
  */
-function fetch_page_table_data($project, $page_selector = null, $work_round = null)
+function fetch_page_table_data($project, $page_selector = null, $work_round = null, $only_rounds = null)
 {
     if (!$project->pages_table_exists) {
         throw new NoProjectPageTable(_("Project page table does not exist."));
     }
 
-    $rounds_to_display = get_rounds_to_display($project);
+    // If $only_rounds is set, only return that round's data -- regardless
+    // if that round would be returned from get_rounds_to_display() or not.
+    if ($only_rounds === null) {
+        $rounds_to_display = get_rounds_to_display($project);
+        $include_ocr = true;
+    } else {
+        $rounds_to_display = array_diff($only_rounds, ["OCR"]);
+        $include_ocr = in_array("OCR", $only_rounds);
+    }
 
     $fields_to_get = "{$project->projectid}.image AS image, length(master_text), state";
     $tables = $project->projectid;
-    $prev_text_column_name = 'master_text';
     foreach ($rounds_to_display as $round) {
         $rn = $round->round_number;
+        if ($rn == 1) {
+            $prev_text_column_name = 'master_text';
+        } else {
+            $prev_text_column_name = get_Round_for_round_number($rn - 1)->text_column_name;
+        }
 
         $tallyboard = new TallyBoard($round->id, 'U');
         [$joined_with_user_page_tallies, $user_page_tally_column] =
@@ -169,11 +198,13 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
             "state" => $row['state'],
         ];
 
-        $pagerounds = [
-            "OCR" => [
+        $pagerounds = [];
+
+        if ($include_ocr) {
+            $pagerounds["OCR"] = [
                 "page_size" => (int)$row["length(master_text)"],
-            ],
-        ];
+            ];
+        }
 
         foreach ($rounds_to_display as $round) {
             $rn = $round->round_number;


### PR DESCRIPTION
The [Gap Games](https://www.pgdp.net/wiki/Gap_Game) use the DP API to pull some information from the `v1/projects/:projectid/pagedetails` endpoint (which is the same underlying function that renders the Page Details table for a project). This returns data for every round which
1. is a lot of data if you only need one round of it
2. is a pretty expensive DB query for later-round projects with lots of pages

This PR allows the user to just request the round(s) they care about making the data smaller and the SQL simpler. By default the endpoint still returns all rounds. The new `pageroundid` query param works similarly to the [`field` query param for the `v1/projects` endpoint](https://github.com/DistributedProofreaders/dproofreaders/blob/master/api/dp-openapi.yaml#L79) by allowing multiple to be specified if desired.

This is testable in https://www.pgdp.org/~cpeel/c.branch/api-pagedetail-single-round/ -- confirm that a project's page details hasn't changed -- and via curl, eg:
```bash
API_KEY=xxxxxxx  # your API key
PROJECTID=projectID4c49f39aa829c

# all rounds
curl -i -X GET \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY" \
    "https://www.pgdp.org/~cpeel/c.branch/api-pagedetail-single-round/api/index.php?url=v1/projects/$PROJECTID/pagedetails"

# just P3
curl -i -X GET \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY" \
    "https://www.pgdp.org/~cpeel/c.branch/api-pagedetail-single-round/api/index.php?url=v1/projects/$PROJECTID/pagedetails&pageroundid=P3"

# just OCR and F2
curl -i -X GET \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY" \
    "https://www.pgdp.org/~cpeel/c.branch/api-pagedetail-single-round/api/index.php?url=v1/projects/$PROJECTID/pagedetails&pageroundid[]=OCR&pageroundid[]=F2"

```
