### PR TITLE
api1/v1/queues: Add a first cut read-only API for querying release qu…

### DIFF
--- a/api/api_common.inc
+++ b/api/api_common.inc
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Check to see if the user requested a flag parameter.
+ *
+ * This returns one of three possible states:
+ * - null - no parameter with this key was set
+ * - true - parameter was set to "true" or an empty string (for ?flagname)
+ * - false - parameter was set to "false"
+ */
+function get_flag_value($query_params, $flagname)
+{
+    if (!isset($query_params[$flagname])) {
+        return null;
+    } elseif ($query_params[$flagname] == "") {
+        // make '?flagname' work as if '?flagname=true'
+        return true;
+    } else {
+        $bool = filter_var($query_params[$flagname], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($bool === null) {
+            throw new ValueError("Invalid value for '$flagname'");
+        }
+        return $bool;
+    }
+}

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -690,6 +690,202 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /queues:
+    get:
+      tags:
+      - queues
+      description: Gets the release queues for a round (or all rounds)
+      parameters:
+      - name: roundid
+        in: query
+        description: Round ID for queues (all rounds if not provided)
+        schema:
+          type: string
+      - name: field
+        description: Queue field to return, if not set all fields are returned.
+          <br><br>
+          To request multiple fields, append with [] and pass one per desired
+          field (e.g. field[]=projectid&field[]=author).
+        in: query
+        schema:
+          type: string
+      - name: show
+        description: Which queues to show.
+          <dl>
+          <dt>all</dt> <dd>all queues</dd>
+          <dt>enabled</dt> <dd>queues that are enabled</dd>
+          <dt>populated</dt> <dd>queues that are enabled and have projects to release</dd>
+          </dl>
+        in: query
+        schema:
+          type: string
+          enum: [all, enabled, populated]
+      - name: name
+        description: Release queue name substring to match. If not set, all queues are returned.
+          <br><br>
+          To request multiple possible queue names (results ORed together), append with []
+          and pass one per desired name (e.g. name[]=Klingon&name[]=Shakespeare).
+        in: query
+        schema:
+          type: string
+      - name: group
+        description: Release queue group name substring to match. If not set all groups are
+          returned (as well as all matching queues in those groups).
+          <br><br>
+          To match multiple possible group names (results ORed together), append with []
+          and pass one per desired name (e.g. group[]=PM&group[]=Math).
+        in: query
+        schema:
+          type: string
+
+      responses:
+        200:
+          description: Requested release queue list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/release_queue_detail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /queues/{queueid}/stats:
+    get:
+      tags:
+      - queues
+      description: Get release queue stats
+      parameters:
+      - name: queueid
+        in: path
+        description: Queue ID
+        required: true
+        schema:
+          type: integer
+      responses:
+        200:
+          description: Release queue stats
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    days_ago:
+                      type: integer
+                    projects_released:
+                      type: integer
+                    pages_released:
+                      type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /queues/{queueid}/projects:
+    get:
+      tags:
+      - queues
+      description: Get projects in release queue
+      parameters:
+      - name: queueid
+        in: path
+        description: Queue ID
+        required: true
+        schema:
+          type: integer
+      - name: unheld_only
+        in: query
+        schema:
+          type: boolean
+      - name: field
+        description: Project field to return, if not set all fields are returned.
+          <br><br>
+          To request multiple fields, append with [] and pass one per desired
+          field (e.g. field[]=title&field[]=author).
+        in: query
+        schema:
+          type: string
+
+      responses:
+        200:
+          description: Release queue projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    projectid:
+                      type: string
+                    title:
+                      type: string
+                    author:
+                      type: string
+                    languages:
+                      type: array
+                      items:
+                        type: string
+                      minItems: 1
+                      maxItems: 2
+                    genre:
+                      type: string
+                    difficulty:
+                      type: string
+                    last_state_change_time:
+                      type: string
+                      format: dateTime
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /queues/{queueid}:
+    get:
+      tags:
+      - queues
+      description: Get release queue information
+      parameters:
+      - name: queueid
+        in: path
+        description: Queue ID
+        required: true
+        schema:
+          type: integer
+      responses:
+        200:
+          description: Release queue information
+          content:
+            application/json:
+              schema:
+
+                type: object
+                $ref: '#/components/schemas/release_queue_detail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /stats/site:
     get:
       tags:
@@ -914,6 +1110,31 @@ components:
         text:
           type: string
         state:
+          type: string
+
+    release_queue_detail:
+      properties:
+        id:
+          type: integer
+        round_id:
+          type: string
+        ordering:
+          type: integer
+        name:
+          type: string
+        enabled:
+          type: boolean
+        populated:
+          type: boolean
+        length:
+          type: integer
+        unheld_length:
+          type: integer
+        comment:
+          type: string
+        project_selector:
+          type: string
+        release_criterion:
           type: string
 
     charsuite:

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -4,6 +4,7 @@ include_once("ApiRouter.inc");
 // DP API v1
 include_once("v1_validators.inc");
 include_once("v1_projects.inc");
+include_once("v1_queues.inc");
 include_once("v1_stats.inc");
 
 $router = ApiRouter::get_router();
@@ -14,6 +15,7 @@ $router->add_validator(":projectid", "validate_project");
 $router->add_validator(":roundid", "validate_round");
 $router->add_validator(":pagename", "validate_page_name");
 $router->add_validator(":pageroundid", "validate_page_round");
+$router->add_validator(":queueid", "validate_release_queue");
 
 // Add routes
 $router->add_route("GET", "v1/projects", "api_v1_projects");
@@ -36,6 +38,12 @@ $router->add_route("PUT", "v1/projects/:projectid/wordlists/:wordlist_type", "ap
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
 $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
+
+$router->add_route("GET", "v1/queues", "api_v1_queues");
+$router->add_route("GET", "v1/queues/:queueid", "api_v1_queue");
+$router->add_route("GET", "v1/queues/:queueid/stats", "api_v1_queue_stats");
+$router->add_route("GET", "v1/queues/:queueid/projects", "api_v1_queue_projects");
+
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
 $router->add_route("GET", "v1/stats/site/rounds", "api_v1_stats_site_rounds");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -124,10 +124,7 @@ function api_v1_projects($method, $data, $query_params)
     api_send_pagination_header($query_params, $total_rows, $per_page, $page);
 
     // restrict to list of desired fields, if set
-    $return_fields = array_get($query_params, "field", null);
-    if ($return_fields && !is_array($return_fields)) {
-        $return_fields = [$return_fields];
-    }
+    $return_fields = array_get_as_array($query_params, "field", null);
 
     $output = [];
     while ($row = mysqli_fetch_assoc($result)) {
@@ -311,11 +308,7 @@ function render_project_json($project, $return_fields = null)
     );
 
     // remove any fields that weren't requested
-    if ($return_fields) {
-        foreach (array_diff(array_keys($return_array), $return_fields) as $field) {
-            unset($return_array[$field]);
-        }
-    }
+    array_remove_invalid_fields($return_array, $return_fields);
 
     return $return_array;
 }

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -5,6 +5,7 @@ include_once($relPath.'ProjectSearchForm.inc');
 include_once($relPath.'page_table.inc');
 include_once($relPath.'special_colors.inc');
 include_once("exceptions.inc");
+include_once("api_common.inc");
 
 // DP API v1 -- Projects
 
@@ -65,7 +66,7 @@ function api_v1_projects($method, $data, $query_params)
     }
 
     foreach (array_intersect(array_keys($valid_flags), array_keys($query_params)) as $flag) {
-        if (_get_flag_value($query_params, $flag)) {
+        if (get_flag_value($query_params, $flag)) {
             $where .= " AND " . $valid_flags[$flag];
         }
     }
@@ -656,30 +657,6 @@ function api_v1_projects_holdstates($method, $data, $query_params)
 
 //---------------------------------------------------------------------------
 // Utility functions
-
-/**
- * Check to see if the user requested a flag parameter.
- *
- * This returns one of three possible states:
- * - null - no parameter with this key was set
- * - true - parameter was set to "true" or an empty string (for ?flagname)
- * - false - parameter was set to "false"
- */
-function _get_flag_value($query_params, $flagname)
-{
-    if (!isset($query_params[$flagname])) {
-        return null;
-    } elseif ($query_params[$flagname] == "") {
-        // make '?flagname' work as if '?flagname=true'
-        return true;
-    } else {
-        $bool = filter_var($query_params[$flagname], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-        if ($bool === null) {
-            throw new ValueError("Invalid value for '$flagname'");
-        }
-        return $bool;
-    }
-}
 
 /**
  * Check to see if the user requested an enabled filter.

--- a/api/v1_queues.inc
+++ b/api/v1_queues.inc
@@ -1,0 +1,109 @@
+<?php
+include_once($relPath.'release_queue.inc');
+include_once($relPath.'user_is.inc');
+include_once("exceptions.inc");
+include_once("api_common.inc");
+
+// DP API v1 -- Queues
+
+//---------------------------------------------------------------------------
+// queues -- list queues, optionally filtered by round
+function api_v1_queues($method, $data, $query_params)
+{
+    $roundid = array_get($query_params, "roundid", null);
+    $round = !is_null($roundid) ? validate_round($roundid, null) : null;
+
+    $show = get_enumerated_param($query_params, "show", "all", ["enabled", "populated", "all"]);
+
+    // Fields we  can query on
+    $valid_fields = [
+        "name",
+        "group",
+    ];
+
+    $valid_return_fields = [
+        "id",
+        "round_id",
+        "group",
+        "ordering",
+        "name",
+        "enabled",
+        "populated",
+        "length",
+        "unheld_length",
+        "comment",
+    ];
+
+    if (user_can_see_queue_settings()) {
+        array_push($valid_return_fields, "project_selector", "release_criterion");
+    }
+
+    // restrict to list of desired fields, if set
+    $return_fields = array_get_as_array($query_params, "field", $valid_return_fields);
+    $return_fields = array_intersect($return_fields, $valid_return_fields);
+
+    $name_selector = array_get($query_params, "name", null);
+    $group_selector = array_get($query_params, "group", null);
+
+    $output = [];
+    foreach (fetch_queues_data($round, $show, false, $name_selector, $group_selector) as $queue_data) {
+        array_remove_invalid_fields($queue_data, $return_fields);
+        $output[] = $queue_data;
+    }
+    return $output;
+}
+
+//---------------------------------------------------------------------------
+// queues/:queueid -- return release queue info
+function api_v1_queue($method, $data, $query_params)
+{
+    $queue = $data[":queueid"];
+
+    return $queue;
+}
+
+//---------------------------------------------------------------------------
+// queue/:queueid/stats -- return release queue stats
+function api_v1_queue_stats($method, $data, $query_params)
+{
+    $queue = $data[":queueid"];
+
+    $round = validate_round($queue["round_id"], null);
+    $name = $queue["name"];
+
+    return fetch_queue_stats_data($round, $name);
+}
+
+//---------------------------------------------------------------------------
+// queue/:queueid/projects -- list projects in release queue
+function api_v1_queue_projects($method, $data, $query_params)
+{
+    $queue = $data[":queueid"];
+    $unheld_only = (bool) get_flag_value($query_params, "unheld_only");
+
+    $valid_return_fields = [
+        "projectid",
+        "title",
+        "author",
+        "languages",
+        "genre",
+        "difficulty",
+        "last_state_change_time",
+    ];
+
+    // restrict to list of desired fields, if set
+    $return_fields = array_get_as_array($query_params, "field", $valid_return_fields);
+    $return_fields = array_intersect($return_fields, $valid_return_fields);
+
+    $round = validate_round($queue["round_id"], null);
+
+    $output = [];
+    foreach(fetch_queue_projects_data($round, $queue["project_selector"], $unheld_only) as $proj_data) {
+        array_remove_invalid_fields($proj_data, $return_fields);
+        if (isset($proj_data["last_state_change_time"])) {
+            $proj_data["last_state_change_time"] = date(DATE_ATOM, $proj_data["last_state_change_time"]);
+        }
+        $output[] = $proj_data;
+    }
+    return $output;
+}

--- a/api/v1_validators.inc
+++ b/api/v1_validators.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'stages.inc');
 include_once($relPath.'Project.inc');
+include_once($relPath.'release_queue.inc');
 
 //===========================================================================
 // Validators
@@ -64,4 +65,13 @@ function validate_page_round($pageround, $data)
     } catch (InvalidPageRoundException $exception) {
         throw new NotFoundError($exception->getMessage(), $exception->getCode());
     }
+}
+
+function validate_release_queue($queueid, $data)
+{
+    $queue_data = fetch_queue_data($queueid);
+    if (is_null($queue_data)) {
+        throw new NotFoundError("queue {$queueid} not found");
+    }
+    return $queue_data;
 }

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -751,8 +751,8 @@ function surround_and_join($strings, $L, $R, $joiner)
 /**
  * Return true if a non-null `$haystack` contains any of the `$needles` as a substring.
  *
- * @param string $haystack
- *   The string to search
+ * @param null|string $haystack
+ *   The string to search. A null haystack can never contain a needle
  * @param null|string|array $needles
  *   Search term. If:
  *   * null - Returns true for any non-null haystack.

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -39,6 +39,39 @@ function array_extract_field($array, $field)
 }
 
 /**
+ * Return $array[$key], or $default.
+ * If the result is non-null and not an array, wrap it up as a single value array
+ *
+ * null             -> null
+ * []               -> []
+ * "foo"            -> ["foo"]
+ * ["bar"]          -> ["bar"]
+ * ["foo" => "bar"] -> ["foo" => "bar"]
+ */
+function array_get_as_array($array, $key, $default)
+{
+    $value = array_get($array, $key, $default);
+    if (!is_null($value) && !is_array($value)) {
+        $value = [$value];
+    }
+    return $value;
+}
+
+/**
+ * Remove fields from the associative array `$array` that aren't in the valid list.
+ *
+ * Note: This is an in-place operation that mutates `$array`!
+ **/
+function array_remove_invalid_fields(&$array, $valid_fields)
+{
+    if ($valid_fields) {
+        foreach (array_diff(array_keys($array), $valid_fields) as $field) {
+            unset($array[$field]);
+        }
+    }
+}
+
+/**
  * Return an array whose values are the names of the properties
  * whose values differ between the two objects $new and $old.
  *

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -716,6 +716,38 @@ function surround_and_join($strings, $L, $R, $joiner)
 }
 
 /**
+ * Return true if a non-null `$haystack` contains any of the `$needles` as a substring.
+ *
+ * @param string $haystack
+ *   The string to search
+ * @param null|string|array $needles
+ *   Search term. If:
+ *   * null - Returns true for any non-null haystack.
+ *   * string - Returns true if haystack contains the needle.
+ *   * array - Returns true if haystack contains any of the needles (false if array is empty).
+ *
+ * * @return boolean
+ */
+function str_contains_any_of($haystack, $needles)
+{
+    if (is_null($haystack)) {
+        return false;
+    }
+    if (is_null($needles)) {
+        return true;
+    }
+    if (is_string($needles)) {
+        return str_contains($haystack, $needles);
+    }
+    foreach($needles as $n) {
+        if (str_contains($haystack, $n)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
  * Return a SQL "colname='value'" clause, where `$colname` is
  * not escaped, and `$s` is an escaped and quoted string.
  */

--- a/pinc/release_queue.inc
+++ b/pinc/release_queue.inc
@@ -1,5 +1,6 @@
 <?php
 // A place for shared functions dealing with release queues.
+include_once($relPath.'Project.inc');
 
 $today_MMDD = date('md', strtotime('today'));
 $tomorrow_MMDD = date('md', strtotime('tomorrow'));
@@ -19,4 +20,324 @@ function cook_project_selector($project_selector)
             [$today_MMDD,      $tomorrow_MMDD],
             $project_selector
         );
+}
+
+function _get_queue_length($cooked_project_selector, $project_waiting_state)
+{
+    $state_clause = set_col_str("state", $project_waiting_state);
+    $c_sql = "
+        SELECT count(*) as total, SUM(CASE WHEN project_holds.state is NULL THEN 1 ELSE 0 END) as unheld
+        FROM projects
+            LEFT OUTER JOIN project_holds USING (projectid, state)
+        WHERE ($cooked_project_selector)
+            AND $state_clause
+    ";
+
+    try {
+        $c_res = DPDatabase::query($c_sql);
+        $row = mysqli_fetch_row($c_res);
+        return [$row[0], $row[1] ?? 0];
+    } catch (DBQueryError $error) {
+        return [null, null];
+    }
+}
+
+/**
+ * Generator to return queue_defns table data for queues, one queue at a time.
+ *
+ * Data is returned as an array of associative arrays that abstracts away
+ * the lower-level database structure.
+ *
+ * For rows that represent queue groups, the returned format looks like:
+ * ```
+ * {
+ *    "is_group": true,
+ *    "group": "PM Queues (experimental)",
+ * }
+ * ```
+ * For rows that represent queues, the returned format looks like:
+ * ```
+ * {
+ *     "is_group": false,
+ *     "group": "PM Queues (experimental)",
+ *     "ordering": 3999,
+ *     "name": "EASY English",
+ *     "enabled": true,
+ *     "populated": true,
+ *     "length": 1,
+ *     "unheld_length": 0,
+ *     "comment": "Always have EASY English in P1",
+ *     "release_criterion": "pages < 120 or projects < 4"
+ * }
+ * ```
+ *
+ * @param Round $round
+ *   Return the queues for the specified round.
+ * @param string $show
+ *   Select which queues to return:
+ *   * all - Don't filter out any queues
+ *   * enabled - Filter out queues which aren't enabled
+ *   * populated - Filter out queues which aren't enabled *OR* contain no projects
+ * * @param null|string|array $name_selector
+ *   Select which queues to return in the query where:
+ *   * null - Don't filter out any queues
+ *   * string - Filter out queues whose name does not contain string
+ *   * array - Filter out queues whose name contains none of the strings
+ * @param null|string|array $group_selector
+ *   Select which groups and queues to return:
+ *   * null - Don't filter out any groups/queues.
+ *   * string - Filter out queues/groups whose group name does not contain string
+ *   * array - Filter out queues/groups whose group name contains none of the strings
+ * @param boolean show_groups
+ *   If true, return dummy group objects as well as queues
+ *
+ * @return generator
+ */
+function fetch_queues_data($round, $show, $show_groups, $name_selector = null, $group_selector = null)
+{
+    // Building the WHERE clause is rather ad-hoc, mostly because
+    // a bunch of the output fields don't come directly from the DB result.
+    $proj_where = set_col_str("round_id", $round->id);
+    $clauses = [];
+    if (in_array($show, ["enabled", "populated"])) {
+        $clauses[] = "enabled = 1";
+    }
+    if (is_string($name_selector)) {
+        $name_selector = [$name_selector];
+    }
+    if (is_array($name_selector)) {
+        $values = array_map("DPDatabase::escape", $name_selector);
+        $clauses[] = surround_and_join($values, "name LIKE '%", "%'", ' OR ');
+    }
+    if (empty($clauses)) {
+        $clauses = ["1"];
+    }
+    $filter_where = surround_and_join($clauses, "(", ")", " AND ");
+    // We always want to see the rows that introduce groups.
+    $where = "$proj_where AND ($filter_where OR (SUBSTR(name, 1, 1) = '*'))";
+    $sql = "
+        SELECT *
+        FROM queue_defns
+        WHERE $where
+        ORDER BY ordering
+    ";
+
+    // Because queues are ordered, there is a convention to break them up
+    // into sections with a disabled queue at the start of the section
+    // indicating the section's name. These queue names start with "***"
+    // and we identify them here and treat them differently.
+    $group = null; // the most recently seen row defining a group
+    $res = DPDatabase::query($sql);
+    while ($row = mysqli_fetch_assoc($res)) {
+        if (startswith($row["name"], "***")) {
+            $group = str_replace("***", "", $row["name"]);
+            // Check for group
+            if ($show_groups && str_contains_any_of($group, $group_selector)) {
+                yield [
+                    "is_group" => true,
+                    "group" => $group,
+                ];
+            }
+            continue;
+        }
+
+        // Check for project in group.
+        if (!str_contains_any_of($group, $group_selector)) {
+            continue;
+        }
+
+        [$length, $unheld_length] = _get_queue_length($row["project_selector"], $round->project_waiting_state);
+        if ($show == "populated" && $length == 0) {
+            continue;
+        }
+        $data = _queue_data($row, $length, $unheld_length);
+        $data["is_group"] = false;
+        $data["group"] = $group;
+        yield $data;
+    }
+}
+
+/**
+ * Return queue data array for a specified release queue
+ *
+ * @param Round $round
+ *   The round containing the release queue
+ * @param string $name
+ *   The release queue's name
+ *
+ * @return array|null
+ **/
+function fetch_queue_data_by_name($round, $name)
+{
+    $sql = sprintf(
+        "
+        SELECT *
+        FROM queue_defns
+        WHERE round_id='%s' AND name='%s'
+        ",
+        DPDatabase::escape($round->id),
+        DPDatabase::escape($name)
+    );
+    $res = mysqli_fetch_assoc(DPDatabase::query($sql));
+    if (!$res) {
+        return null;
+    }
+    return _queue_data($res);
+}
+
+/**
+ * Return queue data array for a specified release queue
+ *
+ * @param int $queueid
+ *   The release queue ID
+ *
+ * @return array|null
+ **/
+function fetch_queue_data($queueid)
+{
+    $sql = sprintf(
+        "
+        SELECT *
+        FROM queue_defns
+        WHERE id=%d
+        ",
+        $queueid
+    );
+    $res = mysqli_fetch_assoc(DPDatabase::query($sql));
+    if (!$res) {
+        return null;
+    }
+    return _queue_data($res);
+}
+
+function _queue_data($row, $length = null, $unheld_length = null)
+{
+    global $Round_for_round_id_;
+    $round = $Round_for_round_id_[$row["round_id"]];
+    if (is_null($length) || is_null($unheld_length)) {
+        [$length, $unheld_length] = _get_queue_length($row["project_selector"], $round->project_waiting_state);
+    }
+    return [
+        "id" => (int)$row["id"],
+        "round_id" => $row["round_id"],
+        "ordering" => (int)$row["ordering"],
+        "name" => $row["name"],
+        "enabled" => (bool)$row["enabled"],
+        "populated" => $length != 0,
+        "length" => (int)$length,
+        "unheld_length" => (int)$unheld_length,
+        "comment" => $row["comment"],
+        "project_selector" => $row["project_selector"],
+        "release_criterion" => $row["release_criterion"],
+    ];
+}
+
+/**
+ * A generator that yields project data for projects in a queue
+ *
+ * @param Round $round
+ *   The queue the round is in.
+ * @param string $project_selector
+ *   The `queue_defns.project_selector` field for the queue
+ * @param bool unheld_only
+ *   Only return projects that aren't in the hold state.
+ *
+ * @return generator
+ **/
+function fetch_queue_projects_data($round, $project_selector, $unheld_only)
+{
+    $cooked_project_selector = cook_project_selector($project_selector);
+    $unheld_only_sql = $unheld_only ? "project_holds.state is NULL" : "1";
+
+    $sql = "
+        SELECT
+            projectID,
+            nameofwork,
+            authorsname,
+            language,
+            genre,
+            difficulty,
+            username,
+            modifieddate,
+            project_holds.state as holds_state
+        FROM projects
+            LEFT OUTER JOIN project_holds USING (projectid, state)
+        WHERE ($cooked_project_selector)
+            AND state='{$round->project_waiting_state}'
+            AND $unheld_only_sql
+        ORDER BY modifieddate, nameofwork
+    ";
+    $res = DPDatabase::query($sql);
+    while ($row = mysqli_fetch_assoc($res)) {
+        yield [
+            "projectid" => $row["projectID"],
+            "title" => $row["nameofwork"],
+            "author" => $row["authorsname"],
+            "languages" => Project::decode_language($row["language"]),
+            "genre" => $row["genre"],
+            "difficulty" => $row["difficulty"],
+            "username" => $row["username"],
+            "last_state_change_time" => (int)$row["modifieddate"],
+            "holds_state" => $row["holds_state"],
+        ];
+    }
+}
+
+/**
+ * Return the page and project releases stats for a given release queue
+ * @param int round
+ *   The round containing the release queue
+ * @param string name
+ *   The name of the release queue
+ *
+ * @return array
+ **/
+function fetch_queue_stats_data($round, $name)
+{
+    $data = [];
+    foreach ([1, 7, 28, 84] as $days_ago) {
+        $seconds_ago = time() - 60 * 60 * 24 * $days_ago;
+        $sql = sprintf(
+            "
+            SELECT count(*)
+            FROM project_events
+            WHERE event_type = 'transition'
+                AND details1 = '%s'
+                AND details3 = 'via_q: %s'
+                AND timestamp >= %d
+            ",
+            DPDatabase::escape($round->project_waiting_state),
+            DPDatabase::escape($name),
+            $seconds_ago
+        );
+        $result = DPDatabase::query($sql);
+        $projects_released = mysqli_fetch_row($result)[0];
+
+        $sql = sprintf(
+            "
+            SELECT sum(n_pages)
+            FROM projects
+            WHERE projectid in (
+                SELECT projectid
+                FROM project_events
+                WHERE event_type = 'transition'
+                    AND details1 = '%s'
+                    AND details3 = 'via_q: %s'
+                    AND timestamp >= %d
+            )
+            ",
+            DPDatabase::escape($round->project_waiting_state),
+            DPDatabase::escape($name),
+            $seconds_ago
+        );
+        $result = DPDatabase::query($sql);
+        $pages_released = mysqli_fetch_row($result)[0] ?? 0;
+
+        $data[] = [
+            "days_ago" => $days_ago,
+            "projects_released" => $projects_released,
+            "pages_released" => $pages_released,
+        ];
+    }
+    return $data;
 }

--- a/pinc/release_queue.inc
+++ b/pinc/release_queue.inc
@@ -58,6 +58,8 @@ function _get_queue_length($cooked_project_selector, $project_waiting_state)
  * For rows that represent queues, the returned format looks like:
  * ```
  * {
+ *     "id": 161,
+ *     "round_id": "P1",
  *     "is_group": false,
  *     "group": "PM Queues (experimental)",
  *     "ordering": 3999,
@@ -71,14 +73,14 @@ function _get_queue_length($cooked_project_selector, $project_waiting_state)
  * }
  * ```
  *
- * @param Round $round
- *   Return the queues for the specified round.
+ * @param null|Round $round
+ *   Return the queues for the specified round, or all rounds if null.
  * @param string $show
  *   Select which queues to return:
  *   * all - Don't filter out any queues
  *   * enabled - Filter out queues which aren't enabled
  *   * populated - Filter out queues which aren't enabled *OR* contain no projects
- * * @param null|string|array $name_selector
+ * @param null|string|array $name_selector
  *   Select which queues to return in the query where:
  *   * null - Don't filter out any queues
  *   * string - Filter out queues whose name does not contain string
@@ -95,9 +97,15 @@ function _get_queue_length($cooked_project_selector, $project_waiting_state)
  */
 function fetch_queues_data($round, $show, $show_groups, $name_selector = null, $group_selector = null)
 {
+    global $Round_for_round_id_;
+
     // Building the WHERE clause is rather ad-hoc, mostly because
     // a bunch of the output fields don't come directly from the DB result.
-    $proj_where = set_col_str("round_id", $round->id);
+    if (!is_null($round)) {
+        $proj_where = set_col_str("round_id", $round->id);
+    } else {
+        $proj_where = "1";
+    }
     $clauses = [];
     if (in_array($show, ["enabled", "populated"])) {
         $clauses[] = "enabled = 1";
@@ -119,7 +127,7 @@ function fetch_queues_data($round, $show, $show_groups, $name_selector = null, $
         SELECT *
         FROM queue_defns
         WHERE $where
-        ORDER BY ordering
+        ORDER BY round_id, ordering
     ";
 
     // Because queues are ordered, there is a convention to break them up
@@ -127,8 +135,15 @@ function fetch_queues_data($round, $show, $show_groups, $name_selector = null, $
     // indicating the section's name. These queue names start with "***"
     // and we identify them here and treat them differently.
     $group = null; // the most recently seen row defining a group
+    $round = null; // the most recently seen round.
     $res = DPDatabase::query($sql);
     while ($row = mysqli_fetch_assoc($res)) {
+        // If we've gone from (eg) round F2 in the previous loop iteration, to P1
+        // in this iteration, then reset the group
+        if (!$round || $round->id != $row["round_id"]) {
+            $round = $Round_for_round_id_[$row["round_id"]];
+            $group = null;
+        }
         if (startswith($row["name"], "***")) {
             $group = str_replace("***", "", $row["name"]);
             // Check for group
@@ -141,8 +156,7 @@ function fetch_queues_data($round, $show, $show_groups, $name_selector = null, $
             continue;
         }
 
-        // Check for project in group.
-        if (!str_contains_any_of($group, $group_selector)) {
+        if (!is_null($group_selector) && !str_contains_any_of($group, $group_selector)) {
             continue;
         }
 

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -248,3 +248,10 @@ function user_has_DU_access()
     $userSettings = & get_pguser_settings();
     return $userSettings->get_boolean("DU.access") || $userSettings->get_boolean("PPV.access");
 }
+
+function user_can_see_queue_settings()
+{
+    global $ordinary_users_can_see_queue_settings;
+    return $ordinary_users_can_see_queue_settings ||
+        user_is_a_sitemanager() || user_is_proj_facilitator();
+}

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -10,9 +10,6 @@ include_once($relPath.'release_queue.inc');
 
 require_login();
 
-$user_can_see_queue_settings = $ordinary_users_can_see_queue_settings ||
-    user_is_a_sitemanager() || user_is_proj_facilitator();
-
 $listing_view_modes = [
     "populated" => [
         "label" => _("Enabled & populated queues"),
@@ -61,7 +58,7 @@ function _show_available_rounds()
 
 function _show_round_queues($round, $listing_view_mode)
 {
-    global $code_url, $listing_view_modes, $user_can_see_queue_settings;
+    global $code_url, $listing_view_modes;
 
     echo "<p>";
     echo "<a href='?'>" . html_safe(_("Back to queue round selection")) ."</a> | ";
@@ -111,7 +108,7 @@ function _show_round_queues($round, $listing_view_mode)
         echo "<th>", html_safe(_("Name")), "</th>\n";
         echo "<th>", html_safe(_("Current length")), "</th>\n";
         echo "<th>", html_safe(_("Length without holds")), "</th>\n";
-        if ($user_can_see_queue_settings) {
+        if (user_can_see_queue_settings()) {
             echo "<th>", html_safe(_("Release criterion")), "</th>\n";
             $columns += 1;
         }
@@ -119,63 +116,43 @@ function _show_round_queues($round, $listing_view_mode)
         echo "</tr>\n";
     }
 
-    $q_sql = sprintf(
-        "
-        SELECT *
-        FROM queue_defns
-        WHERE round_id='%s' AND ((%s) OR (SUBSTR(name, 1, 1) = '*'))
-        ORDER BY ordering
-        ",
-        DPDatabase::escape($round->id),
-        in_array($listing_view_mode, ["enabled", "populated"]) ? "enabled = 1" : "1"
-    );
-    $q_res = DPDatabase::query($q_sql);
-
-    while ($qd = mysqli_fetch_object($q_res)) {
+    foreach (fetch_queues_data($round, $listing_view_mode, true, null, null) as $queue_data) {
         // Because queues are ordered, there is a convention to break them up
-        // into sections with a disabled queue at the start of the section
-        // indicating the section's name. These queue names start with "***"
-        // and we identify them here and treat them differently.
-        if (startswith($qd->name, "***")) {
+        // into sections with a 'group queue' at the start of the section.
+        if ($queue_data["is_group"]) {
             echo "<tr>";
-            echo "<td colspan='$columns' class='bold'>" . html_safe(str_replace("***", "", $qd->name)) . "</td>";
+            echo "<td colspan='$columns' class='bold'>" . html_safe($queue_data["group"]) . "</td>";
             echo "</tr>";
             continue;
         }
-
-        [$current_length, $current_unheld_length] = _get_queue_length($qd->project_selector, $round->project_waiting_state);
-        if ($listing_view_mode == "populated" && $current_length == 0) {
-            continue;
-        }
-
-        if ($current_length === null) {
-            $current_length = '???';
-            $current_unheld_length = '???';
-            $holds = '???';
+        $length = $queue_data["length"];
+        $unheld_length = $queue_data["unheld_length"];
+        if ($length === null) {
+            $length = '???';
+            $unheld_length = '???';
             $errors[] = sprintf(
                 _('There is a syntax error in the project selector for #%1$d "%2$s"'),
-                $qd->ordering,
-                $qd->name
+                $queue_data["ordering"],
+                $queue_data["name"],
             );
-            $link_cell = html_safe($qd->name);
+            $link_cell = html_safe($queue_data["name"]);
         } else {
-            $ename = urlencode($qd->name);
-            $link_cell = "<a href='?round_id=$round->id&amp;name=$ename'>" . html_safe($qd->name) . "</a>";
-            $holds = $current_length - $current_unheld_length;
+            $ename = urlencode($queue_data["name"]);
+            $link_cell = "<a href='?round_id=$round->id&amp;name=$ename'>" . html_safe($queue_data["name"]) . "</a>";
         }
 
         echo "<tr>";
-        echo "<td>$qd->ordering</td>\n";
+        echo "<td>", $queue_data["ordering"], "</td>\n";
         if (!in_array($listing_view_mode, ["enabled", "populated"])) {
-            echo "<td>" . html_safe($qd->enabled ? _("Yes") : "") . "</td>";
+            echo "<td>" . html_safe($queue_data["enabled"] ? _("Yes") : "") . "</td>";
         }
         echo "<td>$link_cell</td>\n";
-        echo "<td>$current_length</td>\n";
-        echo "<td>$current_unheld_length</td>\n";
-        if ($user_can_see_queue_settings) {
-            echo "<td>", html_safe($qd->release_criterion), "</td>\n";
+        echo "<td>$length</td>\n";
+        echo "<td>$unheld_length</td>\n";
+        if (user_can_see_queue_settings()) {
+            echo "<td>", html_safe($queue_data["release_criterion"]), "</td>\n";
         }
-        echo "<td>", html_safe($qd->comment), "</td>\n";
+        echo "<td>", html_safe($queue_data["comment"]), "</td>\n";
         echo "</tr>\n";
     }
     echo "</table>\n";
@@ -185,44 +162,11 @@ function _show_round_queues($round, $listing_view_mode)
     }
 }
 
-function _get_queue_length($cooked_project_selector, $project_waiting_state)
-{
-    $state_clause = sprintf(
-        "state='%s'",
-        DPDatabase::escape($project_waiting_state)
-    );
-    $c_sql = "
-        SELECT count(*) as total, SUM(CASE WHEN project_holds.state is NULL THEN 1 ELSE 0 END) as unheld
-        FROM projects
-            LEFT OUTER JOIN project_holds USING (projectid, state)
-        WHERE ($cooked_project_selector)
-            AND $state_clause
-    ";
-
-    try {
-        $c_res = DPDatabase::query($c_sql);
-        $row = mysqli_fetch_row($c_res);
-        return [$row[0], $row[1] ?? 0];
-    } catch (DBQueryError $error) {
-        return [null, null];
-    }
-}
-
 function _show_queue_details($round, $name, $unheld_only)
 {
-    global $code_url, $user_can_see_queue_settings;
-
-    $sql = sprintf(
-        "
-        SELECT *
-        FROM queue_defns
-        WHERE round_id='%s' AND name='%s'
-        ",
-        DPDatabase::escape($round->id),
-        DPDatabase::escape($name)
-    );
-    $qd = mysqli_fetch_object(DPDatabase::query($sql));
-    if (!$qd) {
+    global $code_url;
+    $queue = fetch_queue_data_by_name($round, $name);
+    if (is_null($queue)) {
         die(html_safe("No such release queue '$name' in $round->id."));
     }
 
@@ -231,23 +175,22 @@ function _show_queue_details($round, $name, $unheld_only)
     // TRANSLATORS: %s is the name of this release queue.
     echo "<h2>" . html_safe(sprintf(_('%1$s release queue: %2$s'), $round->id, $name)) . "</h2>";
 
-    $cooked_project_selector = cook_project_selector($qd->project_selector);
-
-    [$length, $length_unheld] = _get_queue_length($cooked_project_selector, $round->project_waiting_state);
-
     $fields = [
-        _("Comment") => $qd->comment,
-        _("Status") => $qd->enabled ? _("enabled") : _("disabled"),
-        _("Current length") => $length,
-        _("Length without holds") => $length_unheld,
+        _("Id") => $queue["id"],
+        _("Comment") => $queue["comment"],
+        _("Status") => $queue["enabled"] ? _("enabled") : _("disabled"),
+        _("Current length") => $queue["length"],
+        _("Length without holds") => $queue["unheld_length"],
     ];
 
-    if ($user_can_see_queue_settings) {
-        $fields[_("Selector")] = $qd->project_selector;
-        if ($cooked_project_selector != $qd->project_selector) {
+    $cooked_project_selector = cook_project_selector($queue["project_selector"]);
+
+    if (user_can_see_queue_settings()) {
+        $fields[_("Selector")] = $queue["project_selector"];
+        if ($cooked_project_selector != $queue["project_selector"]) {
             $fields[_("Filled-in")] = $cooked_project_selector;
         }
-        $fields[_("Release Criterion")] = $qd->release_criterion;
+        $fields[_("Release Criterion")] = $queue["release_criterion"];
     }
 
     echo "<p>";
@@ -267,20 +210,18 @@ function _show_queue_details($round, $name, $unheld_only)
     echo "<th>" . html_safe(_("Pages")) . "</th>";
     echo "</tr>";
 
-    foreach ([1, 7, 28, 84] as $days_ago) {
-        $seconds_ago = time() - 60 * 60 * 24 * $days_ago;
-        [$projects_released, $pages_released] = _get_num_projects_and_pages_released_in_last($name, $seconds_ago, $round->project_waiting_state);
+    foreach (fetch_queue_stats_data($round, $name) as $stats) {
         echo "<tr>";
-        echo "<td class='right-align'>$days_ago</td>";
-        echo "<td class='right-align'>$projects_released</td>";
-        echo "<td class='right-align'>$pages_released</td>";
+        echo "<td class='right-align'>", $stats["days_ago"], "</td>";
+        echo "<td class='right-align'>", $stats["projects_released"], "</td>";
+        echo "<td class='right-align'>", $stats["pages_released"], "</td>";
         echo "</tr>";
     }
     echo "</table>";
 
     echo "<h3>" . html_safe(_("Projects currently in queue")) . "</h3>";
 
-    $ename = urlencode($qd->name);
+    $ename = urlencode($queue["name"]);
     echo "<p>";
     if ($unheld_only) {
         echo "<a href='?round_id=$round->id&amp;name=$ename&amp;unheld_only=0'>" . html_safe("Show all projects") . "</a> | ";
@@ -291,73 +232,33 @@ function _show_queue_details($round, $name, $unheld_only)
     }
     echo "</p>";
 
-
-    $comments_url1 = DPDatabase::escape("<a href='$code_url/project.php?id=");
-    $comments_url2 = DPDatabase::escape("'>");
-    $comments_url3 = DPDatabase::escape("</a>");
-
-    $unheld_only_sql = $unheld_only ? "project_holds.state is NULL" : "1";
-    dpsql_dump_themed_query("
-        SELECT
-
-            concat('$comments_url1',projectID,'$comments_url2', nameofwork, '$comments_url3') as '"
-                . DPDatabase::escape(_("Title")) . "',
-            authorsname as '" . DPDatabase::escape(_("Author")) . "',
-            language    as '" . DPDatabase::escape(_("Language")) . "',
-            genre       as '" . DPDatabase::escape(_("Genre")) . "',
-            difficulty  as '" . DPDatabase::escape(_("Difficulty")) . "',
-            username    as '" . DPDatabase::escape(_("Project Manager")) . "',
-            FROM_UNIXTIME(modifieddate) as '"
-                . DPDatabase::escape(_("Date Last Modified")) . "',
-            IF(ISNULL(project_holds.state),'&nbsp;','Y') AS '" . DPDatabase::escape(_("Hold?")) . "'
-        FROM projects
-            LEFT OUTER JOIN project_holds USING (projectid, state)
-        WHERE ($cooked_project_selector)
-            AND state='{$round->project_waiting_state}'
-            AND $unheld_only_sql
-        ORDER BY modifieddate, nameofwork
-    ");
-}
-
-function _get_num_projects_and_pages_released_in_last($name, $seconds_ago, $waiting_state)
-{
-    $sql = sprintf(
-        "
-        SELECT count(*)
-        FROM project_events
-        WHERE event_type = 'transition'
-            AND details1 = '%s'
-            AND details3 = 'via_q: %s'
-            AND timestamp >= %d
-        ",
-        DPDatabase::escape($waiting_state),
-        DPDatabase::escape($name),
-        $seconds_ago
-    );
-    $result = DPDatabase::query($sql);
-    $projects_released = mysqli_fetch_row($result)[0];
-
-    $sql = sprintf(
-        "
-        SELECT sum(n_pages)
-        FROM projects
-        WHERE projectid in (
-            SELECT projectid
-            FROM project_events
-            WHERE event_type = 'transition'
-                AND details1 = '%s'
-                AND details3 = 'via_q: %s'
-                AND timestamp >= %d
-        )
-        ",
-        DPDatabase::escape($waiting_state),
-        DPDatabase::escape($name),
-        $seconds_ago
-    );
-    $result = DPDatabase::query($sql);
-    $pages_released = mysqli_fetch_row($result)[0] ?? 0;
-
-    return [$projects_released, $pages_released];
+    $headers = [
+        _("Title"),
+        _("Author"),
+        _("Languages"),
+        _("Genre"),
+        _("Difficulty"),
+        _("Project Manager"),
+        _("Date Last Modified"),
+        _("Hold?"),
+    ];
+    echo "<table class='themed theme_striped stats' style='width: 100%; table-layout: fixed'>\n";
+    echo "<tr>\n";
+    echo surround_and_join(array_map("html_safe", $headers), "<th>", "</th>\n", "");
+    echo "</tr>\n";
+    foreach(fetch_queue_projects_data($round, $queue["project_selector"], $unheld_only) as $p) {
+        echo "<tr>\n";
+        echo "<td><a href='$code_url/project.php?id=", attr_safe($p["projectid"]), "'>", html_safe($p["title"]), "</a></td>\n";
+        echo "<td>", html_safe($p["author"]), "</td>\n";
+        echo "<td>", html_safe(Project::encode_languages($p["languages"])), "</td>\n";
+        echo "<td>", html_safe($p["genre"]), "</td>\n";
+        echo "<td>", html_safe($p["difficulty"]), "</td>\n";
+        echo "<td>", html_safe($p["username"]), "</td>\n";
+        echo "<td>", date("Y-m-d H:i:s", $p["last_state_change_time"]), "</td>\n";
+        echo "<td>", is_null($p["holds_state"]) ? "&nbsp;" : "Y", "</td>\n";
+        echo "</tr>";
+    }
+    echo "</table>";
 }
 
 function _get_num_projects_and_pages_available($round)


### PR DESCRIPTION
…eues

Much of this can probably be implemented better, but this is a first pass for discussion.

Example use:
API_KEY=...
ROOT=https://www.pgdp.org/~bfoley/c.branch/api-queue FILTER="show=enabled&group[]=Uber&group[]=PM&name[]=Eng&name[]=LOTE" FIELDS="field[]=name&field[]=group&field[]=ordering&field[]=release_criterion" curl -X GET "$ROOT/api/v1/queues/P1?$FILTER&$FIELDS" \
    -H "Accept: application/json" \
    -H "X-API-KEY: $API_KEY"