### PR TITLE
Avoid repeating round definitions when defining project states

### DIFF
--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -29,8 +29,8 @@ class RoundTest extends ProjectUtils
         $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
         $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
         $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
-//        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
-//        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
+        //        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
+        //        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
         $this->assertEquals('PAGE_EDITING', get_phase_containing_project_state("P1.proj_bad"));
         $this->assertEquals("(state='proj_submit_pgposted')", SQL_CONDITION_GOLD);
     }

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -1,0 +1,37 @@
+<?php
+
+class RoundTest extends ProjectUtils
+{
+    //------------------------------------------------------------------------
+
+    public function test_get_round()
+    {
+        $this->assertEquals("P1", get_Round_for_round_number(1)->id);
+        $this->assertEquals("P2", get_Round_for_page_state("P2.page_temp")->id);
+        $this->assertEquals("P3", get_Round_for_round_id("P3")->id);
+        $this->assertEquals("P2", get_Round_for_project_state("P2.proj_waiting")->id);
+        $this->assertEquals("F1", get_Round_for_text_column_name("round4_text")->id);
+    }
+
+    public function test_round_states()
+    {
+        $p1 = get_Round_for_round_id("P1");
+        $this->assertEquals('Proofreading Prodigy', $p1->get_honorific_for_page_tally(1200));
+        $this->assertEquals('Novice', $p1->get_honorific_for_page_tally(-10));
+        $this->assertEquals('P1.proj_unavail', $p1->project_unavailable_state);
+    }
+
+    public function test_project_states()
+    {
+        global $projects_forum_idx, $waiting_projects_forum_idx, $PROJECT_STATES_IN_ORDER;
+
+        $this->assertTrue(PROJ_P1_UNAVAILABLE === "P1.proj_unavail");
+        $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
+        $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
+        $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
+//        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
+//        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
+        $this->assertEquals('PAGE_EDITING', get_phase_containing_project_state("P1.proj_bad"));
+        $this->assertEquals("(state='proj_submit_pgposted')", SQL_CONDITION_GOLD);
+    }
+}

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -37,6 +37,8 @@ class RoundTest extends ProjectUtils
         $this->assertTrue(PROJ_P1_UNAVAILABLE === "P1.proj_unavail");
         $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
         $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
+        $this->assertEquals("PP: Available", get_medium_label_for_project_state("proj_post_first_available"));
+        $this->assertEquals("Post-Processing: Available", project_states_text("proj_post_first_available"));
         $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
         // $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
         // $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -21,6 +21,15 @@ class RoundTest extends ProjectUtils
         $this->assertEquals('P1.proj_unavail', $p1->project_unavailable_state);
     }
 
+    public function test_pools()
+    {
+        $this->assertEquals("PP", get_Pool_for_id("PP")->id);
+        $this->assertEquals("PPV", get_Pool_for_id("PPV")->id);
+        $this->assertEquals("PP", get_Pool_for_state(PROJ_POST_FIRST_AVAILABLE)->id);
+        $this->assertEquals("PP", get_Pool_for_state(PROJ_POST_FIRST_CHECKED_OUT)->id);
+        $this->assertEquals("PPV", get_Pool_for_state(PROJ_POST_SECOND_CHECKED_OUT)->id);
+    }
+
     public function test_project_states()
     {
         global $projects_forum_idx, $waiting_projects_forum_idx, $PROJECT_STATES_IN_ORDER;

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -38,8 +38,8 @@ class RoundTest extends ProjectUtils
         $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
         $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
         $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
-        //        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
-        //        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
+        // $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
+        // $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
         $this->assertEquals('PAGE_EDITING', get_phase_containing_project_state("P1.proj_bad"));
         $this->assertEquals("(state='proj_submit_pgposted')", SQL_CONDITION_GOLD);
     }

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -35,7 +35,8 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $ordinal,
+        $project_available_state,
+        $project_checkedout_state,
         $available_short_label,
         $available_long_label,
         $checked_out_short_label,
@@ -56,7 +57,8 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
-        $this->ordinal = $ordinal;
+        $this->project_available_state = $project_available_state;
+        $this->project_checkedout_state = $project_checkedout_state;
         $this->available_short_label = $available_short_label;
         $this->available_long_label = $available_long_label;
         $this->checked_out_short_label = $checked_out_short_label;
@@ -66,7 +68,11 @@ class Pool extends Stage
         $this->blather = $blather;
 
         global $Pool_for_id_;
-        $Pool_for_id_[$this->id] = & $this;
+        $Pool_for_id_[$id] = $this;
+
+        global $Pool_for_state_;
+        $Pool_for_state_[$project_available_state] = $this;
+        $Pool_for_state_[$project_checkedout_state] = $this;
     }
 }
 

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -4,9 +4,8 @@ include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------
 
-global $Pool_for_id_, $Pool_for_state_;
+global $Pool_for_id_;
 $Pool_for_id_ = [];
-$Pool_for_state_ = [];
 
 class Pool extends Stage
 {
@@ -66,12 +65,6 @@ function get_Pool_for_id($pool_id)
 {
     global $Pool_for_id_;
     return array_get($Pool_for_id_, $pool_id, null);
-}
-
-function get_Pool_for_state($state)
-{
-    global $Pool_for_state_;
-    return array_get($Pool_for_state_, $state, null);
 }
 
 // ---------------------------

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -4,6 +4,7 @@ include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------
 
+global $Pool_for_id_, $Pool_for_state_;
 $Pool_for_id_ = [];
 $Pool_for_state_ = [];
 

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -35,8 +35,11 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $project_checkedout_state,
-        $project_available_state,
+        $ordinal,
+        $available_short_label,
+        $available_long_label,
+        $checked_out_short_label,
+        $checked_out_long_label,
         $foo_Header,
         $foo_field_name,
         $blather
@@ -53,18 +56,17 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
-        $this->project_checkedout_state = $project_checkedout_state;
-        $this->project_available_state = $project_available_state;
+        $this->ordinal = $ordinal;
+        $this->available_short_label = $available_short_label;
+        $this->available_long_label = $available_long_label;
+        $this->checked_out_short_label = $checked_out_short_label;
+        $this->checked_out_long_label = $checked_out_long_label;
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;
         $this->blather = $blather;
 
         global $Pool_for_id_;
         $Pool_for_id_[$this->id] = & $this;
-
-        global $Pool_for_state_;
-        $Pool_for_state_[$this->project_checkedout_state] = & $this;
-        $Pool_for_state_[$this->project_available_state] = & $this;
     }
 }
 

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -35,12 +35,6 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $project_available_state,
-        $project_checkedout_state,
-        $available_short_label,
-        $available_long_label,
-        $checked_out_short_label,
-        $checked_out_long_label,
         $foo_Header,
         $foo_field_name,
         $blather
@@ -57,22 +51,12 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
-        $this->project_available_state = $project_available_state;
-        $this->project_checkedout_state = $project_checkedout_state;
-        $this->available_short_label = $available_short_label;
-        $this->available_long_label = $available_long_label;
-        $this->checked_out_short_label = $checked_out_short_label;
-        $this->checked_out_long_label = $checked_out_long_label;
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;
         $this->blather = $blather;
 
         global $Pool_for_id_;
         $Pool_for_id_[$id] = $this;
-
-        global $Pool_for_state_;
-        $Pool_for_state_[$project_available_state] = $this;
-        $Pool_for_state_[$project_checkedout_state] = $this;
     }
 }
 

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -99,6 +99,12 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
+        $this->project_bad_state = "$round_id.proj_bad";
+        $this->project_unavailable_state = "$round_id.proj_unavail";
+        $this->project_waiting_state = "$round_id.proj_waiting";
+        $this->project_available_state = "$round_id.proj_avail";
+        $this->project_complete_state = "$round_id.proj_done";
+
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";
@@ -146,6 +152,13 @@ class Round extends Stage
 
         global $Round_for_round_number_;
         $Round_for_round_number_[$this->round_number] = & $this;
