### PR TITLE
Preload wordcheck_events for project details

### DIFF
--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -106,6 +106,35 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         $include_ocr = in_array("OCR", $only_rounds);
     }
 
+    // load wordcheck_event counts for this table for lookup in building the
+    // page table later, this is faster than doing subqueries in single SQL
+    $round_ids_to_load_wordcheck_events = [];
+    foreach ($rounds_to_display as $round) {
+        if (!is_formatting_round($round)) {
+            $round_ids_to_load_wordcheck_events[] = $round->id;
+        }
+    }
+    if ($round_ids_to_load_wordcheck_events) {
+        $sql = sprintf(
+            "
+            SELECT image, username, round_id, count(*)
+            FROM wordcheck_events
+            WHERE projectid = '%s' and round_id in (%s)
+            GROUP BY image, username, round_id
+            ",
+            DPDatabase::escape($project->projectid),
+            surround_and_join($round_ids_to_load_wordcheck_events, "'", "'", ",")
+        );
+        $res = DPDatabase::query($sql);
+
+        $wordcheck_events = [];
+        while ([$image, $username, $round_id, $count] = mysqli_fetch_row($res)) {
+            $wordcheck_events["$image$username$round_id"] = 1;
+        }
+    } else {
+        $wordcheck_events = [];
+    }
+
     $rounds_with_data = get_rounds_with_data($project->projectid);
 
     $fields_to_get = "{$project->projectid}.image AS image, length(master_text), state";
@@ -127,31 +156,12 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         [$joined_with_user_page_tallies, $user_page_tally_column] =
             $tallyboard->get_sql_joinery_for_current_tallies("users$rn.u_id");
 
-        if (is_formatting_round($round)) {
-            $wordcheck_query = "NULL as wordcheck_status$rn";
-        } else {
-            $wordcheck_query = sprintf(
-                "
-                (
-                    SELECT count(*)
-                    FROM wordcheck_events
-                    WHERE projectid = '%s' AND
-                        image = {$project->projectid}.image AND
-                        username = $round->user_column_name AND
-                        round_id = '%s'
-                ) as wordcheck_status$rn
-                ",
-                DPDatabase::escape($project->projectid),
-                DPDatabase::escape($round->id)
-            );
-        }
         $fields_to_get .= ",
             STRCMP($prev_text_column_name, $round->text_column_name) AS {$rn}_compare,
             $round->time_column_name,
             $round->user_column_name,
             $user_page_tally_column AS `$rn.user_page_tally`,
-            length($round->text_column_name),
-            $wordcheck_query
+            length($round->text_column_name)
         ";
         $tables .= "
             LEFT OUTER JOIN users AS users$rn
@@ -216,11 +226,10 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         foreach ($rounds_to_display as $round) {
             $rn = $round->round_number;
 
-            $wordcheck_status = $row["wordcheck_status$rn"];
-            if ($wordcheck_status == null) {
+            if (is_formatting_round($round)) {
                 $wordcheck_ran = null;
             } else {
-                $wordcheck_ran = $wordcheck_status > 0;
+                $wordcheck_ran = $wordcheck_events[$row['image'] . $row[$round->user_column_name] . $round->id] ?? 0;
             }
 
             $pagerounds[$round->id] = [


### PR DESCRIPTION
To load the "wordcheck ran" boolean for a project's page detail we currently do a subquery against `wordcheck_events` for each round. As the table has grown the query has become less and less performant despite there being an index for `projectid` already. The more pages a project has and the more rounds it has gone through increases the work required by the SQL. For some projects on PROD page details can take over 30 seconds to load (all of which is spent in the mysql server). 

I evaluated a few different ways to solve this, including changing to do a full table join (much worse performance) and adding a compound `(projectid, image)` or `(projectid, username)` index (ruled out as it makes the tablespace even bigger, and it's already at 1GB -- one of our biggest).

I settled on preloading the project's wordcheck events into an associative array and determining the "wordcheck ran" boolean in the code instead of in the SQL. This improves performance on some pages on PROD by 5x. The only downside to this method is that it uses memory for the hash. Despite the worst-case cardinality of the hash being `(min(num_rounds, 3) * num_unique_proofreaders * num_project_pages)` we're only storing an integer and PHP uses a [hashmap under the covers](https://stackoverflow.com/a/25114841) so it's not that bad.

The code can be tested on TEST at https://www.pgdp.org/~cpeel/c.branch/better-pagedetail-perf/ . It is very unlikely to see performance differences on TEST, even with projects in many rounds with many pages, but it should render the same HTML as what's in the main TEST sandbox.

I have a copy of `page_detail.php` on PROD in noncvs that uses the code in this PR and can be used to compare performance against the main PROD site. For instance:
* [noncvs version against projectID5f70409ee5bbb](https://www.pgdp.net/noncvs/cpeel/page_detail.php?project=projectID5f70409ee5bbb) -- <7 seconds
* [PROD version against projectID5f70409ee5bbb](https://www.pgdp.net/c/tools/project_manager/page_detail.php?project=projectID5f70409ee5bbb) -- ~ 37 seconds