### PR TITLE
Add type declarations for get_*_param functions

### DIFF
--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -57,4 +57,41 @@ class ActivityTest extends PHPUnit\Framework\TestCase
         global $ACCESS_CRITERIA;
         $this->assertEquals("'P2' pages completed", $ACCESS_CRITERIA["P2"]);
     }
+
+    //------------------------------------------------------------------------
+    // get_round_param() tests
+
+    public function test_get_round_param()
+    {
+        $GET = ["round" => "P1"];
+        $round = get_round_param($GET, "round");
+        $this->assertEquals("P1", $round->id);
+    }
+
+    public function test_get_round_param_invalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is not a valid round ID");
+        $GET = ["round" => "X4"];
+        get_round_param($GET, "round");
+    }
+
+    public function test_get_round_param_default()
+    {
+        $round = get_round_param([], "round", Rounds::get_by_id("P1"));
+        $this->assertEquals("P1", $round->id);
+    }
+
+    public function test_get_round_param_default_null()
+    {
+        $round = get_round_param([], "round", null, true);
+        $this->assertEquals(null, $round);
+    }
+
+    public function test_get_round_param_no_default()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is required");
+        get_round_param([], "round", null);
+    }
 }

--- a/SETUP/tests/misc_ParamValidatorTest.php
+++ b/SETUP/tests/misc_ParamValidatorTest.php
@@ -7,11 +7,21 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         "i10" => "10",
         "f10" => "10.0",
         "s10" => "ten",
+        "date" => "2024-02-10",
     ];
     private $ENUM_CHOICES = ["a", "b"];
 
     //------------------------------------------------------------------------
     // get_enumerated_param() tests
+
+    public function testEnumInvalidArray()
+    {
+        // sanity check PHP's built-in type checking, we're not going
+        // to do this for every param and every function
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage("must be of the type array, null given");
+        get_enumerated_param(null, 'c', null, $this->ENUM_CHOICES);
+    }
 
     public function testEnum()
     {
@@ -30,8 +40,9 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testEnumNoDefault()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is required");
         $default = null;
-        $result = get_enumerated_param($this->GET, 'none', $default, $this->ENUM_CHOICES);
+        get_enumerated_param($this->GET, 'none', $default, $this->ENUM_CHOICES);
     }
 
     public function testEnumNull()
@@ -44,9 +55,71 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testEnumInvalidOption()
     {
         $this->expectException(InvalidArgumentException::class);
-        $result = get_enumerated_param($this->GET, 'i10', null, $this->ENUM_CHOICES);
+        $this->expectExceptionMessage("is not one of");
+        get_enumerated_param($this->GET, 'i10', null, $this->ENUM_CHOICES);
     }
 
+    public function testEnumInvalidDefault()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("\$default not in \$choices");
+        get_enumerated_param($this->GET, 'enum', 'c', $this->ENUM_CHOICES);
+    }
+
+    public function testEnumNoChoices()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is an empty array");
+        get_enumerated_param($this->GET, 'enum', 'a', []);
+    }
+
+    public function testEnumDefaultAndNull()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("\$allownull = true but \$default is specified");
+        get_enumerated_param($this->GET, 'enum', 'a', $this->ENUM_CHOICES, true);
+    }
+
+    //------------------------------------------------------------------------
+    // get_numeric_param() tests
+
+    // The testInteger* and testFloat* functions test most of this already,
+    // so just handle the interesting edgecases
+
+    public function testNumericType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("must be 'integer' or 'float'");
+        get_numeric_param("boolean", $this->GET, 'enum', 1, 0, 1, false);
+    }
+
+    public function testNumericMinType()
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage("must be of the type numeric or null");
+        get_numeric_param("integer", $this->GET, 'enum', 1, "min", 1, false);
+    }
+
+    public function testNumericMaxType()
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage("must be of the type numeric or null");
+        get_numeric_param("integer", $this->GET, 'enum', 1, 0, "max", false);
+    }
+
+    public function testNumericMinLtMax()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("\$min must be <= \$max");
+        get_numeric_param("integer", $this->GET, 'enum', null, 1, 0, true);
+    }
+
+    public function testNumericDefaultAndNull()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("\$allownull = true but \$default is specified");
+        get_numeric_param("integer", $this->GET, 'enum', 1, 0, 1, true);
+    }
 
     //------------------------------------------------------------------------
     // get_integer_param() tests