+
+        global $Round_for_project_state_;
+        $Round_for_project_state_[$this->project_unavailable_state] = & $this;
+        $Round_for_project_state_[$this->project_waiting_state] = & $this;
+        $Round_for_project_state_[$this->project_bad_state] = & $this;
+        $Round_for_project_state_[$this->project_available_state] = & $this;
+        $Round_for_project_state_[$this->project_complete_state] = & $this;
 
         global $Round_for_page_state_;
         $Round_for_page_state_[$this->page_avail_state] = & $this;

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -99,12 +99,6 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
-        $this->project_unavailable_state = constant("PROJ_{$round_id}_UNAVAILABLE");
-        $this->project_waiting_state = constant("PROJ_{$round_id}_WAITING_FOR_RELEASE");
-        $this->project_bad_state = constant("PROJ_{$round_id}_BAD_PROJECT");
-        $this->project_available_state = constant("PROJ_{$round_id}_AVAILABLE");
-        $this->project_complete_state = constant("PROJ_{$round_id}_COMPLETE");
-
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";
@@ -152,13 +146,6 @@ class Round extends Stage
 
         global $Round_for_round_number_;
         $Round_for_round_number_[$this->round_number] = & $this;
-
-        global $Round_for_project_state_;
-        $Round_for_project_state_[$this->project_unavailable_state] = & $this;
-        $Round_for_project_state_[$this->project_waiting_state] = & $this;
-        $Round_for_project_state_[$this->project_bad_state] = & $this;
-        $Round_for_project_state_[$this->project_available_state] = & $this;
-        $Round_for_project_state_[$this->project_complete_state] = & $this;
 
         global $Round_for_page_state_;
         $Round_for_page_state_[$this->page_avail_state] = & $this;

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -99,12 +99,6 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
-        $this->project_bad_state = "$round_id.proj_bad";
-        $this->project_unavailable_state = "$round_id.proj_unavail";
-        $this->project_waiting_state = "$round_id.proj_waiting";
-        $this->project_available_state = "$round_id.proj_avail";
-        $this->project_complete_state = "$round_id.proj_done";
-
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";
@@ -152,13 +146,6 @@ class Round extends Stage
 
         global $Round_for_round_number_;
         $Round_for_round_number_[$this->round_number] = & $this;
-
-        global $Round_for_project_state_;
-        $Round_for_project_state_[$this->project_unavailable_state] = & $this;
-        $Round_for_project_state_[$this->project_waiting_state] = & $this;
-        $Round_for_project_state_[$this->project_bad_state] = & $this;
-        $Round_for_project_state_[$this->project_available_state] = & $this;
-        $Round_for_project_state_[$this->project_complete_state] = & $this;
 
         global $Round_for_page_state_;
         $Round_for_page_state_[$this->page_avail_state] = & $this;

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -7,12 +7,11 @@ include_once($relPath.'Stage.inc');
 // -----------------------------------------------------------------------------
 
 global $n_rounds, $Round_for_round_id_, $Round_for_round_number_;
-global $Round_for_project_state_, $Round_for_page_state_, $PAGE_STATES_IN_ORDER;
+global $Round_for_page_state_, $PAGE_STATES_IN_ORDER;
 
 $n_rounds = 0;
 $Round_for_round_id_ = [];
 $Round_for_round_number_ = [];
-$Round_for_project_state_ = [];
 $Round_for_page_state_ = [];
 $PAGE_STATES_IN_ORDER = [];
 
@@ -234,14 +233,6 @@ function get_Round_for_round_number($round_number)
 {
     global $Round_for_round_number_;
     return array_get($Round_for_round_number_, $round_number, null);
-}
-
-// ---------------------------
-
-function get_Round_for_project_state($project_state)
-{
-    global $Round_for_project_state_;
-    return array_get($Round_for_project_state_, $project_state, null);
 }
 
 // ---------------------------

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -22,6 +22,8 @@ include_once($relPath.'site_vars.php');
 
   (Actually, the naming convention is in transition.)
 */
