### PR TITLE
Add autoincrement id to queue_defns

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -408,6 +408,7 @@ CREATE TABLE `projects` (
 #
 
 CREATE TABLE `queue_defns` (
+  `id` int(4) NOT NULL auto_increment,
   `round_id` char(2) NOT NULL default '',
   `ordering` mediumint(5) NOT NULL default '0',
   `enabled` tinyint(1) NOT NULL default '0',
@@ -415,6 +416,7 @@ CREATE TABLE `queue_defns` (
   `project_selector` text NOT NULL,
   `release_criterion` text NOT NULL,
   `comment` text,
+  PRIMARY KEY  (`id`),
   UNIQUE KEY `ordering` (`round_id`,`ordering`),
   UNIQUE KEY `name` (`round_id`,`name`)
 );

--- a/SETUP/upgrade/20/20240129_add_id_to_queue_defns.php
+++ b/SETUP/upgrade/20/20240129_add_id_to_queue_defns.php
@@ -1,0 +1,19 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding autoincrement id to queue_defns\n";
+$sql = "
+    ALTER TABLE queue_defns
+    ADD COLUMN `id` INT AUTO_INCREMENT PRIMARY KEY FIRST
+";
+
+$result = mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";


### PR DESCRIPTION
Add an auto-incremented integer ID to the release queue definitions so we can refer to them in a more sensible way. This way the API doesn't need to worry about parsing queue names to refer to them and the user doesn't have to focus on escaping them.

Because this is an autoincrement field none of the code needs updating -- it's all just going to ignore it. This was tested on TEST by adding a new PM queue via the noncvs script.

This has been run on TEST and since all sandboxes use the same DB any validation we want to do can be done via the main sandbox.