### PR TITLE
Remove globals from api and stats files

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -569,9 +569,7 @@ function api_v1_projects_states($method, $data, $query_params)
 
 function api_v1_projects_pagerounds($method, $data, $query_params)
 {
-    global $Round_for_round_id_;
-
-    return array_merge(["OCR"], array_keys($Round_for_round_id_));
+    return array_merge(["OCR"], Rounds::get_ids());
 }
 
 //---------------------------------------------------------------------------

--- a/api/v1_stats.inc
+++ b/api/v1_stats.inc
@@ -77,13 +77,9 @@ function api_v1_stats_site_projects_states($method, $data, $query_params)
 
 function api_v1_stats_site_projects_stages($method, $data, $query_params)
 {
-    global $Stage_for_id_;
-    global $Round_for_project_state_;
-    global $Pool_for_state_;
-
     // Make sure all project stage statistics are provided.
     $output = [];
-    foreach ($Stage_for_id_ as $s) {
+    foreach (Stages::get_all() as $s) {
         $output[$s->id] = 0;
     }
 
@@ -95,13 +91,13 @@ function api_v1_stats_site_projects_stages($method, $data, $query_params)
     $result = DPDatabase::query($sql);
     while ([$project_state, $count] = mysqli_fetch_row($result)) {
         // If the stage is in a round, add it to the round's count
-        $r = array_get($Round_for_project_state_, $project_state, null);
+        $r = Rounds::get_by_project_state($project_state);
         if ($r) {
             $output[$r->id] += (int)$count;
             continue;
         }
         // If the stage is in a pool, add it to the pool's count
-        $p = array_get($Pool_for_state_, $project_state, null);
+        $p = Pools::get_by_state($project_state);
         if ($p) {
             $output[$p->id] += (int)$count;
             continue;
@@ -143,10 +139,8 @@ function render_round_stats($round_id)
 
 function api_v1_stats_site_rounds($method, $data, $query_params)
 {
-    global $Round_for_round_id_;
-
     $return = [];
-    foreach (array_keys($Round_for_round_id_) as $round_id) {
+    foreach (Rounds::get_ids() as $round_id) {
         $return[$round_id] = render_round_stats($round_id);
     }
 

--- a/api/v1_validators.inc
+++ b/api/v1_validators.inc
@@ -8,13 +8,12 @@ include_once($relPath.'release_queue.inc');
 
 function validate_round($roundid, $data)
 {
-    global $Round_for_round_id_;
-
     try {
-        if (!array_key_exists($roundid, $Round_for_round_id_)) {
+        $round = Rounds::get_by_id($roundid);
+        if (!$round) {
             throw new InvalidRoundException("Invalid round");
         }
-        return $Round_for_round_id_[$roundid];
+        return $round;
     } catch (InvalidRoundException $exception) {
         throw new NotFoundError($exception->getMessage(), $exception->getCode());
     }
@@ -53,10 +52,8 @@ function validate_page_name($pagename, $data)
 
 function validate_page_round($pageround, $data)
 {
-    global $Round_for_round_id_;
-
     try {
-        $pagerounds = array_merge(["OCR"], array_keys($Round_for_round_id_));
+        $pagerounds = array_merge(["OCR"], Rounds::get_ids());
 
         if (!in_array($pageround, $pagerounds)) {
             throw new InvalidPageRoundException("Invalid page round");

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -148,8 +148,7 @@ function showMbrRoles($user)
         $roles[] = ['pm', _("Project Manager"), 50];
     }
 
-    global $Round_for_round_id_;
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         if ($round->is_a_mentor_round()) {
             $access_id = $round->id . "_mentor.access";
             if ($settings->get_boolean($access_id)) {

--- a/stats/pages_in_states.php
+++ b/stats/pages_in_states.php
@@ -37,7 +37,7 @@ $waiting_n_pages[] = 0;
 $available_n_pages[] = 0;
 $progordone_n_pages[] = 0;
 
-foreach ($Round_for_round_id_ as $round) {
+foreach (Rounds::get_all() as $round) {
     $stage_labels[] = $round->id;
     $unavail_n_pages[] = @$n_pages_[$round->project_unavailable_state] + @$n_pages_[$round->project_bad_state];
     $waiting_n_pages[] = @$n_pages_[$round->project_waiting_state];

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -12,7 +12,7 @@ $m_start = mktime(0, 0, 0, date('m'), 1, date('Y'));
 // We want the "PP pages goal" to be equal to the current month's last round before PP (F2) actuals
 $page_offset = 0;
 $round_before_PP = null;
-foreach ($Round_for_round_id_ as $id => $round) {
+foreach (Rounds::get_all() as $round) {
     if ($round->id == "PP") {
         break;
     }

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -45,12 +45,10 @@ if (is_null($round)) {
 
 function _show_available_rounds()
 {
-    global $Round_for_round_id_;
-
     echo html_safe(_("Each round has its own set of release queues.")), "\n";
     echo html_safe(_("Please select the round that you're interested in:")), "\n";
     echo "<ul>\n";
-    foreach (array_keys($Round_for_round_id_) as $round_id) {
+    foreach (Rounds::get_ids() as $round_id) {
         echo "<li><a href='?round_id=$round_id'>$round_id</a></li>\n";
     }
     echo "</ul>\n";

--- a/stats/round_backlog.php
+++ b/stats/round_backlog.php
@@ -20,10 +20,8 @@ $height = 200;
 
 function _get_round_backlog_data()
 {
-    global $Round_for_round_id_;
-
     // Pull all interested phases, primarily all the rounds and PP
-    $interested_phases = array_keys($Round_for_round_id_);
+    $interested_phases = Rounds::get_ids();
     $interested_phases[] = "PP";
 
     // Pull the stats data out of the database

--- a/stats/round_backlog_days.php
+++ b/stats/round_backlog_days.php
@@ -18,10 +18,8 @@ $height = 200;
 
 function _get_round_backlog_days_data()
 {
-    global $Round_for_round_id_;
-
     // Pull all interested phases, primarily all the rounds and PP
-    $interested_phases = array_keys($Round_for_round_id_);
+    $interested_phases = Rounds::get_ids();
 
     // Pull the stats data out of the database
     $stats = get_round_backlog_stats($interested_phases);


### PR DESCRIPTION
This PR removes the globals from the API and stats/* files.

Testable in https://www.pgdp.org/~cpeel/c.branch/remove-round-globals-api-stats/