### PR TITLE
Remove activity globals and avoid duplicate round definitions.

### DIFF
--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -29,8 +29,8 @@ class RoundTest extends ProjectUtils
         $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
         $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
         $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
-//        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
-//        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
+        //        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
+        //        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
         $this->assertEquals('PAGE_EDITING', get_phase_containing_project_state("P1.proj_bad"));
         $this->assertEquals("(state='proj_submit_pgposted')", SQL_CONDITION_GOLD);
     }

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -11,6 +11,9 @@ class RoundTest extends ProjectUtils
         $this->assertEquals("P3", get_Round_for_round_id("P3")->id);
         $this->assertEquals("P2", get_Round_for_project_state("P2.proj_waiting")->id);
         $this->assertEquals("F1", get_Round_for_text_column_name("round4_text")->id);
+
+        global $activities;
+        $this->assertEquals("'P2' pages completed", $activities->access_criteria["P2"]);
     }
 
     public function test_round_states()

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -1,0 +1,37 @@
+<?php
+
+class RoundTest extends ProjectUtils
+{
+    //------------------------------------------------------------------------
+
+    public function test_get_round()
+    {
+        $this->assertEquals("P1", get_Round_for_round_number(1)->id);
+        $this->assertEquals("P2", get_Round_for_page_state("P2.page_temp")->id);
+        $this->assertEquals("P3", get_Round_for_round_id("P3")->id);
+        $this->assertEquals("P2", get_Round_for_project_state("P2.proj_waiting")->id);
+        $this->assertEquals("F1", get_Round_for_text_column_name("round4_text")->id);
+    }
+
+    public function test_round_states()
+    {
+        $p1 = get_Round_for_round_id("P1");
+        $this->assertEquals('Proofreading Prodigy', $p1->get_honorific_for_page_tally(1200));
+        $this->assertEquals('Novice', $p1->get_honorific_for_page_tally(-10));
+        $this->assertEquals('P1.proj_unavail', $p1->project_unavailable_state);
+    }
+
+    public function test_project_states()
+    {
+        global $projects_forum_idx, $waiting_projects_forum_idx, $PROJECT_STATES_IN_ORDER;
+
+        $this->assertTrue(PROJ_P1_UNAVAILABLE === "P1.proj_unavail");
+        $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
+        $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
+        $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
+//        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
+//        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
+        $this->assertEquals('PAGE_EDITING', get_phase_containing_project_state("P1.proj_bad"));
+        $this->assertEquals("(state='proj_submit_pgposted')", SQL_CONDITION_GOLD);
+    }
+}

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -11,6 +11,7 @@ class RoundTest extends ProjectUtils
         $this->assertEquals("P3", get_Round_for_round_id("P3")->id);
         $this->assertEquals("P2", get_Round_for_project_state("P2.proj_waiting")->id);
         $this->assertEquals("F1", get_Round_for_text_column_name("round4_text")->id);
+        $this->assertEquals("F2", get_Round_for_text_column_name("round5_text")->id);
 
         global $activities;
         $this->assertEquals("'P2' pages completed", $activities->access_criteria["P2"]);

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -37,6 +37,8 @@ class RoundTest extends ProjectUtils
         $this->assertTrue(PROJ_P1_UNAVAILABLE === "P1.proj_unavail");
         $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
         $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
+        $this->assertEquals("PP: Available", get_medium_label_for_project_state("proj_post_first_available"));
+        $this->assertEquals("Post-Processing: Available", project_states_text("proj_post_first_available"));
         $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
         // $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
         // $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -21,6 +21,15 @@ class RoundTest extends ProjectUtils
         $this->assertEquals('P1.proj_unavail', $p1->project_unavailable_state);
     }
 
+    public function test_pools()
+    {
+        $this->assertEquals("PP", get_Pool_for_id("PP")->id);
+        $this->assertEquals("PPV", get_Pool_for_id("PPV")->id);
+        $this->assertEquals("PP", get_Pool_for_state(PROJ_POST_FIRST_AVAILABLE)->id);
+        $this->assertEquals("PP", get_Pool_for_state(PROJ_POST_FIRST_CHECKED_OUT)->id);
+        $this->assertEquals("PPV", get_Pool_for_state(PROJ_POST_SECOND_CHECKED_OUT)->id);
+    }
+
     public function test_project_states()
     {
         global $projects_forum_idx, $waiting_projects_forum_idx, $PROJECT_STATES_IN_ORDER;

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -38,8 +38,8 @@ class RoundTest extends ProjectUtils
         $this->assertEquals("F1.proj_bad", $PROJECT_STATES_IN_ORDER[16]);
         $this->assertEquals("P2: Waiting", get_medium_label_for_project_state("P2.proj_waiting"));
         $this->assertEquals("Proofreading Round 2: Waiting for Release", project_states_text("P2.proj_waiting"));
-        //        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
-        //        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
+        // $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state("P2.proj_unavail"));
+        // $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state("P1.proj_unavail"));
         $this->assertEquals('PAGE_EDITING', get_phase_containing_project_state("P1.proj_bad"));
         $this->assertEquals("(state='proj_submit_pgposted')", SQL_CONDITION_GOLD);
     }

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -5,21 +5,6 @@ include_once($relPath.'Settings.inc');
 include_once($relPath.'quizzes.inc'); // get_Quiz_with_id
 include_once($relPath.'User.inc');
 
-// $ACCESS_CRITERIA and $Activity_for_id_ are extended as activities are defined.
-
-global $ACCESS_CRITERIA;
-$ACCESS_CRITERIA = [
-    'days since reg' => _('Days since registration'),
-    'quiz/p_basic' => sprintf(_('Up-to-date completion of the <a href="%1$s">Basic Proofreading Quiz</a>'), "$code_url/quiz/start.php?show_level=P_BASIC"),
-    'quiz/p_mod1' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 1),
-    'quiz/p_mod2' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 2),
-    'quiz/f_only' => sprintf(_("Up-to-date completion of the <a href='%s'>Formatting Quiz</a>"), "$code_url/quiz/start.php?show_only=format"),
-];
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-$Activity_for_id_ = [];
-
 class Activity
 {
     /**
@@ -84,19 +69,12 @@ class Activity
                 }
             }
         }
+    }
 
-        // This is kludgey, since Activity shouldn't have to know about Round.
-        // But the alternative is that Round know about $ACCESS_CRITERIA,
-        // which seems worse.
-        // TODO: We should probably have a function for declaring criteria.
-        global $ACCESS_CRITERIA;
-        if (is_a($this, 'Round')) {
-            $ACCESS_CRITERIA[$this->id] =
-                sprintf(_("'%s' pages completed"), $this->id);
-        }
-
-        global $Activity_for_id_;
-        $Activity_for_id_[$id] = & $this;
+    // overridden by activities that define access criteria
+    public function get_access_criteria()
+    {
+        return [];
     }
 
     public function __toString()

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -35,7 +35,8 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $ordinal,
+        $project_available_state,
+        $project_checkedout_state,
         $available_short_label,
         $available_long_label,
         $checked_out_short_label,
@@ -56,7 +57,8 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
-        $this->ordinal = $ordinal;
+        $this->project_available_state = $project_available_state;
+        $this->project_checkedout_state = $project_checkedout_state;
         $this->available_short_label = $available_short_label;
         $this->available_long_label = $available_long_label;
         $this->checked_out_short_label = $checked_out_short_label;
@@ -66,7 +68,11 @@ class Pool extends Stage
         $this->blather = $blather;
 
         global $Pool_for_id_;
-        $Pool_for_id_[$this->id] = & $this;
+        $Pool_for_id_[$id] = $this;
+
+        global $Pool_for_state_;
+        $Pool_for_state_[$project_available_state] = $this;
+        $Pool_for_state_[$project_checkedout_state] = $this;
     }
 }
 

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -4,9 +4,6 @@ include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------
 
-global $Pool_for_id_;
-$Pool_for_id_ = [];
-
 class Pool extends Stage
 {
     /**
@@ -53,18 +50,5 @@ class Pool extends Stage
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;
         $this->blather = $blather;
-
-        global $Pool_for_id_;
-        $Pool_for_id_[$id] = $this;
     }
 }
-
-// ---------------------------
-
-function get_Pool_for_id($pool_id)
-{
-    global $Pool_for_id_;
-    return array_get($Pool_for_id_, $pool_id, null);
-}
-
-// ---------------------------

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -4,9 +4,8 @@ include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------
 
-global $Pool_for_id_, $Pool_for_state_;
+global $Pool_for_id_;
 $Pool_for_id_ = [];
-$Pool_for_state_ = [];
 
 class Pool extends Stage
 {
@@ -66,12 +65,6 @@ function get_Pool_for_id($pool_id)
 {
     global $Pool_for_id_;
     return array_get($Pool_for_id_, $pool_id, null);
-}
-
-function get_Pool_for_state($state)
-{
-    global $Pool_for_state_;
-    return array_get($Pool_for_state_, $state, null);
 }
 
 // ---------------------------

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -4,6 +4,7 @@ include_once($relPath.'Stage.inc');
 
 // -----------------------------------------------------------------------------
 
+global $Pool_for_id_, $Pool_for_state_;
 $Pool_for_id_ = [];
 $Pool_for_state_ = [];
 

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -35,8 +35,11 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $project_checkedout_state,
-        $project_available_state,
+        $ordinal,
+        $available_short_label,
+        $available_long_label,
+        $checked_out_short_label,
+        $checked_out_long_label,
         $foo_Header,
         $foo_field_name,
         $blather
@@ -53,18 +56,17 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
-        $this->project_checkedout_state = $project_checkedout_state;
-        $this->project_available_state = $project_available_state;
+        $this->ordinal = $ordinal;
+        $this->available_short_label = $available_short_label;
+        $this->available_long_label = $available_long_label;
+        $this->checked_out_short_label = $checked_out_short_label;
+        $this->checked_out_long_label = $checked_out_long_label;
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;
         $this->blather = $blather;
 
         global $Pool_for_id_;
         $Pool_for_id_[$this->id] = & $this;
-
-        global $Pool_for_state_;
-        $Pool_for_state_[$this->project_checkedout_state] = & $this;
-        $Pool_for_state_[$this->project_available_state] = & $this;
     }
 }
 

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -35,12 +35,6 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $project_available_state,
-        $project_checkedout_state,
-        $available_short_label,
-        $available_long_label,
-        $checked_out_short_label,
-        $checked_out_long_label,
         $foo_Header,
         $foo_field_name,
         $blather
@@ -57,22 +51,12 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
-        $this->project_available_state = $project_available_state;
-        $this->project_checkedout_state = $project_checkedout_state;
-        $this->available_short_label = $available_short_label;
-        $this->available_long_label = $available_long_label;
-        $this->checked_out_short_label = $checked_out_short_label;
-        $this->checked_out_long_label = $checked_out_long_label;
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;
         $this->blather = $blather;
 
         global $Pool_for_id_;
         $Pool_for_id_[$id] = $this;
-
-        global $Pool_for_state_;
-        $Pool_for_state_[$project_available_state] = $this;
-        $Pool_for_state_[$project_checkedout_state] = $this;
     }
 }
 

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -133,6 +133,11 @@ class Round extends Stage
         $this->mentee_round = null;
     }
 
+    public function get_access_criteria()
+    {
+        return [$this->id => sprintf(_("'%s' pages completed"), $this->id)];
+    }
+
     public function is_a_mentee_round()
     {
         return !is_null($this->mentor_round);
@@ -230,8 +235,8 @@ function sql_collater_for_page_state($state_column)
  */
 function declare_mentoring_pair($mentee_round_id, $mentor_round_id)
 {
-    $mentee_round = & get_Stage_for_id($mentee_round_id);
-    $mentor_round = & get_Stage_for_id($mentor_round_id);
+    $mentee_round = get_Stage_for_id($mentee_round_id);
+    $mentor_round = get_Stage_for_id($mentor_round_id);
     assert(is_a($mentee_round, 'Round'));
     assert(is_a($mentor_round, 'Round'));
 

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -99,6 +99,12 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
+        $this->project_bad_state = "$round_id.proj_bad";
+        $this->project_unavailable_state = "$round_id.proj_unavail";
+        $this->project_waiting_state = "$round_id.proj_waiting";
+        $this->project_available_state = "$round_id.proj_avail";
+        $this->project_complete_state = "$round_id.proj_done";
+
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";
@@ -146,6 +152,13 @@ class Round extends Stage
 
         global $Round_for_round_number_;
         $Round_for_round_number_[$this->round_number] = & $this;
+
+        global $Round_for_project_state_;
+        $Round_for_project_state_[$this->project_unavailable_state] = & $this;
+        $Round_for_project_state_[$this->project_waiting_state] = & $this;
+        $Round_for_project_state_[$this->project_bad_state] = & $this;
+        $Round_for_project_state_[$this->project_available_state] = & $this;
+        $Round_for_project_state_[$this->project_complete_state] = & $this;
 
         global $Round_for_page_state_;
         $Round_for_page_state_[$this->page_avail_state] = & $this;

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -99,12 +99,6 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
-        $this->project_unavailable_state = constant("PROJ_{$round_id}_UNAVAILABLE");
-        $this->project_waiting_state = constant("PROJ_{$round_id}_WAITING_FOR_RELEASE");
-        $this->project_bad_state = constant("PROJ_{$round_id}_BAD_PROJECT");
-        $this->project_available_state = constant("PROJ_{$round_id}_AVAILABLE");
-        $this->project_complete_state = constant("PROJ_{$round_id}_COMPLETE");
-
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";
@@ -152,13 +146,6 @@ class Round extends Stage
 
         global $Round_for_round_number_;
         $Round_for_round_number_[$this->round_number] = & $this;
-
-        global $Round_for_project_state_;
-        $Round_for_project_state_[$this->project_unavailable_state] = & $this;
-        $Round_for_project_state_[$this->project_waiting_state] = & $this;
-        $Round_for_project_state_[$this->project_bad_state] = & $this;
-        $Round_for_project_state_[$this->project_available_state] = & $this;
-        $Round_for_project_state_[$this->project_complete_state] = & $this;
 
         global $Round_for_page_state_;
         $Round_for_page_state_[$this->page_avail_state] = & $this;

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -96,9 +96,16 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
+        $this->page_avail_state = "{$round_id}.page_avail";
+        $this->page_out_state = "{$round_id}.page_out";
+        $this->page_temp_state = "{$round_id}.page_temp";
+        $this->page_save_state = "{$round_id}.page_saved";
+        $this->page_bad_state = "{$round_id}.page_bad";
+
         $this->time_column_name = "round{$this->round_number}_time";
         $this->text_column_name = "round{$this->round_number}_text";
         $this->user_column_name = "round{$this->round_number}_user";
+        $this->textdiff_column_name = "round{$this->round_number}_diff"; // a computed column
 
         // prevtext_column_name
         //
@@ -131,6 +138,17 @@ class Round extends Stage
         // These can be changed by calling declare_mentoring_pair():
         $this->mentor_round = null;
         $this->mentee_round = null;
+    }
+
+    public function get_page_states()
+    {
+        return [
+            $this->page_avail_state,
+            $this->page_out_state,
+            $this->page_temp_state,
+            $this->page_save_state,
+            $this->page_bad_state,
+        ];
     }
 
     public function get_access_criteria()

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -99,12 +99,6 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
-        $this->project_bad_state = "$round_id.proj_bad";
-        $this->project_unavailable_state = "$round_id.proj_unavail";
-        $this->project_waiting_state = "$round_id.proj_waiting";
-        $this->project_available_state = "$round_id.proj_avail";
-        $this->project_complete_state = "$round_id.proj_done";
-
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";
@@ -152,13 +146,6 @@ class Round extends Stage
 
         global $Round_for_round_number_;
         $Round_for_round_number_[$this->round_number] = & $this;
-
-        global $Round_for_project_state_;
-        $Round_for_project_state_[$this->project_unavailable_state] = & $this;
-        $Round_for_project_state_[$this->project_waiting_state] = & $this;
-        $Round_for_project_state_[$this->project_bad_state] = & $this;
-        $Round_for_project_state_[$this->project_available_state] = & $this;
-        $Round_for_project_state_[$this->project_complete_state] = & $this;
 
         global $Round_for_page_state_;
         $Round_for_page_state_[$this->page_avail_state] = & $this;

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -105,7 +105,6 @@ class Round extends Stage
         $this->time_column_name = "round{$this->round_number}_time";
         $this->text_column_name = "round{$this->round_number}_text";
         $this->user_column_name = "round{$this->round_number}_user";
-        $this->textdiff_column_name = "round{$this->round_number}_diff"; // a computed column
 
         // prevtext_column_name
         //

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -7,12 +7,11 @@ include_once($relPath.'Stage.inc');
 // -----------------------------------------------------------------------------
 
 global $n_rounds, $Round_for_round_id_, $Round_for_round_number_;
-global $Round_for_project_state_, $Round_for_page_state_, $PAGE_STATES_IN_ORDER;
+global $Round_for_page_state_, $PAGE_STATES_IN_ORDER;
 
 $n_rounds = 0;
 $Round_for_round_id_ = [];
 $Round_for_round_number_ = [];
-$Round_for_project_state_ = [];
 $Round_for_page_state_ = [];
 $PAGE_STATES_IN_ORDER = [];
 
@@ -234,14 +233,6 @@ function get_Round_for_round_number($round_number)
 {
     global $Round_for_round_number_;
     return array_get($Round_for_round_number_, $round_number, null);
-}
-
-// ---------------------------
-
-function get_Round_for_project_state($project_state)
-{
-    global $Round_for_project_state_;
-    return array_get($Round_for_project_state_, $project_state, null);
 }
 
 // ---------------------------

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -61,6 +61,7 @@ class Round extends Stage
      *   (Needn't be in a particular order.)
      */
     public function __construct(
+        $round_number,
         $id,
         $name,
         $access_minima,
@@ -88,21 +89,12 @@ class Round extends Stage
             "tools/proofers/round.php?round_id=$round_id"
         );
 
-        global $n_rounds;
-        $n_rounds++;
-        $this->round_number = $n_rounds;
-
+        $this->round_number = $round_number;
         $this->pi_tools = $pi_tools;
         $this->daily_page_limit = $daily_page_limit;
         $this->other_rounds_with_visible_usernames = $other_rounds_with_visible_usernames;
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
-
-        $this->page_avail_state = "{$round_id}.page_avail";
-        $this->page_out_state = "{$round_id}.page_out";
-        $this->page_temp_state = "{$round_id}.page_temp";
-        $this->page_save_state = "{$round_id}.page_saved";
-        $this->page_bad_state = "{$round_id}.page_bad";
 
         $this->time_column_name = "round{$this->round_number}_time";
         $this->text_column_name = "round{$this->round_number}_text";
@@ -139,26 +131,6 @@ class Round extends Stage
         // These can be changed by calling declare_mentoring_pair():
         $this->mentor_round = null;
         $this->mentee_round = null;
-
-        global $Round_for_round_id_;
-        $Round_for_round_id_[$this->id] = & $this;
-
-        global $Round_for_round_number_;
-        $Round_for_round_number_[$this->round_number] = & $this;
-
-        global $Round_for_page_state_;
-        $Round_for_page_state_[$this->page_avail_state] = & $this;
-        $Round_for_page_state_[$this->page_out_state] = & $this;
-        $Round_for_page_state_[$this->page_temp_state] = & $this;
-        $Round_for_page_state_[$this->page_save_state] = & $this;
-        $Round_for_page_state_[$this->page_bad_state] = & $this;
-
-        global $PAGE_STATES_IN_ORDER;
-        $PAGE_STATES_IN_ORDER[] = $this->page_avail_state;
-        $PAGE_STATES_IN_ORDER[] = $this->page_out_state;
-        $PAGE_STATES_IN_ORDER[] = $this->page_temp_state;
-        $PAGE_STATES_IN_ORDER[] = $this->page_save_state;
-        $PAGE_STATES_IN_ORDER[] = $this->page_bad_state;
     }
 
     public function is_a_mentee_round()
@@ -211,49 +183,6 @@ class Round extends Stage
             throw new UserNotQualifiedForRoundException($message);
         }
     }
