### PR TITLE
tasks.php: Argument to _() should have been for sprintf.

### DIFF
--- a/tasks.php
+++ b/tasks.php
@@ -1289,7 +1289,7 @@ function TaskDetails($tid, $action)
     $task = load_task($tid);
 
     if (!$task) {
-        ShowError(sprintf(_("Task #%d was not found.", $tid)));
+        ShowError(sprintf(_("Task #%d was not found."), $tid));
         return;
     }
 


### PR DESCRIPTION
NB: an identical use of sprintf(_("..."), ...) occurs later in the file.

Found by PHPStan.