### PR TITLE
Remove globals from proofer pages

### DIFF
--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -310,7 +310,7 @@ function do_navigation(
  */
 function can_see_names_for_page($projectid, $image)
 {
-    global $pguser, $Round_for_round_id_;
+    global $pguser;
 
     // If requester isn't logged in, they can't see any names.
     if ($pguser == '') {
@@ -321,7 +321,7 @@ function can_see_names_for_page($projectid, $image)
     $answer = $project->names_can_be_seen_by_current_user; // can see for all pages
     if (! $answer) {
         $fields = "";
-        foreach ($Round_for_round_id_ as $round_id => $round) {
+        foreach (Rounds::get_all() as $round) {
             if ($fields != "") {
                 $fields .= ", ";
             }

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -1,7 +1,7 @@
 <?php
 include_once($relPath.'site_vars.php');
 include_once($relPath.'Project.inc');         // $PROJECT_STATES_IN_ORDER
-include_once($relPath.'Round.inc'); // $PAGE_STATES_IN_ORDER
+include_once($relPath.'Round.inc');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 include_once($relPath.'LPage.inc');
@@ -50,11 +50,11 @@ function url_for_pi_do_particular_page($projectid, $proj_state, $imagefile, $pag
 
 function get_requested_PPage($request_params)
 {
-    global $PROJECT_STATES_IN_ORDER, $PAGE_STATES_IN_ORDER;
+    global $PROJECT_STATES_IN_ORDER;
     $projectid = get_projectID_param($request_params, 'projectid');
     $proj_state = get_enumerated_param($request_params, 'proj_state', null, $PROJECT_STATES_IN_ORDER);
     $imagefile = get_page_image_param($request_params, 'imagefile');
-    $page_state = get_enumerated_param($request_params, 'page_state', null, $PAGE_STATES_IN_ORDER);
+    $page_state = get_enumerated_param($request_params, 'page_state', null, Rounds::get_page_states());
     $reverting = get_integer_param($request_params, 'reverting', 0, 0, 1);
 
     $lpage = get_indicated_LPage(

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -33,7 +33,7 @@ if (!$mentoring_round) {
 
     // If they're coming to this page from a MENTORS ONLY book in X2,
     // referrer should contain &expected_state=X2.proj_avail.
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         if (strpos($referer, $round->project_available_state)) {
             $mentoring_round = $round;
             break;
@@ -42,7 +42,7 @@ if (!$mentoring_round) {
 
     if (!isset($mentoring_round)) {
         // Just take the first.
-        foreach ($Round_for_round_id_ as $round) {
+        foreach (Rounds::get_all() as $round) {
             if ($round->is_a_mentor_round()) {
                 $mentoring_round = $round;
                 break;
@@ -62,7 +62,7 @@ if (!$mentoring_round->is_a_mentor_round()) {
 
 // Are there other mentoring rounds? If so, provide mentoring links for them.
 $other_mentoring_rounds = [];
-foreach ($Round_for_round_id_ as $round) {
+foreach (Rounds::get_all() as $round) {
     if ($round->is_a_mentor_round() && $round->id != $mentoring_round->id) {
         $other_mentoring_rounds[] = $round;
     }

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -92,7 +92,7 @@ maybe_output_new_proofer_message();
 
 // prep an array of available states
 $avail_states = [];
-foreach ($Round_for_round_number_ as $round) {
+foreach (Rounds::get_all() as $round) {
     $avail_states[] = $round->project_available_state;
 }
 

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -14,7 +14,7 @@ define("MESSAGE_WARNING", 1);
 define("MESSAGE_ERROR", 2);
 
 // get an array of round IDs
-$rounds = array_keys($Round_for_round_id_);
+$rounds = Rounds::get_all();
 
 // load any data passed into the page
 $username = array_get($_GET, "username", $pguser);
@@ -103,11 +103,11 @@ function _echo_eval_query_select($selected)
 function _echo_round_select($rounds, $selected_round)
 {
     foreach ($rounds as $round) {
-        echo "<option value='" . attr_safe($round) . "'";
+        echo "<option value='" . attr_safe($round->id) . "'";
         if ($selected_round && $round == $selected_round->id) {
             echo " selected";
         }
-        echo ">$round</option>";
+        echo ">" . $round->id . "</option>";
     }
 }
 


### PR DESCRIPTION
Removes globals from My Projects, My Suggestions, "for mentors" page, the "diff" page for a project page text, and code used when getting a page for the proofreading interface, and finally review work.

Sandbox at: https://www.pgdp.org/~cpeel/c.branch/remove-round-globals-proofers/