### PR TITLE
bootstrap.inc: Allow DPDatabase::connect to be skipped

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -68,8 +68,10 @@ jobs:
         uses: ./.github/actions/setup-php
         with:
           php-version: '7.4'
-      - name: Setup MySQL, install schema
-        uses: ./.github/actions/setup-mysql-db
+      # We don't install MySQL, but we do need pinc/site_vars.php & co.
+      # so the static analysis doesn't fail trying to include_once those files.
+      - name: Configure site setup
+        run: SETUP/configure SETUP/tests/ci_configuration.sh .
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --no-ansi --no-progress --memory-limit=512M
   misc_checks:

--- a/SETUP/phpstan_bootstrap.inc
+++ b/SETUP/phpstan_bootstrap.inc
@@ -1,4 +1,8 @@
 <?php
+
+// Don't open a DB connection in bootstrap.inc so we can run PHPStan w/o MySQL.
+define('SKIP_DB_CONNECT', true);
+
 // Two dummy functions to quell PHPStan warnings when loading bootstrap.inc
 function test_exception_handler($exception)
 {

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -43,13 +43,15 @@ if (!headers_sent()) {
 include_once($relPath.'gettext_setup.inc');
 include_once($relPath.'DPDatabase.inc');
 
-try {
-    DPDatabase::connect();
-} catch (Exception $e) {
-    // If we're in maintenance mode, don't die here - we'll more gracefully
-    // error out later
-    if (!$maintenance) {
-        throw $e;
+if (!defined('SKIP_DB_CONNECT')) {
+    try {
+        DPDatabase::connect();
+    } catch (Exception $e) {
+        // If we're in maintenance mode, don't die here - we'll more gracefully
+        // error out later
+        if (!$maintenance) {
+            throw $e;
+        }
     }
 }
 


### PR DESCRIPTION
So we can run PHPStan without needing to set up mysql.