@@ -69,6 +142,16 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($default, $result);
     }
 
+    public function testIntegerDefaultNotInt()
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage("must be of the type int or null");
+        $default = "string";
+        $min = 0;
+        $max = 100;
+        get_integer_param($this->GET, 'none', $default, $min, $max);
+    }
+
     public function testIntegerNull()
     {
         $default = null;
@@ -81,38 +164,42 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testIntegerNoDefault()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is required");
         $default = null;
         $min = 0;
         $max = 100;
-        $result = get_integer_param($this->GET, 'none', $default, $min, $max);
+        get_integer_param($this->GET, 'none', $default, $min, $max);
     }
 
     public function testIntegerNotAnInt()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is not an integer");
         $default = null;
         $min = 0;
         $max = 100;
-        $result = get_integer_param($this->GET, 'f10', $default, $min, $max);
+        get_integer_param($this->GET, 'f10', $default, $min, $max);
     }
 
 
     public function testIntegerLessThanMin()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is less than the minimum");
         $default = null;
         $min = 90;
         $max = 100;
-        $result = get_integer_param($this->GET, 'i10', $default, $min, $max);
+        get_integer_param($this->GET, 'i10', $default, $min, $max);
     }
 
     public function testIntegerMoreThanMax()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is greater than the maximum");
         $default = null;
         $min = 0;
         $max = 9;
-        $result = get_integer_param($this->GET, 'i10', $default, $min, $max);
+        get_integer_param($this->GET, 'i10', $default, $min, $max);
     }
 
     //------------------------------------------------------------------------
@@ -145,6 +232,16 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($default, $result);
     }
 
+    public function testFloatDefaultNotFloat()
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage("must be of the type float or null");
+        $default = "string";
+        $min = 0;
+        $max = 100;
+        get_float_param($this->GET, 'none', $default, $min, $max);
+    }
+
     public function testFloatNull()
     {
         $default = null;
@@ -157,36 +254,85 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testFloatNoDefault()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is required");
         $default = null;
         $min = 0;
         $max = 100;
-        $result = get_float_param($this->GET, 'none', $default, $min, $max);
+        get_float_param($this->GET, 'none', $default, $min, $max);
     }
 
     public function testFloatNotAFloat()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is not a float");
         $default = null;
         $min = 0;
         $max = 100;
-        $result = get_float_param($this->GET, 's10', $default, $min, $max);
+        get_float_param($this->GET, 's10', $default, $min, $max);
     }
 
     public function testFloatLessThanMin()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is less than the minimum");
         $default = null;
         $min = 90;
         $max = 100;
-        $result = get_float_param($this->GET, 'f10', $default, $min, $max);
+        get_float_param($this->GET, 'f10', $default, $min, $max);
     }
 
     public function testFloatMoreThanMax()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is greater than the maximum");
         $default = null;
         $min = 0;
         $max = 9;
-        $result = get_float_param($this->GET, 'f10', $default, $min, $max);
+        get_float_param($this->GET, 'f10', $default, $min, $max);
     }
+
+    //------------------------------------------------------------------------
+    // get_param_matching_regex() tests
+
+    public function testRegex()
+    {
+        $regex = '/^\d{4}-\d{2}-\d{2}$/';
+        $result = get_param_matching_regex($this->GET, "date", "1999-01-01", $regex);
+        $this->assertEquals($this->GET["date"], $result);
+    }
+
+    public function testRegexDefault()
+    {
+        $default = "1999-01-01";
+        $regex = '/^\d{4}-\d{2}-\d{2}$/';
+        $result = get_param_matching_regex($this->GET, "invalidkey", $default, $regex);
+        $this->assertEquals($default, $result);
+    }
+
+    public function testRegexNoMatch()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("does not match the regex");
+        $default = null;
+        $regex = '/^\d{4}-\d{2}-\d{2}$/';
+        get_param_matching_regex($this->GET, "enum", null, $regex);
+    }
+
+    public function testRegexNoDefault()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is required");
+        $default = null;
+        $regex = '/^\d{4}-\d{2}-\d{2}$/';
+        get_param_matching_regex($this->GET, "invalidkey", null, $regex);
+    }
+
+    public function testRegexDefaultAndNull()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("\$allownull = true but \$default is specified");
+        $regex = '/^\d{4}-\d{2}-\d{2}$/';
+        get_param_matching_regex($this->GET, "date", "1999-01-01", $regex, true);
+    }
+
 }