-}
-
-// ---------------------------
-
-function get_Round_for_round_id($round_id)
-{
-    global $Round_for_round_id_;
-    return array_get($Round_for_round_id_, $round_id, null);
-}
-
-// ---------------------------
-
-/**
- * Get a round object given a round number
- *
- * If `$round_number` is a valid proofreading-round number,
- * return the appropriate Round instance. Otherwise, return NULL.
- */
-function get_Round_for_round_number($round_number)
-{
-    global $Round_for_round_number_;
-    return array_get($Round_for_round_number_, $round_number, null);
-}
-
-// ---------------------------
-
-function get_Round_for_page_state($page_state)
-{
-    global $Round_for_page_state_;
-    return array_get($Round_for_page_state_, $page_state, null);
-}
-
-// ---------------------------
-
-function get_Round_for_text_column_name($text_column_name)
-{
-    global $Round_for_round_id_;
-    foreach ($Round_for_round_id_ as $round_id => $round) {
-        if ($round->text_column_name == $text_column_name) {
-            return $round;
-        }
-    }
-    return null;
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -49,9 +49,6 @@ class Stage extends Activity
         $this->description = $description;
         $this->document = $document;
         $this->relative_url = $relative_url;
-
-        global $Stage_for_id_;
-        $Stage_for_id_[$id] = & $this;
     }
 
 
@@ -84,18 +81,6 @@ class Stage extends Activity
         echo ":</b><br>";
         echo $this->description;
         echo "</p>\n";
-    }
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-function & get_Stage_for_id($id)
-{
-    global $Stage_for_id_;
-    if (array_key_exists($id, $Stage_for_id_)) {
-        return $Stage_for_id_[$id];
-    } else {
-        die("There is no stage with id='$id'.");
     }
 }
 

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -46,6 +46,7 @@ class ProjectStates
         );
 
         foreach($rounds as $round) {
+            // these are for the 'state' column in the projects table
             $round->project_bad_state = "{$round->id}.proj_bad";
             $round->project_unavailable_state = "{$round->id}.proj_unavail";
             $round->project_waiting_state = "{$round->id}.proj_waiting";

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -210,7 +210,7 @@ class ProjectStates
         $star_metal
     ) {
         define($constant_name, $constant_value);
-        $this->states[] = $constant_value;
+        $this->states_in_order[] = $constant_value;
         $this->medium_labels[$constant_value] = $medium_label;
         $this->long_labels[$constant_value] = $long_label;
         $this->project_state_forum[$constant_value] = $forum;
@@ -278,6 +278,12 @@ function get_phase_containing_project_state($state)
     global $project_states;
     return $project_states->project_state_phase[$state] ?? 'NONE';
 }
+
+// aliases for compatibility with existing code
+global $PROJECT_STATES_IN_ORDER, $project_state_phase_;
+
+$PROJECT_STATES_IN_ORDER = $project_states->states_in_order;
+$project_state_phase_ = $project_states->project_state_phase;
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -22,6 +22,8 @@ include_once($relPath.'site_vars.php');
 
   (Actually, the naming convention is in transition.)
 */
+global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_;
+global $project_state_phase_, $project_states_for_star_metal_;
 
 $PROJECT_STATES_IN_ORDER = [];
 $project_state_medium_label_ = [];

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -25,12 +25,6 @@ include_once($relPath.'site_vars.php');
 global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
 $project_state_phase_, $project_states_for_star_metal_;
 
-function define_project_states($rounds, $pools)
-{
-    global $waiting_projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
-    $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx,
-    $project_states_for_star_metal_, $Round_for_project_state_;
-
     $PROJECT_STATES_IN_ORDER = [];
     $project_state_medium_label_ = [];
     $project_state_long_label_ = [];
@@ -42,218 +36,226 @@ function define_project_states($rounds, $pools)
         'GOLD' => [],
     ];
 
