### PR TITLE
Fix definition of is_diff

### DIFF
--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -114,7 +114,6 @@ class Round extends Stage
         $this->time_column_name = "round{$this->round_number}_time";
         $this->text_column_name = "round{$this->round_number}_text";
         $this->user_column_name = "round{$this->round_number}_user";
-        $this->textdiff_column_name = "round{$this->round_number}_diff"; // a computed column
 
         // prevtext_column_name
         //

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -110,7 +110,7 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
             );
         }
         $fields_to_get .= ",
-            $prev_text_column_name = BINARY $round->text_column_name AS $round->textdiff_column_name,
+            STRCMP($prev_text_column_name, $round->text_column_name) AS {$rn}_compare,
             $round->time_column_name,
             $round->user_column_name,
             $user_page_tally_column AS `$rn.user_page_tally`,
@@ -187,7 +187,7 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
 
             $pagerounds[$round->id] = [
                 "page_size" => (int)$row["length($round->text_column_name)"],
-                "is_diff" => $row[$round->textdiff_column_name] == 1,
+                "is_diff" => $row["{$rn}_compare"] != 0,
                 "username" => $row[$round->user_column_name],
                 "user_page_tally" => (int)$row["$rn.user_page_tally"],
                 "wordcheck_ran" => $wordcheck_ran,
@@ -597,9 +597,9 @@ function echo_cells_for_round(
     echo "<td>";
     if ($page_state != $round->page_avail_state) {
         if ($round_data["is_diff"]) {
-            echo _("No diff");
-        } else {
             echo "<a href='$code_url/tools/project_manager/diff.php?project=$projectid&amp;image=$imagename&amp;L_round_num=$diff_round_num&amp;R_round_num=$round_num'>"._("Diff")."</a>";
+        } else {
+            echo _("No diff");
         }
     }
     echo "</td>\n";


### PR DESCRIPTION
Currently the value of `is_diff` returned from `fetch_page_table_data()` is opposite of what it says -- if the value is 1 there is no difference, if the value is 0 there is a difference.

The API directly reports the result of this function directly which means it's been wrong since the API was created. Update the code to use a collation-insensitive comparison operator (and stop using the deprecated BINARY operator) and ensure that `is_diff` is accurate. This removes the unused `textdiff_column_name` Round attribute -- this is the only place this is used in the codebase and noncvs.

Testable in https://www.pgdp.org/~cpeel/c.branch/fix-is_diff/ -- the page details page results should match TEST and the following `curl`:
```bash
API_KEY=xxx  # your key here
PROJECTID=projectID4c49f39aa829c

# all rounds
curl -i -X GET \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY" \
    "https://www.pgdp.org/~cpeel/c.branch/fix-is_diff/api/index.php?url=v1/projects/$PROJECTID/pagedetails"
```

Thanks to @srjfoo for finding this long-standing bug!