### PR TITLE
credits.php: Remove PermissiveRecursiveDirectoryIterator and use CATC…

### DIFF
--- a/credits.php
+++ b/credits.php
@@ -55,8 +55,11 @@ function output_credit_details($credit_details)
 function load_bundled_credit_details($code_dir)
 {
     $credit_details = [];
-    $dir_iter = new PermissiveRecursiveDirectoryIterator($code_dir);
-    $files = new RecursiveIteratorIterator($dir_iter);
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($code_dir),
+        RecursiveIteratorIterator::SELF_FIRST,
+        RecursiveIteratorIterator::CATCH_GET_CHILD
+    );
     foreach ($files as $file_info) {
         $file = $file_info->getPathname();
         if (basename($file) != "details.json") {
@@ -90,26 +93,6 @@ function load_composer_credit_details()
 
     uksort($credit_details, "strcasecmp");
     return $credit_details;
-}
-
-/**
- * A permissive recursive directory iterator
- *
- * Ignore exceptions when iterating over the directory, such as permission
- * errors from `SETUP/`.
- *
- * From antennen at https://www.php.net/manual/en/class.recursivedirectoryiterator.php
- */
-class PermissiveRecursiveDirectoryIterator extends RecursiveDirectoryIterator
-{
-    public function getChildren()
-    {
-        try {
-            return new PermissiveRecursiveDirectoryIterator($this->getPathname());
-        } catch (UnexpectedValueException $e) {
-            return new RecursiveArrayIterator([]);
-        }
-    }
 }
 
 /**


### PR DESCRIPTION
…H_GET_CHILD

Implementing PermissiveRecursiveDirectoryIterator is a lot more boilerplate, and technically it doesn't typecheck: the return types for the 2 returns in getChildren aren't compatible and because of the signatures on RecursiveDirectoryIterator, I couldn't find any good way to make them match.

Test with this sandbox where SETUP/ is chmod 0
https://www.pgdp.org/~bfoley/c.branch/credits-recurse/credits.php