### PR TITLE
DPDatabase.inc: (De)serialization methods must be public

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -196,11 +196,11 @@ final class DPDatabase
     protected function __clone()
     {
     }
-    protected function __sleep()
+    public function __sleep()
     {
         return [];
     }
-    protected function __wakeup()
+    public function __wakeup()
     {
     }
 }


### PR DESCRIPTION
PHP prints a warning if they're not.

This is a partial revert of 255f9c157.