+global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_;
+global $project_state_phase_, $project_states_for_star_metal_;
 
 $PROJECT_STATES_IN_ORDER = [];
 $project_state_medium_label_ = [];

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -58,7 +58,52 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($rounds as $round) {
-        declare_project_states_for_round($round);
+        declare_project_state(
+            "PROJ_{$round->id}_BAD_PROJECT",
+            $round->project_bad_state,
+            "$round->id: " .  _("Bad Project"),
+            "$round->name: " . _("Bad Project"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            ''
+        );
+
+        declare_project_state(
+            "PROJ_{$round->id}_UNAVAILABLE",
+            $round->project_unavailable_state,
+            "$round->id: " . _("Unavailable"),
+            "$round->name: " . _("Unavailable"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
+            ''
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_WAITING_FOR_RELEASE",
+            $round->project_waiting_state,
+            "$round->id: " . _("Waiting"),
+            "$round->name: " . _("Waiting for Release"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
+            ''
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_AVAILABLE",
+            $round->project_available_state,
+            "$round->id: " . _("Available"),
+            "$round->name: " . _("Available"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            'BRONZE'
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_COMPLETE",
+            $round->project_complete_state,
+            "$round->id: " . _("Completed"),
+            "$round->name: " . _("Completed"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            ''
+        );
     }
 
     // POST
@@ -155,59 +200,6 @@ function define_project_states($rounds, $pools)
 
         define($sql_constant_name, $sql_condition);
     }
-}
-
-function declare_project_states_for_round($round)
-{
-    global $projects_forum_idx;
-    global $waiting_projects_forum_idx;
-
-    declare_project_state(
-        "PROJ_{$round->id}_BAD_PROJECT",
-        $round->project_bad_state,
-        "$round->id: " .  _("Bad Project"),
-        "$round->name: " . _("Bad Project"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
-
-    declare_project_state(
-        "PROJ_{$round->id}_UNAVAILABLE",
-        $round->project_unavailable_state,
-        "$round->id: " . _("Unavailable"),
-        "$round->name: " . _("Unavailable"),
-        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round->id}_WAITING_FOR_RELEASE",
-        $round->project_waiting_state,
-        "$round->id: " . _("Waiting"),
-        "$round->name: " . _("Waiting for Release"),
-        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round->id}_AVAILABLE",
-        $round->project_available_state,
-        "$round->id: " . _("Available"),
-        "$round->name: " . _("Available"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        'BRONZE'
-    );
-    declare_project_state(
-        "PROJ_{$round->id}_COMPLETE",
-        $round->project_complete_state,
-        "$round->id: " . _("Completed"),
-        "$round->name: " . _("Completed"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
 }
 
 function declare_project_state(

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -58,6 +58,19 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($rounds as $round) {
+        $round->project_bad_state = "{$round->id}.proj_bad";
+        $round->project_unavailable_state = "{$round->id}.proj_unavail";
+        $round->project_waiting_state = "{$round->id}.proj_waiting";
+        $round->project_available_state = "{$round->id}.proj_avail";
+        $round->project_complete_state = "{$round->id}.proj_done";
+
+        global $Round_for_project_state_;
+        $Round_for_project_state_[$round->project_unavailable_state] = $round;
+        $Round_for_project_state_[$round->project_waiting_state] = $round;
+        $Round_for_project_state_[$round->project_bad_state] = $round;
+        $Round_for_project_state_[$round->project_available_state] = $round;
+        $Round_for_project_state_[$round->project_complete_state] = $round;
+
         declare_project_state(
             "PROJ_{$round->id}_BAD_PROJECT",
             $round->project_bad_state,
@@ -118,11 +131,26 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($pools as $pool) {
+        switch ($pool->id) {
+            case "PP":
+                $pool->project_available_state = "proj_post_first_available";
+                $pool->project_checkedout_state = "proj_post_first_checked_out";
+                break;
+            case "PPV":
+                $pool->project_available_state = "proj_post_second_available";
+                $pool->project_checkedout_state = "proj_post_second_checked_out";
+                break;
+        }
+
+        global $Pool_for_state_;
+        $Pool_for_state_[$pool->project_available_state] = $pool;
+        $Pool_for_state_[$pool->project_checkedout_state] = $pool;
+
         declare_project_state(
             strtoupper($pool->project_available_state),
             $pool->project_available_state,
-            $pool->available_short_label,
-            $pool->available_long_label,
+            "$pool->id: " . _("Available"),
+            "$pool->name: " . _("Available"),
             $pp_projects_forum_idx,
             'PP',
             'SILVER'
@@ -131,8 +159,8 @@ function define_project_states($rounds, $pools)
         declare_project_state(
             strtoupper($pool->project_checkedout_state),
             $pool->project_checkedout_state,
-            $pool->checked_out_short_label,
-            $pool->checked_out_long_label,
+            "$pool->id: " . _("Checked out"),
+            "$pool->name: " . _("Checked out"),
             $pp_projects_forum_idx,
             'PP',
             'SILVER'

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -25,7 +25,7 @@ include_once($relPath.'site_vars.php');
 global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
 $project_state_phase_, $project_states_for_star_metal_;
 
-function define_project_states($rounds)
+function define_project_states($rounds, $pools)
 {
     global $waiting_projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
     $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx,
@@ -94,45 +94,36 @@ function define_project_states($rounds)
         'PP',
         'SILVER'
     );
-    declare_project_state(
-        "PROJ_POST_FIRST_AVAILABLE",
-        "proj_post_first_available",
-        _("Available for PP"),
-        _("Available for Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
 
-    declare_project_state(
-        "PROJ_POST_FIRST_CHECKED_OUT",
-        "proj_post_first_checked_out",
-        _("In PP"),
-        _("In Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+    foreach($pools as $pool) {
+        $upper_ordinal = strtoupper($pool->ordinal);
+        $project_available_state = "proj_post_{$pool->ordinal}_available";
+        $project_checkedout_state = "proj_post_{$pool->ordinal}_checked_out";
 
-    declare_project_state(
-        "PROJ_POST_SECOND_AVAILABLE",
-        "proj_post_second_available",
-        _("Available for PPV"),
-        _("Available for Verifying Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+        declare_project_state(
+            "PROJ_POST_{$upper_ordinal}_AVAILABLE",
+            $project_available_state,
+            $pool->available_short_label,
+            $pool->available_long_label,
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
 
-    declare_project_state(
-        "PROJ_POST_SECOND_CHECKED_OUT",
-        "proj_post_second_checked_out",
-        _("In PPV"),
-        _("Verifying Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+        declare_project_state(
+            "PROJ_POST_{$upper_ordinal}_CHECKED_OUT",
+            $project_checkedout_state,
+            $pool->checked_out_short_label,
+            $pool->checked_out_long_label,
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
+
+        global $Pool_for_state_;
+        $Pool_for_state_[$project_available_state] = $pool;
+        $Pool_for_state_[$project_checkedout_state] = $pool;
+    }
 
     declare_project_state(
         "PROJ_POST_COMPLETE",

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -42,14 +42,6 @@ function define_project_states($rounds, $pools)
         'GOLD' => [],
     ];
 
-    $project_round_states = [
-        ["BAD_PROJECT", "bad", "bad", _("Bad Project"), _("Bad Project")],
-        ["UNAVAILABLE", "unavail", "unavailable", _("Unavailable"), _("Unavailable")],
-        ["WAITING_FOR_RELEASE", "waiting", "waiting", _("Waiting"), _("Waiting for Release")],
-        ["AVAILABLE", "avail", "available", _("Available"), _("Available")],
-        ["COMPLETE", "done", "complete", _("Completed"), _("Completed")],
-    ];
-
     // Note that the order in which these project states are declared
     // is the order in which they will be displayed in various contexts
     // (via $PROJECT_STATES_IN_ORDER).
@@ -66,22 +58,7 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($rounds as $round) {
-        foreach($project_round_states as [$const, $state, $long_state, $short_label, $long_label]) {
-            $project_state = "{$round->id}.proj_$state";
-            $round_project_state = "project_{$long_state}_state";
-            $round->$round_project_state = $project_state;
-            $Round_for_project_state_[$project_state] = $round;
-
-            declare_project_state(
-                "PROJ_{$round->id}_{$const}",
-                $project_state,
-                "$round->id: $short_label",
-                "$round->name: $long_label",
-                (($round->id == 'P1') && (($state == "unavail") || ($state == "waiting"))) ? $waiting_projects_forum_idx : $projects_forum_idx,
-                'PAGE_EDITING',
-                ''
-            );
-        }
+        declare_project_states_for_round($round);
     }
 
     // POST
@@ -178,6 +155,59 @@ function define_project_states($rounds, $pools)
 
         define($sql_constant_name, $sql_condition);
     }
+}
+
+function declare_project_states_for_round($round)
+{
+    global $projects_forum_idx;
+    global $waiting_projects_forum_idx;
+
+    declare_project_state(
+        "PROJ_{$round->id}_BAD_PROJECT",
+        $round->project_bad_state,
+        "$round->id: " .  _("Bad Project"),
+        "$round->name: " . _("Bad Project"),
+        $projects_forum_idx,
+        'PAGE_EDITING',
+        ''
+    );
+
+    declare_project_state(
+        "PROJ_{$round->id}_UNAVAILABLE",
+        $round->project_unavailable_state,
+        "$round->id: " . _("Unavailable"),
+        "$round->name: " . _("Unavailable"),
+        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+        'PAGE_EDITING',
+        ''
+    );
+    declare_project_state(
+        "PROJ_{$round->id}_WAITING_FOR_RELEASE",
+        $round->project_waiting_state,
+        "$round->id: " . _("Waiting"),
+        "$round->name: " . _("Waiting for Release"),
+        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+        'PAGE_EDITING',
+        ''
+    );
+    declare_project_state(
+        "PROJ_{$round->id}_AVAILABLE",
+        $round->project_available_state,
+        "$round->id: " . _("Available"),
+        "$round->name: " . _("Available"),
+        $projects_forum_idx,
+        'PAGE_EDITING',
+        'BRONZE'
+    );
+    declare_project_state(
+        "PROJ_{$round->id}_COMPLETE",
+        $round->project_complete_state,
+        "$round->id: " . _("Completed"),
+        "$round->name: " . _("Completed"),
+        $projects_forum_idx,
+        'PAGE_EDITING',
+        ''
+    );
 }
 
 function declare_project_state(

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -257,6 +257,20 @@ function declare_project_state(
     }
 }
 
+function get_Round_for_project_state($project_state)
+{
+    global $Round_for_project_state_;
+    return array_get($Round_for_project_state_, $project_state, null);
+}
+
+function get_Pool_for_state($state)
+{
+    global $Pool_for_state_;
+    return array_get($Pool_for_state_, $state, null);
+}
+
+// ---------------------------
+
 function get_medium_label_for_project_state($state)
 {
     global $project_state_medium_label_;

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -96,13 +96,9 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($pools as $pool) {
-        $upper_ordinal = strtoupper($pool->ordinal);
-        $project_available_state = "proj_post_{$pool->ordinal}_available";
-        $project_checkedout_state = "proj_post_{$pool->ordinal}_checked_out";
-
         declare_project_state(
-            "PROJ_POST_{$upper_ordinal}_AVAILABLE",
-            $project_available_state,
+            strtoupper($pool->project_available_state),
+            $pool->project_available_state,
             $pool->available_short_label,
             $pool->available_long_label,
             $pp_projects_forum_idx,
@@ -111,18 +107,14 @@ function define_project_states($rounds, $pools)
         );
 
         declare_project_state(
-            "PROJ_POST_{$upper_ordinal}_CHECKED_OUT",
-            $project_checkedout_state,
+            strtoupper($pool->project_checkedout_state),
+            $pool->project_checkedout_state,
             $pool->checked_out_short_label,
             $pool->checked_out_long_label,
             $pp_projects_forum_idx,
             'PP',
             'SILVER'
         );
-
-        global $Pool_for_state_;
-        $Pool_for_state_[$project_available_state] = $pool;
-        $Pool_for_state_[$project_checkedout_state] = $pool;
     }
 
     declare_project_state(

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -22,19 +22,180 @@ include_once($relPath.'site_vars.php');
 
   (Actually, the naming convention is in transition.)
 */
-global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_;
-global $project_state_phase_, $project_states_for_star_metal_;
+global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
+$project_state_phase_, $project_states_for_star_metal_;
 
-$PROJECT_STATES_IN_ORDER = [];
-$project_state_medium_label_ = [];
-$project_state_long_label_ = [];
-$project_state_forum_ = [];
-$project_state_phase_ = [];
-$project_states_for_star_metal_ = [
-    'BRONZE' => [],
-    'SILVER' => [],
-    'GOLD' => [],
-];
+function define_project_states($rounds)
+{
+    global $waiting_projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
+    $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx,
+    $project_states_for_star_metal_, $Round_for_project_state_;
+
+    $PROJECT_STATES_IN_ORDER = [];
+    $project_state_medium_label_ = [];
+    $project_state_long_label_ = [];
+    $project_state_forum_ = [];
+    $project_state_phase_ = [];
+    $project_states_for_star_metal_ = [
+        'BRONZE' => [],
+        'SILVER' => [],
+        'GOLD' => [],
+    ];
+
+    $project_round_states = [
+        ["BAD_PROJECT", "bad", "bad", _("Bad Project"), _("Bad Project")],
+        ["UNAVAILABLE", "unavail", "unavailable", _("Unavailable"), _("Unavailable")],
+        ["WAITING_FOR_RELEASE", "waiting", "waiting", _("Waiting"), _("Waiting for Release")],
+        ["AVAILABLE", "avail", "available", _("Available"), _("Available")],
+        ["COMPLETE", "done", "complete", _("Completed"), _("Completed")],
+    ];
+
+    // Note that the order in which these project states are declared
+    // is the order in which they will be displayed in various contexts
+    // (via $PROJECT_STATES_IN_ORDER).
+
+    // for the initial creation of a project
+    declare_project_state(
+        "PROJ_NEW",
+        "project_new",
+        _("New Project"),
+        _("New Project"),
+        $waiting_projects_forum_idx,
+        'NEW',
+        ''
+    );
+
+    foreach($rounds as $round) {
+        foreach($project_round_states as [$const, $state, $long_state, $short_label, $long_label]) {
+            $project_state = "{$round->id}.proj_$state";
+            $round_project_state = "project_{$long_state}_state";
+            $round->$round_project_state = $project_state;
+            $Round_for_project_state_[$project_state] = $round;
+
+            declare_project_state(
+                "PROJ_{$round->id}_{$const}",
+                $project_state,
+                "$round->id: $short_label",
+                "$round->name: $long_label",
+                (($round->id == 'P1') && (($state == "unavail") || ($state == "waiting"))) ? $waiting_projects_forum_idx : $projects_forum_idx,
+                'PAGE_EDITING',
+                ''
+            );
+        }
+    }
+
+    // POST
+    declare_project_state(
+        "PROJ_POST_FIRST_UNAVAILABLE",
+        "proj_post_first_unavailable",
+        _("Unavailable for PP"),
+        _("Unavailable for Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+    declare_project_state(
+        "PROJ_POST_FIRST_AVAILABLE",
+        "proj_post_first_available",
+        _("Available for PP"),
+        _("Available for Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_FIRST_CHECKED_OUT",
+        "proj_post_first_checked_out",
+        _("In PP"),
+        _("In Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_SECOND_AVAILABLE",
+        "proj_post_second_available",
+        _("Available for PPV"),
+        _("Available for Verifying Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_SECOND_CHECKED_OUT",
+        "proj_post_second_checked_out",
+        _("In PPV"),
+        _("Verifying Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_COMPLETE",
+        "proj_post_complete",
+        _("Completed Post"),
+        _("Completed Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    // SUBMIT (was GB)
+    declare_project_state(
+        "PROJ_SUBMIT_PG_POSTED",
+        "proj_submit_pgposted",
+        _("Posted to PG"),
+        _("Completed and Posted to Project Gutenberg"),
+        $posted_projects_forum_idx,
+        'GB',
+        'GOLD'
+    );
+
+    // for complete project
+    declare_project_state(
+        "PROJ_COMPLETE",
+        "project_complete",
+        _("Project Complete"),
+        _("Project Complete"),
+        $completed_projects_forum_idx,
+        'COMPLETE',
+        ''
+    );
+
+    // for the 'deletion' of a project
+    declare_project_state(
+        "PROJ_DELETE",
+        "project_delete",
+        _("Delete Project"),
+        _("Delete Project"),
+        $deleted_projects_forum_idx,
+        'NONE',
+        ''
+    );
+
+    // Define constants for use in SQL queries:
+    // SQL_CONDITION_BRONZE
+    // SQL_CONDITION_SILVER
+    // SQL_CONDITION_GOLD
+
+    foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
+        $sql_constant_name = "SQL_CONDITION_$star_metal";
+        $sql_condition = '(';
+        foreach ($project_states as $project_state) {
+            if ($sql_condition != '(') {
+                $sql_condition .= ' OR ';
+            }
+            $sql_condition .= "state='$project_state'";
+        }
+        $sql_condition .= ')';
+
+        define($sql_constant_name, $sql_condition);
+    }
+}
 
 function declare_project_state(
     $constant_name,
@@ -85,207 +246,6 @@ function get_phase_containing_project_state($state)
 {
     global $project_state_phase_;
     return array_get($project_state_phase_, $state, 'NONE');
-}
-
-// -----------------------------------------------
-
-function declare_project_states_for_round($round_id, $round_name)
-{
-    global $projects_forum_idx;
-    global $waiting_projects_forum_idx;
-
-    declare_project_state(
-        "PROJ_{$round_id}_BAD_PROJECT",
-        "$round_id.proj_bad",
-        "$round_id: " .  _("Bad Project"),
-        "$round_name: " . _("Bad Project"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_UNAVAILABLE",
-        "$round_id.proj_unavail",
-        "$round_id: " . _("Unavailable"),
-        "$round_name: " . _("Unavailable"),
-        ($round_id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_WAITING_FOR_RELEASE",
-        "$round_id.proj_waiting",
-        "$round_id: " . _("Waiting"),
-        "$round_name: " . _("Waiting for Release"),
-        ($round_id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_AVAILABLE",
-        "$round_id.proj_avail",
-        "$round_id: " . _("Available"),
-        "$round_name: " . _("Available"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        'BRONZE'
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_COMPLETE",
-        "$round_id.proj_done",
-        "$round_id: " . _("Completed"),
-        "$round_name: " . _("Completed"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
-}
-
-// -----------------------------------------------
-
-// Note that the order in which these project states are declared
-// is the order in which they will be displayed in various contexts
-// (via $PROJECT_STATES_IN_ORDER).
-
-
-// PR
-
-
-// for the initial creation of a project
-declare_project_state(
-    "PROJ_NEW",
-    "project_new",
-    _("New Project"),
-    _("New Project"),
-    $waiting_projects_forum_idx,
-    'NEW',
-    ''
-);
-
-
-// PROOF
-declare_project_states_for_round('P1', _('Proofreading Round 1'));
-declare_project_states_for_round('P2', _('Proofreading Round 2'));
-declare_project_states_for_round('P3', _('Proofreading Round 3'));
-
-// FORMAT
-declare_project_states_for_round('F1', _('Formatting Round 1'));
-declare_project_states_for_round('F2', _('Formatting Round 2'));
-
-
-// POST
-declare_project_state(
-    "PROJ_POST_FIRST_UNAVAILABLE",
-    "proj_post_first_unavailable",
-    _("Unavailable for PP"),
-    _("Unavailable for Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-declare_project_state(
-    "PROJ_POST_FIRST_AVAILABLE",
-    "proj_post_first_available",
-    _("Available for PP"),
-    _("Available for Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_FIRST_CHECKED_OUT",
-    "proj_post_first_checked_out",
-    _("In PP"),
-    _("In Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_SECOND_AVAILABLE",
-    "proj_post_second_available",
-    _("Available for PPV"),
-    _("Available for Verifying Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_SECOND_CHECKED_OUT",
-    "proj_post_second_checked_out",
-    _("In PPV"),
-    _("Verifying Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-declare_project_state(
-    "PROJ_POST_COMPLETE",
-    "proj_post_complete",
-    _("Completed Post"),
-    _("Completed Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-
-
-// SUBMIT (was GB)
-declare_project_state(
-    "PROJ_SUBMIT_PG_POSTED",
-    "proj_submit_pgposted",
-    _("Posted to PG"),
-    _("Completed and Posted to Project Gutenberg"),
-    $posted_projects_forum_idx,
-    'GB',
-    'GOLD'
-);
-
-// for complete project
-declare_project_state(
-    "PROJ_COMPLETE",
-    "project_complete",
-    _("Project Complete"),
-    _("Project Complete"),
-    $completed_projects_forum_idx,
-    'COMPLETE',
-    ''
-);
-
-// for the 'deletion' of a project
-declare_project_state(
-    "PROJ_DELETE",
-    "project_delete",
-    _("Delete Project"),
-    _("Delete Project"),
-    $deleted_projects_forum_idx,
-    'NONE',
-    ''
-);
-
-// -----------------------------------------------------------------------------
-
-// Define constants for use in SQL queries:
-// SQL_CONDITION_BRONZE
-// SQL_CONDITION_SILVER
-// SQL_CONDITION_GOLD
-
-foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
-    $sql_constant_name = "SQL_CONDITION_$star_metal";
-    $sql_condition = '(';
-    foreach ($project_states as $project_state) {
-        if ($sql_condition != '(') {
-            $sql_condition .= ' OR ';
-        }
-        $sql_condition .= "state='$project_state'";
-    }
-    $sql_condition .= ')';
-
-    define($sql_constant_name, $sql_condition);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -277,7 +277,8 @@ function define_activities()
         null, // access_change_callback
         _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
         'post_proof.php',
-        "first",
+        "proj_post_first_available",
+        "proj_post_first_checked_out",
         _("Available for PP"),
         _("Available for Post-Processing"),
         _("In PP"),
@@ -330,7 +331,8 @@ function define_activities()
         null, // access_change_callback
         _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
         'ppv.php',
-        'second',
+        "proj_post_second_available",
+        "proj_post_second_checked_out",
         _("Available for PPV"),
         _("Available for Verifying Post-Processing"),
         _("In PPV"),

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -46,6 +46,8 @@ $ELR_round = get_Round_for_round_number(1);
 
 function define_activities()
 {
+    global $code_url, $post_processing_forum_idx;
+
     // $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
     // what proofreading tools are shown in the toolbox in the proofreading
     // interface for the proofreading (P) and the formatting (F) rounds. These are
@@ -265,8 +267,6 @@ function define_activities()
             150000 => _('Preserver of Texts'),
         ]
     );
-
-    global $code_url, $post_processing_forum_idx, $post_processing_forum_idx;
 
     new Pool(
         'PP',

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -13,20 +13,17 @@ include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// first define rounds
-define_rounds();
+// first define activities
+define_activities();
 
-// then define project states using defined rounds
-define_project_states($Round_for_round_id_);
+// then define project states using defined rounds and pools
+define_project_states($Round_for_round_id_, $Pool_for_id_);
 
 // After creating all rounds:
 define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
 assert($n_rounds == MAX_NUM_PAGE_EDITING_ROUNDS);
 
 declare_mentoring_pair('P1', 'P2');
-
-// other activities depend on constants from define_project_states()
-define_other_activities();
 
 // -----------------------------------------------------------------------------
 
@@ -47,7 +44,7 @@ $ELR_round = get_Round_for_round_number(1);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function define_rounds()
+function define_activities()
 {
     // $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
     // what proofreading tools are shown in the toolbox in the proofreading
@@ -268,10 +265,7 @@ function define_rounds()
             150000 => _('Preserver of Texts'),
         ]
     );
-}
 
-function define_other_activities()
-{
     global $code_url, $post_processing_forum_idx, $post_processing_forum_idx;
 
     new Pool(
@@ -283,8 +277,11 @@ function define_other_activities()
         null, // access_change_callback
         _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
         'post_proof.php',
-        PROJ_POST_FIRST_CHECKED_OUT,
-        PROJ_POST_FIRST_AVAILABLE,
+        "first",
+        _("Available for PP"),
+        _("Available for Post-Processing"),
+        _("In PP"),
+        _("In Post-Processing"),
         _("Manager"),
         'username',
         [
@@ -333,8 +330,11 @@ function define_other_activities()
         null, // access_change_callback
         _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
         'ppv.php',
-        PROJ_POST_SECOND_CHECKED_OUT,
-        PROJ_POST_SECOND_AVAILABLE,
+        'second',
+        _("Available for PPV"),
+        _("Available for Verifying Post-Processing"),
+        _("In PPV"),
+        _("Verifying Post-Processing"),
         _("Post-Processor"),
         'postproofer',
         [

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -13,236 +13,20 @@ include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
-// what proofreading tools are shown in the toolbox in the proofreading
-// interface for the proofreading (P) and the formatting (F) rounds. These are
-// passed into the Round() constructors below. The names refer to ToolButtons
-// and PopupLink objects defined in pinc/ProofreadingToolbox.inc.
+// first define rounds
+define_rounds();
 
-$pi_tools_for_P = [
-    'popup_links' => ['search_and_replace', 'greek_transliterator', 'hieroglyph_transliterator'],
-    'tool_buttons' => ['remove_markup', 'upper_case', 'title_case', 'lower_case'],
-    'tool_links' => ['greek', 'note', 'brackets', 'braces', 'blank_page'],
-];
-$pi_tools_for_F = [
-    'popup_links' => 'ALL',
-    'tool_buttons' => 'ALL',
-    'tool_links' => 'ALL',
-];
-
-new Round(
-    'P1',
-    _('Proofreading Round 1'),
-    [],
-    'IMMEDIATE',
-    '',
-    null, // access_change_callback
-    _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
-    'proofreading_guidelines.php',
-    $pi_tools_for_P,
-    null, // daily_page_limit
-    [],
-    [
-        0 => _('Novice'),
-        25 => _('Proofreading Pupil'),
-        100 => _('Proofreading Apprentice'),
-        500 => _('Proofreading Scholar'),
-        1000 => _('Proofreading Prodigy'),
-        2500 => _('Proofreading Mastermind'),
-        5000 => _('Proofreading Graduate'),
-        10000 => _('Proofreading Alumnus'),
-        20000 => _('Fellow of Proofreading'),
-        30000 => _('Doctor of Proofreading'),
-        40000 => _('Proofreading Don'),
-        50000 => _('Dean of Proofreading'),
-        60000 => _('Proofreading Proctor'),
-        70000 => _('Principal Proofreader'),
-        80000 => _('Master Proofreader'),
-        90000 => _('Prefect of Proofreaders'),
-        99000 => _('Supervising Proofreader'),
-        100000 => _('Proofreading Professor'),
-        110000 => _('Peer of Proofreading'),
-        120000 => _('Doyen of Proofreading'),
-        130000 => _('Proofreading Chancellor'),
-        140000 => _('Proofreading Primate'),
-        150000 => _('Paramount Proofreader'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'P2',
-    _('Proofreading Round 2'),
-    ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
-    'REQ-AUTO',
-    '',
-    null, // access_change_callback
-    _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
-    'proofreading_guidelines.php',
-    $pi_tools_for_P,
-    null, // daily_page_limit
-    ['P1'],
-    [
-        0 => _('Precise Proofreader'),
-        25 => _('Picky Proofreader'),
-        100 => _('Painstaking Proofreader'),
-        500 => _('Punctilious Proofreader'),
-        1000 => _('Persnickety Proofreader'),
-        2500 => _('Particular Proofreader'),
-        5000 => _('Proficient Proofreader'),
-        10000 => _('Proper Proofreader'),
-        20000 => _('Prudent Proofreader'),
-        30000 => _('Proofreading Personage'),
-        40000 => _('Proofreading Poppet'),
-        50000 => _('Plighted Proofreader'),
-        60000 => _('Proofreading Proctor'),
-        70000 => _('Principal Proofreader'),
-        80000 => _('Prime Proofreader'),
-        90000 => _('Primal Proofreader'),
-        99000 => _('Proofreading Personality'),
-        100000 => _('Proofreading Professional'),
-        110000 => _('Peerless Proofreader'),
-        120000 => _('Perspicacious Proofreader'),
-        130000 => _('Paraproofreader'),
-        140000 => _('Proofreading Panjandrum'),
-        150000 => _('Perfectionist Proofreader'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'P3',
-    _('Proofreading Round 3'),
-    ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
-    'REQ-HUMAN',
-    _("Once you have met the requirements and requested access to P3, an evaluator will check over at least 50 of your recent P2 pages that have been completed in P3. If you proofread them to P3 standards, you'll be granted access."),
-    null, // access_change_callback
-    _("The page-texts have already been proofread, but now need to be examined <b>closely</b> for small errors that may have been missed."),
-    'proofreading_guidelines.php',
-    $pi_tools_for_P,
-    null, // daily_page_limit
-    ['P1', 'P2'],
-    [
-        0 => _('Specialist Proofreader'),
-        25 => _('Precious Proofreader'),
-        100 => _('Prized Proofreader'),
-        500 => _('Premiere Proofreader'),
-        1000 => _('Proofreading Perfectionist'),
-        2500 => _('Pillar of Proofreading'),
-        5000 => _('Proofreading Purist'),
-        10000 => _('Proofreader of Precision'),
-        20000 => _('Archetypal Proofreader'),
-        30000 => _('Proofreading Nonpareil'),
-        40000 => _('Paradigmatic Proofreader'),
-        50000 => _('Preeminent Proofreader'),
-        60000 => _('Prime Proofreader'),
-        70000 => _('Proofreader of Plenariness'),
-        80000 => _('Perpetual Proofreader'),
-        90000 => _('Prefect of Proofreaders'),
-        99000 => _('Impeccable Proofreader'),
-        100000 => _('Proofreader of Persistence'),
-        110000 => _('Patent Proofreader'),
-        120000 => _('Proofreading Philosopher'),
-        130000 => _('Patron of Proofreaders'),
-        140000 => _('Proofreading Partner'),
-        150000 => _('Pioneer of Proofreaders'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'F1',
-    _('Formatting Round 1'),
-    ['P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1],
-    'REQ-AUTO',
-    '',
-    null, // access_change_callback
-    _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),
-    'formatting_guidelines.php',
-    $pi_tools_for_F,
-    null, // daily_page_limit
-    [],
-    [
-        0 => _('Formatting Neophyte'),
-        25 => _('Formatting Intern'),
-        100 => _('Journeyman Formatter'),
-        500 => _('Crafter of Texts'),
-        1000 => _('Detailer of Books'),
-        2500 => _('Fastidious Formatter'),
-        5000 => _('Foremost Formatter'),
-        10000 => _('Fine Formatter'),
-        20000 => _('Flamboyant Formatter'),
-        30000 => _('Fabulous Formatter'),
-        40000 => _('Upgrader of Texts'),
-        50000 => _('Famous Formatter'),
-        60000 => _('Indefatigable Formatter'),
-        70000 => _('Finisher of Texts'),
-        80000 => _('Formatter of Choice'),
-        90000 => _('Capital Formatter'),
-        99000 => _('Formatter with Flair'),
-        100000 => _('Formatter of Finesse'),
-        110000 => _('Formatter with Forte'),
-        120000 => _('First-Class Formatter'),
-        130000 => _('Formatter of Favour'),
-        140000 => _('Formatter of Refinement'),
-        150000 => _('Flawless Formatter'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'F2',
-    _('Formatting Round 2'),
-    ['F1' => 400, 'days since reg' => 91], // 'F1' => 1000, 3 months after rollout
-    'REQ-HUMAN', // "peer approval"
-    _("Once you have met the requirements and requested access to F2, an evaluator will check over at least 150 of your recent F1 pages that have been completed in F2. If they've been formatted to F2 standards, you'll be granted access."),
-    null, // access_change_callback
-    _("The page-texts in this round need to be carefully checked to remove any remaining formatting errors."),
-    'formatting_guidelines.php',
-    $pi_tools_for_F,
-    null, // daily_page_limit
-    ['F1'],
-    [
-        0 => _('Refurbisher of Texts'),
-        25 => _('Sprucer of Texts'),
-        100 => _('Formatter Savant'),
-        500 => _('Formatting Wunderkind'),
-        1000 => _('Elite Formatter'),
-        2500 => _('Polisher of Texts'),
-        5000 => _('Formatting Artiste'),
-        10000 => _('Cultivator of Texts'),
-        20000 => _('Formatter of Enrichment'),
-        30000 => _('Designing Formatter'),
-        40000 => _('Formatting Artisan'),
-        50000 => _('Formatting Aficionado'),
-        60000 => _('Guru of Formatters'),
-        70000 => _('Formatting Familiar'),
-        80000 => _('Formatting Virtuoso'),
-        90000 => _('Formatter of Excellence'),
-        99000 => _('Exquisite Formatter'),
-        100000 => _('Formatting Specialist'),
-        110000 => _('Formatting Genius'),
-        120000 => _('Formatter of Fine Feats'),
-        130000 => _('Harmoniser of Texts'),
-        140000 => _('Formatting Architect'),
-        150000 => _('Preserver of Texts'),
-    ]
-);
-
-// ---------------------------
+// then define project states using defined rounds
+define_project_states($Round_for_round_id_);
 
 // After creating all rounds:
-
 define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
 assert($n_rounds == MAX_NUM_PAGE_EDITING_ROUNDS);
 
-// ---------------------------
-
 declare_mentoring_pair('P1', 'P2');
+
+// other activities depend on constants from define_project_states()
+define_other_activities();
 
 // -----------------------------------------------------------------------------
 
@@ -261,110 +45,337 @@ $ELR_round = get_Round_for_round_number(1);
 // round (e.g., everyone can work in multiple rounds from their first day),
 // then you may have to do some hacking (sorry).
 
-
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-new Pool(
-    'PP',
-    _('Post-Processing'),
-    ['F1' => 400],
-    'REQ-AUTO',
-    '',
-    null, // access_change_callback
-    _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
-    'post_proof.php',
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_FIRST_AVAILABLE,
-    _("Manager"),
-    'username',
-    [
-        "<p>",
-        "<b>" . _("First Time Here?") . "</b>",
-        sprintf(
-            _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
-            "$code_url/faq/post_proof.php"
-        ),
-        _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
-        sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
-        _("If nothing interests you right now, check back later and there will be more!"),
-        "</p>",
+function define_rounds()
+{
+    // $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
+    // what proofreading tools are shown in the toolbox in the proofreading
+    // interface for the proofreading (P) and the formatting (F) rounds. These are
+    // passed into the Round() constructors below. The names refer to ToolButtons
+    // and PopupLink objects defined in pinc/ProofreadingToolbox.inc.
 
-        "<p>",
-        _("Each book listed below has gone through multiple rounds of proofreading and formatting, and now needs to be massaged into a final e-text."),
-        _("Once you have checked out and downloaded a book it will remain checked out to you until you check it back in."),
-        _("When you have finished your work on the book, select <i>Upload for Verification</i> from the drop-down list for that project."),
-        _("If you have several files to submit for a single project (say a text and HTML version), zip them up together first."),
-        "</p>",
-    ]
-);
+    $pi_tools_for_P = [
+        'popup_links' => ['search_and_replace', 'greek_transliterator', 'hieroglyph_transliterator'],
+        'tool_buttons' => ['remove_markup', 'upper_case', 'title_case', 'lower_case'],
+        'tool_links' => ['greek', 'note', 'brackets', 'braces', 'blank_page'],
+    ];
+    $pi_tools_for_F = [
+        'popup_links' => 'ALL',
+        'tool_buttons' => 'ALL',
+        'tool_links' => 'ALL',
+    ];
 
-// -----------------------------------------------------------------------------
+    new Round(
+        'P1',
+        _('Proofreading Round 1'),
+        [],
+        'IMMEDIATE',
+        '',
+        null, // access_change_callback
+        _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
+        'proofreading_guidelines.php',
+        $pi_tools_for_P,
+        null, // daily_page_limit
+        [],
+        [
+            0 => _('Novice'),
+            25 => _('Proofreading Pupil'),
+            100 => _('Proofreading Apprentice'),
+            500 => _('Proofreading Scholar'),
+            1000 => _('Proofreading Prodigy'),
+            2500 => _('Proofreading Mastermind'),
+            5000 => _('Proofreading Graduate'),
+            10000 => _('Proofreading Alumnus'),
+            20000 => _('Fellow of Proofreading'),
+            30000 => _('Doctor of Proofreading'),
+            40000 => _('Proofreading Don'),
+            50000 => _('Dean of Proofreading'),
+            60000 => _('Proofreading Proctor'),
+            70000 => _('Principal Proofreader'),
+            80000 => _('Master Proofreader'),
+            90000 => _('Prefect of Proofreaders'),
+            99000 => _('Supervising Proofreader'),
+            100000 => _('Proofreading Professor'),
+            110000 => _('Peer of Proofreading'),
+            120000 => _('Doyen of Proofreading'),
+            130000 => _('Proofreading Chancellor'),
+            140000 => _('Proofreading Primate'),
+            150000 => _('Paramount Proofreader'),
+        ]
+    );
 
-new Stage(
-    'SR',
-    _('Smooth Reading'),
-    [],
-    'IMMEDIATE',
-    '',
-    null, // access_change_callback
-    _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
-    null,
-    "tools/post_proofers/smooth_reading.php"
-);
+    // -----------------------------------------------------------------------------
 
-// -----------------------------------------------------------------------------
+    new Round(
+        'P2',
+        _('Proofreading Round 2'),
+        ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
+        'REQ-AUTO',
+        '',
+        null, // access_change_callback
+        _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
+        'proofreading_guidelines.php',
+        $pi_tools_for_P,
+        null, // daily_page_limit
+        ['P1'],
+        [
+            0 => _('Precise Proofreader'),
+            25 => _('Picky Proofreader'),
+            100 => _('Painstaking Proofreader'),
+            500 => _('Punctilious Proofreader'),
+            1000 => _('Persnickety Proofreader'),
+            2500 => _('Particular Proofreader'),
+            5000 => _('Proficient Proofreader'),
+            10000 => _('Proper Proofreader'),
+            20000 => _('Prudent Proofreader'),
+            30000 => _('Proofreading Personage'),
+            40000 => _('Proofreading Poppet'),
+            50000 => _('Plighted Proofreader'),
+            60000 => _('Proofreading Proctor'),
+            70000 => _('Principal Proofreader'),
+            80000 => _('Prime Proofreader'),
+            90000 => _('Primal Proofreader'),
+            99000 => _('Proofreading Personality'),
+            100000 => _('Proofreading Professional'),
+            110000 => _('Peerless Proofreader'),
+            120000 => _('Perspicacious Proofreader'),
+            130000 => _('Paraproofreader'),
+            140000 => _('Proofreading Panjandrum'),
+            150000 => _('Perfectionist Proofreader'),
+        ]
+    );
 
-new Pool(
-    'PPV',
-    _('Post-Processing Verification'),
-    [],
-    'NOREQ', // "Peer approval. Also gives F2 access."
-    '',
-    null, // access_change_callback
-    _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
-    'ppv.php',
-    PROJ_POST_SECOND_CHECKED_OUT,
-    PROJ_POST_SECOND_AVAILABLE,
-    _("Post-Processor"),
-    'postproofer',
-    [
-        "<p>",
-        _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
-        sprintf(
-            _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
-            "$code_url/faq/ppv.php"
-        ),
-        sprintf(
-            _("The PPV reporting form is <a href='%s'>here</a>."),
-            "$code_url/tools/post_proofers/ppv_report.php"
-        ),
-        "</p>",
+    // -----------------------------------------------------------------------------
 
-        "<p>",
-        sprintf(
-            _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
-            get_url_to_view_forum($post_processing_forum_idx)
-        ),
-        "</p>",
-    ]
-);
+    new Round(
+        'P3',
+        _('Proofreading Round 3'),
+        ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
+        'REQ-HUMAN',
+        _("Once you have met the requirements and requested access to P3, an evaluator will check over at least 50 of your recent P2 pages that have been completed in P3. If you proofread them to P3 standards, you'll be granted access."),
+        null, // access_change_callback
+        _("The page-texts have already been proofread, but now need to be examined <b>closely</b> for small errors that may have been missed."),
+        'proofreading_guidelines.php',
+        $pi_tools_for_P,
+        null, // daily_page_limit
+        ['P1', 'P2'],
+        [
+            0 => _('Specialist Proofreader'),
+            25 => _('Precious Proofreader'),
+            100 => _('Prized Proofreader'),
+            500 => _('Premiere Proofreader'),
+            1000 => _('Proofreading Perfectionist'),
+            2500 => _('Pillar of Proofreading'),
+            5000 => _('Proofreading Purist'),
+            10000 => _('Proofreader of Precision'),
+            20000 => _('Archetypal Proofreader'),
+            30000 => _('Proofreading Nonpareil'),
+            40000 => _('Paradigmatic Proofreader'),
+            50000 => _('Preeminent Proofreader'),
+            60000 => _('Prime Proofreader'),
+            70000 => _('Proofreader of Plenariness'),
+            80000 => _('Perpetual Proofreader'),
+            90000 => _('Prefect of Proofreaders'),
+            99000 => _('Impeccable Proofreader'),
+            100000 => _('Proofreader of Persistence'),
+            110000 => _('Patent Proofreader'),
+            120000 => _('Proofreading Philosopher'),
+            130000 => _('Patron of Proofreaders'),
+            140000 => _('Proofreading Partner'),
+            150000 => _('Pioneer of Proofreaders'),
+        ]
+    );
 
-// -----------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------
 
-new Activity(
-    'DU',
-    _('Uploading to Project Gutenberg'),
-    [],
-    'NOREQ',
-    'OOGA',
-    null // access_change_callback
-);
+    new Round(
+        'F1',
+        _('Formatting Round 1'),
+        ['P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1],
+        'REQ-AUTO',
+        '',
+        null, // access_change_callback
+        _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),
+        'formatting_guidelines.php',
+        $pi_tools_for_F,
+        null, // daily_page_limit
+        [],
+        [
+            0 => _('Formatting Neophyte'),
+            25 => _('Formatting Intern'),
+            100 => _('Journeyman Formatter'),
+            500 => _('Crafter of Texts'),
+            1000 => _('Detailer of Books'),
+            2500 => _('Fastidious Formatter'),
+            5000 => _('Foremost Formatter'),
+            10000 => _('Fine Formatter'),
+            20000 => _('Flamboyant Formatter'),
+            30000 => _('Fabulous Formatter'),
+            40000 => _('Upgrader of Texts'),
+            50000 => _('Famous Formatter'),
+            60000 => _('Indefatigable Formatter'),
+            70000 => _('Finisher of Texts'),
+            80000 => _('Formatter of Choice'),
+            90000 => _('Capital Formatter'),
+            99000 => _('Formatter with Flair'),
+            100000 => _('Formatter of Finesse'),
+            110000 => _('Formatter with Forte'),
+            120000 => _('First-Class Formatter'),
+            130000 => _('Formatter of Favour'),
+            140000 => _('Formatter of Refinement'),
+            150000 => _('Flawless Formatter'),
+        ]
+    );
 
-new Activity(
-    "P2_mentor",
-    sprintf(_("Mentoring in round %s"), 'P2'),
-    [],
-    'NOREQ',
-    '',
-    null // access_change_callback
-);
+    // -----------------------------------------------------------------------------
+
+    new Round(
+        'F2',
+        _('Formatting Round 2'),
+        ['F1' => 400, 'days since reg' => 91], // 'F1' => 1000, 3 months after rollout
+        'REQ-HUMAN', // "peer approval"
+        _("Once you have met the requirements and requested access to F2, an evaluator will check over at least 150 of your recent F1 pages that have been completed in F2. If they've been formatted to F2 standards, you'll be granted access."),
+        null, // access_change_callback
+        _("The page-texts in this round need to be carefully checked to remove any remaining formatting errors."),
+        'formatting_guidelines.php',
+        $pi_tools_for_F,
+        null, // daily_page_limit
+        ['F1'],
+        [
+            0 => _('Refurbisher of Texts'),
+            25 => _('Sprucer of Texts'),
+            100 => _('Formatter Savant'),
+            500 => _('Formatting Wunderkind'),
+            1000 => _('Elite Formatter'),
+            2500 => _('Polisher of Texts'),
+            5000 => _('Formatting Artiste'),
+            10000 => _('Cultivator of Texts'),
+            20000 => _('Formatter of Enrichment'),
+            30000 => _('Designing Formatter'),
+            40000 => _('Formatting Artisan'),
+            50000 => _('Formatting Aficionado'),
+            60000 => _('Guru of Formatters'),
+            70000 => _('Formatting Familiar'),
+            80000 => _('Formatting Virtuoso'),
+            90000 => _('Formatter of Excellence'),
+            99000 => _('Exquisite Formatter'),
+            100000 => _('Formatting Specialist'),
+            110000 => _('Formatting Genius'),
+            120000 => _('Formatter of Fine Feats'),
+            130000 => _('Harmoniser of Texts'),
+            140000 => _('Formatting Architect'),
+            150000 => _('Preserver of Texts'),
+        ]
+    );
+}
+
+function define_other_activities()
+{
+    global $code_url, $post_processing_forum_idx, $post_processing_forum_idx;
+
+    new Pool(
+        'PP',
+        _('Post-Processing'),
+        ['F1' => 400],
+        'REQ-AUTO',
+        '',
+        null, // access_change_callback
+        _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
+        'post_proof.php',
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_FIRST_AVAILABLE,
+        _("Manager"),
+        'username',
+        [
+            "<p>",
+            "<b>" . _("First Time Here?") . "</b>",
+            sprintf(
+                _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
+                "$code_url/faq/post_proof.php"
+            ),
+            _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
+            sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
+            _("If nothing interests you right now, check back later and there will be more!"),
+            "</p>",
+
+            "<p>",
+            _("Each book listed below has gone through multiple rounds of proofreading and formatting, and now needs to be massaged into a final e-text."),
+            _("Once you have checked out and downloaded a book it will remain checked out to you until you check it back in."),
+            _("When you have finished your work on the book, select <i>Upload for Verification</i> from the drop-down list for that project."),
+            _("If you have several files to submit for a single project (say a text and HTML version), zip them up together first."),
+            "</p>",
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+
+    new Stage(
+        'SR',
+        _('Smooth Reading'),
+        [],
+        'IMMEDIATE',
+        '',
+        null, // access_change_callback
+        _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
+        null,
+        "tools/post_proofers/smooth_reading.php"
+    );
+
+    // -----------------------------------------------------------------------------
+
+    new Pool(
+        'PPV',
+        _('Post-Processing Verification'),
+        [],
+        'NOREQ', // "Peer approval. Also gives F2 access."
+        '',
+        null, // access_change_callback
+        _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
+        'ppv.php',
+        PROJ_POST_SECOND_CHECKED_OUT,
+        PROJ_POST_SECOND_AVAILABLE,
+        _("Post-Processor"),
+        'postproofer',
+        [
+            "<p>",
+            _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
+            sprintf(
+                _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
+                "$code_url/faq/ppv.php"
+            ),
+            sprintf(
+                _("The PPV reporting form is <a href='%s'>here</a>."),
+                "$code_url/tools/post_proofers/ppv_report.php"
+            ),
+            "</p>",
+
+            "<p>",
+            sprintf(
+                _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
+                get_url_to_view_forum($post_processing_forum_idx)
+            ),
+            "</p>",
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+
+    new Activity(
+        'DU',
+        _('Uploading to Project Gutenberg'),
+        [],
+        'NOREQ',
+        'OOGA',
+        null // access_change_callback
+    );
+
+    new Activity(
+        "P2_mentor",
+        sprintf(_("Mentoring in round %s"), 'P2'),
+        [],
+        'NOREQ',
+        '',
+        null // access_change_callback
+    );
+}

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -277,12 +277,6 @@ function define_activities()
         null, // access_change_callback
         _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
         'post_proof.php',
-        "proj_post_first_available",
-        "proj_post_first_checked_out",
-        _("Available for PP"),
-        _("Available for Post-Processing"),
-        _("In PP"),
-        _("In Post-Processing"),
         _("Manager"),
         'username',
         [
@@ -331,12 +325,6 @@ function define_activities()
         null, // access_change_callback
         _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
         'ppv.php',
-        "proj_post_second_available",
-        "proj_post_second_checked_out",
-        _("Available for PPV"),
-        _("Available for Verifying Post-Processing"),
-        _("In PPV"),
-        _("Verifying Post-Processing"),
         _("Post-Processor"),
         'postproofer',
         [


### PR DESCRIPTION
Define rounds, activities and project states inside functions.  Use the defined rounds when defining project states. Postpone defining 'round project states' until defining project states to avoid duplication. Then define other activities since they use constants defined when defining project states.
This does not make any attempt to reduce the use of global variables but it could be a step on the way to doing so.