--- a/SETUP/tests/misc_ParamValidatorTest.php
+++ b/SETUP/tests/misc_ParamValidatorTest.php
@@ -163,7 +163,7 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testIntegerDefaultNotInt()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("type int or null");
+        $this->expectExceptionMessage("must be of");
         $default = "string";
         $min = 0;
         $max = 100;
@@ -253,7 +253,7 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testFloatDefaultNotFloat()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("type float or null");
+        $this->expectExceptionMessage("must be of");
         $default = "string";
         $min = 0;
         $max = 100;

--- a/SETUP/tests/misc_ParamValidatorTest.php
+++ b/SETUP/tests/misc_ParamValidatorTest.php
@@ -21,7 +21,7 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         // sanity check PHP's built-in type checking, we're not going
         // to do this for every param and every function
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("must be of the type array, null given");
+        $this->expectExceptionMessage("type array, null given");
         get_enumerated_param(null, 'c', null, $this->ENUM_CHOICES);
     }
 
@@ -114,14 +114,14 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testNumericMinType()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("must be of the type numeric or null");
+        $this->expectExceptionMessage("type numeric or null");
         get_numeric_param("integer", $this->GET, 'enum', 1, "min", 1, false);
     }
 
     public function testNumericMaxType()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("must be of the type numeric or null");
+        $this->expectExceptionMessage("type numeric or null");
         get_numeric_param("integer", $this->GET, 'enum', 1, 0, "max", false);
     }
 
@@ -163,7 +163,7 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testIntegerDefaultNotInt()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("must be of the type int or null");
+        $this->expectExceptionMessage("type int or null");
         $default = "string";
         $min = 0;
         $max = 100;
@@ -253,7 +253,7 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     public function testFloatDefaultNotFloat()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("must be of the type float or null");
+        $this->expectExceptionMessage("type float or null");
         $default = "string";
         $min = 0;
         $max = 100;

--- a/SETUP/tests/misc_ParamValidatorTest.php
+++ b/SETUP/tests/misc_ParamValidatorTest.php
@@ -8,8 +8,10 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         "f10" => "10.0",
         "s10" => "ten",
         "date" => "2024-02-10",
+        "one" => 1,
     ];
     private $ENUM_CHOICES = ["a", "b"];
+    private $ENUM_INT_CHOICES = [1, 3, 5, 9];
 
     //------------------------------------------------------------------------
     // get_enumerated_param() tests
@@ -50,6 +52,22 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         $default = null;
         $result = get_enumerated_param($this->GET, 'none', $default, $this->ENUM_CHOICES, true);
         $this->assertEquals(null, $result);
+    }
+
+    public function testEnumInt()
+    {
+        $default = 9;
+        $result = get_enumerated_param($this->GET, 'one', 9, $this->ENUM_INT_CHOICES);
+        $this->assertEquals($result, $this->GET['one']);
+        $this->assertIsInt($result);
+    }
+
+    public function testEnumIntDefault()
+    {
+        $default = 9;
+        $result = get_enumerated_param($this->GET, 'none', $default, $this->ENUM_INT_CHOICES);
+        $this->assertEquals($result, $default);
+        $this->assertIsInt($result);
     }
 
     public function testEnumInvalidOption()

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -565,19 +565,18 @@ function is_formatting_round($round)
  *
  * @param array $arr
  * @param string $key
- * @param mixed $default
+ * @param Round|null $default
  * @param bool $allownull
+ *
+ * @return Round|null
  *
  * @throws InvalidArgumentException
  */
