### PR TITLE
POFile: Update the PHPDoc for count_translated_strings

### DIFF
--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -45,8 +45,6 @@ class POFile
 
     /**
      * Count the total number of strings and the number of translated strings.
-     *
-     * @return array `[$count, $translated]`
      */
     private function count_translated_strings()
     {


### PR DESCRIPTION
It doesn't actually return anything (and the callers don't require it to)

Found by PHPStan