### PR TITLE
faq: Remove incorrect argument to output_header for builtin FAQs

### DIFF
--- a/faq/formatting_guidelines.php
+++ b/faq/formatting_guidelines.php
@@ -9,7 +9,7 @@ maybe_redirect_to_external_faq("en");
 
 $theme_args["css_data"] = "p.backtotop {text-align:right; font-size:75%;margin-right:-5%;}";
 
-output_header('Formatting Guidelines', 'header', NO_STATSBAR, $theme_args);
+output_header('Formatting Guidelines', NO_STATSBAR, $theme_args);
 
 ?>
 

--- a/faq/post_proof.php
+++ b/faq/post_proof.php
@@ -11,7 +11,7 @@ maybe_redirect_to_external_faq();
 $theme_args["css_data"] = "div.note {padding: .75em; background: #f9f9f9; border: 3px #aaa double; width: 90%; margin: 1em 1em 1em 3em;}
 .spaced li {margin-bottom: .5em;}";
 
-output_header('Post-Processing FAQ', 'header', NO_STATSBAR, $theme_args);
+output_header('Post-Processing FAQ', NO_STATSBAR, $theme_args);
 
 $post_processing_forum_url = get_url_to_view_forum($post_processing_forum_idx);
 $teams_forum_url = get_url_to_view_forum($teams_forum_idx);


### PR DESCRIPTION
Because this was in the place of the positional show_stats arg it caused the sidebar to appear.

This was missed in the refactor a2d59202ae483 (by me!)

It was never noticed because on PGDP these FAQs redirect to the wiki.