### PR TITLE
Remove globals from PM and SA pages

### DIFF
--- a/tools/modify_access.php
+++ b/tools/modify_access.php
@@ -47,7 +47,7 @@ foreach ($_POST as $name => $value) {
         die("Error: bad parameter name '$name'");
     }
 
-    @$activity = $Activity_for_id_[$activity_id];
+    $activity = Activities::get_by_id($activity_id);
     if (is_null($activity)) {
         die("Error: no activity named '$activity_id'");
     }

--- a/tools/pending_access_requests.php
+++ b/tools/pending_access_requests.php
@@ -16,7 +16,7 @@ output_header($title);
 
 echo "<h1>$title</h1>\n";
 
-foreach ($Activity_for_id_ as $activity) {
+foreach (Activities::get_all() as $activity) {
     if ($activity->after_satisfying_minima == 'REQ-HUMAN') {
         $activity_ids[] = $activity->id;
     }

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -78,7 +78,7 @@ if ($one_project) {
     $verbose = 1;
 
     $condition = "0";
-    foreach ($Round_for_round_id_ as $round_id => $round) {
+    foreach (Rounds::get_all() as $round) {
         $condition .= sprintf(
             "
             OR state = '%s'

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -9,7 +9,7 @@ include_once('./post_files.inc');
 
 require_login();
 
-$valid_round_ids = array_keys($Round_for_round_id_);
+$valid_round_ids = Rounds::get_ids();
 array_unshift($valid_round_ids, '[OCR]');
 
 $projectid = get_projectID_param($_REQUEST, 'projectid');

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -154,7 +154,7 @@ if (!$resolution) {
     }
 } else {
     //Get variables passed from form
-    $state = get_enumerated_param($_POST, 'state', null, $PAGE_STATES_IN_ORDER);
+    $state = get_enumerated_param($_POST, 'state', null, Rounds::get_page_states());
 
     //If the PM fixed the problem or stated the report was invalid update the database to reflect
     if (($resolution == "fixed") || ($resolution == "invalid")) {
@@ -180,7 +180,7 @@ function get_round_name($round_number)
 
 function show_resolution_form($projectid, $image, $state, $project_round, $is_a_bad_page, $b_user, $b_code)
 {
-    global $code_url, $PAGE_BADNESS_REASONS, $Round_for_round_id_;
+    global $code_url, $PAGE_BADNESS_REASONS;
 
     if ($is_a_bad_page) {
         echo "<h2>" . _("Resolve bad page") . "</h2>";
@@ -212,9 +212,9 @@ function show_resolution_form($projectid, $image, $state, $project_round, $is_a_
         echo "<input type='hidden' name='state' value='$state'>";
         echo "<select name='text_column'>";
         echo "<option value='master_text'>" . _("OCR") . "</option>";
-        foreach ($Round_for_round_id_ as $round_id => $round) {
+        foreach (Rounds::get_all() as $round) {
             echo "<option value='$round->text_column_name'";
-            if ($project_round->id == $round_id) {
+            if ($project_round->id == $round->id) {
                 echo "SELECTED";
             }
             echo ">$round_id</option>";
@@ -246,13 +246,11 @@ function show_resolution_form($projectid, $image, $state, $project_round, $is_a_
 
 function show_text_update_form($projectid, $image, $prev_text, $text_column, $modify = 'current_text')
 {
-    global $Round_for_round_id_;
-
     echo "<h2>" . _("Update page text") . "</h2>";
 
     // look up the round_id from the $text_column
     $round_id = _("OCR");
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         if ($round->text_column_name == $text_column) {
             $round_id = $round->id;
         }

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -287,11 +287,9 @@ function _get_projects_for_pm($pm)
 
 function _get_project_states_in_order()
 {
-    global $Round_for_round_id_;
-
     $projectStates = [];
 
-    foreach ($Round_for_round_id_ as $round_id => $round) {
+    foreach (Rounds::get_all() as $round) {
         array_push($projectStates, $round->project_unavailable_state);
         array_push($projectStates, $round->project_waiting_state);
         array_push($projectStates, $round->project_bad_state);

--- a/tools/project_manager/show_project_wordcheck_usage.php
+++ b/tools/project_manager/show_project_wordcheck_usage.php
@@ -39,7 +39,7 @@ echo "</ul>";
     <th class='label'><?php echo _("Page"); ?></th>
     <th class='label'><?php echo pgettext("page state", "State"); ?></th>
 <?php
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         echo "<th class='label'>$round->id</td>";
     }
 ?>
@@ -53,7 +53,7 @@ echo "</ul>";
 
 // build the SQL to return the fields and WordCheck status for each round
 $round_fields_select = "";
-foreach ($Round_for_round_id_ as $round) {
+foreach (Rounds::get_all() as $round) {
     $rn = $round->round_number;
     $round_fields_select .= "
         $round->user_column_name,
@@ -88,7 +88,7 @@ while ($result = mysqli_fetch_assoc($res)) {
     $currentRound = get_Round_for_page_state($result["state"]);
 
     // foreach round print out the available info
-    foreach ($Round_for_round_id_ as $round) {
+    foreach (Rounds::get_all() as $round) {
         $roundID = $round->id;
         $rn = $round->round_number;
 

--- a/tools/set_project_holds.php
+++ b/tools/set_project_holds.php
@@ -35,7 +35,7 @@ $delta_ = [
 
 $old_hold_states = $project->get_hold_states();
 
-foreach ($Round_for_round_id_ as $round) {
+foreach (Rounds::get_all() as $round) {
     foreach (['project_waiting_state', 'project_available_state'] as $s) {
         $state = $round->$s;
 

--- a/tools/site_admin/project_jump.php
+++ b/tools/site_admin/project_jump.php
@@ -15,7 +15,7 @@ if (!user_is_a_sitemanager()) {
 $action = get_enumerated_param($_POST, 'action', 'showform', ['showform', 'check', 'dojump']);
 $projectid = get_projectID_param($_POST, 'projectid', true);
 $valid_new_states = [];
-foreach ($Round_for_round_id_ as $id => $round) {
+foreach (Rounds::get_all() as $round) {
     $valid_new_states[] = $round->project_unavailable_state;
 }
 $new_state = get_enumerated_param($_POST, 'new_state', null, $valid_new_states, true);
@@ -46,8 +46,6 @@ switch ($action) {
 
 function display_form($action, $projectid, $new_state)
 {
-    global $Round_for_round_id_;
-
     echo "<form method='post'>\n";
     echo "<table>\n";
     if ($action == "showform") {
@@ -59,7 +57,7 @@ function display_form($action, $projectid, $new_state)
         echo "<tr>";
         echo "<th>" . _("State") . ":</th>\n";
         echo "<td><select name='new_state'>";
-        foreach ($Round_for_round_id_ as $id => $round) {
+        foreach (Rounds::get_all() as $round) {
             echo "<option value='{$round->project_unavailable_state}'>{$round->project_unavailable_state}</option>";
         }
         echo "</select></td>\n";


### PR DESCRIPTION
Remove the last activity/stage/round/pool globals, these from the PM and SA pages.

Sandbox at https://www.pgdp.org/~cpeel/c.branch/remove-round-globals-pm-and-sa/