### PR TITLE
SETUP/configure: Switch on bash errors for unset env vars etc

### DIFF
--- a/SETUP/configure
+++ b/SETUP/configure
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -uo pipefail
 
 if [ $# != 2 ]; then
     echo 'usage: configure <path-to-site-config-file> <path-to-code-dir>'


### PR DESCRIPTION
This helps catch configuration errors when installing PGDP.