### PR TITLE
Remove Twitter as a referrer source

### DIFF
--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -522,7 +522,6 @@ class User
             "school" => _("School / College / University"),
             "work" => _("Work"),
             "news" => _("News Article"),
-            "twitter" => _("Twitter"),
             "facebook" => _("Facebook"),
             "other" => _("Other"),
         ];


### PR DESCRIPTION
Remove Twitter as a referrer source, as requested by @lhamilton1.