### PR TITLE
my_suggestions.php: get_desired_language() doesn't take an arg

### DIFF
--- a/tools/proofers/my_suggestions.php
+++ b/tools/proofers/my_suggestions.php
@@ -602,7 +602,7 @@ function get_user_suggestion_criteria($username, $flush_cache = false)
     // proofread in the language the UI is in and fall back to English
     if (!$user_languages) {
         $user_languages = [
-            lang_name(short_lang_code(get_desired_language($username))) => 5,
+            lang_name(short_lang_code(get_user_language($username))) => 5,
         ];
         $user_languages["English"] = 1;
     }


### PR DESCRIPTION
Even back in the dawn of time (ie 786723b9c96), it didn't.

Found by PHPStan