### PR TITLE
avoid creating project transitions unless needed

### DIFF
--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -12,9 +12,6 @@ include_once($relPath.'User.inc');
 
 define('PT_AUTO', '[AUTO]');
 
-global $PROJECT_TRANSITIONS;
-$PROJECT_TRANSITIONS = [];
-
 class ProjectTransition
 {
     /**
@@ -61,9 +58,6 @@ class ProjectTransition
                 project_states_text($this->to_state)
             );
         }
-
-        global $PROJECT_TRANSITIONS;
-        $PROJECT_TRANSITIONS[] = & $this;
     }
 
     public function is_valid_for($project, $who)
@@ -418,8 +412,6 @@ function project_pre_release_check($project, $round)
  */
 function get_valid_transitions($project, $username)
 {
-    global $PROJECT_TRANSITIONS;
-
     // Keep a cache of viable transitions for a given "from" state
     // so we don't have to iterate over every transition for every project/user
     // combo. We must still do the check for the specific project and user, but
@@ -428,7 +420,7 @@ function get_valid_transitions($project, $username)
     static $viable_transitions_from = [];
     if (!isset($viable_transitions_from[$project->state])) {
         $viable_transitions_from[$project->state] = [];
-        foreach ($PROJECT_TRANSITIONS as $transition) {
+        foreach (create_all_transitions() as $transition) {
             if ($transition->from_state == $project->state) {
                 $viable_transitions_from[$project->state][] = $transition;
             }
@@ -449,8 +441,7 @@ function get_valid_transitions($project, $username)
 
 function get_transition($from_state, $to_state)
 {
-    global $PROJECT_TRANSITIONS;
-    foreach ($PROJECT_TRANSITIONS as $transition) {
+    foreach (create_all_transitions() as $transition) {
         if ($transition->from_state == $from_state &&
              $transition->to_state == $to_state) {
             return $transition;
@@ -462,303 +453,736 @@ function get_transition($from_state, $to_state)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-new ProjectTransition(
-    PROJ_NEW,
-    PROJ_P1_UNAVAILABLE,
-    'unrestricted_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => null,
-        'detour' => null,
-        'settings_template' => '',
-        'collateral_actions' => null,
-    ]
-);
+function create_all_transitions()
+{
+    global $code_url, $PROJECT_STATES_IN_ORDER;
 
-// -----------------------------------------------------------------------------
+    static $project_transitions = null;
+    if($project_transitions) {
+        return $project_transitions;
+    }
 
-for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-    $round = get_Round_for_round_number($rn);
-
-    // setting modifieddate:
-    //
-    // The time when projects enter the Waiting state
-    // is the overall ordering criterion for the "release queue".
-    // Thus, we set modifieddate when transiting to Waiting
-    // (from Unavailable or the previous round's Complete).
-    //
-    // The time when projects enter the Available state
-    // is the ordering criterion for "Sort by Days"
-    // in the list of available projects.
-    // (But if the project is just coming back from
-    // Bad, that shouldn't affect the sort order.)
-    // Thus, we set modifieddate when transiting to Available
-    // from anything other than Bad (i.e., from Waiting).
-
-
-    new ProjectTransition(
-        $round->project_unavailable_state,
-        $round->project_waiting_state,
-        // PMs with project loads disabled can't move a project
-        // out of unavailable, either
+    $project_transitions[] = new ProjectTransition(
+        PROJ_NEW,
+        PROJ_P1_UNAVAILABLE,
         'unrestricted_manager',
         [
             'project_restriction' => null,
             'action_name' => '[default]',
             'confirmation_question' => null,
             'detour' => null,
-            'settings_template' => 'modifieddate="<TIMESTAMP>"',
-            'collateral_actions' => null,
-        ]
-    );
-
-    new ProjectTransition(
-        $round->project_waiting_state,
-        $round->project_unavailable_state,
-        'manager',
-        [
-            'project_restriction' => null,
-            'action_name' => '[default]',
-            'confirmation_question' => null,
-            'detour' => null,
-            'settings_template' => '',
-            'collateral_actions' => 'to_unavailable_collateral',
-        ]
-    );
-
-    new ProjectTransition(
-        $round->project_waiting_state,
-        $round->project_available_state,
-        'proj_facilitator|auto',
-        [
-            'project_restriction' => null,
-            'action_name' => '[default]',
-            'confirmation_question' => '[default]',
-            'detour' => null,
-            'settings_template' => 'modifieddate="<TIMESTAMP>"',
-            'collateral_actions' => 'round_release_collateral',
-        ]
-    );
-
-    new ProjectTransition(
-        $round->project_bad_state,
-        $round->project_unavailable_state,
-        'manager',
-        [
-            'project_restriction' => null,
-            'action_name' => '[default]',
-            'confirmation_question' => null,
-            'detour' => null,
-            'settings_template' => '',
-            'collateral_actions' => 'to_unavailable_collateral',
-        ]
-    );
-
-    new ProjectTransition(
-        $round->project_bad_state,
-        'automodify',
-        'manager',
-        [
-            'project_restriction' => null,
-            'action_name' => _('automodify'),
-            'confirmation_question' => null,
-            'detour' => "$code_url/tools/project_manager/automodify.php?project=<PROJECTID>",
-            'settings_template' => '',
-            'collateral_actions' => null,
-        ]
-    );
-    // automodify.php will leave the project in the appropriate
-    // BAD, AVAILABLE, or COMPLETE state.
-    // ($settings_template of this ProjectTransition
-    // will never be consulted.)
-
-    new ProjectTransition(
-        $round->project_available_state,
-        $round->project_unavailable_state,
-        'manager',
-        [
-            'project_restriction' => null,
-            'action_name' => '[default]',
-            'confirmation_question' => '[default]',
-            'detour' => null,
-            'settings_template' => '',
-            'collateral_actions' => 'to_unavailable_collateral',
-        ]
-    );
-
-    new ProjectTransition(
-        $round->project_available_state,
-        'automodify',
-        'manager',
-        [
-            'project_restriction' => null,
-            'action_name' => _('automodify'),
-            'confirmation_question' => null,
-            'detour' => "$code_url/tools/project_manager/automodify.php?project=<PROJECTID>",
             'settings_template' => '',
             'collateral_actions' => null,
         ]
     );
 
-    new ProjectTransition(
-        $round->project_waiting_state,
-        $round->project_bad_state,
-        'auto',
-        [
-            'project_restriction' => null,
-            'action_name' => null,
-            'confirmation_question' => null,
-            'detour' => null,
-            'settings_template' => '',
-            'collateral_actions' => null,
-        ]
-    );
+    // -----------------------------------------------------------------------------
 
-    new ProjectTransition(
-        $round->project_available_state,
-        $round->project_bad_state,
-        'auto',
-        [
-            'project_restriction' => null,
-            'action_name' => null,
-            'confirmation_question' => null,
-            'detour' => null,
-            'settings_template' => '',
-            'collateral_actions' => 'bad_project_collateral',
-        ]
-    );
+    for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
+        $round = get_Round_for_round_number($rn);
 
-    new ProjectTransition(
-        $round->project_bad_state,
-        $round->project_available_state,
-        'auto',
-        [
-            'project_restriction' => null,
-            'action_name' => null,
-            'confirmation_question' => null,
-            'detour' => null,
-            'settings_template' => '',
-            'collateral_actions' => null,
-        ]
-    );
+        // setting modifieddate:
+        //
+        // The time when projects enter the Waiting state
+        // is the overall ordering criterion for the "release queue".
+        // Thus, we set modifieddate when transiting to Waiting
+        // (from Unavailable or the previous round's Complete).
+        //
+        // The time when projects enter the Available state
+        // is the ordering criterion for "Sort by Days"
+        // in the list of available projects.
+        // (But if the project is just coming back from
+        // Bad, that shouldn't affect the sort order.)
+        // Thus, we set modifieddate when transiting to Available
+        // from anything other than Bad (i.e., from Waiting).
 
-    new ProjectTransition(
-        $round->project_available_state,
-        $round->project_complete_state,
-        'auto',
-        [
-            'project_restriction' => null,
-            'action_name' => null,
-            'confirmation_question' => null,
-            'detour' => null,
-            'settings_template' => '',
-            'collateral_actions' => 'round_complete_collateral',
-        ]
-    );
 
-    if ($rn < MAX_NUM_PAGE_EDITING_ROUNDS) {
-        $next_round = get_Round_for_round_number($rn + 1);
-
-        new ProjectTransition(
-            $round->project_complete_state,
-            $next_round->project_waiting_state,
-            'auto',
+        $project_transitions[] = new ProjectTransition(
+            $round->project_unavailable_state,
+            $round->project_waiting_state,
+            // PMs with project loads disabled can't move a project
+            // out of unavailable, either
+            'unrestricted_manager',
             [
                 'project_restriction' => null,
-                'action_name' => null,
+                'action_name' => '[default]',
                 'confirmation_question' => null,
                 'detour' => null,
                 'settings_template' => 'modifieddate="<TIMESTAMP>"',
                 'collateral_actions' => null,
             ]
         );
-    } else {
-        new ProjectTransition(
-            $round->project_complete_state,
-            PROJ_POST_FIRST_AVAILABLE,
-            'auto',
-            [
-                'project_restriction' => null,
-                'action_name' => null,
-                'confirmation_question' => null,
-                'detour' => null,
-                'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby=''",
-                'collateral_actions' => 'round_to_PP_avail_collateral',
-            ]
-        );
 
-        new ProjectTransition(
-            $round->project_complete_state,
-            PROJ_POST_FIRST_CHECKED_OUT,
-            'auto',
-            [
-                'project_restriction' => null,
-                'action_name' => null,
-                'confirmation_question' => null,
-                'detour' => null,
-                'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby=IF(checkedoutby!='',checkedoutby,username)",
-                'collateral_actions' => 'round_to_PP_out_collateral',
-            ]
-        );
-    }
-
-    if (1) {
-        // Transitions to skip rounds
-
-        $from_states = [
+        $project_transitions[] = new ProjectTransition(
             $round->project_waiting_state,
             $round->project_unavailable_state,
-        ];
+            'manager',
+            [
+                'project_restriction' => null,
+                'action_name' => '[default]',
+                'confirmation_question' => null,
+                'detour' => null,
+                'settings_template' => '',
+                'collateral_actions' => 'to_unavailable_collateral',
+            ]
+        );
 
-        foreach ($from_states as $from_state) {
-            if ($rn < MAX_NUM_PAGE_EDITING_ROUNDS) {
-                $next_round = get_Round_for_round_number($rn + 1);
+        $project_transitions[] = new ProjectTransition(
+            $round->project_waiting_state,
+            $round->project_available_state,
+            'proj_facilitator|auto',
+            [
+                'project_restriction' => null,
+                'action_name' => '[default]',
+                'confirmation_question' => '[default]',
+                'detour' => null,
+                'settings_template' => 'modifieddate="<TIMESTAMP>"',
+                'collateral_actions' => 'round_release_collateral',
+            ]
+        );
 
-                new ProjectTransition(
-                    $from_state,
-                    $next_round->project_waiting_state,
-                    'site_manager',
-                    [
-                        'project_restriction' => null,
-                        'action_name' => _('Skip this round'),
-                        'confirmation_question' => '[default]',
-                        'detour' => null,
-                        'settings_template' => "modifieddate='<TIMESTAMP>', nameofwork=CONCAT(nameofwork,' {{$round->id} skipped}')",
-                        'collateral_actions' => null,
-                    ]
-                );
-            } else {
-                new ProjectTransition(
-                    $from_state,
-                    PROJ_POST_FIRST_AVAILABLE,
-                    'site_manager',
-                    [
-                        'project_restriction' => 'proj_would_go_to_PP_avail',
-                        'action_name' => _('Skip this round'),
-                        'confirmation_question' => '[default]',
-                        'detour' => null,
-                        'settings_template' => "modifieddate='<TIMESTAMP>', nameofwork=CONCAT(nameofwork,' {{$round->id} skipped}'), n_available_pages=0, checkedoutby=''",
-                        'collateral_actions' => 'round_to_PP_avail_collateral',
-                    ]
-                );
+        $project_transitions[] = new ProjectTransition(
+            $round->project_bad_state,
+            $round->project_unavailable_state,
+            'manager',
+            [
+                'project_restriction' => null,
+                'action_name' => '[default]',
+                'confirmation_question' => null,
+                'detour' => null,
+                'settings_template' => '',
+                'collateral_actions' => 'to_unavailable_collateral',
+            ]
+        );
 
-                new ProjectTransition(
-                    $from_state,
-                    PROJ_POST_FIRST_CHECKED_OUT,
-                    'site_manager',
-                    [
-                        'project_restriction' => 'proj_would_go_to_PP_out',
-                        'action_name' => _('Skip this round'),
-                        'confirmation_question' => '[default]',
-                        'detour' => null,
-                        'settings_template' => "modifieddate='<TIMESTAMP>', nameofwork=CONCAT(nameofwork,' {{$round->id} skipped}'), n_available_pages=0, checkedoutby=IF(checkedoutby!='',checkedoutby,username)",
-                        'collateral_actions' => 'round_to_PP_out_collateral',
-                    ]
-                );
+        $project_transitions[] = new ProjectTransition(
+            $round->project_bad_state,
+            'automodify',
+            'manager',
+            [
+                'project_restriction' => null,
+                'action_name' => _('automodify'),
+                'confirmation_question' => null,
+                'detour' => "$code_url/tools/project_manager/automodify.php?project=<PROJECTID>",
+                'settings_template' => '',
+                'collateral_actions' => null,
+            ]
+        );
+        // automodify.php will leave the project in the appropriate
+        // BAD, AVAILABLE, or COMPLETE state.
+        // ($settings_template of this ProjectTransition
+        // will never be consulted.)
+
+        $project_transitions[] = new ProjectTransition(
+            $round->project_available_state,
+            $round->project_unavailable_state,
+            'manager',
+            [
+                'project_restriction' => null,
+                'action_name' => '[default]',
+                'confirmation_question' => '[default]',
+                'detour' => null,
+                'settings_template' => '',
+                'collateral_actions' => 'to_unavailable_collateral',
+            ]
+        );
+
+        $project_transitions[] = new ProjectTransition(
+            $round->project_available_state,
+            'automodify',
+            'manager',
+            [
+                'project_restriction' => null,
+                'action_name' => _('automodify'),
+                'confirmation_question' => null,
+                'detour' => "$code_url/tools/project_manager/automodify.php?project=<PROJECTID>",
+                'settings_template' => '',
+                'collateral_actions' => null,
+            ]
+        );
+
+        $project_transitions[] = new ProjectTransition(
+            $round->project_waiting_state,
+            $round->project_bad_state,
+            'auto',
+            [
+                'project_restriction' => null,
+                'action_name' => null,
+                'confirmation_question' => null,
+                'detour' => null,
+                'settings_template' => '',
+                'collateral_actions' => null,
+            ]
+        );
+
+        $project_transitions[] = new ProjectTransition(
+            $round->project_available_state,
+            $round->project_bad_state,
+            'auto',
+            [
+                'project_restriction' => null,
+                'action_name' => null,
+                'confirmation_question' => null,
+                'detour' => null,
+                'settings_template' => '',
+                'collateral_actions' => 'bad_project_collateral',
+            ]
+        );
+
+        $project_transitions[] = new ProjectTransition(
+            $round->project_bad_state,
+            $round->project_available_state,
+            'auto',
+            [
+                'project_restriction' => null,
+                'action_name' => null,
+                'confirmation_question' => null,
+                'detour' => null,
+                'settings_template' => '',
+                'collateral_actions' => null,
+            ]
+        );
+
+        $project_transitions[] = new ProjectTransition(
+            $round->project_available_state,
+            $round->project_complete_state,
+            'auto',
+            [
+                'project_restriction' => null,
+                'action_name' => null,
+                'confirmation_question' => null,
+                'detour' => null,
+                'settings_template' => '',
+                'collateral_actions' => 'round_complete_collateral',
+            ]
+        );
+
+        if ($rn < MAX_NUM_PAGE_EDITING_ROUNDS) {
+            $next_round = get_Round_for_round_number($rn + 1);
+
+            $project_transitions[] = new ProjectTransition(
+                $round->project_complete_state,
+                $next_round->project_waiting_state,
+                'auto',
+                [
+                    'project_restriction' => null,
+                    'action_name' => null,
+                    'confirmation_question' => null,
+                    'detour' => null,
+                    'settings_template' => 'modifieddate="<TIMESTAMP>"',
+                    'collateral_actions' => null,
+                ]
+            );
+        } else {
+            $project_transitions[] = new ProjectTransition(
+                $round->project_complete_state,
+                PROJ_POST_FIRST_AVAILABLE,
+                'auto',
+                [
+                    'project_restriction' => null,
+                    'action_name' => null,
+                    'confirmation_question' => null,
+                    'detour' => null,
+                    'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby=''",
+                    'collateral_actions' => 'round_to_PP_avail_collateral',
+                ]
+            );
+
+            $project_transitions[] = new ProjectTransition(
+                $round->project_complete_state,
+                PROJ_POST_FIRST_CHECKED_OUT,
+                'auto',
+                [
+                    'project_restriction' => null,
+                    'action_name' => null,
+                    'confirmation_question' => null,
+                    'detour' => null,
+                    'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby=IF(checkedoutby!='',checkedoutby,username)",
+                    'collateral_actions' => 'round_to_PP_out_collateral',
+                ]
+            );
+        }
+
+        if (1) {
+            // Transitions to skip rounds
+
+            $from_states = [
+                $round->project_waiting_state,
+                $round->project_unavailable_state,
+            ];
+
+            foreach ($from_states as $from_state) {
+                if ($rn < MAX_NUM_PAGE_EDITING_ROUNDS) {
+                    $next_round = get_Round_for_round_number($rn + 1);
+
+                    $project_transitions[] = new ProjectTransition(
+                        $from_state,
+                        $next_round->project_waiting_state,
+                        'site_manager',
+                        [
+                            'project_restriction' => null,
+                            'action_name' => _('Skip this round'),
+                            'confirmation_question' => '[default]',
+                            'detour' => null,
+                            'settings_template' => "modifieddate='<TIMESTAMP>', nameofwork=CONCAT(nameofwork,' {{$round->id} skipped}')",
+                            'collateral_actions' => null,
+                        ]
+                    );
+                } else {
+                    $project_transitions[] = new ProjectTransition(
+                        $from_state,
+                        PROJ_POST_FIRST_AVAILABLE,
+                        'site_manager',
+                        [
+                            'project_restriction' => 'proj_would_go_to_PP_avail',
+                            'action_name' => _('Skip this round'),
+                            'confirmation_question' => '[default]',
+                            'detour' => null,
+                            'settings_template' => "modifieddate='<TIMESTAMP>', nameofwork=CONCAT(nameofwork,' {{$round->id} skipped}'), n_available_pages=0, checkedoutby=''",
+                            'collateral_actions' => 'round_to_PP_avail_collateral',
+                        ]
+                    );
+
+                    $project_transitions[] = new ProjectTransition(
+                        $from_state,
+                        PROJ_POST_FIRST_CHECKED_OUT,
+                        'site_manager',
+                        [
+                            'project_restriction' => 'proj_would_go_to_PP_out',
+                            'action_name' => _('Skip this round'),
+                            'confirmation_question' => '[default]',
+                            'detour' => null,
+                            'settings_template' => "modifieddate='<TIMESTAMP>', nameofwork=CONCAT(nameofwork,' {{$round->id} skipped}'), n_available_pages=0, checkedoutby=IF(checkedoutby!='',checkedoutby,username)",
+                            'collateral_actions' => 'round_to_PP_out_collateral',
+                        ]
+                    );
+                }
             }
         }
     }
+
+    // -----------------------------------------------------------------------------
+    // X_AVAILABLE -> X_CHECKED_OUT
+    // Anyone who can work in stage X can check out the project.
+    // OR, anyone who is currently allowed to check out in stage X
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_AVAILABLE,
+        PROJ_POST_FIRST_CHECKED_OUT,
+        'user_can_check_out_in_stage PP',
+        [
+            'project_restriction' => null,
+            'action_name' => _("Check Out Book"),
+            'confirmation_question' => _("Are you sure you want to check this book out for post processing?"),
+            'detour' => null,
+            'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='<WHO>'",
+            'collateral_actions' => 'PP_to_PP_out_collateral',
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_AVAILABLE,
+        PROJ_POST_SECOND_CHECKED_OUT,
+        'user_can_work_in_stage PPV',
+        [
+            'project_restriction' => null,
+            'action_name' => _("Check Out Book"),
+            'confirmation_question' => _("Are you sure you want to check this book out for verifying post processing?"),
+            'detour' => null,
+            'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, checkedoutby='<WHO>'",
+            'collateral_actions' => null,
+        ]
+    );
+
+    // PPer can grab a project back from the PPV pool
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_AVAILABLE,
+        PROJ_POST_FIRST_CHECKED_OUT,
+        'holder',
+        [
+            'project_restriction' => null,
+            'action_name' => _("Return to Post-Processor for further work"),
+            'confirmation_question' => _("Are you sure you want to take this book back for further work?"),
+            'detour' => null,
+            'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=''",
+            'collateral_actions' => null,
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+
+    // X_CHECKED_OUT -> X_AVAILABLE
+    // The user who has the project checked out for X can abandon/return it,
+    // making it available for others to check out.
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_FIRST_AVAILABLE,
+        'holder',
+        [
+            'project_restriction' => null,
+            'action_name' => _("Return to Available"),
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=return_1",
+            'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier=NULL, smoothread_deadline='0', postcomments=CONCAT(postcomments,'<G:postcomments>')",
+            'collateral_actions' => 'to_PP_available_collateral',
+            'disabled_during_SR' => true,
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_CHECKED_OUT,
+        PROJ_POST_SECOND_AVAILABLE,
+        'holder',
+        [
+            'project_restriction' => null,
+            'action_name' => _("Return to Available"),
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=return_2",
+            'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby=postproofer, postcomments=CONCAT(postcomments,'<G:postcomments>')",
+            'collateral_actions' => 'to_PPV_available_collateral',
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+
+    // X_CHECKED_OUT -> something other than X_AVAILABLE
+    // The user who has the project checked out for X
+    // can check it in (or return it to a previous holder).
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_SECOND_AVAILABLE,
+        'holder',
+        [
+            'project_restriction' => "project_was_not_returned_from_PPV",
+            'action_name' => _("Upload to the PPV pool for verification"),
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
+            'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
+            'collateral_actions' => 'to_PPV_available_collateral',
+            'disabled_during_SR' => true,
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_SECOND_AVAILABLE,
+        'site_manager',
+        [
+            'project_restriction' => "project_was_returned_from_PPV",
+            'action_name' => _("Upload to the PPV pool for verification"),
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
+            'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
+            'collateral_actions' => 'to_PPV_available_collateral',
+            'disabled_during_SR' => true,
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_CHECKED_OUT,
+        PROJ_POST_FIRST_CHECKED_OUT,
+        'holder',
+        [
+            'project_restriction' => null,
+            'action_name' => _("Return to Post-Processor"),
+            'confirmation_question' => _("Are you sure you want to return this book to the post-processor for further work?"),
+            'detour' => null,
+            // formerly ppverifier was only set when the project was uploaded to PG
+            // it is set here so the PPer can return it to the same PPVer
+            // any transition out of PROJ_POST_FIRST_CHECKED_OUT sets it to NULL
+            // this will not affect how the PPVer is ultimately set.
+            'settings_template' => "modifieddate='<TIMESTAMP>', ppverifier=checkedoutby, checkedoutby=postproofer, postproofer=''",
+            'collateral_actions' => "return_to_PP_collateral",
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_SECOND_CHECKED_OUT,
+        'holder',
+        [
+            'project_restriction' => "project_was_returned_from_PPV",
+            'action_name' => _("Return to your current PPVer for further checking"),
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=re_post_1",
+            'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, checkedoutby=ppverifier, ppverifier=NULL",
+            'collateral_actions' => "return_from_PP_to_PPV_collateral",
+            'disabled_during_SR' => true,
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+    // Transitions to and from PROJ_POST_FIRST_UNAVAILABLE:
+
+    // To PROJ_POST_FIRST_UNAVAILABLE:
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_AVAILABLE,
+        PROJ_POST_FIRST_UNAVAILABLE,
+        'manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => '[default]',
+            'detour' => null,
+            'settings_template' => '',
+            'collateral_actions' => 'to_unavailable_collateral',
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_FIRST_UNAVAILABLE,
+        'manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => _('Someone currently has this project checked out. Are you sure you want to make it unavailable?'),
+            'detour' => null,
+            'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier=NULL, smoothread_deadline='0'",
+            'collateral_actions' => 'to_unavailable_collateral',
+            'disabled_during_SR' => true,
+        ]
+    );
+
+    // From PROJ_POST_FIRST_UNAVAILABLE:
+
+    $pp_unavail_to_avail_confirm_question = sprintf(
+        _("This will clear the reserved PPer if there is one.") . " " .
+    _("Are you sure you want to change the state of this project to %s?"),
+        project_states_text(PROJ_POST_FIRST_AVAILABLE)
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_UNAVAILABLE,
+        PROJ_POST_FIRST_AVAILABLE,
+        // PMs with project loads disabled can't move a project
+        // out of unavailable, either
+        'unrestricted_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => _('Make Project Available for Post-Processing'),
+            'confirmation_question' => $pp_unavail_to_avail_confirm_question,
+            'detour' => null,
+            'settings_template' => "checkedoutby=''",   // Clear reserved PPer
+            'collateral_actions' => 'to_PP_available_collateral',
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_UNAVAILABLE,
+        PROJ_POST_FIRST_CHECKED_OUT,
+        // PMs with project load disabled can't move a project
+        // out of unavailable, either
+        'unrestricted_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => _('Check Out Project for Post-Processing'),
+            'confirmation_question' => _("It's unclear whether this transition should even be possible. Are you sure?"),
+            'detour' => null,
+            'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='<WHO>'",
+            'collateral_actions' => 'PP_to_PP_out_collateral',
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+    // Transitions to PROJ_POST_COMPLETE:
+    // (We should probably eliminate these, and the PROJ_POST_COMPLETE state.)
+
+    $post_complete_question =
+        _("Sending a project to post_complete probably isn't a good idea. Are you sure?");
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_POST_COMPLETE,
+        'site_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => $post_complete_question,
+            'detour' => null,
+            'settings_template' => "ppverifier=NULL",
+            'collateral_actions' => null,
+            'disabled_during_SR' => true,
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_AVAILABLE,
+        PROJ_POST_COMPLETE,
+        'site_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => $post_complete_question,
+            'detour' => null,
+            'settings_template' => '',
+            'collateral_actions' => null,
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_CHECKED_OUT,
+        PROJ_POST_COMPLETE,
+        'site_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => $post_complete_question,
+            'detour' => null,
+            'settings_template' => '',
+            'collateral_actions' => null,
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+    // Transitions to PROJ_SUBMIT_PG_POSTED:
+
+    /*
+        The following table describes the required values for checkedoutby,
+        postproofer and ppverifier after the transition to the named state.
+        The states are listed in their normal order, though projects that have
+        not yet reached "posted" may step back to the previous row,
+        e.g. 2-->1 or 5-->4. Note that the step from 4 to 5 is equivalent to
+        jumping from 4 to 2 but preserving the PPVer's name so that the
+        PPer can later move the project from 5 back to 4 for another PPV check.
+
+        Columns 2, 3 and 4 correspond to values set in fields in the
+        "projects" database table:
+            cob - checkedoutby
+            pp  - postproofer
+            ppv - ppverifier
+
+        a is the PPer
+        b is the PPVer, not the same user as the PPer
+
+            cob pp  ppv    state                         description
+
+        1.  -   -   NULL   proj_post_first_available,    available for PP
+        2.  a   -   NULL   proj_post_first_checked_out,  checked out for PP
+        3.  a   a   NULL   proj_post_second_available,   available for PPV
+        4.  b   a   NULL   proj_post_second_checked_out, checked out for PPV
+        5.  a   -   b      proj_post_first_checked_out,  returned to PP by PPV
+        6.  a   a   NULL   proj_submit_pgposted,         posted to PG, PPer has DU
+        7.  b   a   b      proj_submit_pgposted,         posted to PG, project was PPV'd
+
+
+        pseudo-code for transitions to PROJ_SUBMIT_PG_POSTED:
+        IF postproofer == '' THEN
+            # No postproofer has been recorded, so the project has been DUed
+            # by the PPer who has it checked out (not the PPVer).
+            postproofer=checkedoutby
+        ENDIF
+        IF postproofer != checkedoutby THEN
+            # checkedoutby must be the PPVer...
+            # (This assumes a project is only posted once!
+            # otherwise, maybe also test that ppverifier is null?)
+            ppverifier=checkedoutby
+        ELSE
+            # PPer has it checked out, and has therefore DUed the project
+            # so the PPVer did not complete PPV - remove their name
+            ppverifier=NULL
+        ENDIF
+
+    */
+
+    $pg_posted_settings_template =
+        "modifieddate='<TIMESTAMP>',
+        postproofer = IF( postproofer = '', checkedoutby, postproofer ),
+        ppverifier = IF( postproofer != checkedoutby, checkedoutby, NULL )";
+
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_FIRST_CHECKED_OUT,
+        PROJ_SUBMIT_PG_POSTED,
+        'site_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
+            'settings_template' => $pg_posted_settings_template,
+            'collateral_actions' => 'pg_posted_collateral',
+            'disabled_during_SR' => true,
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_AVAILABLE,
+        PROJ_SUBMIT_PG_POSTED,
+        'site_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
+            'settings_template' => $pg_posted_settings_template,
+            'collateral_actions' => 'pg_posted_collateral',
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_SECOND_CHECKED_OUT,
+        PROJ_SUBMIT_PG_POSTED,
+        'site_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
+            'settings_template' => $pg_posted_settings_template,
+            'collateral_actions' => 'pg_posted_collateral',
+        ]
+    );
+
+    $project_transitions[] = new ProjectTransition(
+        PROJ_POST_COMPLETE,
+        PROJ_SUBMIT_PG_POSTED,
+        'site_manager',
+        [
+            'project_restriction' => null,
+            'action_name' => '[default]',
+            'confirmation_question' => null,
+            'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
+            'settings_template' => $pg_posted_settings_template,
+            'collateral_actions' => 'pg_posted_collateral',
+        ]
+    );
+
+    // -----------------------------------------------------------------------------
+    // Transitions to PROJ_DELETE.
+
+    foreach ($PROJECT_STATES_IN_ORDER as $from_state) {
+        // Don't bother creating a transition for Delete -> Delete.
+        if ($from_state == PROJ_DELETE) {
+            continue;
+        }
+
+        // A NEW project can be deleted by its manager.
+        // Anything else requires an SA.
+        $who_may_delete = (
+            $from_state == PROJ_NEW
+            ? 'manager'
+            : 'site_manager'
+        );
+
+        $project_transitions[] = new ProjectTransition(
+            $from_state,
+            PROJ_DELETE,
+            $who_may_delete,
+            [
+                'project_restriction' => null,
+                'action_name' => _('Delete Project'),
+                'confirmation_question' => _('You should only delete a project that is beyond repair. Are you sure you want to delete this project?'),
+                'detour' => null,
+                'settings_template' => "modifieddate='<TIMESTAMP>'",
+                'collateral_actions' => null,
+            ]
+        );
+    }
+    return $project_transitions;
 }
 
 function round_release_collateral($old_project, $project, $transition, $who)
@@ -981,147 +1405,10 @@ function PP_to_PP_out_collateral($old_project, $project, $transition, $who)
     configure_gettext_for_user();
 }
 
-// -----------------------------------------------------------------------------
-// X_AVAILABLE -> X_CHECKED_OUT
-// Anyone who can work in stage X can check out the project.
-// OR, anyone who is currently allowed to check out in stage X
-
-new ProjectTransition(
-    PROJ_POST_FIRST_AVAILABLE,
-    PROJ_POST_FIRST_CHECKED_OUT,
-    'user_can_check_out_in_stage PP',
-    [
-        'project_restriction' => null,
-        'action_name' => _("Check Out Book"),
-        'confirmation_question' => _("Are you sure you want to check this book out for post processing?"),
-        'detour' => null,
-        'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='<WHO>'",
-        'collateral_actions' => 'PP_to_PP_out_collateral',
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_SECOND_AVAILABLE,
-    PROJ_POST_SECOND_CHECKED_OUT,
-    'user_can_work_in_stage PPV',
-    [
-        'project_restriction' => null,
-        'action_name' => _("Check Out Book"),
-        'confirmation_question' => _("Are you sure you want to check this book out for verifying post processing?"),
-        'detour' => null,
-        'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, checkedoutby='<WHO>'",
-        'collateral_actions' => null,
-    ]
-);
-
-// PPer can grab a project back from the PPV pool
-new ProjectTransition(
-    PROJ_POST_SECOND_AVAILABLE,
-    PROJ_POST_FIRST_CHECKED_OUT,
-    'holder',
-    [
-        'project_restriction' => null,
-        'action_name' => _("Return to Post-Processor for further work"),
-        'confirmation_question' => _("Are you sure you want to take this book back for further work?"),
-        'detour' => null,
-        'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=''",
-        'collateral_actions' => null,
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-// X_CHECKED_OUT -> X_AVAILABLE
-// The user who has the project checked out for X can abandon/return it,
-// making it available for others to check out.
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_FIRST_AVAILABLE,
-    'holder',
-    [
-        'project_restriction' => null,
-        'action_name' => _("Return to Available"),
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=return_1",
-        'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier=NULL, smoothread_deadline='0', postcomments=CONCAT(postcomments,'<G:postcomments>')",
-        'collateral_actions' => 'to_PP_available_collateral',
-        'disabled_during_SR' => true,
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_SECOND_CHECKED_OUT,
-    PROJ_POST_SECOND_AVAILABLE,
-    'holder',
-    [
-        'project_restriction' => null,
-        'action_name' => _("Return to Available"),
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=return_2",
-        'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby=postproofer, postcomments=CONCAT(postcomments,'<G:postcomments>')",
-        'collateral_actions' => 'to_PPV_available_collateral',
-    ]
-);
-
-// -----------------------------------------------------------------------------
-
-// X_CHECKED_OUT -> something other than X_AVAILABLE
-// The user who has the project checked out for X
-// can check it in (or return it to a previous holder).
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_SECOND_AVAILABLE,
-    'holder',
-    [
-        'project_restriction' => "project_was_not_returned_from_PPV",
-        'action_name' => _("Upload to the PPV pool for verification"),
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
-        'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
-        'collateral_actions' => 'to_PPV_available_collateral',
-        'disabled_during_SR' => true,
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_SECOND_AVAILABLE,
-    'site_manager',
-    [
-        'project_restriction' => "project_was_returned_from_PPV",
-        'action_name' => _("Upload to the PPV pool for verification"),
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=post_1",
-        'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, ppverifier=NULL, postcomments=CONCAT(postcomments,'<G:postcomments>')",
-        'collateral_actions' => 'to_PPV_available_collateral',
-        'disabled_during_SR' => true,
-    ]
-);
-
 function to_PPV_available_collateral($old_project, $project, $transition, $who)
 {
     notify_project_event_subscribers($project, 'ppv_enter');
 }
-
-new ProjectTransition(
-    PROJ_POST_SECOND_CHECKED_OUT,
-    PROJ_POST_FIRST_CHECKED_OUT,
-    'holder',
-    [
-        'project_restriction' => null,
-        'action_name' => _("Return to Post-Processor"),
-        'confirmation_question' => _("Are you sure you want to return this book to the post-processor for further work?"),
-        'detour' => null,
-        // formerly ppverifier was only set when the project was uploaded to PG
-        // it is set here so the PPer can return it to the same PPVer
-        // any transition out of PROJ_POST_FIRST_CHECKED_OUT sets it to NULL
-        // this will not affect how the PPVer is ultimately set.
-        'settings_template' => "modifieddate='<TIMESTAMP>', ppverifier=checkedoutby, checkedoutby=postproofer, postproofer=''",
-        'collateral_actions' => "return_to_PP_collateral",
-    ]
-);
 
 function return_to_PP_collateral($old_project, $project, $transition, $who)
 {
@@ -1139,21 +1426,6 @@ function return_to_PP_collateral($old_project, $project, $transition, $who)
 
     send_mail($PPer_email_addr, $subject, $body_blurb);
 }
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_SECOND_CHECKED_OUT,
-    'holder',
-    [
-        'project_restriction' => "project_was_returned_from_PPV",
-        'action_name' => _("Return to your current PPVer for further checking"),
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/upload_text.php?project=<PROJECTID>&stage=re_post_1",
-        'settings_template' => "modifieddate='<TIMESTAMP>', postproofer=checkedoutby, checkedoutby=ppverifier, ppverifier=NULL",
-        'collateral_actions' => "return_from_PP_to_PPV_collateral",
-        'disabled_during_SR' => true,
-    ]
-);
 
 function project_was_returned_from_PPV($project, $transition)
 {
@@ -1184,80 +1456,6 @@ function return_from_PP_to_PPV_collateral($old_project, $project, $transition, $
     send_mail($PPVer_email_addr, $subject, $body_blurb);
 }
 
-// -----------------------------------------------------------------------------
-// Transitions to and from PROJ_POST_FIRST_UNAVAILABLE:
-
-// To PROJ_POST_FIRST_UNAVAILABLE:
-
-new ProjectTransition(
-    PROJ_POST_FIRST_AVAILABLE,
-    PROJ_POST_FIRST_UNAVAILABLE,
-    'manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => '[default]',
-        'detour' => null,
-        'settings_template' => '',
-        'collateral_actions' => 'to_unavailable_collateral',
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_FIRST_UNAVAILABLE,
-    'manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => _('Someone currently has this project checked out. Are you sure you want to make it unavailable?'),
-        'detour' => null,
-        'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='', ppverifier=NULL, smoothread_deadline='0'",
-        'collateral_actions' => 'to_unavailable_collateral',
-        'disabled_during_SR' => true,
-    ]
-);
-
-// From PROJ_POST_FIRST_UNAVAILABLE:
-
-$pp_unavail_to_avail_confirm_question = sprintf(
-    _("This will clear the reserved PPer if there is one.") . " " .
-   _("Are you sure you want to change the state of this project to %s?"),
-    project_states_text(PROJ_POST_FIRST_AVAILABLE)
-);
-
-new ProjectTransition(
-    PROJ_POST_FIRST_UNAVAILABLE,
-    PROJ_POST_FIRST_AVAILABLE,
-    // PMs with project loads disabled can't move a project
-    // out of unavailable, either
-    'unrestricted_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => _('Make Project Available for Post-Processing'),
-        'confirmation_question' => $pp_unavail_to_avail_confirm_question,
-        'detour' => null,
-        'settings_template' => "checkedoutby=''",   // Clear reserved PPer
-        'collateral_actions' => 'to_PP_available_collateral',
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_FIRST_UNAVAILABLE,
-    PROJ_POST_FIRST_CHECKED_OUT,
-    // PMs with project load disabled can't move a project
-    // out of unavailable, either
-    'unrestricted_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => _('Check Out Project for Post-Processing'),
-        'confirmation_question' => _("It's unclear whether this transition should even be possible. Are you sure?"),
-        'detour' => null,
-        'settings_template' => "modifieddate='<TIMESTAMP>', checkedoutby='<WHO>'",
-        'collateral_actions' => 'PP_to_PP_out_collateral',
-    ]
-);
-
 // From either PP Checked out or PP Available to PP Unavailable
 // Or to Unavailable in a round
 function to_unavailable_collateral($old_project, $project, $transition, $who)
@@ -1276,203 +1474,7 @@ function to_unavailable_collateral($old_project, $project, $transition, $who)
     configure_gettext_for_user();
 }
 
-// -----------------------------------------------------------------------------
-// Transitions to PROJ_POST_COMPLETE:
-// (We should probably eliminate these, and the PROJ_POST_COMPLETE state.)
-
-$post_complete_question =
-    _("Sending a project to post_complete probably isn't a good idea. Are you sure?");
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_COMPLETE,
-    'site_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => $post_complete_question,
-        'detour' => null,
-        'settings_template' => "ppverifier=NULL",
-        'collateral_actions' => null,
-        'disabled_during_SR' => true,
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_SECOND_AVAILABLE,
-    PROJ_POST_COMPLETE,
-    'site_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => $post_complete_question,
-        'detour' => null,
-        'settings_template' => '',
-        'collateral_actions' => null,
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_SECOND_CHECKED_OUT,
-    PROJ_POST_COMPLETE,
-    'site_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => $post_complete_question,
-        'detour' => null,
-        'settings_template' => '',
-        'collateral_actions' => null,
-    ]
-);
-
-// -----------------------------------------------------------------------------
-// Transitions to PROJ_SUBMIT_PG_POSTED:
-
-/*
-    The following table describes the required values for checkedoutby,
-    postproofer and ppverifier after the transition to the named state.
-    The states are listed in their normal order, though projects that have
-    not yet reached "posted" may step back to the previous row,
-    e.g. 2-->1 or 5-->4. Note that the step from 4 to 5 is equivalent to
-    jumping from 4 to 2 but preserving the PPVer's name so that the
-    PPer can later move the project from 5 back to 4 for another PPV check.
-
-    Columns 2, 3 and 4 correspond to values set in fields in the
-    "projects" database table:
-        cob - checkedoutby
-        pp  - postproofer
-        ppv - ppverifier
-
-    a is the PPer
-    b is the PPVer, not the same user as the PPer
-
-        cob pp  ppv    state                         description
-
-    1.  -   -   NULL   proj_post_first_available,    available for PP
-    2.  a   -   NULL   proj_post_first_checked_out,  checked out for PP
-    3.  a   a   NULL   proj_post_second_available,   available for PPV
-    4.  b   a   NULL   proj_post_second_checked_out, checked out for PPV
-    5.  a   -   b      proj_post_first_checked_out,  returned to PP by PPV
-    6.  a   a   NULL   proj_submit_pgposted,         posted to PG, PPer has DU
-    7.  b   a   b      proj_submit_pgposted,         posted to PG, project was PPV'd
-
-
-    pseudo-code for transitions to PROJ_SUBMIT_PG_POSTED:
-    IF postproofer == '' THEN
-        # No postproofer has been recorded, so the project has been DUed
-        # by the PPer who has it checked out (not the PPVer).
-        postproofer=checkedoutby
-    ENDIF
-    IF postproofer != checkedoutby THEN
-        # checkedoutby must be the PPVer...
-        # (This assumes a project is only posted once!
-        # otherwise, maybe also test that ppverifier is null?)
-        ppverifier=checkedoutby
-    ELSE
-        # PPer has it checked out, and has therefore DUed the project
-        # so the PPVer did not complete PPV - remove their name
-        ppverifier=NULL
-    ENDIF
-
-*/
-
-$pg_posted_settings_template =
-    "modifieddate='<TIMESTAMP>',
-    postproofer = IF( postproofer = '', checkedoutby, postproofer ),
-    ppverifier = IF( postproofer != checkedoutby, checkedoutby, NULL )";
-
-
-new ProjectTransition(
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_SUBMIT_PG_POSTED,
-    'site_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
-        'settings_template' => $pg_posted_settings_template,
-        'collateral_actions' => 'pg_posted_collateral',
-        'disabled_during_SR' => true,
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_SECOND_AVAILABLE,
-    PROJ_SUBMIT_PG_POSTED,
-    'site_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
-        'settings_template' => $pg_posted_settings_template,
-        'collateral_actions' => 'pg_posted_collateral',
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_SECOND_CHECKED_OUT,
-    PROJ_SUBMIT_PG_POSTED,
-    'site_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
-        'settings_template' => $pg_posted_settings_template,
-        'collateral_actions' => 'pg_posted_collateral',
-    ]
-);
-
-new ProjectTransition(
-    PROJ_POST_COMPLETE,
-    PROJ_SUBMIT_PG_POSTED,
-    'site_manager',
-    [
-        'project_restriction' => null,
-        'action_name' => '[default]',
-        'confirmation_question' => null,
-        'detour' => "$code_url/tools/project_manager/editproject.php?action=edit&project=<PROJECTID>&posted=1",
-        'settings_template' => $pg_posted_settings_template,
-        'collateral_actions' => 'pg_posted_collateral',
-    ]
-);
-
 function pg_posted_collateral($old_project, $project, $transition, $who)
 {
     notify_project_event_subscribers($project, 'posted');
-}
-
-// -----------------------------------------------------------------------------
-// Transitions to PROJ_DELETE.
-
-foreach ($PROJECT_STATES_IN_ORDER as $from_state) {
-    // Don't bother creating a transition for Delete -> Delete.
-    if ($from_state == PROJ_DELETE) {
-        continue;
-    }
-
-    // A NEW project can be deleted by its manager.
-    // Anything else requires an SA.
-    $who_may_delete = (
-        $from_state == PROJ_NEW
-        ? 'manager'
-        : 'site_manager'
-    );
-
-    new ProjectTransition(
-        $from_state,
-        PROJ_DELETE,
-        $who_may_delete,
-        [
-            'project_restriction' => null,
-            'action_name' => _('Delete Project'),
-            'confirmation_question' => _('You should only delete a project that is beyond repair. Are you sure you want to delete this project?'),
-            'detour' => null,
-            'settings_template' => "modifieddate='<TIMESTAMP>'",
-            'collateral_actions' => null,
-        ]
-    );
 }

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -412,7 +412,7 @@ class ProjectTransitions
 
     public static function get_all()
     {
-        if(!self::$_project_transitions) {
+        if (!self::$_project_transitions) {
             self::$_project_transitions = create_project_transitions();
         }
         return self::$_project_transitions;

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -406,6 +406,21 @@ function project_pre_release_check($project, $round)
 
 // -----------------------------------------------------------------------------
 
+class ProjectTransitions
+{
+    private static $_project_transitions = [];
+
+    public static function get_all()
+    {
+        if(!self::$_project_transitions) {
+            self::$_project_transitions = create_project_transitions();
+        }
+        return self::$_project_transitions;
+    }
+}
+
+// -----------------------------------------------------------------------------
+
 /**
  * Return an array of transitions that the given user
  * can perform on the project (in its current state).
@@ -420,7 +435,7 @@ function get_valid_transitions($project, $username)
     static $viable_transitions_from = [];
     if (!isset($viable_transitions_from[$project->state])) {
         $viable_transitions_from[$project->state] = [];
-        foreach (create_all_transitions() as $transition) {
+        foreach (ProjectTransitions::get_all() as $transition) {
             if ($transition->from_state == $project->state) {
                 $viable_transitions_from[$project->state][] = $transition;
             }
@@ -441,7 +456,7 @@ function get_valid_transitions($project, $username)
 
 function get_transition($from_state, $to_state)
 {
-    foreach (create_all_transitions() as $transition) {
+    foreach (ProjectTransitions::get_all() as $transition) {
         if ($transition->from_state == $from_state &&
              $transition->to_state == $to_state) {
             return $transition;
@@ -453,14 +468,9 @@ function get_transition($from_state, $to_state)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function create_all_transitions()
+function create_project_transitions()
 {
     global $code_url, $PROJECT_STATES_IN_ORDER;
-
-    static $project_transitions = null;
-    if($project_transitions) {
-        return $project_transitions;
-    }
 
     $project_transitions[] = new ProjectTransition(
         PROJ_NEW,

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1195,6 +1195,11 @@ function create_project_transitions()
     return $project_transitions;
 }
 
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// The functions below are used as callbacks for ProjectTransitions, either
+// as the project_restriction or the collateral_actions.
+
 function round_release_collateral($old_project, $project, $transition, $who)
 {
     $round = get_Round_for_project_state($transition->to_state);


### PR DESCRIPTION
Whenever `ProjectTranstion.inc` was included it made all the project transition data whether it was needed or not. (`LPage` includes `ProjectTranstion.inc` because it is needed for `markAsBad()` and `v1.inc` includes `LPage.inc` indirectly.)
This removes the global `PROJECT_TRANSITIONS` and makes them once if they are needed.

Best viewed with hide whitespace.
The interleaved functions have been moved to the end.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/avoid_proj_trans
