### PR TITLE
Improve the API user's guide

### DIFF
--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -7,14 +7,19 @@ programmatically using a well-defined structure instead of HTML scraping.
 
 The DP API is a RESTful API. Among other things, this means that all requests
 to the API will be via URL (possibly with JSON request body) and all responses
--- including error messages -- will be JSON objects.
+-- including error messages -- will be JSON objects. Additional metadata may
+be included in the HTML response headers, such as pagination and rate limiting
+details.
 
 ## Documentation
 
-The `dp-openapi.yaml` file should always contain the definitive OpenAPI on what
-is currently implemented. This file is best edited via
-[Swagger Editor](https://editor.swagger.io/). Indeed, that's a great place
-to test out the APIs as well.
+The [`dp-openapi.yaml`](dp-openapi.yaml) file should always contain the
+definitive OpenAPI specification on what is currently implemented. This file
+can be viewed with the [Swagger Editor](https://editor.swagger.io/)
+(File -> Import URL and paste in [the URL from github](https://raw.githubusercontent.com/DistributedProofreaders/dproofreaders/master/api/dp-openapi.yaml))
+and allows trying out endpoints. The Swagger Editor doesn't show HTTP response
+headers or allow the inclusion of pagination details on applicable endpoints
+and is not a complete solution for an API client.
 
 ## Access
 
@@ -58,7 +63,7 @@ Attempts to access the API with a missing or invalid API key will return a
 
 Your site may have API rate limiting enabled. This prevents overwhelming the
 system by limiting the number of API requests per unit of time. API responses
-will include three HTTP headers to let the caller know how many more requests
+will include three HTTP headers to let the client know how many more requests
 they have remaining in the limit window.
 
 * `X-Rate-Limit-Limit` - total number of requests allowed within the window
@@ -104,8 +109,18 @@ usually 100.
 
 ## Examples
 
-Here are some examples using `curl`. See the `dp-openapi.yaml` file for all
-available endpoints and their parameters and return values.
+Here are some examples using `curl` against the `pgdp.org` _test server_. Data
+on the test server changes often and the examples below may not always return
+results but the queries should always succeed and respond with a 200.
+
+See the [`dp-openapi.yaml`](dp-openapi.yaml) file for all available endpoints
+and their parameters and return values.
+
+All examples assume your API key is set in `$API_KEY`, eg:
+
+```bash
+export API_KEY=xxxxxxxx
+```
 
 ### Project searches
 
@@ -116,34 +131,30 @@ with `[]` (e.g. `projectid[]=`). Unique parameters are ANDed together.
 Search for all projects with genre `Other`:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects?genre=Other" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects?genre=Other"
 ```
 
 Search for all projects with genre `Science` or `Sports`:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects?genre[]=Science&genre[]=Sports" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects?genre[]=Science&genre[]=Sports"
 ```
 
 Search for all projects with the word `Monster` in their title:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects?title=Monster" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects?title=Monster"
 ```
 
 Search for all projects with genre `Science` or `Sports` and with `Monster`
 in their title, ie `(genre = Science OR genre = Sports) AND (title like %Monster%)`:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects?genre[]=Science&genre[]=Sports&title=Monster" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects?genre[]=Science&genre[]=Sports&title=Monster"
 ```
 
 To limit which project fields are included, use the `field` parameter. Request
@@ -152,9 +163,8 @@ of them.
 
 To return only the `projectid` and `title` fields:
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects?field[]=projectid&field[]=title" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects?field[]=projectid&field[]=title"
 ```
 
 ### Project details
@@ -162,41 +172,36 @@ curl -i -X GET "https://www.pgdp.org/api/v1/projects?field[]=projectid&field[]=t
 Get details about a specific project:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1"
 ```
 
 See all pages in a project:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages"
 ```
 
-Get the P1 text for a project page:
+Get the OCR text for a project page:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages/001.png/pagerounds/P1" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/pages/001.png/pagerounds/OCR"
 ```
 
 Get the good wordlist for a project:
 
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good"
 ```
 
 Update the project's good wordlist with an entirely new set:
 
 ```bash
-curl -i -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
-    -H "Content-Type: application/json" \
-    -H "X-API-KEY: $API_KEY" \
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordlists/good" \
     -d @data.json
 ```
 
@@ -212,9 +217,8 @@ Where `data.json` contains the new word list:
 
 Update details about a specific project:
 ```bash
-curl -i -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
-    -H "Content-Type: application/json" \
-    -H "X-API-KEY: $API_KEY" \
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1" \
     -d @data.json
 ```
 
@@ -230,9 +234,8 @@ Where `data.json` contains the fields you want to modify:
 
 Create a project:
 ```bash
-curl -i -X POST "https://www.pgdp.org/api/v1/projects" \
-    -H "Content-Type: application/json" \
-    -H "X-API-KEY: $API_KEY" \
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X POST "https://www.pgdp.org/api/v1/projects" \
     -d @data.json
 ```
 
@@ -254,23 +257,20 @@ Where `data.json` contains at least all the required fields:
 
 Get a list of all holdable project states:
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects/holdstates" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects/holdstates"
 ```
 
 Get the current hold states for a project:
 ```bash
-curl -i -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/holdstates" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY"
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X GET "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/holdstates"
 ```
 
 Set a project's hold states:
 ```bash
-curl -i -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/holdstates" \
-    -H "Accept: application/json" \
-    -H "X-API-KEY: $API_KEY" \
+curl -i -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/holdstates" \
     -d @data.json
 ```
 


### PR DESCRIPTION
Provide more details on how the API should be used, including the limitations of the Swagger Editor.

I've updated the examples such that all of the boilerplate is in the first line and all the useful stuff we want people to focus on is on the second line. This also makes it easier to repeat a command on the command line and make changes to it.

Viewing the [rendered markdown of this file](https://github.com/cpeel/dproofreaders/blob/update-api-docs/api/USERS_GUIDE.md) is likely to be useful when reviewing the updates.