### PR TITLE
cleanup: use array_key_exists($k, $a) instead of in_array($k, array_keys($a))

### DIFF
--- a/api/v1_validators.inc
+++ b/api/v1_validators.inc
@@ -10,7 +10,7 @@ function validate_round($roundid, $data)
     global $Round_for_round_id_;
 
     try {
-        if (!in_array($roundid, array_keys($Round_for_round_id_))) {
+        if (!array_key_exists($roundid, $Round_for_round_id_)) {
             throw new InvalidRoundException("Invalid round");
         }
         return $Round_for_round_id_[$roundid];

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -313,7 +313,7 @@ class Project
             }
         }
 
-        if ($this->genre && !in_array($this->genre, array_keys(load_genre_translation_array()))) {
+        if ($this->genre && !array_key_exists($this->genre, load_genre_translation_array())) {
             $errors[] = sprintf(_("%s is not a valid genre."), $this->genre);
         }
 
@@ -321,7 +321,7 @@ class Project
             $errors[] = sprintf(_("%s is not a valid image source."), $this->image_source);
         }
 
-        if ($this->difficulty && !in_array($this->difficulty, array_keys(get_project_difficulties()))) {
+        if ($this->difficulty && !array_key_exists($this->difficulty, get_project_difficulties())) {
             $errors[] = sprintf(_("%s is not a valid difficulty."), $this->difficulty);
         }
 
@@ -337,7 +337,7 @@ class Project
                     $errors[] = _("Month and Day are required for Birthday or Otherday Specials.");
                 }
             } else {
-                if (!in_array($this->special_code, array_keys(load_special_days()))) {
+                if (!array_key_exists($this->special_code, load_special_days())) {
                     $errors[] = sprintf(_("%s is not a valid special day."), $this->special_code);
                 }
             }

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -713,7 +713,7 @@ function get_pool_query_result($pool_view, $pool_sort, $pool_column_specs, $user
     }
 
     [$order_col, $order_dir] = get_sort_col_and_dir($pool_sort);
-    if (!in_array($order_col, array_keys($pool_column_specs))) {
+    if (!array_key_exists($order_col, $pool_column_specs)) {
         $order_col = 'title';
         $order_dir = 'A';
     }


### PR DESCRIPTION
array_key_exists was introduced in PHP 4.0.7.

It's a little shorter to write and (after looking at the Zend source), it is more efficient because it tests directly against $a rather than allocating a temporary new list with the keys in it.