### PR TITLE
Replace globals in project, AH, and Pool pages

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -53,7 +53,7 @@ thoughts_re_mentor_feedback($pagesproofed);
 show_news_for_page("HUB");
 
 // Show any mentor banners.
-foreach ($Round_for_round_id_ as $round) {
+foreach (Rounds::get_all() as $round) {
     if ($round->is_a_mentor_round() &&
         user_can_work_on_beginner_pages_in_round($round)) {
         mentor_banner($round);
@@ -160,8 +160,6 @@ activity_descriptions();
  */
 function progress_snapshot_table($show_filtered_projects, $show_filtering_links, $show_beginner_help)
 {
-    global $Stage_for_id_;
-
     // start the table
     echo "<h2 id='progress_snapshot'>" . _("Site Progress Snapshot") . "</h2>";
 
@@ -209,14 +207,10 @@ function progress_snapshot_table($show_filtered_projects, $show_filtering_links,
     echo "</tr>\n";
 
     // Round rows
-    foreach ($Stage_for_id_ as $stage) {
-        if (!is_a($stage, 'Round')) {
-            continue;
-        }
+    foreach (Rounds::get_all() as $round) {
+        $desired_states = [$round->project_waiting_state, $round->project_available_state, $round->project_complete_state];
 
-        $desired_states = [$stage->project_waiting_state, $stage->project_available_state, $stage->project_complete_state];
-
-        summarize_stage($stage, $desired_states, $show_filtered_projects, $stage->id);
+        summarize_stage($round, $desired_states, $show_filtered_projects, $round->id);
     }
 
     // Pool and Stage headers
@@ -247,18 +241,14 @@ function progress_snapshot_table($show_filtered_projects, $show_filtering_links,
     echo "</tr>\n";
 
     // Pool rows
-    foreach ($Stage_for_id_ as $stage) {
-        if (!is_a($stage, 'Pool')) {
-            continue;
-        }
+    foreach (Pools::get_all() as $pool) {
+        $desired_states = [$pool->project_available_state, $pool->project_checkedout_state];
 
-        $desired_states = [$stage->project_available_state, $stage->project_checkedout_state];
-
-        summarize_stage($stage, $desired_states, $show_filtered_projects, "{$stage->id}_av");
+        summarize_stage($pool, $desired_states, $show_filtered_projects, "{$pool->id}_av");
     }
 
     // Stage rows
-    foreach ($Stage_for_id_ as $stage) {
+    foreach (Stages::get_all() as $stage) {
         if (is_a($stage, 'Pool') || is_a($stage, 'Round')) {
             continue;
         }
@@ -504,7 +494,7 @@ function summarize_stage($stage, $desired_states, $show_filtered_projects = fals
  */
 function activity_descriptions()
 {
-    global $Stage_for_id_, $code_url;
+    global $code_url;
 
     echo "<h2>" . _("Activity descriptions") . "</h2>";
     echo "<div id='stagedescriptions'>";
@@ -520,7 +510,7 @@ function activity_descriptions()
         echo "</dd>\n";
     }
 
-    foreach ($Stage_for_id_ as $stage) {
+    foreach (Stages::get_all() as $stage) {
         echo "<dt><b>$stage->id</b>: <a href='$code_url/{$stage->relative_url}'>{$stage->name}</a></dt>";
         echo "<dd>{$stage->description}";
         if (($stage->id == "PP") || ($stage->id == "SR")) {

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1406,10 +1406,8 @@ class Project
 
     public static function get_holdable_states()
     {
-        global $Round_for_round_id_;
-
         $states = [];
-        foreach ($Round_for_round_id_ as $round) {
+        foreach (Rounds::get_all() as $round) {
             foreach (['project_waiting_state', 'project_available_state'] as $s) {
                 $states[] = $round->$s;
             }

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -126,10 +126,9 @@ class Quiz
         // This assumes that the access minima quiz strings are names
         // 'quiz/X' where X is some quiz ID (eg 'f_only', 'p_mod2', 'p_greek')
         $stage_required_for = [];
-        global $Stage_for_id_;
-        foreach ($Stage_for_id_ as $stage_id => $stage) {
+        foreach (Stages::get_all() as $stage) {
             if (array_key_exists("quiz/$this->id", $stage->access_minima)) {
-                $stage_required_for[$stage_id] = $stage;
+                $stage_required_for[$stage->id] = $stage;
             }
         }
 

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -342,8 +342,6 @@ class User
 
     private function _change_access($action_type, $activity, $requester, $use_access_suffix)
     {
-        global $Activity_for_id_;
-
         if ($use_access_suffix) {
             $suffix = '.access';
         } else {
@@ -361,8 +359,8 @@ class User
         log_access_change($this->username, $requester, $activity, $action_type);
 
         // do callback if defined
-        if (isset($Activity_for_id_[$activity])) {
-            $callback_function = $Activity_for_id_[$activity]->access_change_callback;
+        if (Activities::get_by_id($activity)) {
+            $callback_function = Activities::get_by_id($activity)->access_change_callback;
             if ($callback_function) {
                 $callback_function($this, $action_type);
             }

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -249,13 +249,13 @@ function maybe_output_new_proofer_project_message($project)
  */
 function encourage_highest_round($username, $round_id = null)
 {
-    global $code_url, $Round_for_round_id_, $ELR_round, $ACCESS_CRITERIA;
+    global $code_url, $ELR_round, $ACCESS_CRITERIA;
 
     // This URL fragment gets used a lot in this file
     $round_url = "$code_url/tools/proofers/round.php?round_id=";
 
     // get the backlog stats for all rounds sorted largest first
-    $backlog_stats = get_round_backlog_stats(array_keys($Round_for_round_id_));
+    $backlog_stats = get_round_backlog_stats(Rounds::get_ids());
     arsort($backlog_stats);
 
     // get all the rounds a user can work

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -569,11 +569,9 @@ function get_rounds_with_data($projectid)
     // So a column of empty users is the best indication of a skipped round.
     // (And also works for a not-yet-reached round.)
 
-    global $Round_for_round_id_;
-
     $sums = [];
-    foreach ($Round_for_round_id_ as $round_id => $round) {
-        $sums[] = "SUM({$round->user_column_name} != '') AS $round_id";
+    foreach (Rounds::get_all() as $round) {
+        $sums[] = "SUM({$round->user_column_name} != '') AS " . $round->id;
     }
     $body = join(',', $sums);
 
@@ -585,8 +583,8 @@ function get_rounds_with_data($projectid)
     $res = DPDatabase::query($sql);
     $num_filled_user_fields_for_round_ = mysqli_fetch_assoc($res);
 
-    foreach ($Round_for_round_id_ as $round_id => $round) {
-        if ($num_filled_user_fields_for_round_[$round_id] == 0) {
+    foreach (Rounds::get_all() as $round) {
+        if ($num_filled_user_fields_for_round_[$round->id] == 0) {
             // no real info in this slot
             // (skipped round or not-yet-reached round)
         } else {

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -20,14 +20,12 @@ include_once($relPath.'User.inc');
 
 function get_page_tally_names()
 {
-    global $Round_for_round_id_;
-
     $page_tally_names = [];
     if (true) {
         $page_tally_names['R*'] =
             _('Pages saved-as-done in old rounds R1+R2');
     }
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         $page_tally_names[$round->id] =
             sprintf(_('Pages saved-as-done in round %s'), $round->id);
     }

--- a/pinc/release_queue.inc
+++ b/pinc/release_queue.inc
@@ -97,8 +97,6 @@ function _get_queue_length($cooked_project_selector, $project_waiting_state)
  */
 function fetch_queues_data($round, $show, $show_groups, $name_selector = null, $group_selector = null)
 {
-    global $Round_for_round_id_;
-
     // Building the WHERE clause is rather ad-hoc, mostly because
     // a bunch of the output fields don't come directly from the DB result.
     if (!is_null($round)) {
@@ -141,7 +139,7 @@ function fetch_queues_data($round, $show, $show_groups, $name_selector = null, $
         // If we've gone from (eg) round F2 in the previous loop iteration, to P1
         // in this iteration, then reset the group
         if (!$round || $round->id != $row["round_id"]) {
-            $round = $Round_for_round_id_[$row["round_id"]];
+            $round = Rounds::get_by_id($row["round_id"]);
             $group = null;
         }
         if (startswith($row["name"], "***")) {
@@ -226,8 +224,7 @@ function fetch_queue_data($queueid)
 
 function _queue_data($row, $length = null, $unheld_length = null)
 {
-    global $Round_for_round_id_;
-    $round = $Round_for_round_id_[$row["round_id"]];
+    $round = Rounds::get_by_id($row["round_id"]);
     if (is_null($length) || is_null($unheld_length)) {
         [$length, $unheld_length] = _get_queue_length($row["project_selector"], $round->project_waiting_state);
     }

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -11,8 +11,8 @@ $NEWS_PAGES = [
     'SR_PREV' => _('Smooth Reading Preview'),
     'PM' => _('Project Management'),
 ];
-foreach ($Stage_for_id_ as $stage_id => $stage) {
-    $NEWS_PAGES[$stage_id] = $stage->name;
+foreach (Stages::get_all() as $stage) {
+    $NEWS_PAGES[$stage->id] = $stage->name;
 }
 
 function get_news_subject($news_page_id)

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -519,7 +519,7 @@ function maybe_show_language_selector()
  */
 function get_activity_links()
 {
-    global $Stage_for_id_, $ELR_round;
+    global $ELR_round;
 
     $user = User::load_current();
 
@@ -541,9 +541,8 @@ function get_activity_links()
     // Always allow users to see the ELR
     $stages_user_can_see[$ELR_round->id] = $ELR_round;
 
-    // we still need to loop through $Stage_for_id_ to output the stages
-    // in order
-    foreach ($Stage_for_id_ as $stage) {
+    // we still need to loop through all stages to output them in order
+    foreach (Stages::get_all() as $stage) {
         if (isset($stages_user_can_see[$stage->id])) {
             $text = $stage->id;
 

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -173,14 +173,12 @@ function user_is_site_translator()
 
 function user_can_mentor_in_any_round()
 {
-    global $Round_for_round_id_;
-
     if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
         return true;
     }
 
     $userSettings = & get_pguser_settings();
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         if ($userSettings->get_boolean("{$round->id}_mentor.access")) {
             return true;
         }

--- a/project.php
+++ b/project.php
@@ -1462,10 +1462,10 @@ function do_post_files()
     // this to people allowed to work in PP? If so, we should definitely
     // include the PM of this project.
 
-    global $Round_for_round_id_, $code_url;
+    global $code_url;
 
     $sums = [];
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         $sums[] = "SUM( $round->text_column_name != '' ) AS $round->id";
     }
     $sums = join(", ", $sums);
@@ -1476,7 +1476,7 @@ function do_post_files()
     $res = DPDatabase::query($sql);
     $sums = mysqli_fetch_assoc($res);
 
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         if (intval($sums[$round->id]) != 0) {
             $highest_round_id = $round->id;
         }
@@ -1493,7 +1493,7 @@ function do_post_files()
 
     if (isset($highest_round_id)) {
         echo "<input type='radio' name='round_id' value='[OCR]'>[OCR]&nbsp;\n";
-        foreach ($Round_for_round_id_ as $round) {
+        foreach (Rounds::get_all() as $round) {
             $checked = ($round->id == $highest_round_id ? 'CHECKED' : '');
             echo "<input type='radio' name='round_id' value='$round->id' $checked>$round->id&nbsp;\n";
             if ($round->id == $highest_round_id) {

--- a/tools/pool.php
+++ b/tools/pool.php
@@ -10,7 +10,7 @@ include_once($relPath.'showavailablebooks.inc');
 
 require_login();
 
-$pool_id = get_enumerated_param($_GET, 'pool_id', null, array_keys($Pool_for_id_));
+$pool_id = get_enumerated_param($_GET, 'pool_id', null, Pools::get_ids());
 
 $pool = get_Pool_for_id($pool_id);
 $header_args = ["js_files" => ["$code_url/scripts/filter_project.js"]];


### PR DESCRIPTION
This PR removes round globals in four broad areas:
* `project.php`
* `activity_hub.php`
* `pool.php`
* `pinc/*` files

Broadly speaking, validating the following should cover most of these changed files (but perhaps not all):
* Viewing the pool page
* Editing site news (and seeing all the activities up top)
* Viewing a project page
* Viewing a project's page table listing
* Changing a user's access to a round
* Viewing the release queue page

Sandbox: https://www.pgdp.org/~cpeel/c.branch/remove-round-globals-project-pinc