### PR TITLE
.github: Update actions/setup-node tag to v4

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -2,7 +2,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
     - name: Install NPM packages


### PR DESCRIPTION
This uses Node 20 internally in the action script itself, rather than the older Node 16 which is now deprecated on GitHub.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/