### PR TITLE
Update php-cs-fixer version to latest

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,13 @@ return $config->setRules([
         // whitespace
         'no_spaces_around_offset' => ['positions' => ['inside', 'outside']],
         'binary_operator_spaces' => ['operators' => ['=' => 'single_space']],
+        // spaces around constructs is part of PSR2 spec (which is part of @PSR12
+        // ruleset) but isn't being picked up when this was introduced in 3.16.0
+        'single_space_around_construct' => [
+            // remove 'echo' from the default list since we sometimes use it
+            // for laying out HTML blocks in a more human-readable way
+            'constructs_followed_by_a_single_space' => ['abstract', 'as', 'attribute', 'break', 'case', 'catch', 'class', 'clone', 'comment', 'const', 'const_import', 'continue', 'do', 'else', 'elseif', 'enum', 'extends', 'final', 'finally', 'for', 'foreach', 'function', 'function_import', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'match', 'named_argument', 'namespace', 'new', 'open_tag_with_echo', 'php_doc', 'php_open', 'print', 'private', 'protected', 'public', 'readonly', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'type_colon', 'use', 'use_lambda', 'use_trait', 'var', 'while', 'yield', 'yield_from'],
+        ],
         'space_after_semicolon' => true,
         // comments
         'single_line_comment_style' => ['comment_types' => ['asterisk', 'hash']],

--- a/SETUP/import_old_configuration.php
+++ b/SETUP/import_old_configuration.php
@@ -76,7 +76,7 @@ function load_config_file_values($filename)
 
     fclose($fh);
 
-    return($config_values);
+    return ($config_values);
 }
 
 function output_config_file_with_new_values($filename, $config_values)
@@ -107,7 +107,7 @@ function output_config_file_with_new_values($filename, $config_values)
 
     fclose($fh);
 
-    return([$new_config_parameters, $unused_config_parameters]);
+    return ([$new_config_parameters, $unused_config_parameters]);
 }
 
 // ---------------------------------------------------------------------------

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -515,7 +515,7 @@ function api_v1_project_transitions($method, $data, $query_params)
     );
     $result = DPDatabase::query($sql);
     $return_data = [];