-function get_round_param($arr, $key, $default = null, $allownull = false)
+function get_round_param(array $arr, string $key, ?Round $default = null, bool $allownull = false): ?Round
 {
     // sanity checks on the args
-    assert(is_array($arr));
-    assert(!is_array($key));
-    assert(is_null($default) || is_string($default));
-    if (!is_null($default)) {
-        assert(!$allownull);
+    if (!is_null($default) && $allownull) {
+        throw new InvalidArgumentException("\$allownull = true but \$default is specified");
     }
     if (isset($arr[$key])) {
         $s = $arr[$key];

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -123,25 +123,30 @@ function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
  * @param array $choices
  * @param bool $allownull
  *
+ * @return mixed
+ *
  * @throws InvalidArgumentException
  */
-function get_enumerated_param($arr, $key, $default, $choices, $allownull = false)
+function get_enumerated_param(array $arr, string $key, $default, array $choices, bool $allownull = false)
 {
-    {
-        // sanity checks on the args
-        assert(is_array($arr));
-        assert(!is_array($key));
+    // TODO: On move to PHP 8.0 as a minimum version, add 'mixed' type def to
+    // $default and a return of mixed
 
-        assert(is_null($default) || is_string($default));
-        assert(is_array($choices));
-        assert(count($choices) > 0);
+    // sanity checks on the args
+    if (count($choices) <= 0) {
+        throw new InvalidArgumentException("\$choices is an empty array");
+    }
 
-        if (!is_null($default)) {
-            assert(in_array($default, $choices));
-            assert(!$allownull);
+    if (!is_null($default)) {
+        if (!in_array($default, $choices)) {
+            throw new InvalidArgumentException("\$default not in \$choices");
+        }
+        if ($allownull) {
+            throw new InvalidArgumentException("\$allownull = true but \$default is specified");
         }
     }
 
+    // get and validate string
     if (isset($arr[$key])) {
         $s = $arr[$key];
 
@@ -251,11 +256,13 @@ function get_enumerated_param($arr, $key, $default, $choices, $allownull = false
  * @param int|null $max
  * @param bool $allownull
  *
+ * @return string|null
+ *
  * @throws InvalidArgumentException
  *
  * @see get_float_param()
  */
-function get_integer_param($arr, $key, $default, $min, $max, $allownull = false)
+function get_integer_param(array $arr, string $key, ?int $default, ?int $min, ?int $max, bool $allownull = false): ?int
 {
     return get_numeric_param("integer", $arr, $key, $default, $min, $max, $allownull);
 }
@@ -275,11 +282,13 @@ function get_integer_param($arr, $key, $default, $min, $max, $allownull = false)
  * @param float|null $max
  * @param bool $allownull
  *
+ * @return float|null
+ *
  * @throws InvalidArgumentException
  *
  * @see get_integer_param()
  */
-function get_float_param($arr, $key, $default, $min, $max, $allownull = false)
+function get_float_param(array $arr, string $key, ?float $default, ?float $min, ?float $max, bool $allownull = false): ?float
 {
     return get_numeric_param("float", $arr, $key, $default, $min, $max, $allownull);
 }
@@ -298,41 +307,56 @@ function get_float_param($arr, $key, $default, $min, $max, $allownull = false)
  * @param int|float|null $max
  * @param bool $allownull
  *
+ * @return int|float|null
+ *
  * @throws InvalidArgumentException
  *
  * @see get_integer_param()
  * @see get_float_param()
  */
-function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
+function get_numeric_param(string $type, array $arr, string $key, $default, $min, $max, bool $allownull)
 {
-    {
-        // sanity checks on the args
-        assert(is_array($arr));
-        assert(!is_array($key));
-
-        if ($type == 'integer') {
-            assert(is_null($default) || is_int($default));
-        } else {
-            assert(is_null($default) || is_float($default));
+    // sanity checks on the args
+    if ($type == 'integer') {
+        if (! (is_null($default) || is_int($default))) {
+            throw new TypeError("\$default must be of the type int or null");
         }
-        assert(is_null($min) || is_numeric($min));
-        assert(is_null($max) || is_numeric($max));
-
-        if (!is_null($default)) {
-            if (!is_null($min)) {
-                assert($default >= $min);
-            }
-            if (!is_null($max)) {
-                assert($default <= $max);
-            }
-            assert(!$allownull);
+    } elseif ($type == 'float') {
+        if (! (is_null($default) || is_float($default))) {
+            throw new TypeError("\$default must be of the type float or null");
         }
+    } else {
+        throw new InvalidArgumentException("\$type must be 'integer' or 'float'");
+    }
 
-        if (!is_null($min) && !is_null($max)) {
-            assert($min <= $max);
+    // TODO: On move to PHP 8.0 as a minimum version, the following two checks
+    // (and the unit tests for them) can be removed as we can then use union
+    // type defs for $min and $max, eg: int|float|null $min. Also add a
+    // int_float_null as a return type for this function.
+    if (! (is_null($min) || is_numeric($min))) {
+        throw new TypeError("\$min must be of the type numeric or null");
+    }
+    if (! (is_null($max) || is_numeric($max))) {
+        throw new TypeError("\$max must be of the type numeric or null");
+    }
+
+    if (!is_null($default)) {
+        if (!is_null($min) && $default < $min) {
+            throw new InvalidArgumentException("\$default must be >= \$min");
+        }
+        if (!is_null($max) && $default > $max) {
+            throw new InvalidArgumentException("\$default must be <= \$max");
+        }
+        if ($allownull) {
+            throw new InvalidArgumentException("\$allownull = true but \$default is specified");
         }
     }
 
+    if (!is_null($min) && !is_null($max) && $min > $max) {
+        throw new InvalidArgumentException("\$min must be <= \$max");
+    }
+
+    // get and validate number
     if (isset($arr[$key])) {
         $s = $arr[$key];
 
@@ -421,7 +445,7 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
  *   ```
  * @param array $arr
  * @param string $key
- * @param mixed $default
+ * @param string|null $default
  * @param string $regex
  *   For security, $regex should almost certainly be anchored at both ends,
  *   and should not contain:
@@ -429,21 +453,15 @@ function get_numeric_param($type, $arr, $key, $default, $min, $max, $allownull)
  *   - (unescaped) '.' (e.g., in "/foo.+bar/").
  * @param bool $allownull
  *
+ * @return string|null
+ *
  * @throws InvalidArgumentException
  */
-function get_param_matching_regex($arr, $key, $default, $regex, $allownull = false)
+function get_param_matching_regex(array $arr, string $key, ?string $default, string $regex, bool $allownull = false): ?string
 {
     // sanity checks on args
-    {
-        assert(is_array($arr));
-        assert(!is_array($key));
-
-        assert(is_null($default) || is_string($default));
-        assert(is_string($regex));
-
-        if (!is_null($default)) {
-            assert(!$allownull);
-        }
+    if (!is_null($default) && $allownull) {
+        throw new InvalidArgumentException("\$allownull = true but \$default is specified");
     }
 
     if (isset($arr[$key])) {

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -102,8 +102,8 @@ function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
 /**
  * Get and validate a value from an array against a known set of values
  *
- * If `$arr[$key]` is defined and is one of the strings in `$choices`,
- * return that string.
+ * If `$arr[$key]` is defined and is one of the values in `$choices`,
+ * return that value.
  * If it's not defined, and `$default` is non-null, return `$default`.
  * If `$default` is null and `$allownull` is true, return null (useful for optional params).
  *
@@ -150,15 +150,10 @@ function get_enumerated_param(array $arr, string $key, $default, array $choices,
     if (isset($arr[$key])) {
         $s = $arr[$key];
 
-        if (!is_string($s)) {
-            throw new InvalidArgumentException(sprintf(
-                _("Parameter '%1\$s' is not a valid type"),
-                $key
-            ));
+        if (is_string($s)) {
+            // Trim whitespace from both ends of the string.
+            $s = trim($s);
         }
-
-        // Trim whitespace from both ends of the string.
-        $s = trim($s);
 
         // Although this function was written assuming that $choices is an array
         // of strings, tasks.php started calling it with an array of integers.
@@ -360,15 +355,10 @@ function get_numeric_param(string $type, array $arr, string $key, $default, $min
     if (isset($arr[$key])) {
         $s = $arr[$key];
 
-        if (!is_string($s)) {
-            throw new InvalidArgumentException(sprintf(
-                _("Parameter '%1\$s' is not a valid type"),
-                $key
-            ));
+        if (is_string($s)) {
+            // Trim whitespace from both ends of the string.
+            $s = trim($s);
         }
-
-        // Trim whitespace from both ends of the string.
-        $s = trim($s);
 
         if ($type == 'integer') {
             if (preg_match('/^[-+]?\d+$/', $s)) {
@@ -473,9 +463,6 @@ function get_param_matching_regex(array $arr, string $key, ?string $default, str
                 $key
             ));
         }
-
-        // Trim whitespace from both ends of the string.
-        $s = trim($s);
 
         if (preg_match($regex, $s)) {
             return $s;

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -117,10 +117,10 @@ function get_changed_fields_for_objects($new, $old, $remove_non_public = true)
  *   $round = get_enumerated_param( $_GET, 'tally_name', null, $rounds, true);
  *   ```
  *
- * @param array $arr
+ * @param array<string, mixed> $arr
  * @param string $key
  * @param mixed $default
- * @param array $choices
+ * @param array<string|int> $choices
  * @param bool $allownull
  *
  * @return mixed
@@ -133,7 +133,7 @@ function get_enumerated_param(array $arr, string $key, $default, array $choices,
     // $default and a return of mixed
 
     // sanity checks on the args
-    if (count($choices) <= 0) {
+    if (empty($choices)) {
         throw new InvalidArgumentException("\$choices is an empty array");
     }
 
@@ -249,14 +249,14 @@ function get_enumerated_param(array $arr, string $key, $default, array $choices,
  *   $per_page = get_integer_param($_GET, 'per_page', null, 1, null, true);
  *   ```
  *
- * @param array $arr
+ * @param array<string, mixed> $arr
  * @param string $key
  * @param int|null $default
  * @param int|null $min
  * @param int|null $max
  * @param bool $allownull
  *
- * @return string|null
+ * @return int|null
  *
  * @throws InvalidArgumentException
  *
@@ -275,7 +275,7 @@ function get_integer_param(array $arr, string $key, ?int $default, ?int $min, ?i
  * If it's not defined, and `$default` is non-null, return `$default`.
  * If it's not defined, and `$default` is null and `$allownull` is true, return null.
  *
- * @param array $arr
+ * @param array<string, mixed> $arr
  * @param string $key
  * @param float|null $default
  * @param float|null $min
@@ -300,7 +300,7 @@ function get_float_param(array $arr, string $key, ?float $default, ?float $min, 
  * use those versions instead.
  *
  * @param string $type - One of "integer" or "float"
- * @param array $arr
+ * @param array<string, mixed> $arr
  * @param string $key
  * @param int|float|null $default
  * @param int|float|null $min
@@ -443,7 +443,7 @@ function get_numeric_param(string $type, array $arr, string $key, $default, $min
  *   ```
  *   $word = get_param_matching_regex($_GET, 'word', NULL, '/^\w+$/')
  *   ```
- * @param array $arr
+ * @param array<string, mixed> $arr
  * @param string $key
  * @param string|null $default
  * @param string $regex


### PR DESCRIPTION
Improve the robustness of our `get_*_param()` function calls by adding type definitions rather than assert checking where we can. If the caller passes in the wrong type, PHP will raise an exception which most likely means a developer coded something wrong. Change all non-type validation asserts to raise exceptions. This introduces a slew of new unit tests as well as updating some exiting tests to check the exception message to make sure we're testing the right thing.

Because union types and the `mixed` type didn't enter PHP until 8.0 we are limited in a couple of cases and some comments have been added accordingly.

Code inspection and unit tests should be sufficient but for a sanity check, here's a sandbox: https://www.pgdp.org/~cpeel/c.branch/type-decls-in-get-params/