### PR TITLE
Remove remaining(?) reference to R rounds in master

### DIFF
--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -21,10 +21,6 @@ include_once($relPath.'User.inc');
 function get_page_tally_names()
 {
     $page_tally_names = [];
-    if (true) {
-        $page_tally_names['R*'] =
-            _('Pages saved-as-done in old rounds R1+R2');
-    }
     foreach (Rounds::get_all() as $round) {
         $page_tally_names[$round->id] =
             sprintf(_('Pages saved-as-done in round %s'), $round->id);

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -404,24 +404,17 @@ function showMbrTallySelector($u_id, $tally_name)
 
 function showMbrPageStats($user, $tally_name)
 {
+    global $ELR_round;
+
     $users_tallyboard = new TallyBoard($tally_name, 'U');
 
     $vitals = $users_tallyboard->get_vitals($user->u_id);
 
     $now = time();
 
-    // There are two special cases needed here:
-    // Firstly, the R* tally should span the time period from date_created to the site R* apocalypse
-    // Secondly, the P1 tally should start from the site P genesis, or date_created, whichever is later.
-
-    $site_R_apocalypse = 1117576800;
-    $site_P_genesis = 1117720800;
-
-    if ($tally_name == "R*") {
+    // If this is the entry-level round, use the user creation date
+    if ($tally_name == $ELR_round->id) {
         $firstWorkInRound = $user->date_created;
-        $daysInRoundInteger = floor(($site_R_apocalypse - $firstWorkInRound) / 86400);
-    } elseif ($tally_name == "P1") {
-        $firstWorkInRound = ($user->date_created > $site_P_genesis) ? $user->date_created : $site_P_genesis;
         $daysInRoundInteger = floor(($now - $firstWorkInRound) / 86400);
     } else {
         $firstWorkInRound = get_first_granted_date($user->username, $tally_name);

--- a/stats/proof_stats.php
+++ b/stats/proof_stats.php
@@ -25,7 +25,7 @@ $users_tallyboard = new TallyBoard($tally_name, 'U');
 [$joined_with_user_page_tallies, $user_page_tally_column] =
     $users_tallyboard->get_sql_joinery_for_current_tallies('users.u_id');
 
-// TRANSLATORS: %s is a page tally name (i.e. 'P1' or 'F2' or 'R*')
+// TRANSLATORS: %s is a page tally name (i.e. 'P1' or 'F2')
 $sql_upt_column_name = sprintf(_("%s Pages Completed"), $tally_name);
 
 $sql = sprintf(


### PR DESCRIPTION
These will be moved to `pgdp-production` branch immediately after this merges.

Direct link to stats page in test sandbox: https://www.pgdp.org/~cpeel/c.branch/remove-r-rounds-from-master/stats/members/mdetail.php?id=1&tally_name=P1