### PR TITLE
DPDatabase.inc: Make (de)serialization funcs protected too

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -196,10 +196,11 @@ final class DPDatabase
     protected function __clone()
     {
     }
-    public function __sleep()
+    protected function __sleep()
     {
+        return [];
     }
-    public function __wakeup()
+    protected function __wakeup()
     {
     }
 }


### PR DESCRIPTION
...to remove another way of creating instances of the class

And fix the return type of __sleep (should be a list of strings) to quell PHPStan.