### PR TITLE
api/v1/queues/:id/projects: Add project_manager field to output

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -863,6 +863,8 @@ paths:
                       type: string
                     author:
                       type: string
+                    project_manager:
+                      type: string
                     languages:
                       type: array
                       items:

--- a/api/v1_queues.inc
+++ b/api/v1_queues.inc
@@ -85,6 +85,7 @@ function api_v1_queue_projects($method, $data, $query_params)
         "projectid",
         "title",
         "author",
+        "project_manager",
         "languages",
         "genre",
         "difficulty",

--- a/pinc/release_queue.inc
+++ b/pinc/release_queue.inc
@@ -318,7 +318,7 @@ function fetch_queue_projects_data($round, $project_selector, $unheld_only)
             "languages" => Project::decode_language($row["language"]),
             "genre" => $row["genre"],
             "difficulty" => $row["difficulty"],
-            "username" => $row["username"],
+            "project_manager" => $row["username"],
             "last_state_change_time" => (int)$row["modifieddate"],
             "holds_state" => $row["holds_state"],
         ];

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -260,7 +260,7 @@ function _show_queue_details($round, $name, $unheld_only)
         echo "<td>", html_safe(Project::encode_languages($p["languages"])), "</td>\n";
         echo "<td>", html_safe($p["genre"]), "</td>\n";
         echo "<td>", html_safe($p["difficulty"]), "</td>\n";
-        echo "<td>", html_safe($p["username"]), "</td>\n";
+        echo "<td>", html_safe($p["project_manager"]), "</td>\n";
         echo "<td>", date("Y-m-d H:i:s", $p["last_state_change_time"]), "</td>\n";
         echo "<td>", is_null($p["holds_state"]) ? "&nbsp;" : "Y", "</td>\n";
         echo "</tr>";


### PR DESCRIPTION
This is already visible on stats/release_queue.php and in api/v1/projects/:pid, and it's useful (read: I have a use for :)), so make it visible in the queue projects API too.