### PR TITLE
Cache page stats graphs as long as possible

### DIFF
--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -876,7 +876,7 @@ function get_round_backlog_stats($interested_phases)
  * Note that the graph function might include _() so it's important that we
  * include the user's language in the key.
  */
-function query_graph_cache($function, $args = [], $expire_from_now = 3600)
+function query_graph_cache($function, $args = [], $expiration = 3600)
 {
-    return memoize_function($function, $args, $expire_from_now, get_desired_language());
+    return memoize_function($function, $args, $expiration, get_desired_language());
 }

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1290,7 +1290,7 @@ function factor_strings($strings)
  * If the requested function returns data that has localized strings, it's
  * important that $key_salt = get_desired_language();
  */
-function memoize_function($function, $args = [], $expire_from_now = 3600, $key_salt = "")
+function memoize_function($function, $args = [], $expiration = 3600, $key_salt = "")
 {
     // cache this connection for possible re-use during this page load
     static $memcache = null;
@@ -1310,7 +1310,7 @@ function memoize_function($function, $args = [], $expire_from_now = 3600, $key_s
     // if not, call the function to return the data
     $data = call_user_func_array($function, $args);
 
-    $memcache->set($key, gzcompress(serialize($data)), time() + $expire_from_now);
+    $memcache->set($key, gzcompress(serialize($data)), $expiration);
 
     return $data;
 }

--- a/stats/pages_proofed_graphs.php
+++ b/stats/pages_proofed_graphs.php
@@ -12,7 +12,7 @@ $tally_name = get_enumerated_param($_GET, 'tally_name', null, $valid_tally_names
 // cache the graphs for as long as is reasonable
 $now = new DateTimeImmutable("now");
 $tomorrow_midnight = new DateTimeImmutable("tomorrow");
-$first_next_month = new DateTimeImmutable("first day of next month");
+$first_next_month = new DateTimeImmutable("midnight first day of next month");
 $first_next_week = new DateTimeImmutable("next Sunday");
 
 $title = sprintf(_('Graphs for Pages Saved-as-Done in Round %s'), $tally_name);

--- a/stats/pages_proofed_graphs.php
+++ b/stats/pages_proofed_graphs.php
@@ -9,20 +9,59 @@ require_login();
 $valid_tally_names = array_keys(get_page_tally_names());
 $tally_name = get_enumerated_param($_GET, 'tally_name', null, $valid_tally_names);
 
+// cache the graphs for as long as is reasonable
+$now = new DateTimeImmutable("now");
+$tomorrow_midnight = new DateTimeImmutable("tomorrow");
+$first_next_month = new DateTimeImmutable("first day of next month");
+$first_next_week = new DateTimeImmutable("next Sunday");
+
 $title = sprintf(_('Graphs for Pages Saved-as-Done in Round %s'), $tally_name);
 $graphs = [
-    ["barLineGraph", "pages_daily_increments_curr_month", pages_daily($tally_name, "increments", "curr_month")],
-    ["barLineGraph", "pages_daily_cumulative_curr_month", pages_daily($tally_name, "cumulative", "curr_month")],
-    ["barLineGraph", "pages_daily_increments_prev_month", pages_daily($tally_name, "increments", "prev_month")],
-    ["barLineGraph", "pages_daily_increments_all_time", query_graph_cache("pages_daily", [$tally_name, "increments", "all_time"], 60 * 60 * 6)], // cache for 6 hours
-    ["barLineGraph", "pages_daily_cumulative_all_time", pages_daily($tally_name, "cumulative", "all_time")],
-    ["barLineGraph", "total_pages_by_month_graph", total_pages_by_month_graph($tally_name)],
+    [
+        "barLineGraph",
+        "pages_daily_increments_curr_month",
+        query_graph_cache("pages_daily", [$tally_name, "increments", "curr_month"], $tomorrow_midnight->format("U")),
+    ],
+    [
+        "barLineGraph",
+        "pages_daily_cumulative_curr_month",
+        query_graph_cache("pages_daily", [$tally_name, "cumulative", "curr_month"], $tomorrow_midnight->format("U")),
+    ],
+    [
+        "barLineGraph",
+        "pages_daily_increments_prev_month",
+        query_graph_cache("pages_daily", [$tally_name, "increments", "prev_month"], $first_next_month->format("U")),
+    ],
+    [
+        "barLineGraph",
+        "pages_daily_increments_all_time",
+        query_graph_cache("pages_daily", [$tally_name, "increments", "all_time"], $first_next_week->format("U")),
+    ],
+    [
+        "barLineGraph",
+        "pages_daily_cumulative_all_time",
+        query_graph_cache("pages_daily", [$tally_name, "cumulative", "all_time"], $first_next_week->format("U")),
+    ],
+    [
+        "barLineGraph",
+        "total_pages_by_month_graph",
+        query_graph_cache("total_pages_by_month_graph", [$tally_name], $first_next_month->format("U")),
+    ],
 ];
 
 output_header($title, SHOW_STATSBAR, [
     "js_files" => get_graph_js_files(),
     "js_data" => build_svg_graph_inits($graphs),
 ]);
+
+echo <<<DEBUG
+        <!--          Now: {$now->format("c")}
+        Tomorrow midnight: {$tomorrow_midnight->format("c")}
+         First next month: {$first_next_month->format("c")}
+          First next week: {$first_next_week->format("c")}
+        -->
+    DEBUG;
+
 echo "<h1>$title</h1>";
 
 echo "<div style='max-width: 640px'>";


### PR DESCRIPTION
Generating the page stats is very resource intensive and can take a very long time. Cache the stats for as long as is reasonable which in some cases is up to a month. This mitigates https://github.com/DistributedProofreaders/dproofreaders/issues/1025

Clarify that memcached accepts both a timestamp *and* seconds from now: https://github.com/memcached/memcached/wiki/Programming#expiration

Testable in https://www.pgdp.org/~cpeel/c.branch/cache-graphs-longer/ -- note that the HTML for the page as a comment that shows exactly what the expiration times are evaluated to.