### PR TITLE
tools/authors/manage.php: Remove redundant isset($_POST)

### DIFF
--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -24,7 +24,7 @@ if (isset($message)) {
     echo html_safe($message) . '<br>';
 }
 
-if (isset($_POST) && count($_POST) > 0) {
+if ($_POST) {
 
     // find out what to do -- store in different 'queues'
 


### PR DESCRIPTION
$_POST is always defined, and non-empty arrays are truthy.

See https://stackoverflow.com/questions/15220704/#comment21453983_15220719

Mostly just to quieten PHPStan