-    // Note that the order in which these project states are declared
-    // is the order in which they will be displayed in various contexts
-    // (via $PROJECT_STATES_IN_ORDER).
+class ProjectStates
+{
+    public function __construct($rounds, $pools)
+    {
+        global $waiting_projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
+        $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx,
+        $project_states_for_star_metal_;
 
-    // for the initial creation of a project
-    declare_project_state(
-        "PROJ_NEW",
-        "project_new",
-        _("New Project"),
-        _("New Project"),
-        $waiting_projects_forum_idx,
-        'NEW',
-        ''
-    );
+        // Note that the order in which these project states are declared
+        // is the order in which they will be displayed in various contexts
+        // (via $PROJECT_STATES_IN_ORDER).
 
-    foreach($rounds as $round) {
-        $round->project_bad_state = "{$round->id}.proj_bad";
-        $round->project_unavailable_state = "{$round->id}.proj_unavail";
-        $round->project_waiting_state = "{$round->id}.proj_waiting";
-        $round->project_available_state = "{$round->id}.proj_avail";
-        $round->project_complete_state = "{$round->id}.proj_done";
-
-        global $Round_for_project_state_;
-        $Round_for_project_state_[$round->project_unavailable_state] = $round;
-        $Round_for_project_state_[$round->project_waiting_state] = $round;
-        $Round_for_project_state_[$round->project_bad_state] = $round;
-        $Round_for_project_state_[$round->project_available_state] = $round;
-        $Round_for_project_state_[$round->project_complete_state] = $round;
-
-        declare_project_state(
-            "PROJ_{$round->id}_BAD_PROJECT",
-            $round->project_bad_state,
-            "$round->id: " .  _("Bad Project"),
-            "$round->name: " . _("Bad Project"),
-            $projects_forum_idx,
-            'PAGE_EDITING',
+        // for the initial creation of a project
+        $this->declare_project_state(
+            "PROJ_NEW",
+            "project_new",
+            _("New Project"),
+            _("New Project"),
+            $waiting_projects_forum_idx,
+            'NEW',
             ''
         );
 
-        declare_project_state(
-            "PROJ_{$round->id}_UNAVAILABLE",
-            $round->project_unavailable_state,
-            "$round->id: " . _("Unavailable"),
-            "$round->name: " . _("Unavailable"),
-            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-            'PAGE_EDITING',
-            ''
-        );
-        declare_project_state(
-            "PROJ_{$round->id}_WAITING_FOR_RELEASE",
-            $round->project_waiting_state,
-            "$round->id: " . _("Waiting"),
-            "$round->name: " . _("Waiting for Release"),
-            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-            'PAGE_EDITING',
-            ''
-        );
-        declare_project_state(
-            "PROJ_{$round->id}_AVAILABLE",
-            $round->project_available_state,
-            "$round->id: " . _("Available"),
-            "$round->name: " . _("Available"),
-            $projects_forum_idx,
-            'PAGE_EDITING',
-            'BRONZE'
-        );
-        declare_project_state(
-            "PROJ_{$round->id}_COMPLETE",
-            $round->project_complete_state,
-            "$round->id: " . _("Completed"),
-            "$round->name: " . _("Completed"),
-            $projects_forum_idx,
-            'PAGE_EDITING',
-            ''
-        );
-    }
+        foreach($rounds as $round) {
+            $round->project_bad_state = "{$round->id}.proj_bad";
+            $round->project_unavailable_state = "{$round->id}.proj_unavail";
+            $round->project_waiting_state = "{$round->id}.proj_waiting";
+            $round->project_available_state = "{$round->id}.proj_avail";
+            $round->project_complete_state = "{$round->id}.proj_done";
 
-    // POST
-    declare_project_state(
-        "PROJ_POST_FIRST_UNAVAILABLE",
-        "proj_post_first_unavailable",
-        _("Unavailable for PP"),
-        _("Unavailable for Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+            $this->round_for_project_state_[$round->project_unavailable_state] = $round;
+            $this->round_for_project_state_[$round->project_waiting_state] = $round;
+            $this->round_for_project_state_[$round->project_bad_state] = $round;
+            $this->round_for_project_state_[$round->project_available_state] = $round;
+            $this->round_for_project_state_[$round->project_complete_state] = $round;
 
-    foreach($pools as $pool) {
-        switch ($pool->id) {
-            case "PP":
-                $pool->project_available_state = "proj_post_first_available";
-                $pool->project_checkedout_state = "proj_post_first_checked_out";
-                break;
-            case "PPV":
-                $pool->project_available_state = "proj_post_second_available";
-                $pool->project_checkedout_state = "proj_post_second_checked_out";
-                break;
+            $this->declare_project_state(
+                "PROJ_{$round->id}_BAD_PROJECT",
+                $round->project_bad_state,
+                "$round->id: " .  _("Bad Project"),
+                "$round->name: " . _("Bad Project"),
+                $projects_forum_idx,
+                'PAGE_EDITING',
+                ''
+            );
+
+            $this->declare_project_state(
+                "PROJ_{$round->id}_UNAVAILABLE",
+                $round->project_unavailable_state,
+                "$round->id: " . _("Unavailable"),
+                "$round->name: " . _("Unavailable"),
+                ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+                'PAGE_EDITING',
+                ''
+            );
+            $this->declare_project_state(
+                "PROJ_{$round->id}_WAITING_FOR_RELEASE",
+                $round->project_waiting_state,
+                "$round->id: " . _("Waiting"),
+                "$round->name: " . _("Waiting for Release"),
+                ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+                'PAGE_EDITING',
+                ''
+            );
+            $this->declare_project_state(
+                "PROJ_{$round->id}_AVAILABLE",
+                $round->project_available_state,
+                "$round->id: " . _("Available"),
+                "$round->name: " . _("Available"),
+                $projects_forum_idx,
+                'PAGE_EDITING',
+                'BRONZE'
+            );
+            $this->declare_project_state(
+                "PROJ_{$round->id}_COMPLETE",
+                $round->project_complete_state,
+                "$round->id: " . _("Completed"),
+                "$round->name: " . _("Completed"),
+                $projects_forum_idx,
+                'PAGE_EDITING',
+                ''
+            );
         }
 
-        global $Pool_for_state_;
-        $Pool_for_state_[$pool->project_available_state] = $pool;
-        $Pool_for_state_[$pool->project_checkedout_state] = $pool;
-
-        declare_project_state(
-            strtoupper($pool->project_available_state),
-            $pool->project_available_state,
-            "$pool->id: " . _("Available"),
-            "$pool->name: " . _("Available"),
+        // POST
+        $this->declare_project_state(
+            "PROJ_POST_FIRST_UNAVAILABLE",
+            "proj_post_first_unavailable",
+            _("Unavailable for PP"),
+            _("Unavailable for Post-Processing"),
             $pp_projects_forum_idx,
             'PP',
             'SILVER'
         );
 
-        declare_project_state(
-            strtoupper($pool->project_checkedout_state),
-            $pool->project_checkedout_state,
-            "$pool->id: " . _("Checked out"),
-            "$pool->name: " . _("Checked out"),
-            $pp_projects_forum_idx,
-            'PP',
-            'SILVER'
-        );
-    }
-
-    declare_project_state(
-        "PROJ_POST_COMPLETE",
-        "proj_post_complete",
-        _("Completed Post"),
-        _("Completed Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
-
-    // SUBMIT (was GB)
-    declare_project_state(
-        "PROJ_SUBMIT_PG_POSTED",
-        "proj_submit_pgposted",
-        _("Posted to PG"),
-        _("Completed and Posted to Project Gutenberg"),
-        $posted_projects_forum_idx,
-        'GB',
-        'GOLD'
-    );
-
-    // for complete project
-    declare_project_state(
-        "PROJ_COMPLETE",
-        "project_complete",
-        _("Project Complete"),
-        _("Project Complete"),
-        $completed_projects_forum_idx,
-        'COMPLETE',
-        ''
-    );
-
-    // for the 'deletion' of a project
-    declare_project_state(
-        "PROJ_DELETE",
-        "project_delete",
-        _("Delete Project"),
-        _("Delete Project"),
-        $deleted_projects_forum_idx,
-        'NONE',
-        ''
-    );
-
-    // Define constants for use in SQL queries:
-    // SQL_CONDITION_BRONZE
-    // SQL_CONDITION_SILVER
-    // SQL_CONDITION_GOLD
-
-    foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
-        $sql_constant_name = "SQL_CONDITION_$star_metal";
-        $sql_condition = '(';
-        foreach ($project_states as $project_state) {
-            if ($sql_condition != '(') {
-                $sql_condition .= ' OR ';
+        foreach($pools as $pool) {
+            switch ($pool->id) {
+                case "PP":
+                    $pool->project_available_state = "proj_post_first_available";
+                    $pool->project_checkedout_state = "proj_post_first_checked_out";
+                    break;
+                case "PPV":
+                    $pool->project_available_state = "proj_post_second_available";
+                    $pool->project_checkedout_state = "proj_post_second_checked_out";
+                    break;
             }
-            $sql_condition .= "state='$project_state'";
+
+            global $Pool_for_state_;
+            $Pool_for_state_[$pool->project_available_state] = $pool;
+            $Pool_for_state_[$pool->project_checkedout_state] = $pool;
+
+            $this->declare_project_state(
+                strtoupper($pool->project_available_state),
+                $pool->project_available_state,
+                "$pool->id: " . _("Available"),
+                "$pool->name: " . _("Available"),
+                $pp_projects_forum_idx,
+                'PP',
+                'SILVER'
+            );
+
+            $this->declare_project_state(
+                strtoupper($pool->project_checkedout_state),
+                $pool->project_checkedout_state,
+                "$pool->id: " . _("Checked out"),
+                "$pool->name: " . _("Checked out"),
+                $pp_projects_forum_idx,
+                'PP',
+                'SILVER'
+            );
         }
-        $sql_condition .= ')';
 
-        define($sql_constant_name, $sql_condition);
+        $this->declare_project_state(
+            "PROJ_POST_COMPLETE",
+            "proj_post_complete",
+            _("Completed Post"),
+            _("Completed Post-Processing"),
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
+
+        // SUBMIT (was GB)
+        $this->declare_project_state(
+            "PROJ_SUBMIT_PG_POSTED",
+            "proj_submit_pgposted",
+            _("Posted to PG"),
+            _("Completed and Posted to Project Gutenberg"),
+            $posted_projects_forum_idx,
+            'GB',
+            'GOLD'
+        );
+
+        // for complete project
+        $this->declare_project_state(
+            "PROJ_COMPLETE",
+            "project_complete",
+            _("Project Complete"),
+            _("Project Complete"),
+            $completed_projects_forum_idx,
+            'COMPLETE',
+            ''
+        );
+
+        // for the 'deletion' of a project
+        $this->declare_project_state(
+            "PROJ_DELETE",
+            "project_delete",
+            _("Delete Project"),
+            _("Delete Project"),
+            $deleted_projects_forum_idx,
+            'NONE',
+            ''
+        );
+
+        // Define constants for use in SQL queries:
+        // SQL_CONDITION_BRONZE
+        // SQL_CONDITION_SILVER
+        // SQL_CONDITION_GOLD
+
+        foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
+            $sql_constant_name = "SQL_CONDITION_$star_metal";
+            $sql_condition = '(';
+            foreach ($project_states as $project_state) {
+                if ($sql_condition != '(') {
+                    $sql_condition .= ' OR ';
+                }
+                $sql_condition .= "state='$project_state'";
+            }
+            $sql_condition .= ')';
+
+            define($sql_constant_name, $sql_condition);
+        }
     }
-}
 
-function declare_project_state(
-    $constant_name,
-    $constant_value,
-    $medium_label,
-    $long_label,
-    $forum,
-    $phase,
-    $star_metal
-) {
-    global $PROJECT_STATES_IN_ORDER;
-    global $project_state_medium_label_;
-    global $project_state_long_label_;
-    global $project_state_forum_;
-    global $project_state_phase_;
-    global $project_states_for_star_metal_;
+    private function declare_project_state(
+        $constant_name,
+        $constant_value,
+        $medium_label,
+        $long_label,
+        $forum,
+        $phase,
+        $star_metal
+    ) {
+        global $PROJECT_STATES_IN_ORDER;
+        global $project_state_medium_label_;
+        global $project_state_long_label_;
+        global $project_state_forum_;
+        global $project_state_phase_;
+        global $project_states_for_star_metal_;
 
-    define($constant_name, $constant_value);
-    $PROJECT_STATES_IN_ORDER[] = $constant_value;
-    $project_state_medium_label_[$constant_value] = $medium_label;
-    $project_state_long_label_[$constant_value] = $long_label;
-    $project_state_forum_[$constant_value] = $forum;
-    $project_state_phase_[$constant_value] = $phase;
-    if ($star_metal) {
-        $project_states_for_star_metal_[$star_metal][] = $constant_value;
+        define($constant_name, $constant_value);
+        $PROJECT_STATES_IN_ORDER[] = $constant_value;
+        $project_state_medium_label_[$constant_value] = $medium_label;
+        $project_state_long_label_[$constant_value] = $long_label;
+        $project_state_forum_[$constant_value] = $forum;
+        $project_state_phase_[$constant_value] = $phase;
+        if ($star_metal) {
+            $project_states_for_star_metal_[$star_metal][] = $constant_value;
+        }
     }
 }
 

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -279,12 +279,6 @@ function get_phase_containing_project_state($state)
     return $project_states->project_state_phase[$state] ?? 'NONE';
 }
 
-// aliases for compatibility with existing code
-global $PROJECT_STATES_IN_ORDER, $project_state_phase_;
-
-$PROJECT_STATES_IN_ORDER = $project_states->states_in_order;
-$project_state_phase_ = $project_states->project_state_phase;
-
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 /**

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -58,7 +58,52 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($rounds as $round) {
-        declare_project_states_for_round($round);
+        declare_project_state(
+            "PROJ_{$round->id}_BAD_PROJECT",
+            $round->project_bad_state,
+            "$round->id: " .  _("Bad Project"),
+            "$round->name: " . _("Bad Project"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            ''
+        );
+
+        declare_project_state(
+            "PROJ_{$round->id}_UNAVAILABLE",
+            $round->project_unavailable_state,
+            "$round->id: " . _("Unavailable"),
+            "$round->name: " . _("Unavailable"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
+            ''
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_WAITING_FOR_RELEASE",
+            $round->project_waiting_state,
+            "$round->id: " . _("Waiting"),
+            "$round->name: " . _("Waiting for Release"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
+            ''
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_AVAILABLE",
+            $round->project_available_state,
+            "$round->id: " . _("Available"),
+            "$round->name: " . _("Available"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            'BRONZE'
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_COMPLETE",
+            $round->project_complete_state,
+            "$round->id: " . _("Completed"),
+            "$round->name: " . _("Completed"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            ''
+        );
     }
 
     // POST
@@ -155,59 +200,6 @@ function define_project_states($rounds, $pools)
 
         define($sql_constant_name, $sql_condition);
     }
-}
-
-function declare_project_states_for_round($round)
-{
-    global $projects_forum_idx;
-    global $waiting_projects_forum_idx;
-
-    declare_project_state(
-        "PROJ_{$round->id}_BAD_PROJECT",
-        $round->project_bad_state,
-        "$round->id: " .  _("Bad Project"),
-        "$round->name: " . _("Bad Project"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
-
-    declare_project_state(
-        "PROJ_{$round->id}_UNAVAILABLE",
-        $round->project_unavailable_state,
-        "$round->id: " . _("Unavailable"),
-        "$round->name: " . _("Unavailable"),
-        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round->id}_WAITING_FOR_RELEASE",
-        $round->project_waiting_state,
-        "$round->id: " . _("Waiting"),
-        "$round->name: " . _("Waiting for Release"),
-        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round->id}_AVAILABLE",
-        $round->project_available_state,
-        "$round->id: " . _("Available"),
-        "$round->name: " . _("Available"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        'BRONZE'
-    );
-    declare_project_state(
-        "PROJ_{$round->id}_COMPLETE",
-        $round->project_complete_state,
-        "$round->id: " . _("Completed"),
-        "$round->name: " . _("Completed"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
 }
 
 function declare_project_state(

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -58,6 +58,19 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($rounds as $round) {
+        $round->project_bad_state = "{$round->id}.proj_bad";
+        $round->project_unavailable_state = "{$round->id}.proj_unavail";
+        $round->project_waiting_state = "{$round->id}.proj_waiting";
+        $round->project_available_state = "{$round->id}.proj_avail";
+        $round->project_complete_state = "{$round->id}.proj_done";
+
+        global $Round_for_project_state_;
+        $Round_for_project_state_[$round->project_unavailable_state] = $round;
+        $Round_for_project_state_[$round->project_waiting_state] = $round;
+        $Round_for_project_state_[$round->project_bad_state] = $round;
+        $Round_for_project_state_[$round->project_available_state] = $round;
+        $Round_for_project_state_[$round->project_complete_state] = $round;
+
         declare_project_state(
             "PROJ_{$round->id}_BAD_PROJECT",
             $round->project_bad_state,
@@ -118,11 +131,26 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($pools as $pool) {
+        switch ($pool->id) {
+            case "PP":
+                $pool->project_available_state = "proj_post_first_available";
+                $pool->project_checkedout_state = "proj_post_first_checked_out";
+                break;
+            case "PPV":
+                $pool->project_available_state = "proj_post_second_available";
+                $pool->project_checkedout_state = "proj_post_second_checked_out";
+                break;
+        }
+
+        global $Pool_for_state_;
+        $Pool_for_state_[$pool->project_available_state] = $pool;
+        $Pool_for_state_[$pool->project_checkedout_state] = $pool;
+
         declare_project_state(
             strtoupper($pool->project_available_state),
             $pool->project_available_state,
-            $pool->available_short_label,
-            $pool->available_long_label,
+            "$pool->id: " . _("Available"),
+            "$pool->name: " . _("Available"),
             $pp_projects_forum_idx,
             'PP',
             'SILVER'
@@ -131,8 +159,8 @@ function define_project_states($rounds, $pools)
         declare_project_state(
             strtoupper($pool->project_checkedout_state),
             $pool->project_checkedout_state,
-            $pool->checked_out_short_label,
-            $pool->checked_out_long_label,
+            "$pool->id: " . _("Checked out"),
+            "$pool->name: " . _("Checked out"),
             $pp_projects_forum_idx,
             'PP',
             'SILVER'

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -25,7 +25,7 @@ include_once($relPath.'site_vars.php');
 global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
 $project_state_phase_, $project_states_for_star_metal_;
 
-function define_project_states($rounds)
+function define_project_states($rounds, $pools)
 {
     global $waiting_projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
     $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx,
@@ -94,45 +94,36 @@ function define_project_states($rounds)
         'PP',
         'SILVER'
     );
-    declare_project_state(
-        "PROJ_POST_FIRST_AVAILABLE",
-        "proj_post_first_available",
-        _("Available for PP"),
-        _("Available for Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
 
-    declare_project_state(
-        "PROJ_POST_FIRST_CHECKED_OUT",
-        "proj_post_first_checked_out",
-        _("In PP"),
-        _("In Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+    foreach($pools as $pool) {
+        $upper_ordinal = strtoupper($pool->ordinal);
+        $project_available_state = "proj_post_{$pool->ordinal}_available";
+        $project_checkedout_state = "proj_post_{$pool->ordinal}_checked_out";
 
-    declare_project_state(
-        "PROJ_POST_SECOND_AVAILABLE",
-        "proj_post_second_available",
-        _("Available for PPV"),
-        _("Available for Verifying Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+        declare_project_state(
+            "PROJ_POST_{$upper_ordinal}_AVAILABLE",
+            $project_available_state,
+            $pool->available_short_label,
+            $pool->available_long_label,
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
 
-    declare_project_state(
-        "PROJ_POST_SECOND_CHECKED_OUT",
-        "proj_post_second_checked_out",
-        _("In PPV"),
-        _("Verifying Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+        declare_project_state(
+            "PROJ_POST_{$upper_ordinal}_CHECKED_OUT",
+            $project_checkedout_state,
+            $pool->checked_out_short_label,
+            $pool->checked_out_long_label,
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
+
+        global $Pool_for_state_;
+        $Pool_for_state_[$project_available_state] = $pool;
+        $Pool_for_state_[$project_checkedout_state] = $pool;
+    }
 
     declare_project_state(
         "PROJ_POST_COMPLETE",

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -42,14 +42,6 @@ function define_project_states($rounds, $pools)
         'GOLD' => [],
     ];
 
-    $project_round_states = [
-        ["BAD_PROJECT", "bad", "bad", _("Bad Project"), _("Bad Project")],
-        ["UNAVAILABLE", "unavail", "unavailable", _("Unavailable"), _("Unavailable")],
-        ["WAITING_FOR_RELEASE", "waiting", "waiting", _("Waiting"), _("Waiting for Release")],
-        ["AVAILABLE", "avail", "available", _("Available"), _("Available")],
-        ["COMPLETE", "done", "complete", _("Completed"), _("Completed")],
-    ];
-
     // Note that the order in which these project states are declared
     // is the order in which they will be displayed in various contexts
     // (via $PROJECT_STATES_IN_ORDER).
@@ -66,22 +58,7 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($rounds as $round) {
-        foreach($project_round_states as [$const, $state, $long_state, $short_label, $long_label]) {
-            $project_state = "{$round->id}.proj_$state";
-            $round_project_state = "project_{$long_state}_state";
-            $round->$round_project_state = $project_state;
-            $Round_for_project_state_[$project_state] = $round;
-
-            declare_project_state(
-                "PROJ_{$round->id}_{$const}",
-                $project_state,
-                "$round->id: $short_label",
-                "$round->name: $long_label",
-                (($round->id == 'P1') && (($state == "unavail") || ($state == "waiting"))) ? $waiting_projects_forum_idx : $projects_forum_idx,
-                'PAGE_EDITING',
-                ''
-            );
-        }
+        declare_project_states_for_round($round);
     }
 
     // POST
@@ -178,6 +155,59 @@ function define_project_states($rounds, $pools)
 
         define($sql_constant_name, $sql_condition);
     }
+}
+
+function declare_project_states_for_round($round)
+{
+    global $projects_forum_idx;
+    global $waiting_projects_forum_idx;
+
+    declare_project_state(
+        "PROJ_{$round->id}_BAD_PROJECT",
+        $round->project_bad_state,
+        "$round->id: " .  _("Bad Project"),
+        "$round->name: " . _("Bad Project"),
+        $projects_forum_idx,
+        'PAGE_EDITING',
+        ''
+    );
+
+    declare_project_state(
+        "PROJ_{$round->id}_UNAVAILABLE",
+        $round->project_unavailable_state,
+        "$round->id: " . _("Unavailable"),
+        "$round->name: " . _("Unavailable"),
+        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+        'PAGE_EDITING',
+        ''
+    );
+    declare_project_state(
+        "PROJ_{$round->id}_WAITING_FOR_RELEASE",
+        $round->project_waiting_state,
+        "$round->id: " . _("Waiting"),
+        "$round->name: " . _("Waiting for Release"),
+        ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+        'PAGE_EDITING',
+        ''
+    );
+    declare_project_state(
+        "PROJ_{$round->id}_AVAILABLE",
+        $round->project_available_state,
+        "$round->id: " . _("Available"),
+        "$round->name: " . _("Available"),
+        $projects_forum_idx,
+        'PAGE_EDITING',
+        'BRONZE'
+    );
+    declare_project_state(
+        "PROJ_{$round->id}_COMPLETE",
+        $round->project_complete_state,
+        "$round->id: " . _("Completed"),
+        "$round->name: " . _("Completed"),
+        $projects_forum_idx,
+        'PAGE_EDITING',
+        ''
+    );
 }
 
 function declare_project_state(

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -257,6 +257,20 @@ function declare_project_state(
     }
 }
 
+function get_Round_for_project_state($project_state)
+{
+    global $Round_for_project_state_;
+    return array_get($Round_for_project_state_, $project_state, null);
+}
+
+function get_Pool_for_state($state)
+{
+    global $Pool_for_state_;
+    return array_get($Pool_for_state_, $state, null);
+}
+
+// ---------------------------
+
 function get_medium_label_for_project_state($state)
 {
     global $project_state_medium_label_;

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -22,27 +22,13 @@ include_once($relPath.'site_vars.php');
 
   (Actually, the naming convention is in transition.)
 */
-global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
-$project_state_phase_, $project_states_for_star_metal_;
-
-    $PROJECT_STATES_IN_ORDER = [];
-    $project_state_medium_label_ = [];
-    $project_state_long_label_ = [];
-    $project_state_forum_ = [];
-    $project_state_phase_ = [];
-    $project_states_for_star_metal_ = [
-        'BRONZE' => [],
-        'SILVER' => [],
-        'GOLD' => [],
-    ];
 
 class ProjectStates
 {
     public function __construct($rounds, $pools)
     {
         global $waiting_projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
-        $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx,
-        $project_states_for_star_metal_;
+        $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx;
 
         // Note that the order in which these project states are declared
         // is the order in which they will be displayed in various contexts
@@ -66,11 +52,11 @@ class ProjectStates
             $round->project_available_state = "{$round->id}.proj_avail";
             $round->project_complete_state = "{$round->id}.proj_done";
 
-            $this->round_for_project_state_[$round->project_unavailable_state] = $round;
-            $this->round_for_project_state_[$round->project_waiting_state] = $round;
-            $this->round_for_project_state_[$round->project_bad_state] = $round;
-            $this->round_for_project_state_[$round->project_available_state] = $round;
-            $this->round_for_project_state_[$round->project_complete_state] = $round;
+            $this->round_for_project_state[$round->project_unavailable_state] = $round;
+            $this->round_for_project_state[$round->project_waiting_state] = $round;
+            $this->round_for_project_state[$round->project_bad_state] = $round;
+            $this->round_for_project_state[$round->project_available_state] = $round;
+            $this->round_for_project_state[$round->project_complete_state] = $round;
 
             $this->declare_project_state(
                 "PROJ_{$round->id}_BAD_PROJECT",
@@ -143,9 +129,8 @@ class ProjectStates
                     break;
             }
 
-            global $Pool_for_state_;
-            $Pool_for_state_[$pool->project_available_state] = $pool;
-            $Pool_for_state_[$pool->project_checkedout_state] = $pool;
+            $this->pool_for_state[$pool->project_available_state] = $pool;
+            $this->pool_for_state[$pool->project_checkedout_state] = $pool;
 
             $this->declare_project_state(
                 strtoupper($pool->project_available_state),
@@ -211,12 +196,37 @@ class ProjectStates
             ''
         );
 
-        // Define constants for use in SQL queries:
-        // SQL_CONDITION_BRONZE
-        // SQL_CONDITION_SILVER
-        // SQL_CONDITION_GOLD
+        $this->define_metal_sql();
+    }
 
-        foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
+    private function declare_project_state(
+        $constant_name,
+        $constant_value,
+        $medium_label,
+        $long_label,
+        $forum,
+        $phase,
+        $star_metal
+    ) {
+        define($constant_name, $constant_value);
+        $this->states[] = $constant_value;
+        $this->medium_labels[$constant_value] = $medium_label;
+        $this->long_labels[$constant_value] = $long_label;
+        $this->project_state_forum[$constant_value] = $forum;
+        $this->project_state_phase[$constant_value] = $phase;
+        if ($star_metal) {
+            // don't define anything for empty string
+            $this->project_states_for_star_metal[$star_metal][] = $constant_value;
+        }
+    }
+
+    // Define constants for use in SQL queries:
+    // SQL_CONDITION_BRONZE
+    // SQL_CONDITION_SILVER
+    // SQL_CONDITION_GOLD
+    private function define_metal_sql()
+    {
+        foreach ($this->project_states_for_star_metal as $star_metal => $project_states) {
             $sql_constant_name = "SQL_CONDITION_$star_metal";
             $sql_condition = '(';
             foreach ($project_states as $project_state) {
@@ -230,71 +240,42 @@ class ProjectStates
             define($sql_constant_name, $sql_condition);
         }
     }
-
-    private function declare_project_state(
-        $constant_name,
-        $constant_value,
-        $medium_label,
-        $long_label,
-        $forum,
-        $phase,
-        $star_metal
-    ) {
-        global $PROJECT_STATES_IN_ORDER;
-        global $project_state_medium_label_;
-        global $project_state_long_label_;
-        global $project_state_forum_;
-        global $project_state_phase_;
-        global $project_states_for_star_metal_;
-
-        define($constant_name, $constant_value);
-        $PROJECT_STATES_IN_ORDER[] = $constant_value;
-        $project_state_medium_label_[$constant_value] = $medium_label;
-        $project_state_long_label_[$constant_value] = $long_label;
-        $project_state_forum_[$constant_value] = $forum;
-        $project_state_phase_[$constant_value] = $phase;
-        if ($star_metal) {
-            $project_states_for_star_metal_[$star_metal][] = $constant_value;
-        }
-    }
 }
 
 function get_Round_for_project_state($project_state)
 {
-    global $Round_for_project_state_;
-    return array_get($Round_for_project_state_, $project_state, null);
+    global $project_states;
+    return $project_states->round_for_project_state[$project_state] ?? null;
 }
 
 function get_Pool_for_state($state)
 {
-    global $Pool_for_state_;
-    return array_get($Pool_for_state_, $state, null);
+    global $project_states;
+    return $project_states->pool_for_state[$state] ?? null;
 }
-
-// ---------------------------
 
 function get_medium_label_for_project_state($state)
 {
-    global $project_state_medium_label_;
-    return array_get($project_state_medium_label_, $state, '');
+    global $project_states;
+    return $project_states->medium_labels[$state] ?? '';
 }
 
 function project_states_text($state)
 {
-    global $project_state_long_label_;
-    return array_get($project_state_long_label_, $state, '');
+    global $project_states;
+    return $project_states->long_labels[$state] ?? '';
 }
 
 function get_forum_id_for_project_state($state)
 {
-    global $project_state_forum_;
-    return array_get($project_state_forum_, $state, -1);
+    global $project_states;
+    return $project_states->project_state_forum[$state] ?? -1;
 }
 
 function get_phase_containing_project_state($state)
 {
-    global $project_state_phase_;
-    return array_get($project_state_phase_, $state, 'NONE');
+    global $project_states;
+    return $project_states->project_state_phase[$state] ?? 'NONE';
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -96,13 +96,9 @@ function define_project_states($rounds, $pools)
     );
 
     foreach($pools as $pool) {
-        $upper_ordinal = strtoupper($pool->ordinal);
-        $project_available_state = "proj_post_{$pool->ordinal}_available";
-        $project_checkedout_state = "proj_post_{$pool->ordinal}_checked_out";
-
         declare_project_state(
-            "PROJ_POST_{$upper_ordinal}_AVAILABLE",
-            $project_available_state,
+            strtoupper($pool->project_available_state),
+            $pool->project_available_state,
             $pool->available_short_label,
             $pool->available_long_label,
             $pp_projects_forum_idx,
@@ -111,18 +107,14 @@ function define_project_states($rounds, $pools)
         );
 
         declare_project_state(
-            "PROJ_POST_{$upper_ordinal}_CHECKED_OUT",
-            $project_checkedout_state,
+            strtoupper($pool->project_checkedout_state),
+            $pool->project_checkedout_state,
             $pool->checked_out_short_label,
             $pool->checked_out_long_label,
             $pp_projects_forum_idx,
             'PP',
             'SILVER'
         );
-
-        global $Pool_for_state_;
-        $Pool_for_state_[$project_available_state] = $pool;
-        $Pool_for_state_[$project_checkedout_state] = $pool;
     }
 
     declare_project_state(

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -22,19 +22,180 @@ include_once($relPath.'site_vars.php');
 
   (Actually, the naming convention is in transition.)
 */
-global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_;
-global $project_state_phase_, $project_states_for_star_metal_;
+global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
+$project_state_phase_, $project_states_for_star_metal_;
 
-$PROJECT_STATES_IN_ORDER = [];
-$project_state_medium_label_ = [];
-$project_state_long_label_ = [];
-$project_state_forum_ = [];
-$project_state_phase_ = [];
-$project_states_for_star_metal_ = [
-    'BRONZE' => [],
-    'SILVER' => [],
-    'GOLD' => [],
-];
+function define_project_states($rounds)
+{
+    global $waiting_projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
+    $projects_forum_idx, $completed_projects_forum_idx, $deleted_projects_forum_idx,
+    $project_states_for_star_metal_, $Round_for_project_state_;
+
+    $PROJECT_STATES_IN_ORDER = [];
+    $project_state_medium_label_ = [];
+    $project_state_long_label_ = [];
+    $project_state_forum_ = [];
+    $project_state_phase_ = [];
+    $project_states_for_star_metal_ = [
+        'BRONZE' => [],
+        'SILVER' => [],
+        'GOLD' => [],
+    ];
+
+    $project_round_states = [
+        ["BAD_PROJECT", "bad", "bad", _("Bad Project"), _("Bad Project")],
+        ["UNAVAILABLE", "unavail", "unavailable", _("Unavailable"), _("Unavailable")],
+        ["WAITING_FOR_RELEASE", "waiting", "waiting", _("Waiting"), _("Waiting for Release")],
+        ["AVAILABLE", "avail", "available", _("Available"), _("Available")],
+        ["COMPLETE", "done", "complete", _("Completed"), _("Completed")],
+    ];
+
+    // Note that the order in which these project states are declared
+    // is the order in which they will be displayed in various contexts
+    // (via $PROJECT_STATES_IN_ORDER).
+
+    // for the initial creation of a project
+    declare_project_state(
+        "PROJ_NEW",
+        "project_new",
+        _("New Project"),
+        _("New Project"),
+        $waiting_projects_forum_idx,
+        'NEW',
+        ''
+    );
+
+    foreach($rounds as $round) {
+        foreach($project_round_states as [$const, $state, $long_state, $short_label, $long_label]) {
+            $project_state = "{$round->id}.proj_$state";
+            $round_project_state = "project_{$long_state}_state";
+            $round->$round_project_state = $project_state;
+            $Round_for_project_state_[$project_state] = $round;
+
+            declare_project_state(
+                "PROJ_{$round->id}_{$const}",
+                $project_state,
+                "$round->id: $short_label",
+                "$round->name: $long_label",
+                (($round->id == 'P1') && (($state == "unavail") || ($state == "waiting"))) ? $waiting_projects_forum_idx : $projects_forum_idx,
+                'PAGE_EDITING',
+                ''
+            );
+        }
+    }
+
+    // POST
+    declare_project_state(
+        "PROJ_POST_FIRST_UNAVAILABLE",
+        "proj_post_first_unavailable",
+        _("Unavailable for PP"),
+        _("Unavailable for Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+    declare_project_state(
+        "PROJ_POST_FIRST_AVAILABLE",
+        "proj_post_first_available",
+        _("Available for PP"),
+        _("Available for Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_FIRST_CHECKED_OUT",
+        "proj_post_first_checked_out",
+        _("In PP"),
+        _("In Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_SECOND_AVAILABLE",
+        "proj_post_second_available",
+        _("Available for PPV"),
+        _("Available for Verifying Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_SECOND_CHECKED_OUT",
+        "proj_post_second_checked_out",
+        _("In PPV"),
+        _("Verifying Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    declare_project_state(
+        "PROJ_POST_COMPLETE",
+        "proj_post_complete",
+        _("Completed Post"),
+        _("Completed Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    // SUBMIT (was GB)
+    declare_project_state(
+        "PROJ_SUBMIT_PG_POSTED",
+        "proj_submit_pgposted",
+        _("Posted to PG"),
+        _("Completed and Posted to Project Gutenberg"),
+        $posted_projects_forum_idx,
+        'GB',
+        'GOLD'
+    );
+
+    // for complete project
+    declare_project_state(
+        "PROJ_COMPLETE",
+        "project_complete",
+        _("Project Complete"),
+        _("Project Complete"),
+        $completed_projects_forum_idx,
+        'COMPLETE',
+        ''
+    );
+
+    // for the 'deletion' of a project
+    declare_project_state(
+        "PROJ_DELETE",
+        "project_delete",
+        _("Delete Project"),
+        _("Delete Project"),
+        $deleted_projects_forum_idx,
+        'NONE',
+        ''
+    );
+
+    // Define constants for use in SQL queries:
+    // SQL_CONDITION_BRONZE
+    // SQL_CONDITION_SILVER
+    // SQL_CONDITION_GOLD
+
+    foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
+        $sql_constant_name = "SQL_CONDITION_$star_metal";
+        $sql_condition = '(';
+        foreach ($project_states as $project_state) {
+            if ($sql_condition != '(') {
+                $sql_condition .= ' OR ';
+            }
+            $sql_condition .= "state='$project_state'";
+        }
+        $sql_condition .= ')';
+
+        define($sql_constant_name, $sql_condition);
+    }
+}
 
 function declare_project_state(
     $constant_name,
@@ -85,207 +246,6 @@ function get_phase_containing_project_state($state)
 {
     global $project_state_phase_;
     return array_get($project_state_phase_, $state, 'NONE');
-}
-
-// -----------------------------------------------
-
-function declare_project_states_for_round($round_id, $round_name)
-{
-    global $projects_forum_idx;
-    global $waiting_projects_forum_idx;
-
-    declare_project_state(
-        "PROJ_{$round_id}_BAD_PROJECT",
-        "$round_id.proj_bad",
-        "$round_id: " .  _("Bad Project"),
-        "$round_name: " . _("Bad Project"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_UNAVAILABLE",
-        "$round_id.proj_unavail",
-        "$round_id: " . _("Unavailable"),
-        "$round_name: " . _("Unavailable"),
-        ($round_id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_WAITING_FOR_RELEASE",
-        "$round_id.proj_waiting",
-        "$round_id: " . _("Waiting"),
-        "$round_name: " . _("Waiting for Release"),
-        ($round_id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_AVAILABLE",
-        "$round_id.proj_avail",
-        "$round_id: " . _("Available"),
-        "$round_name: " . _("Available"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        'BRONZE'
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_COMPLETE",
-        "$round_id.proj_done",
-        "$round_id: " . _("Completed"),
-        "$round_name: " . _("Completed"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
-}
-
-// -----------------------------------------------
-
-// Note that the order in which these project states are declared
-// is the order in which they will be displayed in various contexts
-// (via $PROJECT_STATES_IN_ORDER).
-
-
-// PR
-
-
-// for the initial creation of a project
-declare_project_state(
-    "PROJ_NEW",
-    "project_new",
-    _("New Project"),
-    _("New Project"),
-    $waiting_projects_forum_idx,
-    'NEW',
-    ''
-);
-
-
-// PROOF
-declare_project_states_for_round('P1', _('Proofreading Round 1'));
-declare_project_states_for_round('P2', _('Proofreading Round 2'));
-declare_project_states_for_round('P3', _('Proofreading Round 3'));
-
-// FORMAT
-declare_project_states_for_round('F1', _('Formatting Round 1'));
-declare_project_states_for_round('F2', _('Formatting Round 2'));
-
-
-// POST
-declare_project_state(
-    "PROJ_POST_FIRST_UNAVAILABLE",
-    "proj_post_first_unavailable",
-    _("Unavailable for PP"),
-    _("Unavailable for Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-declare_project_state(
-    "PROJ_POST_FIRST_AVAILABLE",
-    "proj_post_first_available",
-    _("Available for PP"),
-    _("Available for Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_FIRST_CHECKED_OUT",
-    "proj_post_first_checked_out",
-    _("In PP"),
-    _("In Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_SECOND_AVAILABLE",
-    "proj_post_second_available",
-    _("Available for PPV"),
-    _("Available for Verifying Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_SECOND_CHECKED_OUT",
-    "proj_post_second_checked_out",
-    _("In PPV"),
-    _("Verifying Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-declare_project_state(
-    "PROJ_POST_COMPLETE",
-    "proj_post_complete",
-    _("Completed Post"),
-    _("Completed Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-
-
-// SUBMIT (was GB)
-declare_project_state(
-    "PROJ_SUBMIT_PG_POSTED",
-    "proj_submit_pgposted",
-    _("Posted to PG"),
-    _("Completed and Posted to Project Gutenberg"),
-    $posted_projects_forum_idx,
-    'GB',
-    'GOLD'
-);
-
-// for complete project
-declare_project_state(
-    "PROJ_COMPLETE",
-    "project_complete",
-    _("Project Complete"),
-    _("Project Complete"),
-    $completed_projects_forum_idx,
-    'COMPLETE',
-    ''
-);
-
-// for the 'deletion' of a project
-declare_project_state(
-    "PROJ_DELETE",
-    "project_delete",
-    _("Delete Project"),
-    _("Delete Project"),
-    $deleted_projects_forum_idx,
-    'NONE',
-    ''
-);
-
-// -----------------------------------------------------------------------------
-
-// Define constants for use in SQL queries:
-// SQL_CONDITION_BRONZE
-// SQL_CONDITION_SILVER
-// SQL_CONDITION_GOLD
-
-foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
-    $sql_constant_name = "SQL_CONDITION_$star_metal";
-    $sql_condition = '(';
-    foreach ($project_states as $project_state) {
-        if ($sql_condition != '(') {
-            $sql_condition .= ' OR ';
-        }
-        $sql_condition .= "state='$project_state'";
-    }
-    $sql_condition .= ')';
-
-    define($sql_constant_name, $sql_condition);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -277,7 +277,8 @@ function define_activities()
         null, // access_change_callback
         _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
         'post_proof.php',
-        "first",
+        "proj_post_first_available",
+        "proj_post_first_checked_out",
         _("Available for PP"),
         _("Available for Post-Processing"),
         _("In PP"),
@@ -330,7 +331,8 @@ function define_activities()
         null, // access_change_callback
         _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
         'ppv.php',
-        'second',
+        "proj_post_second_available",
+        "proj_post_second_checked_out",
         _("Available for PPV"),
         _("Available for Verifying Post-Processing"),
         _("In PPV"),

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -46,6 +46,8 @@ $ELR_round = get_Round_for_round_number(1);
 
 function define_activities()
 {
+    global $code_url, $post_processing_forum_idx;
+
     // $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
     // what proofreading tools are shown in the toolbox in the proofreading
     // interface for the proofreading (P) and the formatting (F) rounds. These are
@@ -265,8 +267,6 @@ function define_activities()
             150000 => _('Preserver of Texts'),
         ]
     );
-
-    global $code_url, $post_processing_forum_idx, $post_processing_forum_idx;
 
     new Pool(
         'PP',

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -11,7 +11,7 @@ include_once($relPath.'Pool.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
 
-class Activities
+class Rounds
 {
     // pi_tools_for_P and pi_tools_for_F are handy helper variables that define
     // what proofreading tools are shown in the toolbox in the proofreading
@@ -32,19 +32,8 @@ class Activities
 
     public function __construct()
     {
-        global $code_url, $post_processing_forum_idx;
-
-        // access_criteria are extended as activities are defined.
-        $this->access_criteria = [
-            'days since reg' => _('Days since registration'),
-            'quiz/p_basic' => sprintf(_('Up-to-date completion of the <a href="%1$s">Basic Proofreading Quiz</a>'), "$code_url/quiz/start.php?show_level=P_BASIC"),
-            'quiz/p_mod1' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 1),
-            'quiz/p_mod2' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 2),
-            'quiz/f_only' => sprintf(_("Up-to-date completion of the <a href='%s'>Formatting Quiz</a>"), "$code_url/quiz/start.php?show_only=format"),
-        ];
-
         $this->round_number = 0;
-        $this->add_round(new Round(
+        $this->add(new Round(
             ++$this->round_number,
             'P1',
             _('Proofreading Round 1'),
@@ -86,7 +75,7 @@ class Activities
 
         // -----------------------------------------------------------------------------
 
-        $this->add_round(new Round(
+        $this->add(new Round(
             ++$this->round_number,
             'P2',
             _('Proofreading Round 2'),
@@ -128,7 +117,7 @@ class Activities
 
         // -----------------------------------------------------------------------------
 
-        $this->add_round(new Round(
+        $this->add(new Round(
             ++$this->round_number,
             'P3',
             _('Proofreading Round 3'),
@@ -170,7 +159,7 @@ class Activities
 
         // -----------------------------------------------------------------------------
 
-        $this->add_round(new Round(
+        $this->add(new Round(
             ++$this->round_number,
             'F1',
             _('Formatting Round 1'),
@@ -212,7 +201,7 @@ class Activities
 
         // -----------------------------------------------------------------------------
 
-        $this->add_round(new Round(
+        $this->add(new Round(
             ++$this->round_number,
             'F2',
             _('Formatting Round 2'),
@@ -251,12 +240,63 @@ class Activities
                 150000 => _('Preserver of Texts'),
             ]
         ));
+    }
 
-        // After creating all rounds:
-        define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
-        assert($this->round_number == MAX_NUM_PAGE_EDITING_ROUNDS);
+    public function add($round)
+    {
+        $this->round_for_id[$round->id] = $round;
+        $this->round_for_number[$round->round_number] = $round;
 
-        $this->add_pool(new Pool(
+        foreach($round->get_page_states() as $page_state) {
+            // e.g. $activities->round_for_page_state["P1.page_avail"] = $P1;
+            $this->round_for_page_state[$page_state] = $round;
+
+            // e.g. $activities->page_states[0] = "P1.page_avail"
+            $this->page_states[] = $page_state;
+        }
+    }
+
+    public function get_all()
+    {
+        return $this->round_for_id;
+    }
+}
+
+class Stages
+{
+    public function __construct()
+    {
+        $this->add(new Stage(
+            'SR',
+            _('Smooth Reading'),
+            [],
+            'IMMEDIATE',
+            '',
+            null, // access_change_callback
+            _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
+            null,
+            "tools/post_proofers/smooth_reading.php"
+        ));
+    }
+
+    public function add($stage)
+    {
+        $this->stage_for_id[$stage->id] = $stage;
+    }
+
+    public function get_all()
+    {
+        return $this->stage_for_id;
+    }
+}
+
+class Pools
+{
+    public function __construct()
+    {
+        global $code_url, $post_processing_forum_idx;
+
+        $this->add(new Pool(
             'PP',
             _('Post-Processing'),
             ['F1' => 400],
@@ -288,23 +328,7 @@ class Activities
             ]
         ));
 
-        // -----------------------------------------------------------------------------
-
-        $this->add_stage(new Stage(
-            'SR',
-            _('Smooth Reading'),
-            [],
-            'IMMEDIATE',
-            '',
-            null, // access_change_callback
-            _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
-            null,
-            "tools/post_proofers/smooth_reading.php"
-        ));
-
-        // -----------------------------------------------------------------------------
-
-        $this->add_pool(new Pool(
+        $this->add(new Pool(
             'PPV',
             _('Post-Processing Verification'),
             [],
@@ -336,10 +360,35 @@ class Activities
                 "</p>",
             ]
         ));
+    }
 
-        // -----------------------------------------------------------------------------
+    public function add($pool)
+    {
+        $this->pool_for_id[$pool->id] = $pool;
+    }
 
-        $this->add_activity(new Activity(
+    public function get_all()
+    {
+        return $this->pool_for_id;
+    }
+}
+
+class Activities
+{
+    public function __construct()
+    {
+        global $code_url;
+
+        // access_criteria are extended as activities are defined.
+        $this->access_criteria = [
+            'days since reg' => _('Days since registration'),
+            'quiz/p_basic' => sprintf(_('Up-to-date completion of the <a href="%1$s">Basic Proofreading Quiz</a>'), "$code_url/quiz/start.php?show_level=P_BASIC"),
+            'quiz/p_mod1' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 1),
+            'quiz/p_mod2' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 2),
+            'quiz/f_only' => sprintf(_("Up-to-date completion of the <a href='%s'>Formatting Quiz</a>"), "$code_url/quiz/start.php?show_only=format"),
+        ];
+
+        $this->add(new Activity(
             'DU',
             _('Uploading to Project Gutenberg'),
             [],
@@ -348,7 +397,7 @@ class Activities
             null // access_change_callback
         ));
 
-        $this->add_activity(new Activity(
+        $this->add(new Activity(
             "P2_mentor",
             sprintf(_("Mentoring in round %s"), 'P2'),
             [],
@@ -358,72 +407,70 @@ class Activities
         ));
     }
 
-    function add_activity($activity)
+    public function add($activity)
     {
         $this->activity_for_id[$activity->id] = $activity;
-
-        foreach($activity->get_access_criteria() as $key => $value) {
-            $this->access_criteria[$key] = $value;
-        }
     }
 
-    function add_stage($stage)
+    public function get_all()
     {
-        $this->stage_for_id[$stage->id] = $stage;
-        $this->add_activity($stage);
-    }
-
-    function add_round($round)
-    {
-        $this->round_for_id[$round->id] = $round;
-        $this->round_for_number[$round->round_number] = $round;
-        $this->add_stage($round);
-
-        foreach($round->get_page_states() as $page_state) {
-            // e.g. $activities->round_for_page_state["P1.page_avail"] = $P1;
-            $this->round_for_page_state[$page_state] = $round;
-
-            // e.g. $activities->page_states[0] = "P1.page_avail"
-            $this->page_states[] = $page_state;
-        }
-    }
-
-    function add_pool($pool)
-    {
-        $this->pool_for_id[$pool->id] = $pool;
-        $this->add_stage($pool);
+        return $this->activity_for_id;
     }
 }
 
-global $activities, $project_states;
+global $rounds, $stages, $activities, $pools, $project_states;
+$rounds = new Rounds();
+// After creating all rounds:
+define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
+assert($rounds->round_number == MAX_NUM_PAGE_EDITING_ROUNDS);
+
+$pools = new Pools();
+
+$stages = new Stages();
+foreach($rounds->get_all() as $round) {
+    $stages->add($round);
+}
+foreach($pools->get_all() as $pool) {
+    $stages->add($pool);
+}
+
 $activities = new Activities();
+foreach($stages->get_all() as $stage) {
+    $activities->add($stage);
+}
 
-$project_states = new ProjectStates($activities->round_for_id, $activities->pool_for_id);
+foreach($activities->get_all() as $activity) {
+    foreach($activity->get_access_criteria() as $key => $value) {
+        $activities->access_criteria[$key] = $value;
+    }
+}
 
-// these can next be made member functions of $activities
-// used as $activities->get_Round_for_page_state($state) etc.
+$project_states = new ProjectStates($rounds->get_all(), $pools->get_all());
+
+// these can next be made member functions
+// used as $rounds->get_Round_for_page_state($state) etc.
 function get_Round_for_page_state($page_state)
 {
-    global $activities;
-    return $activities->round_for_page_state[$page_state] ?? null;
+    global $rounds;
+    return $rounds->round_for_page_state[$page_state] ?? null;
 }
 
 function get_Round_for_round_number($round_number)
 {
-    global $activities;
-    return $activities->round_for_number[$round_number] ?? null;
+    global $rounds;
+    return $rounds->round_for_number[$round_number] ?? null;
 }
 
 function get_Round_for_round_id($round_id)
 {
-    global $activities;
-    return $activities->round_for_id[$round_id] ?? null;
+    global $rounds;
+    return $rounds->round_for_id[$round_id] ?? null;
 }
 
 function get_Round_for_text_column_name($text_column_name)
 {
-    global $activities;
-    foreach ($activities->round_for_id as $round_id => $round) {
+    global $rounds;
+    foreach ($rounds->round_for_id as $round_id => $round) {
         if ($round->text_column_name == $text_column_name) {
             return $round;
         }
@@ -433,8 +480,8 @@ function get_Round_for_text_column_name($text_column_name)
 
 function get_Stage_for_id($id)
 {
-    global $activities;
-    $stage = $activities->stage_for_id[$id] ?? null;
+    global $stages;
+    $stage = $stages->stage_for_id[$id] ?? null;
     if (null !== $stage) {
         return $stage;
     } else {
@@ -444,24 +491,31 @@ function get_Stage_for_id($id)
 
 function get_Pool_for_id($id)
 {
-    global $activities;
-    return $activities->pool_for_id[$id] ?? null;
+    global $pools;
+    return $pools->pool_for_id[$id] ?? null;
 }
 
 // aliases for compatibility with existing code
 global $PAGE_STATES_IN_ORDER, $Round_for_round_id_, $Round_for_round_number_, $Round_for_page_state_,
 $Activity_for_id_, $Pool_for_id_, $ACCESS_CRITERIA, $Stage_for_id_;
-$PAGE_STATES_IN_ORDER = $activities->page_states;
-$Round_for_round_id_ = $activities->round_for_id;
-$Round_for_round_number_ = $activities->round_for_number;
-$Round_for_page_state_ = $activities->round_for_page_state;
+$PAGE_STATES_IN_ORDER = $rounds->page_states;
+$Round_for_round_id_ = $rounds->round_for_id;
+$Round_for_round_number_ = $rounds->round_for_number;
+$Round_for_page_state_ = $rounds->round_for_page_state;
 $Activity_for_id_ = $activities->activity_for_id;
-$Stage_for_id_ = $activities->stage_for_id;
-$Pool_for_id_ = $activities->pool_for_id;
+$Stage_for_id_ = $stages->stage_for_id;
+$Pool_for_id_ = $pools->pool_for_id;
 $ACCESS_CRITERIA = $activities->access_criteria;
 // alias for compatibility with noncvs
 global $n_rounds;
-$n_rounds = $activities->round_number;
+$n_rounds = $rounds->round_number;
+
+// aliases for compatibility with existing code
+global $PROJECT_STATES_IN_ORDER, $project_state_phase_, $project_states;
+
+$PROJECT_STATES_IN_ORDER = $project_states->states_in_order;
+$project_state_phase_ = $project_states->project_state_phase;
+
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -11,17 +11,414 @@ include_once($relPath.'Pool.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
 
+class Activities
+{
+    // pi_tools_for_P and pi_tools_for_F are handy helper variables that define
+    // what proofreading tools are shown in the toolbox in the proofreading
+    // interface for the proofreading (P) and the formatting (F) rounds. These are
+    // passed into the Round() constructors below. The names refer to ToolButtons
+    // and PopupLink objects defined in pinc/ProofreadingToolbox.inc.
+
+    public const pi_tools_for_P = [
+        'popup_links' => ['search_and_replace', 'greek_transliterator', 'hieroglyph_transliterator'],
+        'tool_buttons' => ['remove_markup', 'upper_case', 'title_case', 'lower_case'],
+        'tool_links' => ['greek', 'note', 'brackets', 'braces', 'blank_page'],
+    ];
+    public const pi_tools_for_F = [
+        'popup_links' => 'ALL',
+        'tool_buttons' => 'ALL',
+        'tool_links' => 'ALL',
+    ];
+
+    private const page_state_codes = [
+        "page_avail_state" => "avail",
+        "page_out_state" => "out",
+        "page_temp_state" => "temp",
+        "page_save_state" => "saved",
+        "page_bad_state" => "bad",
+    ];
+
+    public function __construct()
+    {
+        global $code_url, $post_processing_forum_idx;
+
+        $round_number = 0;
+        $this->rounds[++$round_number] = new Round(
+            $round_number,
+            'P1',
+            _('Proofreading Round 1'),
+            [],
+            'IMMEDIATE',
+            '',
+            null, // access_change_callback
+            _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
+            'proofreading_guidelines.php',
+            self::pi_tools_for_P,
+            null, // daily_page_limit
+            [],
+            [
+                0 => _('Novice'),
+                25 => _('Proofreading Pupil'),
+                100 => _('Proofreading Apprentice'),
+                500 => _('Proofreading Scholar'),
+                1000 => _('Proofreading Prodigy'),
+                2500 => _('Proofreading Mastermind'),
+                5000 => _('Proofreading Graduate'),
+                10000 => _('Proofreading Alumnus'),
+                20000 => _('Fellow of Proofreading'),
+                30000 => _('Doctor of Proofreading'),
+                40000 => _('Proofreading Don'),
+                50000 => _('Dean of Proofreading'),
+                60000 => _('Proofreading Proctor'),
+                70000 => _('Principal Proofreader'),
+                80000 => _('Master Proofreader'),
+                90000 => _('Prefect of Proofreaders'),
+                99000 => _('Supervising Proofreader'),
+                100000 => _('Proofreading Professor'),
+                110000 => _('Peer of Proofreading'),
+                120000 => _('Doyen of Proofreading'),
+                130000 => _('Proofreading Chancellor'),
+                140000 => _('Proofreading Primate'),
+                150000 => _('Paramount Proofreader'),
+            ]
+        );
+
+        // -----------------------------------------------------------------------------
+
+        $this->rounds[++$round_number] = new Round(
+            $round_number,
+            'P2',
+            _('Proofreading Round 2'),
+            ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
+            'REQ-AUTO',
+            '',
+            null, // access_change_callback
+            _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
+            'proofreading_guidelines.php',
+            self::pi_tools_for_P,
+            null, // daily_page_limit
+            ['P1'],
+            [
+                0 => _('Precise Proofreader'),
+                25 => _('Picky Proofreader'),
+                100 => _('Painstaking Proofreader'),
+                500 => _('Punctilious Proofreader'),
+                1000 => _('Persnickety Proofreader'),
+                2500 => _('Particular Proofreader'),
+                5000 => _('Proficient Proofreader'),
+                10000 => _('Proper Proofreader'),
+                20000 => _('Prudent Proofreader'),
+                30000 => _('Proofreading Personage'),
+                40000 => _('Proofreading Poppet'),
+                50000 => _('Plighted Proofreader'),
+                60000 => _('Proofreading Proctor'),
+                70000 => _('Principal Proofreader'),
+                80000 => _('Prime Proofreader'),
+                90000 => _('Primal Proofreader'),
+                99000 => _('Proofreading Personality'),
+                100000 => _('Proofreading Professional'),
+                110000 => _('Peerless Proofreader'),
+                120000 => _('Perspicacious Proofreader'),
+                130000 => _('Paraproofreader'),
+                140000 => _('Proofreading Panjandrum'),
+                150000 => _('Perfectionist Proofreader'),
+            ]
+        );
+
+        // -----------------------------------------------------------------------------
+
+        $this->rounds[++$round_number] = new Round(
+            $round_number,
+            'P3',
+            _('Proofreading Round 3'),
+            ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
+            'REQ-HUMAN',
+            _("Once you have met the requirements and requested access to P3, an evaluator will check over at least 50 of your recent P2 pages that have been completed in P3. If you proofread them to P3 standards, you'll be granted access."),
+            null, // access_change_callback
+            _("The page-texts have already been proofread, but now need to be examined <b>closely</b> for small errors that may have been missed."),
+            'proofreading_guidelines.php',
+            self::pi_tools_for_P,
+            null, // daily_page_limit
+            ['P1', 'P2'],
+            [
+                0 => _('Specialist Proofreader'),
+                25 => _('Precious Proofreader'),
+                100 => _('Prized Proofreader'),
+                500 => _('Premiere Proofreader'),
+                1000 => _('Proofreading Perfectionist'),
+                2500 => _('Pillar of Proofreading'),
+                5000 => _('Proofreading Purist'),
+                10000 => _('Proofreader of Precision'),
+                20000 => _('Archetypal Proofreader'),
+                30000 => _('Proofreading Nonpareil'),
+                40000 => _('Paradigmatic Proofreader'),
+                50000 => _('Preeminent Proofreader'),
+                60000 => _('Prime Proofreader'),
+                70000 => _('Proofreader of Plenariness'),
+                80000 => _('Perpetual Proofreader'),
+                90000 => _('Prefect of Proofreaders'),
+                99000 => _('Impeccable Proofreader'),
+                100000 => _('Proofreader of Persistence'),
+                110000 => _('Patent Proofreader'),
+                120000 => _('Proofreading Philosopher'),
+                130000 => _('Patron of Proofreaders'),
+                140000 => _('Proofreading Partner'),
+                150000 => _('Pioneer of Proofreaders'),
+            ]
+        );
+
+        // -----------------------------------------------------------------------------
+
+        $this->rounds[++$round_number] = new Round(
+            $round_number,
+            'F1',
+            _('Formatting Round 1'),
+            ['P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1],
+            'REQ-AUTO',
+            '',
+            null, // access_change_callback
+            _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),
+            'formatting_guidelines.php',
+            self::pi_tools_for_F,
+            null, // daily_page_limit
+            [],
+            [
+                0 => _('Formatting Neophyte'),
+                25 => _('Formatting Intern'),
+                100 => _('Journeyman Formatter'),
+                500 => _('Crafter of Texts'),
+                1000 => _('Detailer of Books'),
+                2500 => _('Fastidious Formatter'),
+                5000 => _('Foremost Formatter'),
+                10000 => _('Fine Formatter'),
+                20000 => _('Flamboyant Formatter'),
+                30000 => _('Fabulous Formatter'),
+                40000 => _('Upgrader of Texts'),
+                50000 => _('Famous Formatter'),
+                60000 => _('Indefatigable Formatter'),
+                70000 => _('Finisher of Texts'),
+                80000 => _('Formatter of Choice'),
+                90000 => _('Capital Formatter'),
+                99000 => _('Formatter with Flair'),
+                100000 => _('Formatter of Finesse'),
+                110000 => _('Formatter with Forte'),
+                120000 => _('First-Class Formatter'),
+                130000 => _('Formatter of Favour'),
+                140000 => _('Formatter of Refinement'),
+                150000 => _('Flawless Formatter'),
+            ]
+        );
+
+        // -----------------------------------------------------------------------------
+
+        $this->rounds[++$round_number] = new Round(
+            $round_number,
+            'F2',
+            _('Formatting Round 2'),
+            ['F1' => 400, 'days since reg' => 91], // 'F1' => 1000, 3 months after rollout
+            'REQ-HUMAN', // "peer approval"
+            _("Once you have met the requirements and requested access to F2, an evaluator will check over at least 150 of your recent F1 pages that have been completed in F2. If they've been formatted to F2 standards, you'll be granted access."),
+            null, // access_change_callback
+            _("The page-texts in this round need to be carefully checked to remove any remaining formatting errors."),
+            'formatting_guidelines.php',
+            self::pi_tools_for_F,
+            null, // daily_page_limit
+            ['F1'],
+            [
+                0 => _('Refurbisher of Texts'),
+                25 => _('Sprucer of Texts'),
+                100 => _('Formatter Savant'),
+                500 => _('Formatting Wunderkind'),
+                1000 => _('Elite Formatter'),
+                2500 => _('Polisher of Texts'),
+                5000 => _('Formatting Artiste'),
+                10000 => _('Cultivator of Texts'),
+                20000 => _('Formatter of Enrichment'),
+                30000 => _('Designing Formatter'),
+                40000 => _('Formatting Artisan'),
+                50000 => _('Formatting Aficionado'),
+                60000 => _('Guru of Formatters'),
+                70000 => _('Formatting Familiar'),
+                80000 => _('Formatting Virtuoso'),
+                90000 => _('Formatter of Excellence'),
+                99000 => _('Exquisite Formatter'),
+                100000 => _('Formatting Specialist'),
+                110000 => _('Formatting Genius'),
+                120000 => _('Formatter of Fine Feats'),
+                130000 => _('Harmoniser of Texts'),
+                140000 => _('Formatting Architect'),
+                150000 => _('Preserver of Texts'),
+            ]
+        );
+
+        // After creating all rounds:
+        define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
+        assert($round_number == MAX_NUM_PAGE_EDITING_ROUNDS);
+
+        foreach($this->rounds as $round) {
+
+            // e.g. $activities->round_for_round_id["P1"] = $P1;
+            $this->round_for_round_id[$round->id] = $round;
+
+            foreach(self::page_state_codes as $page_state => $state_code) {
+
+                // e.g. $P1->page_avail_state = "P1.page_avail"
+                $round->$page_state = "{$round->id}.page_$state_code";
+
+                // e.g. $activities->round_for_page_state["P1.page_avail"] = $P1;
+                $this->round_for_page_state[$round->$page_state] = $round;
+
+                // e.g. $activities->page_sates[0] = "P1.page_avail"
+                $this->page_states[] = $round->$page_state;
+            }
+        }
+
+        $this->pools[] = new Pool(
+            'PP',
+            _('Post-Processing'),
+            ['F1' => 400],
+            'REQ-AUTO',
+            '',
+            null, // access_change_callback
+            _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
+            'post_proof.php',
+            _("Manager"),
+            'username',
+            [
+                "<p>",
+                "<b>" . _("First Time Here?") . "</b>",
+                sprintf(
+                    _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
+                    "$code_url/faq/post_proof.php"
+                ),
+                _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
+                sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
+                _("If nothing interests you right now, check back later and there will be more!"),
+                "</p>",
+
+                "<p>",
+                _("Each book listed below has gone through multiple rounds of proofreading and formatting, and now needs to be massaged into a final e-text."),
+                _("Once you have checked out and downloaded a book it will remain checked out to you until you check it back in."),
+                _("When you have finished your work on the book, select <i>Upload for Verification</i> from the drop-down list for that project."),
+                _("If you have several files to submit for a single project (say a text and HTML version), zip them up together first."),
+                "</p>",
+            ]
+        );
+
+        // -----------------------------------------------------------------------------
+
+        new Stage(
+            'SR',
+            _('Smooth Reading'),
+            [],
+            'IMMEDIATE',
+            '',
+            null, // access_change_callback
+            _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
+            null,
+            "tools/post_proofers/smooth_reading.php"
+        );
+
+        // -----------------------------------------------------------------------------
+
+        $this->pools[] = new Pool(
+            'PPV',
+            _('Post-Processing Verification'),
+            [],
+            'NOREQ', // "Peer approval. Also gives F2 access."
+            '',
+            null, // access_change_callback
+            _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
+            'ppv.php',
+            _("Post-Processor"),
+            'postproofer',
+            [
+                "<p>",
+                _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
+                sprintf(
+                    _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
+                    "$code_url/faq/ppv.php"
+                ),
+                sprintf(
+                    _("The PPV reporting form is <a href='%s'>here</a>."),
+                    "$code_url/tools/post_proofers/ppv_report.php"
+                ),
+                "</p>",
+
+                "<p>",
+                sprintf(
+                    _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
+                    get_url_to_view_forum($post_processing_forum_idx)
+                ),
+                "</p>",
+            ]
+        );
+
+        // -----------------------------------------------------------------------------
+
+        new Activity(
+            'DU',
+            _('Uploading to Project Gutenberg'),
+            [],
+            'NOREQ',
+            'OOGA',
+            null // access_change_callback
+        );
+
+        new Activity(
+            "P2_mentor",
+            sprintf(_("Mentoring in round %s"), 'P2'),
+            [],
+            'NOREQ',
+            '',
+            null // access_change_callback
+        );
+    }
+}
+
+global $activities;
+$activities = new Activities();
+
+$project_states = new ProjectStates($activities->rounds, $activities->pools);
+
+// global for compatibility with noncvs
+//global $n_rounds;
+//$n_rounds = $activities->define_rounds();
+
+foreach($activities->rounds as $round) {
+    $activities->activity_for_id[$round->id] = $round;
+}
+
+function get_Round_for_page_state($page_state)
+{
+    global $activities;
+    return $activities->round_for_page_state[$page_state] ?? null;
+}
+
+function get_Round_for_round_number($round_number)
+{
+    global $activities;
+    return $activities->rounds[$round_number] ?? null;
+}
+
+function get_Round_for_round_id($round_id)
+{
+    global $activities;
+    return $activities->round_for_round_id[$round_id] ?? null;
+}
+
+function get_Round_for_text_column_name($text_column_name)
+{
+    global $activities;
+    foreach ($activities->round_for_round_id as $round_id => $round) {
+        if ($round->text_column_name == $text_column_name) {
+            return $round;
+        }
+    }
+    return null;
+}
+
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-// first define activities
-define_activities();
-
-// then define project states using defined rounds and pools
-define_project_states($Round_for_round_id_, $Pool_for_id_);
-
-// After creating all rounds:
-define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
-assert($n_rounds == MAX_NUM_PAGE_EDITING_ROUNDS);
 
 declare_mentoring_pair('P1', 'P2');
 
@@ -43,329 +440,3 @@ $ELR_round = get_Round_for_round_number(1);
 // then you may have to do some hacking (sorry).
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-function define_activities()
-{
-    global $code_url, $post_processing_forum_idx;
-
-    // $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
-    // what proofreading tools are shown in the toolbox in the proofreading
-    // interface for the proofreading (P) and the formatting (F) rounds. These are
-    // passed into the Round() constructors below. The names refer to ToolButtons
-    // and PopupLink objects defined in pinc/ProofreadingToolbox.inc.
-
-    $pi_tools_for_P = [
-        'popup_links' => ['search_and_replace', 'greek_transliterator', 'hieroglyph_transliterator'],
-        'tool_buttons' => ['remove_markup', 'upper_case', 'title_case', 'lower_case'],
-        'tool_links' => ['greek', 'note', 'brackets', 'braces', 'blank_page'],
-    ];
-    $pi_tools_for_F = [
-        'popup_links' => 'ALL',
-        'tool_buttons' => 'ALL',
-        'tool_links' => 'ALL',
-    ];
-
-    new Round(
-        'P1',
-        _('Proofreading Round 1'),
-        [],
-        'IMMEDIATE',
-        '',
-        null, // access_change_callback
-        _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
-        'proofreading_guidelines.php',
-        $pi_tools_for_P,
-        null, // daily_page_limit
-        [],
-        [
-            0 => _('Novice'),
-            25 => _('Proofreading Pupil'),
-            100 => _('Proofreading Apprentice'),
-            500 => _('Proofreading Scholar'),
-            1000 => _('Proofreading Prodigy'),
-            2500 => _('Proofreading Mastermind'),
-            5000 => _('Proofreading Graduate'),
-            10000 => _('Proofreading Alumnus'),
-            20000 => _('Fellow of Proofreading'),
-            30000 => _('Doctor of Proofreading'),
-            40000 => _('Proofreading Don'),
-            50000 => _('Dean of Proofreading'),
-            60000 => _('Proofreading Proctor'),
-            70000 => _('Principal Proofreader'),
-            80000 => _('Master Proofreader'),
-            90000 => _('Prefect of Proofreaders'),
-            99000 => _('Supervising Proofreader'),
-            100000 => _('Proofreading Professor'),
-            110000 => _('Peer of Proofreading'),
-            120000 => _('Doyen of Proofreading'),
-            130000 => _('Proofreading Chancellor'),
-            140000 => _('Proofreading Primate'),
-            150000 => _('Paramount Proofreader'),
-        ]
-    );
-
-    // -----------------------------------------------------------------------------
-
-    new Round(
-        'P2',
-        _('Proofreading Round 2'),
-        ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
-        'REQ-AUTO',
-        '',
-        null, // access_change_callback
-        _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
-        'proofreading_guidelines.php',
-        $pi_tools_for_P,
-        null, // daily_page_limit
-        ['P1'],
-        [
-            0 => _('Precise Proofreader'),
-            25 => _('Picky Proofreader'),
-            100 => _('Painstaking Proofreader'),
-            500 => _('Punctilious Proofreader'),
-            1000 => _('Persnickety Proofreader'),
-            2500 => _('Particular Proofreader'),
-            5000 => _('Proficient Proofreader'),
-            10000 => _('Proper Proofreader'),
-            20000 => _('Prudent Proofreader'),
-            30000 => _('Proofreading Personage'),
-            40000 => _('Proofreading Poppet'),
-            50000 => _('Plighted Proofreader'),
-            60000 => _('Proofreading Proctor'),
-            70000 => _('Principal Proofreader'),
-            80000 => _('Prime Proofreader'),
-            90000 => _('Primal Proofreader'),
-            99000 => _('Proofreading Personality'),
-            100000 => _('Proofreading Professional'),
-            110000 => _('Peerless Proofreader'),
-            120000 => _('Perspicacious Proofreader'),
-            130000 => _('Paraproofreader'),
-            140000 => _('Proofreading Panjandrum'),
-            150000 => _('Perfectionist Proofreader'),
-        ]
-    );
-
-    // -----------------------------------------------------------------------------
-
-    new Round(
-        'P3',
-        _('Proofreading Round 3'),
-        ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
-        'REQ-HUMAN',
-        _("Once you have met the requirements and requested access to P3, an evaluator will check over at least 50 of your recent P2 pages that have been completed in P3. If you proofread them to P3 standards, you'll be granted access."),
-        null, // access_change_callback
-        _("The page-texts have already been proofread, but now need to be examined <b>closely</b> for small errors that may have been missed."),
-        'proofreading_guidelines.php',
-        $pi_tools_for_P,
-        null, // daily_page_limit
-        ['P1', 'P2'],
-        [
-            0 => _('Specialist Proofreader'),
-            25 => _('Precious Proofreader'),
-            100 => _('Prized Proofreader'),
-            500 => _('Premiere Proofreader'),
-            1000 => _('Proofreading Perfectionist'),
-            2500 => _('Pillar of Proofreading'),
-            5000 => _('Proofreading Purist'),
-            10000 => _('Proofreader of Precision'),
-            20000 => _('Archetypal Proofreader'),
-            30000 => _('Proofreading Nonpareil'),
-            40000 => _('Paradigmatic Proofreader'),
-            50000 => _('Preeminent Proofreader'),
-            60000 => _('Prime Proofreader'),
-            70000 => _('Proofreader of Plenariness'),
-            80000 => _('Perpetual Proofreader'),
-            90000 => _('Prefect of Proofreaders'),
-            99000 => _('Impeccable Proofreader'),
-            100000 => _('Proofreader of Persistence'),
-            110000 => _('Patent Proofreader'),
-            120000 => _('Proofreading Philosopher'),
-            130000 => _('Patron of Proofreaders'),
-            140000 => _('Proofreading Partner'),
-            150000 => _('Pioneer of Proofreaders'),
-        ]
-    );
-
-    // -----------------------------------------------------------------------------
-
-    new Round(
-        'F1',
-        _('Formatting Round 1'),
-        ['P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1],
-        'REQ-AUTO',
-        '',
-        null, // access_change_callback
-        _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),
-        'formatting_guidelines.php',
-        $pi_tools_for_F,
-        null, // daily_page_limit
-        [],
-        [
-            0 => _('Formatting Neophyte'),
-            25 => _('Formatting Intern'),
-            100 => _('Journeyman Formatter'),
-            500 => _('Crafter of Texts'),
-            1000 => _('Detailer of Books'),
-            2500 => _('Fastidious Formatter'),
-            5000 => _('Foremost Formatter'),
-            10000 => _('Fine Formatter'),
-            20000 => _('Flamboyant Formatter'),
-            30000 => _('Fabulous Formatter'),
-            40000 => _('Upgrader of Texts'),
-            50000 => _('Famous Formatter'),
-            60000 => _('Indefatigable Formatter'),
-            70000 => _('Finisher of Texts'),
-            80000 => _('Formatter of Choice'),
-            90000 => _('Capital Formatter'),
-            99000 => _('Formatter with Flair'),
-            100000 => _('Formatter of Finesse'),
-            110000 => _('Formatter with Forte'),
-            120000 => _('First-Class Formatter'),
-            130000 => _('Formatter of Favour'),
-            140000 => _('Formatter of Refinement'),
-            150000 => _('Flawless Formatter'),
-        ]
-    );
-
-    // -----------------------------------------------------------------------------
-
-    new Round(
-        'F2',
-        _('Formatting Round 2'),
-        ['F1' => 400, 'days since reg' => 91], // 'F1' => 1000, 3 months after rollout
-        'REQ-HUMAN', // "peer approval"
-        _("Once you have met the requirements and requested access to F2, an evaluator will check over at least 150 of your recent F1 pages that have been completed in F2. If they've been formatted to F2 standards, you'll be granted access."),
-        null, // access_change_callback
-        _("The page-texts in this round need to be carefully checked to remove any remaining formatting errors."),
-        'formatting_guidelines.php',
-        $pi_tools_for_F,
-        null, // daily_page_limit
-        ['F1'],
-        [
-            0 => _('Refurbisher of Texts'),
-            25 => _('Sprucer of Texts'),
-            100 => _('Formatter Savant'),
-            500 => _('Formatting Wunderkind'),
-            1000 => _('Elite Formatter'),
-            2500 => _('Polisher of Texts'),
-            5000 => _('Formatting Artiste'),
-            10000 => _('Cultivator of Texts'),
-            20000 => _('Formatter of Enrichment'),
-            30000 => _('Designing Formatter'),
-            40000 => _('Formatting Artisan'),
-            50000 => _('Formatting Aficionado'),
-            60000 => _('Guru of Formatters'),
-            70000 => _('Formatting Familiar'),
-            80000 => _('Formatting Virtuoso'),
-            90000 => _('Formatter of Excellence'),
-            99000 => _('Exquisite Formatter'),
-            100000 => _('Formatting Specialist'),
-            110000 => _('Formatting Genius'),
-            120000 => _('Formatter of Fine Feats'),
-            130000 => _('Harmoniser of Texts'),
-            140000 => _('Formatting Architect'),
-            150000 => _('Preserver of Texts'),
-        ]
-    );
-
-    new Pool(
-        'PP',
-        _('Post-Processing'),
-        ['F1' => 400],
-        'REQ-AUTO',
-        '',
-        null, // access_change_callback
-        _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
-        'post_proof.php',
-        _("Manager"),
-        'username',
-        [
-            "<p>",
-            "<b>" . _("First Time Here?") . "</b>",
-            sprintf(
-                _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
-                "$code_url/faq/post_proof.php"
-            ),
-            _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
-            sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
-            _("If nothing interests you right now, check back later and there will be more!"),
-            "</p>",
-
-            "<p>",
-            _("Each book listed below has gone through multiple rounds of proofreading and formatting, and now needs to be massaged into a final e-text."),
-            _("Once you have checked out and downloaded a book it will remain checked out to you until you check it back in."),
-            _("When you have finished your work on the book, select <i>Upload for Verification</i> from the drop-down list for that project."),
-            _("If you have several files to submit for a single project (say a text and HTML version), zip them up together first."),
-            "</p>",
-        ]
-    );
-
-    // -----------------------------------------------------------------------------
-
-    new Stage(
-        'SR',
-        _('Smooth Reading'),
-        [],
-        'IMMEDIATE',
-        '',
-        null, // access_change_callback
-        _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
-        null,
-        "tools/post_proofers/smooth_reading.php"
-    );
-
-    // -----------------------------------------------------------------------------
-
-    new Pool(
-        'PPV',
-        _('Post-Processing Verification'),
-        [],
-        'NOREQ', // "Peer approval. Also gives F2 access."
-        '',
-        null, // access_change_callback
-        _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
-        'ppv.php',
-        _("Post-Processor"),
-        'postproofer',
-        [
-            "<p>",
-            _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
-            sprintf(
-                _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
-                "$code_url/faq/ppv.php"
-            ),
-            sprintf(
-                _("The PPV reporting form is <a href='%s'>here</a>."),
-                "$code_url/tools/post_proofers/ppv_report.php"
-            ),
-            "</p>",
-
-            "<p>",
-            sprintf(
-                _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
-                get_url_to_view_forum($post_processing_forum_idx)
-            ),
-            "</p>",
-        ]
-    );
-
-    // -----------------------------------------------------------------------------
-
-    new Activity(
-        'DU',
-        _('Uploading to Project Gutenberg'),
-        [],
-        'NOREQ',
-        'OOGA',
-        null // access_change_callback
-    );
-
-    new Activity(
-        "P2_mentor",
-        sprintf(_("Mentoring in round %s"), 'P2'),
-        [],
-        'NOREQ',
-        '',
-        null // access_change_callback
-    );
-}

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -13,20 +13,17 @@ include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// first define rounds
-define_rounds();
+// first define activities
+define_activities();
 
-// then define project states using defined rounds
-define_project_states($Round_for_round_id_);
+// then define project states using defined rounds and pools
+define_project_states($Round_for_round_id_, $Pool_for_id_);
 
 // After creating all rounds:
 define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
 assert($n_rounds == MAX_NUM_PAGE_EDITING_ROUNDS);
 
 declare_mentoring_pair('P1', 'P2');
-
-// other activities depend on constants from define_project_states()
-define_other_activities();
 
 // -----------------------------------------------------------------------------
 
@@ -47,7 +44,7 @@ $ELR_round = get_Round_for_round_number(1);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function define_rounds()
+function define_activities()
 {
     // $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
     // what proofreading tools are shown in the toolbox in the proofreading
@@ -268,10 +265,7 @@ function define_rounds()
             150000 => _('Preserver of Texts'),
         ]
     );
-}
 
-function define_other_activities()
-{
     global $code_url, $post_processing_forum_idx, $post_processing_forum_idx;
 
     new Pool(
@@ -283,8 +277,11 @@ function define_other_activities()
         null, // access_change_callback
         _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
         'post_proof.php',
-        PROJ_POST_FIRST_CHECKED_OUT,
-        PROJ_POST_FIRST_AVAILABLE,
+        "first",
+        _("Available for PP"),
+        _("Available for Post-Processing"),
+        _("In PP"),
+        _("In Post-Processing"),
         _("Manager"),
         'username',
         [
@@ -333,8 +330,11 @@ function define_other_activities()
         null, // access_change_callback
         _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
         'ppv.php',
-        PROJ_POST_SECOND_CHECKED_OUT,
-        PROJ_POST_SECOND_AVAILABLE,
+        'second',
+        _("Available for PPV"),
+        _("Available for Verifying Post-Processing"),
+        _("In PPV"),
+        _("Verifying Post-Processing"),
         _("Post-Processor"),
         'postproofer',
         [

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -30,14 +30,6 @@ class Activities
         'tool_links' => 'ALL',
     ];
 
-    private const page_state_codes = [
-        "page_avail_state" => "avail",
-        "page_out_state" => "out",
-        "page_temp_state" => "temp",
-        "page_save_state" => "saved",
-        "page_bad_state" => "bad",
-    ];
-
     public function __construct()
     {
         global $code_url, $post_processing_forum_idx;
@@ -380,20 +372,15 @@ class Activities
     {
         $this->round_for_id[$round->id] = $round;
         $this->round_for_number[$round->round_number] = $round;
+        $this->add_stage($round);
 
-        foreach(self::page_state_codes as $page_state => $state_code) {
-
-            // e.g. $P1->page_avail_state = "P1.page_avail"
-            $round->$page_state = "{$round->id}.page_$state_code";
-
+        foreach($round->get_page_states() as $page_state) {
             // e.g. $activities->round_for_page_state["P1.page_avail"] = $P1;
-            $this->round_for_page_state[$round->$page_state] = $round;
+            $this->round_for_page_state[$page_state] = $round;
 
             // e.g. $activities->page_states[0] = "P1.page_avail"
-            $this->page_states[] = $round->$page_state;
+            $this->page_states[] = $page_state;
         }
-
-        $this->add_stage($round);
     }
 
     function add_pool($pool)

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -13,236 +13,20 @@ include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
-// what proofreading tools are shown in the toolbox in the proofreading
-// interface for the proofreading (P) and the formatting (F) rounds. These are
-// passed into the Round() constructors below. The names refer to ToolButtons
-// and PopupLink objects defined in pinc/ProofreadingToolbox.inc.
+// first define rounds
+define_rounds();
 
-$pi_tools_for_P = [
-    'popup_links' => ['search_and_replace', 'greek_transliterator', 'hieroglyph_transliterator'],
-    'tool_buttons' => ['remove_markup', 'upper_case', 'title_case', 'lower_case'],
-    'tool_links' => ['greek', 'note', 'brackets', 'braces', 'blank_page'],
-];
-$pi_tools_for_F = [
-    'popup_links' => 'ALL',
-    'tool_buttons' => 'ALL',
-    'tool_links' => 'ALL',
-];
-
-new Round(
-    'P1',
-    _('Proofreading Round 1'),
-    [],
-    'IMMEDIATE',
-    '',
-    null, // access_change_callback
-    _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
-    'proofreading_guidelines.php',
-    $pi_tools_for_P,
-    null, // daily_page_limit
-    [],
-    [
-        0 => _('Novice'),
-        25 => _('Proofreading Pupil'),
-        100 => _('Proofreading Apprentice'),
-        500 => _('Proofreading Scholar'),
-        1000 => _('Proofreading Prodigy'),
-        2500 => _('Proofreading Mastermind'),
-        5000 => _('Proofreading Graduate'),
-        10000 => _('Proofreading Alumnus'),
-        20000 => _('Fellow of Proofreading'),
-        30000 => _('Doctor of Proofreading'),
-        40000 => _('Proofreading Don'),
-        50000 => _('Dean of Proofreading'),
-        60000 => _('Proofreading Proctor'),
-        70000 => _('Principal Proofreader'),
-        80000 => _('Master Proofreader'),
-        90000 => _('Prefect of Proofreaders'),
-        99000 => _('Supervising Proofreader'),
-        100000 => _('Proofreading Professor'),
-        110000 => _('Peer of Proofreading'),
-        120000 => _('Doyen of Proofreading'),
-        130000 => _('Proofreading Chancellor'),
-        140000 => _('Proofreading Primate'),
-        150000 => _('Paramount Proofreader'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'P2',
-    _('Proofreading Round 2'),
-    ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
-    'REQ-AUTO',
-    '',
-    null, // access_change_callback
-    _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
-    'proofreading_guidelines.php',
-    $pi_tools_for_P,
-    null, // daily_page_limit
-    ['P1'],
-    [
-        0 => _('Precise Proofreader'),
-        25 => _('Picky Proofreader'),
-        100 => _('Painstaking Proofreader'),
-        500 => _('Punctilious Proofreader'),
-        1000 => _('Persnickety Proofreader'),
-        2500 => _('Particular Proofreader'),
-        5000 => _('Proficient Proofreader'),
-        10000 => _('Proper Proofreader'),
-        20000 => _('Prudent Proofreader'),
-        30000 => _('Proofreading Personage'),
-        40000 => _('Proofreading Poppet'),
-        50000 => _('Plighted Proofreader'),
-        60000 => _('Proofreading Proctor'),
-        70000 => _('Principal Proofreader'),
-        80000 => _('Prime Proofreader'),
-        90000 => _('Primal Proofreader'),
-        99000 => _('Proofreading Personality'),
-        100000 => _('Proofreading Professional'),
-        110000 => _('Peerless Proofreader'),
-        120000 => _('Perspicacious Proofreader'),
-        130000 => _('Paraproofreader'),
-        140000 => _('Proofreading Panjandrum'),
-        150000 => _('Perfectionist Proofreader'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'P3',
-    _('Proofreading Round 3'),
-    ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
-    'REQ-HUMAN',
-    _("Once you have met the requirements and requested access to P3, an evaluator will check over at least 50 of your recent P2 pages that have been completed in P3. If you proofread them to P3 standards, you'll be granted access."),
-    null, // access_change_callback
-    _("The page-texts have already been proofread, but now need to be examined <b>closely</b> for small errors that may have been missed."),
-    'proofreading_guidelines.php',
-    $pi_tools_for_P,
-    null, // daily_page_limit
-    ['P1', 'P2'],
-    [
-        0 => _('Specialist Proofreader'),
-        25 => _('Precious Proofreader'),
-        100 => _('Prized Proofreader'),
-        500 => _('Premiere Proofreader'),
-        1000 => _('Proofreading Perfectionist'),
-        2500 => _('Pillar of Proofreading'),
-        5000 => _('Proofreading Purist'),
-        10000 => _('Proofreader of Precision'),
-        20000 => _('Archetypal Proofreader'),
-        30000 => _('Proofreading Nonpareil'),
-        40000 => _('Paradigmatic Proofreader'),
-        50000 => _('Preeminent Proofreader'),
-        60000 => _('Prime Proofreader'),
-        70000 => _('Proofreader of Plenariness'),
-        80000 => _('Perpetual Proofreader'),
-        90000 => _('Prefect of Proofreaders'),
-        99000 => _('Impeccable Proofreader'),
-        100000 => _('Proofreader of Persistence'),
-        110000 => _('Patent Proofreader'),
-        120000 => _('Proofreading Philosopher'),
-        130000 => _('Patron of Proofreaders'),
-        140000 => _('Proofreading Partner'),
-        150000 => _('Pioneer of Proofreaders'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'F1',
-    _('Formatting Round 1'),
-    ['P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1],
-    'REQ-AUTO',
-    '',
-    null, // access_change_callback
-    _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),
-    'formatting_guidelines.php',
-    $pi_tools_for_F,
-    null, // daily_page_limit
-    [],
-    [
-        0 => _('Formatting Neophyte'),
-        25 => _('Formatting Intern'),
-        100 => _('Journeyman Formatter'),
-        500 => _('Crafter of Texts'),
-        1000 => _('Detailer of Books'),
-        2500 => _('Fastidious Formatter'),
-        5000 => _('Foremost Formatter'),
-        10000 => _('Fine Formatter'),
-        20000 => _('Flamboyant Formatter'),
-        30000 => _('Fabulous Formatter'),
-        40000 => _('Upgrader of Texts'),
-        50000 => _('Famous Formatter'),
-        60000 => _('Indefatigable Formatter'),
-        70000 => _('Finisher of Texts'),
-        80000 => _('Formatter of Choice'),
-        90000 => _('Capital Formatter'),
-        99000 => _('Formatter with Flair'),
-        100000 => _('Formatter of Finesse'),
-        110000 => _('Formatter with Forte'),
-        120000 => _('First-Class Formatter'),
-        130000 => _('Formatter of Favour'),
-        140000 => _('Formatter of Refinement'),
-        150000 => _('Flawless Formatter'),
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-new Round(
-    'F2',
-    _('Formatting Round 2'),
-    ['F1' => 400, 'days since reg' => 91], // 'F1' => 1000, 3 months after rollout
-    'REQ-HUMAN', // "peer approval"
-    _("Once you have met the requirements and requested access to F2, an evaluator will check over at least 150 of your recent F1 pages that have been completed in F2. If they've been formatted to F2 standards, you'll be granted access."),
-    null, // access_change_callback
-    _("The page-texts in this round need to be carefully checked to remove any remaining formatting errors."),
-    'formatting_guidelines.php',
-    $pi_tools_for_F,
-    null, // daily_page_limit
-    ['F1'],
-    [
-        0 => _('Refurbisher of Texts'),
-        25 => _('Sprucer of Texts'),
-        100 => _('Formatter Savant'),
-        500 => _('Formatting Wunderkind'),
-        1000 => _('Elite Formatter'),
-        2500 => _('Polisher of Texts'),
-        5000 => _('Formatting Artiste'),
-        10000 => _('Cultivator of Texts'),
-        20000 => _('Formatter of Enrichment'),
-        30000 => _('Designing Formatter'),
-        40000 => _('Formatting Artisan'),
-        50000 => _('Formatting Aficionado'),
-        60000 => _('Guru of Formatters'),
-        70000 => _('Formatting Familiar'),
-        80000 => _('Formatting Virtuoso'),
-        90000 => _('Formatter of Excellence'),
-        99000 => _('Exquisite Formatter'),
-        100000 => _('Formatting Specialist'),
-        110000 => _('Formatting Genius'),
-        120000 => _('Formatter of Fine Feats'),
-        130000 => _('Harmoniser of Texts'),
-        140000 => _('Formatting Architect'),
-        150000 => _('Preserver of Texts'),
-    ]
-);
-
-// ---------------------------
+// then define project states using defined rounds
+define_project_states($Round_for_round_id_);
 
 // After creating all rounds:
-
 define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
 assert($n_rounds == MAX_NUM_PAGE_EDITING_ROUNDS);
 
-// ---------------------------
-
 declare_mentoring_pair('P1', 'P2');
+
+// other activities depend on constants from define_project_states()
+define_other_activities();
 
 // -----------------------------------------------------------------------------
 
@@ -261,110 +45,337 @@ $ELR_round = get_Round_for_round_number(1);
 // round (e.g., everyone can work in multiple rounds from their first day),
 // then you may have to do some hacking (sorry).
 
-
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-new Pool(
-    'PP',
-    _('Post-Processing'),
-    ['F1' => 400],
-    'REQ-AUTO',
-    '',
-    null, // access_change_callback
-    _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
-    'post_proof.php',
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_FIRST_AVAILABLE,
-    _("Manager"),
-    'username',
-    [
-        "<p>",
-        "<b>" . _("First Time Here?") . "</b>",
-        sprintf(
-            _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
-            "$code_url/faq/post_proof.php"
-        ),
-        _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
-        sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
-        _("If nothing interests you right now, check back later and there will be more!"),
-        "</p>",
+function define_rounds()
+{
+    // $pi_tools_for_P and $pi_tools_for_F are handy helper variables that define
+    // what proofreading tools are shown in the toolbox in the proofreading
+    // interface for the proofreading (P) and the formatting (F) rounds. These are
+    // passed into the Round() constructors below. The names refer to ToolButtons
+    // and PopupLink objects defined in pinc/ProofreadingToolbox.inc.
 
-        "<p>",
-        _("Each book listed below has gone through multiple rounds of proofreading and formatting, and now needs to be massaged into a final e-text."),
-        _("Once you have checked out and downloaded a book it will remain checked out to you until you check it back in."),
-        _("When you have finished your work on the book, select <i>Upload for Verification</i> from the drop-down list for that project."),
-        _("If you have several files to submit for a single project (say a text and HTML version), zip them up together first."),
-        "</p>",
-    ]
-);
+    $pi_tools_for_P = [
+        'popup_links' => ['search_and_replace', 'greek_transliterator', 'hieroglyph_transliterator'],
+        'tool_buttons' => ['remove_markup', 'upper_case', 'title_case', 'lower_case'],
+        'tool_links' => ['greek', 'note', 'brackets', 'braces', 'blank_page'],
+    ];
+    $pi_tools_for_F = [
+        'popup_links' => 'ALL',
+        'tool_buttons' => 'ALL',
+        'tool_links' => 'ALL',
+    ];
 
-// -----------------------------------------------------------------------------
+    new Round(
+        'P1',
+        _('Proofreading Round 1'),
+        [],
+        'IMMEDIATE',
+        '',
+        null, // access_change_callback
+        _("The page-texts are the output from OCR software and need to have the text carefully compared to the image."),
+        'proofreading_guidelines.php',
+        $pi_tools_for_P,
+        null, // daily_page_limit
+        [],
+        [
+            0 => _('Novice'),
+            25 => _('Proofreading Pupil'),
+            100 => _('Proofreading Apprentice'),
+            500 => _('Proofreading Scholar'),
+            1000 => _('Proofreading Prodigy'),
+            2500 => _('Proofreading Mastermind'),
+            5000 => _('Proofreading Graduate'),
+            10000 => _('Proofreading Alumnus'),
+            20000 => _('Fellow of Proofreading'),
+            30000 => _('Doctor of Proofreading'),
+            40000 => _('Proofreading Don'),
+            50000 => _('Dean of Proofreading'),
+            60000 => _('Proofreading Proctor'),
+            70000 => _('Principal Proofreader'),
+            80000 => _('Master Proofreader'),
+            90000 => _('Prefect of Proofreaders'),
+            99000 => _('Supervising Proofreader'),
+            100000 => _('Proofreading Professor'),
+            110000 => _('Peer of Proofreading'),
+            120000 => _('Doyen of Proofreading'),
+            130000 => _('Proofreading Chancellor'),
+            140000 => _('Proofreading Primate'),
+            150000 => _('Paramount Proofreader'),
+        ]
+    );
 
-new Stage(
-    'SR',
-    _('Smooth Reading'),
-    [],
-    'IMMEDIATE',
-    '',
-    null, // access_change_callback
-    _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
-    null,
-    "tools/post_proofers/smooth_reading.php"
-);
+    // -----------------------------------------------------------------------------
 
-// -----------------------------------------------------------------------------
+    new Round(
+        'P2',
+        _('Proofreading Round 2'),
+        ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
+        'REQ-AUTO',
+        '',
+        null, // access_change_callback
+        _("The page-texts have already been proofread, and now need to have the text WordChecked and carefully compared to the image."),
+        'proofreading_guidelines.php',
+        $pi_tools_for_P,
+        null, // daily_page_limit
+        ['P1'],
+        [
+            0 => _('Precise Proofreader'),
+            25 => _('Picky Proofreader'),
+            100 => _('Painstaking Proofreader'),
+            500 => _('Punctilious Proofreader'),
+            1000 => _('Persnickety Proofreader'),
+            2500 => _('Particular Proofreader'),
+            5000 => _('Proficient Proofreader'),
+            10000 => _('Proper Proofreader'),
+            20000 => _('Prudent Proofreader'),
+            30000 => _('Proofreading Personage'),
+            40000 => _('Proofreading Poppet'),
+            50000 => _('Plighted Proofreader'),
+            60000 => _('Proofreading Proctor'),
+            70000 => _('Principal Proofreader'),
+            80000 => _('Prime Proofreader'),
+            90000 => _('Primal Proofreader'),
+            99000 => _('Proofreading Personality'),
+            100000 => _('Proofreading Professional'),
+            110000 => _('Peerless Proofreader'),
+            120000 => _('Perspicacious Proofreader'),
+            130000 => _('Paraproofreader'),
+            140000 => _('Proofreading Panjandrum'),
+            150000 => _('Perfectionist Proofreader'),
+        ]
+    );
 
-new Pool(
-    'PPV',
-    _('Post-Processing Verification'),
-    [],
-    'NOREQ', // "Peer approval. Also gives F2 access."
-    '',
-    null, // access_change_callback
-    _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
-    'ppv.php',
-    PROJ_POST_SECOND_CHECKED_OUT,
-    PROJ_POST_SECOND_AVAILABLE,
-    _("Post-Processor"),
-    'postproofer',
-    [
-        "<p>",
-        _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
-        sprintf(
-            _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
-            "$code_url/faq/ppv.php"
-        ),
-        sprintf(
-            _("The PPV reporting form is <a href='%s'>here</a>."),
-            "$code_url/tools/post_proofers/ppv_report.php"
-        ),
-        "</p>",
+    // -----------------------------------------------------------------------------
 
-        "<p>",
-        sprintf(
-            _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
-            get_url_to_view_forum($post_processing_forum_idx)
-        ),
-        "</p>",
-    ]
-);
+    new Round(
+        'P3',
+        _('Proofreading Round 3'),
+        ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
+        'REQ-HUMAN',
+        _("Once you have met the requirements and requested access to P3, an evaluator will check over at least 50 of your recent P2 pages that have been completed in P3. If you proofread them to P3 standards, you'll be granted access."),
+        null, // access_change_callback
+        _("The page-texts have already been proofread, but now need to be examined <b>closely</b> for small errors that may have been missed."),
+        'proofreading_guidelines.php',
+        $pi_tools_for_P,
+        null, // daily_page_limit
+        ['P1', 'P2'],
+        [
+            0 => _('Specialist Proofreader'),
+            25 => _('Precious Proofreader'),
+            100 => _('Prized Proofreader'),
+            500 => _('Premiere Proofreader'),
+            1000 => _('Proofreading Perfectionist'),
+            2500 => _('Pillar of Proofreading'),
+            5000 => _('Proofreading Purist'),
+            10000 => _('Proofreader of Precision'),
+            20000 => _('Archetypal Proofreader'),
+            30000 => _('Proofreading Nonpareil'),
+            40000 => _('Paradigmatic Proofreader'),
+            50000 => _('Preeminent Proofreader'),
+            60000 => _('Prime Proofreader'),
+            70000 => _('Proofreader of Plenariness'),
+            80000 => _('Perpetual Proofreader'),
+            90000 => _('Prefect of Proofreaders'),
+            99000 => _('Impeccable Proofreader'),
+            100000 => _('Proofreader of Persistence'),
+            110000 => _('Patent Proofreader'),
+            120000 => _('Proofreading Philosopher'),
+            130000 => _('Patron of Proofreaders'),
+            140000 => _('Proofreading Partner'),
+            150000 => _('Pioneer of Proofreaders'),
+        ]
+    );
 
-// -----------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------
 
-new Activity(
-    'DU',
-    _('Uploading to Project Gutenberg'),
-    [],
-    'NOREQ',
-    'OOGA',
-    null // access_change_callback
-);
+    new Round(
+        'F1',
+        _('Formatting Round 1'),
+        ['P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1],
+        'REQ-AUTO',
+        '',
+        null, // access_change_callback
+        _("The page-texts have already been proofread, but now need to be formatted with markup which may be specific to the project."),
+        'formatting_guidelines.php',
+        $pi_tools_for_F,
+        null, // daily_page_limit
+        [],
+        [
+            0 => _('Formatting Neophyte'),
+            25 => _('Formatting Intern'),
+            100 => _('Journeyman Formatter'),
+            500 => _('Crafter of Texts'),
+            1000 => _('Detailer of Books'),
+            2500 => _('Fastidious Formatter'),
+            5000 => _('Foremost Formatter'),
+            10000 => _('Fine Formatter'),
+            20000 => _('Flamboyant Formatter'),
+            30000 => _('Fabulous Formatter'),
+            40000 => _('Upgrader of Texts'),
+            50000 => _('Famous Formatter'),
+            60000 => _('Indefatigable Formatter'),
+            70000 => _('Finisher of Texts'),
+            80000 => _('Formatter of Choice'),
+            90000 => _('Capital Formatter'),
+            99000 => _('Formatter with Flair'),
+            100000 => _('Formatter of Finesse'),
+            110000 => _('Formatter with Forte'),
+            120000 => _('First-Class Formatter'),
+            130000 => _('Formatter of Favour'),
+            140000 => _('Formatter of Refinement'),
+            150000 => _('Flawless Formatter'),
+        ]
+    );
 
-new Activity(
-    "P2_mentor",
-    sprintf(_("Mentoring in round %s"), 'P2'),
-    [],
-    'NOREQ',
-    '',
-    null // access_change_callback
-);
+    // -----------------------------------------------------------------------------
+
+    new Round(
+        'F2',
+        _('Formatting Round 2'),
+        ['F1' => 400, 'days since reg' => 91], // 'F1' => 1000, 3 months after rollout
+        'REQ-HUMAN', // "peer approval"
+        _("Once you have met the requirements and requested access to F2, an evaluator will check over at least 150 of your recent F1 pages that have been completed in F2. If they've been formatted to F2 standards, you'll be granted access."),
+        null, // access_change_callback
+        _("The page-texts in this round need to be carefully checked to remove any remaining formatting errors."),
+        'formatting_guidelines.php',
+        $pi_tools_for_F,
+        null, // daily_page_limit
+        ['F1'],
+        [
+            0 => _('Refurbisher of Texts'),
+            25 => _('Sprucer of Texts'),
+            100 => _('Formatter Savant'),
+            500 => _('Formatting Wunderkind'),
+            1000 => _('Elite Formatter'),
+            2500 => _('Polisher of Texts'),
+            5000 => _('Formatting Artiste'),
+            10000 => _('Cultivator of Texts'),
+            20000 => _('Formatter of Enrichment'),
+            30000 => _('Designing Formatter'),
+            40000 => _('Formatting Artisan'),
+            50000 => _('Formatting Aficionado'),
+            60000 => _('Guru of Formatters'),
+            70000 => _('Formatting Familiar'),
+            80000 => _('Formatting Virtuoso'),
+            90000 => _('Formatter of Excellence'),
+            99000 => _('Exquisite Formatter'),
+            100000 => _('Formatting Specialist'),
+            110000 => _('Formatting Genius'),
+            120000 => _('Formatter of Fine Feats'),
+            130000 => _('Harmoniser of Texts'),
+            140000 => _('Formatting Architect'),
+            150000 => _('Preserver of Texts'),
+        ]
+    );
+}
+
+function define_other_activities()
+{
+    global $code_url, $post_processing_forum_idx, $post_processing_forum_idx;
+
+    new Pool(
+        'PP',
+        _('Post-Processing'),
+        ['F1' => 400],
+        'REQ-AUTO',
+        '',
+        null, // access_change_callback
+        _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
+        'post_proof.php',
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_FIRST_AVAILABLE,
+        _("Manager"),
+        'username',
+        [
+            "<p>",
+            "<b>" . _("First Time Here?") . "</b>",
+            sprintf(
+                _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
+                "$code_url/faq/post_proof.php"
+            ),
+            _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
+            sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
+            _("If nothing interests you right now, check back later and there will be more!"),
+            "</p>",
+
+            "<p>",
+            _("Each book listed below has gone through multiple rounds of proofreading and formatting, and now needs to be massaged into a final e-text."),
+            _("Once you have checked out and downloaded a book it will remain checked out to you until you check it back in."),
+            _("When you have finished your work on the book, select <i>Upload for Verification</i> from the drop-down list for that project."),
+            _("If you have several files to submit for a single project (say a text and HTML version), zip them up together first."),
+            "</p>",
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+
+    new Stage(
+        'SR',
+        _('Smooth Reading'),
+        [],
+        'IMMEDIATE',
+        '',
+        null, // access_change_callback
+        _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
+        null,
+        "tools/post_proofers/smooth_reading.php"
+    );
+
+    // -----------------------------------------------------------------------------
+
+    new Pool(
+        'PPV',
+        _('Post-Processing Verification'),
+        [],
+        'NOREQ', // "Peer approval. Also gives F2 access."
+        '',
+        null, // access_change_callback
+        _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
+        'ppv.php',
+        PROJ_POST_SECOND_CHECKED_OUT,
+        PROJ_POST_SECOND_AVAILABLE,
+        _("Post-Processor"),
+        'postproofer',
+        [
+            "<p>",
+            _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
+            sprintf(
+                _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
+                "$code_url/faq/ppv.php"
+            ),
+            sprintf(
+                _("The PPV reporting form is <a href='%s'>here</a>."),
+                "$code_url/tools/post_proofers/ppv_report.php"
+            ),
+            "</p>",
+
+            "<p>",
+            sprintf(
+                _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
+                get_url_to_view_forum($post_processing_forum_idx)
+            ),
+            "</p>",
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+
+    new Activity(
+        'DU',
+        _('Uploading to Project Gutenberg'),
+        [],
+        'NOREQ',
+        'OOGA',
+        null // access_change_callback
+    );
+
+    new Activity(
+        "P2_mentor",
+        sprintf(_("Mentoring in round %s"), 'P2'),
+        [],
+        'NOREQ',
+        '',
+        null // access_change_callback
+    );
+}

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -42,9 +42,17 @@ class Activities
     {
         global $code_url, $post_processing_forum_idx;
 
-        $round_number = 0;
-        $this->rounds[++$round_number] = new Round(
-            $round_number,
+        $this->access_criteria = [
+            'days since reg' => _('Days since registration'),
+            'quiz/p_basic' => sprintf(_('Up-to-date completion of the <a href="%1$s">Basic Proofreading Quiz</a>'), "$code_url/quiz/start.php?show_level=P_BASIC"),
+            'quiz/p_mod1' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 1),
+            'quiz/p_mod2' => sprintf(_('Up-to-date completion of the <a href="%1$s">Moderate Proofreading Quiz, Part %2$d</a>'), "$code_url/quiz/start.php?show_level=P_MOD", 2),
+            'quiz/f_only' => sprintf(_("Up-to-date completion of the <a href='%s'>Formatting Quiz</a>"), "$code_url/quiz/start.php?show_only=format"),
+        ];
+
+        $this->round_number = 0;
+        $this->add_round(new Round(
+            ++$this->round_number,
             'P1',
             _('Proofreading Round 1'),
             [],
@@ -81,12 +89,12 @@ class Activities
                 140000 => _('Proofreading Primate'),
                 150000 => _('Paramount Proofreader'),
             ]
-        );
+        ));
 
         // -----------------------------------------------------------------------------
 
-        $this->rounds[++$round_number] = new Round(
-            $round_number,
+        $this->add_round(new Round(
+            ++$this->round_number,
             'P2',
             _('Proofreading Round 2'),
             ['P1' => 300, 'days since reg' => 21, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1],
@@ -123,12 +131,12 @@ class Activities
                 140000 => _('Proofreading Panjandrum'),
                 150000 => _('Perfectionist Proofreader'),
             ]
-        );
+        ));
 
         // -----------------------------------------------------------------------------
 
-        $this->rounds[++$round_number] = new Round(
-            $round_number,
+        $this->add_round(new Round(
+            ++$this->round_number,
             'P3',
             _('Proofreading Round 3'),
             ['P2' => 150, 'F1' => 50, 'days since reg' => 42, 'quiz/p_basic' => 1, 'quiz/p_mod1' => 1, 'quiz/p_mod2' => 1],
@@ -165,12 +173,12 @@ class Activities
                 140000 => _('Proofreading Partner'),
                 150000 => _('Pioneer of Proofreaders'),
             ]
-        );
+        ));
 
         // -----------------------------------------------------------------------------
 
-        $this->rounds[++$round_number] = new Round(
-            $round_number,
+        $this->add_round(new Round(
+            ++$this->round_number,
             'F1',
             _('Formatting Round 1'),
             ['P1' => 300, 'days since reg' => 21, 'quiz/f_only' => 1],
@@ -207,12 +215,12 @@ class Activities
                 140000 => _('Formatter of Refinement'),
                 150000 => _('Flawless Formatter'),
             ]
-        );
+        ));
 
         // -----------------------------------------------------------------------------
 
-        $this->rounds[++$round_number] = new Round(
-            $round_number,
+        $this->add_round(new Round(
+            ++$this->round_number,
             'F2',
             _('Formatting Round 2'),
             ['F1' => 400, 'days since reg' => 91], // 'F1' => 1000, 3 months after rollout
@@ -249,31 +257,13 @@ class Activities
                 140000 => _('Formatting Architect'),
                 150000 => _('Preserver of Texts'),
             ]
-        );
+        ));
 
         // After creating all rounds:
         define('MAX_NUM_PAGE_EDITING_ROUNDS', 5);
-        assert($round_number == MAX_NUM_PAGE_EDITING_ROUNDS);
+        assert($this->round_number == MAX_NUM_PAGE_EDITING_ROUNDS);
 
-        foreach($this->rounds as $round) {
-
-            // e.g. $activities->round_for_round_id["P1"] = $P1;
-            $this->round_for_round_id[$round->id] = $round;
-
-            foreach(self::page_state_codes as $page_state => $state_code) {
-
-                // e.g. $P1->page_avail_state = "P1.page_avail"
-                $round->$page_state = "{$round->id}.page_$state_code";
-
-                // e.g. $activities->round_for_page_state["P1.page_avail"] = $P1;
-                $this->round_for_page_state[$round->$page_state] = $round;
-
-                // e.g. $activities->page_sates[0] = "P1.page_avail"
-                $this->page_states[] = $round->$page_state;
-            }
-        }
-
-        $this->pools[] = new Pool(
+        $this->add_pool(new Pool(
             'PP',
             _('Post-Processing'),
             ['F1' => 400],
@@ -303,11 +293,11 @@ class Activities
                 _("If you have several files to submit for a single project (say a text and HTML version), zip them up together first."),
                 "</p>",
             ]
-        );
+        ));
 
         // -----------------------------------------------------------------------------
 
-        new Stage(
+        $this->add_stage(new Stage(
             'SR',
             _('Smooth Reading'),
             [],
@@ -317,11 +307,11 @@ class Activities
             _('Before a final e-text is posted to PG, it can be optionally uploaded for Smooth Reading. Anyone can volunteer to Smooth Read a text, which involves reading through the text for smoothness, marking possible errors and returning it to the PPer.'),
             null,
             "tools/post_proofers/smooth_reading.php"
-        );
+        ));
 
         // -----------------------------------------------------------------------------
 
-        $this->pools[] = new Pool(
+        $this->add_pool(new Pool(
             'PPV',
             _('Post-Processing Verification'),
             [],
@@ -352,41 +342,77 @@ class Activities
                 ),
                 "</p>",
             ]
-        );
+        ));
 
         // -----------------------------------------------------------------------------
 
-        new Activity(
+        $this->add_activity(new Activity(
             'DU',
             _('Uploading to Project Gutenberg'),
             [],
             'NOREQ',
             'OOGA',
             null // access_change_callback
-        );
+        ));
 
-        new Activity(
+        $this->add_activity(new Activity(
             "P2_mentor",
             sprintf(_("Mentoring in round %s"), 'P2'),
             [],
             'NOREQ',
             '',
             null // access_change_callback
-        );
+        ));
+    }
+
+    function add_activity($activity)
+    {
+        $this->activity_for_id[$activity->id] = $activity;
+    }
+
+    function add_stage($stage)
+    {
+        $this->stage_for_id[$stage->id] = $stage;
+        $this->add_activity($stage);
+    }
+
+    function add_round($round)
+    {
+        $this->round_for_id[$round->id] = $round;
+        $this->round_for_number[$round->round_number] = $round;
+
+        foreach(self::page_state_codes as $page_state => $state_code) {
+
+            // e.g. $P1->page_avail_state = "P1.page_avail"
+            $round->$page_state = "{$round->id}.page_$state_code";
+
+            // e.g. $activities->round_for_page_state["P1.page_avail"] = $P1;
+            $this->round_for_page_state[$round->$page_state] = $round;
+
+            // e.g. $activities->page_states[0] = "P1.page_avail"
+            $this->page_states[] = $round->$page_state;
+        }
+
+        $this->add_stage($round);
+    }
+
+    function add_pool($pool)
+    {
+        $this->pool_for_id[$pool->id] = $pool;
+        $this->add_stage($pool);
     }
 }
 
-global $activities;
+global $activities, $project_states;
 $activities = new Activities();
 
-$project_states = new ProjectStates($activities->rounds, $activities->pools);
+$project_states = new ProjectStates($activities->round_for_id, $activities->pool_for_id);
 
-// global for compatibility with noncvs
-//global $n_rounds;
-//$n_rounds = $activities->define_rounds();
-
-foreach($activities->rounds as $round) {
-    $activities->activity_for_id[$round->id] = $round;
+// add any additional access criteria
+foreach($activities->activity_for_id as $activity) {
+    foreach($activity->get_access_criteria() as $key => $value) {
+        $activities->access_criteria[$key] = $value;
+    }
 }
 
 function get_Round_for_page_state($page_state)
@@ -398,25 +424,68 @@ function get_Round_for_page_state($page_state)
 function get_Round_for_round_number($round_number)
 {
     global $activities;
-    return $activities->rounds[$round_number] ?? null;
+    return $activities->round_for_number[$round_number] ?? null;
 }
 
 function get_Round_for_round_id($round_id)
 {
     global $activities;
-    return $activities->round_for_round_id[$round_id] ?? null;
+    return $activities->round_for_id[$round_id] ?? null;
 }
 
 function get_Round_for_text_column_name($text_column_name)
 {
     global $activities;
-    foreach ($activities->round_for_round_id as $round_id => $round) {
+    foreach ($activities->round_for_id as $round_id => $round) {
         if ($round->text_column_name == $text_column_name) {
             return $round;
         }
     }
     return null;
 }
+
+function get_Stage_for_id($id)
+{
+    global $activities;
+    $stage = $activities->stage_for_id[$id] ?? null;
+    if (null !== $stage) {
+        return $stage;
+    } else {
+        die("There is no stage with id='$id'.");
+    }
+}
+
+function get_Pool_for_id($id)
+{
+    global $activities;
+    return $activities->pool_for_id[$id] ?? null;
+}
+
+// aliases for compatibility with existing code
+global $PAGE_STATES_IN_ORDER, $Round_for_round_id_, $Round_for_round_number_, $Round_for_page_state_,
+$Activity_for_id_, $Pool_for_id_, $ACCESS_CRITERIA, $Stage_for_id_;
+$PAGE_STATES_IN_ORDER = $activities->page_states;
+$Round_for_round_id_ = $activities->round_for_id;
+$Round_for_round_number_ = $activities->round_for_number;
+$Round_for_page_state_ = $activities->round_for_page_state;
+$Activity_for_id_ = $activities->activity_for_id;
+$Stage_for_id_ = $activities->stage_for_id;
+$Pool_for_id_ = $activities->pool_for_id;
+$ACCESS_CRITERIA = $activities->access_criteria;
+// alias for compatibility with noncvs
+global $n_rounds;
+$n_rounds = $activities->round_number;
+
+global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
+$project_state_phase_, $project_states_for_star_metal_;
+
+$PROJECT_STATES_IN_ORDER = $project_states->states;
+$project_state_medium_label_ = $project_states->medium_labels;
+$project_state_long_label_ = $project_states->long_labels;
+$project_state_forum_ = $project_states->project_state_forum;
+$project_state_phase_ = $project_states->project_state_phase;
+$project_states_for_star_metal_ = $project_states->project_states_for_star_metal;
+
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -34,6 +34,7 @@ class Activities
     {
         global $code_url, $post_processing_forum_idx;
 
+        // access_criteria are extended as activities are defined.
         $this->access_criteria = [
             'days since reg' => _('Days since registration'),
             'quiz/p_basic' => sprintf(_('Up-to-date completion of the <a href="%1$s">Basic Proofreading Quiz</a>'), "$code_url/quiz/start.php?show_level=P_BASIC"),
@@ -360,6 +361,10 @@ class Activities
     function add_activity($activity)
     {
         $this->activity_for_id[$activity->id] = $activity;
+
+        foreach($activity->get_access_criteria() as $key => $value) {
+            $this->access_criteria[$key] = $value;
+        }
     }
 
     function add_stage($stage)
@@ -395,13 +400,8 @@ $activities = new Activities();
 
 $project_states = new ProjectStates($activities->round_for_id, $activities->pool_for_id);
 
-// add any additional access criteria
-foreach($activities->activity_for_id as $activity) {
-    foreach($activity->get_access_criteria() as $key => $value) {
-        $activities->access_criteria[$key] = $value;
-    }
-}
-
+// these can next be made member functions of $activities
+// used as $activities->get_Round_for_page_state($state) etc.
 function get_Round_for_page_state($page_state)
 {
     global $activities;

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -277,12 +277,6 @@ function define_activities()
         null, // access_change_callback
         _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
         'post_proof.php',
-        "proj_post_first_available",
-        "proj_post_first_checked_out",
-        _("Available for PP"),
-        _("Available for Post-Processing"),
-        _("In PP"),
-        _("In Post-Processing"),
         _("Manager"),
         'username',
         [
@@ -331,12 +325,6 @@ function define_activities()
         null, // access_change_callback
         _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
         'ppv.php',
-        "proj_post_second_available",
-        "proj_post_second_checked_out",
-        _("Available for PPV"),
-        _("Available for Verifying Post-Processing"),
-        _("In PPV"),
-        _("Verifying Post-Processing"),
         _("Post-Processor"),
         'postproofer',
         [

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -463,17 +463,6 @@ $ACCESS_CRITERIA = $activities->access_criteria;
 global $n_rounds;
 $n_rounds = $activities->round_number;
 
-global $PROJECT_STATES_IN_ORDER, $project_state_medium_label_, $project_state_long_label_,
-$project_state_phase_, $project_states_for_star_metal_;
-
-$PROJECT_STATES_IN_ORDER = $project_states->states;
-$project_state_medium_label_ = $project_states->medium_labels;
-$project_state_long_label_ = $project_states->long_labels;
-$project_state_forum_ = $project_states->project_state_forum;
-$project_state_phase_ = $project_states->project_state_phase;
-$project_states_for_star_metal_ = $project_states->project_states_for_star_metal;
-
-
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 declare_mentoring_pair('P1', 'P2');


### PR DESCRIPTION
This only makes the Rounds etc. objects like @cpeel's PR but does not use them but aliases back to the old globals. It is only to indicate another way of doing it. The commit history is probably not useful. There could be some spurious reversions so it would need re-making.