-    while($row = mysqli_fetch_assoc($result)) {
+    while ($row = mysqli_fetch_assoc($result)) {
         $return_data[] = [
             "timestamp" => date(DATE_ATOM, (int)$row["timestamp"]),
             "event_type" => $row["event_type"],

--- a/api/v1_queues.inc
+++ b/api/v1_queues.inc
@@ -98,7 +98,7 @@ function api_v1_queue_projects($method, $data, $query_params)
     $round = validate_round($queue["round_id"], null);
 
     $output = [];
-    foreach(fetch_queue_projects_data($round, $queue["project_selector"], $unheld_only) as $proj_data) {
+    foreach (fetch_queue_projects_data($round, $queue["project_selector"], $unheld_only) as $proj_data) {
         array_remove_invalid_fields($proj_data, $return_fields);
         if (isset($proj_data["last_state_change_time"])) {
             $proj_data["last_state_change_time"] = date(DATE_ATOM, $proj_data["last_state_change_time"]);

--- a/api/v1_stats.inc
+++ b/api/v1_stats.inc
@@ -58,7 +58,7 @@ function api_v1_stats_site_projects_states($method, $data, $query_params)
     // Make sure all project state statistics are provided.
     $output = [];
     global $PROJECT_STATES_IN_ORDER;
-    foreach($PROJECT_STATES_IN_ORDER as $s) {
+    foreach ($PROJECT_STATES_IN_ORDER as $s) {
         $output[$s] = 0;
     }
 
@@ -69,7 +69,7 @@ function api_v1_stats_site_projects_states($method, $data, $query_params)
         GROUP BY state
     ";
     $result = DPDatabase::query($sql);
-    while([$project_state, $count] = mysqli_fetch_row($result)) {
+    while ([$project_state, $count] = mysqli_fetch_row($result)) {
         $output[$project_state] = (int)$count;
     }
     return $output;
@@ -83,7 +83,7 @@ function api_v1_stats_site_projects_stages($method, $data, $query_params)
 
     // Make sure all project stage statistics are provided.
     $output = [];
-    foreach($Stage_for_id_ as $s) {
+    foreach ($Stage_for_id_ as $s) {
         $output[$s->id] = 0;
     }
 
@@ -93,7 +93,7 @@ function api_v1_stats_site_projects_stages($method, $data, $query_params)
         GROUP BY state
     ";
     $result = DPDatabase::query($sql);
-    while([$project_state, $count] = mysqli_fetch_row($result)) {
+    while ([$project_state, $count] = mysqli_fetch_row($result)) {
         // If the stage is in a round, add it to the round's count
         $r = array_get($Round_for_project_state_, $project_state, null);
         if ($r) {

--- a/composer.lock
+++ b/composer.lock
@@ -803,50 +803,48 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.35.1",
+            "version": "v3.49.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "ec1ccc264994b6764882669973ca435cf05bab08"
+                "reference": "8742f7aa6f72a399688b65e4f58992c2d4681fc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/ec1ccc264994b6764882669973ca435cf05bab08",
-                "reference": "ec1ccc264994b6764882669973ca435cf05bab08",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/8742f7aa6f72a399688b65e4f58992c2d4681fc2",
+                "reference": "8742f7aa6f72a399688b65e4f58992c2d4681fc2",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^3.3",
+                "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.3",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
                 "sebastian/diff": "^4.0 || ^5.0",
-                "symfony/console": "^5.4 || ^6.0",
-                "symfony/event-dispatcher": "^5.4 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/finder": "^5.4 || ^6.0",
-                "symfony/options-resolver": "^5.4 || ^6.0",
-                "symfony/polyfill-mbstring": "^1.27",
-                "symfony/polyfill-php80": "^1.27",
-                "symfony/polyfill-php81": "^1.27",
-                "symfony/process": "^5.4 || ^6.0",
-                "symfony/stopwatch": "^5.4 || ^6.0"
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+                "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+                "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",
+                "symfony/polyfill-mbstring": "^1.28",
+                "symfony/polyfill-php80": "^1.28",
+                "symfony/polyfill-php81": "^1.28",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0",
+                "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0"
             },
             "require-dev": {
                 "facile-it/paraunit": "^1.3 || ^2.0",
                 "justinrainbow/json-schema": "^5.2",
-                "keradus/cli-executor": "^2.0",
+                "keradus/cli-executor": "^2.1",
                 "mikey179/vfsstream": "^1.6.11",
-                "php-coveralls/php-coveralls": "^2.5.3",
+                "php-coveralls/php-coveralls": "^2.7",
                 "php-cs-fixer/accessible-object": "^1.1",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
-                "phpspec/prophecy": "^1.16",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
-                "symfony/phpunit-bridge": "^6.2.3",
-                "symfony/yaml": "^5.4 || ^6.0"
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.4",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.4",
+                "phpunit/phpunit": "^9.6 || ^10.5.5",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -884,7 +882,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.35.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.49.0"
             },
             "funding": [
                 {
@@ -892,7 +890,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-12T13:47:26+00:00"
+            "time": "2024-02-02T00:41:40+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -336,8 +336,7 @@ if ($i_type == 0) {
             'Report Bad Page',
             'WordCheck',
             'Preview',
-        ]
-        as $name) {
+        ] as $name) {
         echo "<dt>";
         if ($name == 'Switch to Vertical/Horizontal') {
             echo "<input type='button' value='Switch to Vertical'> / ";

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -772,7 +772,7 @@ function str_contains_any_of($haystack, $needles)
     if (is_string($needles)) {
         return str_contains($haystack, $needles);
     }
-    foreach($needles as $n) {
+    foreach ($needles as $n) {
         if (str_contains($haystack, $n)) {
             return true;
         }

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -209,11 +209,11 @@ function validate_uploaded_file($verbose)
         }
 
         $hash_code = $_POST["hash_code"] ?? "no_hash";
-        if($hash_code === "") {
+        if ($hash_code === "") {
             show_upload_message($verbose, _("No checksum provided"));
         } else {
             $up_hash_code = hash_file('sha256', $file_path);
-            if(0 != strcmp($hash_code, $up_hash_code)) {
+            if (0 != strcmp($hash_code, $up_hash_code)) {
                 throw new FileUploadException(_("The file is corrupted"));
             }
             show_upload_message($verbose, _("Checksum validated"));
@@ -223,7 +223,7 @@ function validate_uploaded_file($verbose)
         if (is_file($file_path)) {
             unlink($file_path);
         }
-        throw($e);
+        throw ($e);
     }
     return $file_info;
 }

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -446,7 +446,7 @@ function get_bad_words_with_diacritical_markup($input_words_w_freq)
         }
     }
 
-    return($bad_words);
+    return ($bad_words);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -246,7 +246,7 @@ function _show_queue_details($round, $name, $unheld_only)
     echo "<tr>\n";
     echo surround_and_join(array_map("html_safe", $headers), "<th>", "</th>\n", "");
     echo "</tr>\n";
-    foreach(fetch_queue_projects_data($round, $queue["project_selector"], $unheld_only) as $p) {
+    foreach (fetch_queue_projects_data($round, $queue["project_selector"], $unheld_only) as $p) {
         echo "<tr>\n";
         echo "<td><a href='$code_url/project.php?id=", attr_safe($p["projectid"]), "'>", html_safe($p["title"]), "</a></td>\n";
         echo "<td>", html_safe($p["author"]), "</td>\n";

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -63,8 +63,7 @@ function show_query_form()
                 'isbn' => _('ISBN'),
                 'issn' => _('ISSN'),
                 'lccn' => _('LCCN'),
-            ]
-            as $field_name => $field_label
+            ] as $field_name => $field_label
         ) {
             echo "<tr>";
             echo   "<th class='label'>$field_label</th>";
@@ -187,8 +186,7 @@ function do_search_and_show_hits()
             ['label' => _("Language"),  'value' => $marc_record->language],
             ['label' => _("LCCN"),      'value' => $marc_record->lccn],
             ['label' => _("ISBN"),      'value' => $marc_record->isbn],
-        ]
-            as $couple
+        ] as $couple
         ) {
             $label = $couple['label'];
             $value = $couple['value'];

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -357,8 +357,7 @@ class ImageSource
             '1' => _('Also PMs'),
             // TRANSLATORS: %s is the site abbreviation
             '2' => sprintf(_("All %s Users"), $site_abbreviation),
-            '3' => _('Publicly Visible'), ]
-            as $val => $opt) {
+            '3' => _('Publicly Visible'), ] as $val => $opt) {
             {
                 $editing .= "<option value='$val' " .
                     ($existing_value == $val ? 'selected' : '') .

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -162,9 +162,7 @@ class PPage
             'page_state' => $this->lpage->page_state,
             'projectid' => $this->lpage->projectid,
             'reverting' => $this->lpage->reverting_to_orig,
-        ]
-            as
-            $param_name => $param_value
+        ] as $param_name => $param_value
         ) {
             echo "<input type='hidden' value='$param_value' name='$param_name' id='$param_name'>\n";
         }

--- a/tools/proofers/mktable.php
+++ b/tools/proofers/mktable.php
@@ -256,7 +256,7 @@ function array_pad_internal($input, $pad_size, $pad_type)
 
 function table_pad($table, $rows, $columns, $value = "")
 {
-    for ($i = 0; $i < $rows; $i ++) {
+    for ($i = 0; $i < $rows; $i++) {
         if (!isset($table[$i])) {
             $table[$i] = [];
         }

--- a/tools/proofers/my_suggestions.php
+++ b/tools/proofers/my_suggestions.php
@@ -507,7 +507,7 @@ function get_suggestions($round_view, $username, $selection_criteria)
 
                 // get the field weight from the user weights if one exists,
                 // otherwise try the site weights
-                if(isset($user_weights[$field][$normalized_field_value])) {
+                if (isset($user_weights[$field][$normalized_field_value])) {
                     $field_weight = $user_weights[$field][$normalized_field_value];
                 } elseif (isset($site_weights[$field][$normalized_field_value])) {
                     $field_weight = $site_weights[$field][$normalized_field_value];
@@ -542,7 +542,7 @@ function get_suggestions($round_view, $username, $selection_criteria)
             $round = $Round_for_project_state_[$project->state];
             validate_user_against_project_reserve($user, $project, $round);
             $return_projects[] = $project_row;
-        } catch(Exception $exception) {
+        } catch (Exception $exception) {
             continue;
         }
     }

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -381,7 +381,7 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
     }
 
     // OK, we are definitely interested in this project
-    $total_valid_projects ++;
+    $total_valid_projects++;
 
     validate_projectID($projectid);
     $query = sprintf("

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -204,8 +204,7 @@ function update_settings($user, $user_settings)
         $disposition[$which][] = $setting_name;
     }
 
-    foreach (array_merge($value_user_settings, $freeform_user_settings) as
-        $setting_name => $options) {
+    foreach (array_merge($value_user_settings, $freeform_user_settings) as $setting_name => $options) {
         if (isset($_POST[$setting_name])) {
             if ($user_settings->get_value($setting_name) == $_POST[$setting_name]) {
                 continue;

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -221,7 +221,7 @@ class SpecialDay
         echo "<th class='right'>" . _("Comments") . ":</th><td colspan='7'>" . html_safe($this->comment) . "</td>";
         echo "</tr>\n";
 
-        return($this->open_month);
+        return ($this->open_month);
     }
 
     public function show_buttons()


### PR DESCRIPTION
Also add and configure the [single_space_around_construct rule](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/language_construct/single_space_around_construct.rst) which enforces spacing after `if()`s and and other constructs. Spacing around these are part of the [PSR-2 spec](https://www.php-fig.org/psr/psr-2/#51-if-elseif-else) which we are using (via `@PSR12` ruleset) but isn't being enforced for some reason. This changed in php-cs-fixer 3.16.0 when this new rule was introduced somehow. Restoring this mirrors what we had in php-cs-fixer v2 which was used initially to format the codebase.

This is a code format only change so eval can be done just in PR without a sandbox.