### PR TITLE
CharSuites.__set: Has a void return type so shouldn't return null

### DIFF
--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -72,7 +72,7 @@ class CharSuite
             $this->_pickerset = $value;
             $this->_pickerset->name = $this->name;
         } else {
-            // If we don't recognize the property, raise a notice and return null
+            // If we don't recognize the property, raise a notice
             $trace = debug_backtrace();
             trigger_error(
                 'Undefined property via __get(): ' . $name .
@@ -80,7 +80,6 @@ class CharSuite
                 ' on line ' . $trace[0]['line'],
                 E_USER_NOTICE
             );
-            return null;
         }
     }
 


### PR DESCRIPTION
TIL that PHP is unlike Python (in this way, as well as so many others :) ). Since 7.1 it has an explicit void return type, which differs from null.

You can either let a function implicitly return, or explicitly use `return;`

https://wiki.php.net/rfc/void_return_type