### PR TITLE
api/v1/project/:id/pagedetails: Show username if permitted

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -1058,6 +1058,8 @@ components:
           type: string
           enum: [markdown, html]
         clearance:
+          description: This field will not be included if the requestor
+            is not authorized to see it
           type: string
         custom_characters:
           type: string
@@ -1158,6 +1160,10 @@ components:
         last_modified:
           type: string
           format: dateTime
+        username:
+          description: This field will not be included if the requestor
+            is not authorized to see it
+          type: string
 
     project_transition:
       required:
@@ -1197,6 +1203,10 @@ components:
         text:
           type: string
         state:
+          type: string
+        username:
+          description: This field will not be included if the requestor
+            is not authorized to see it
           type: string
 
     release_queue_detail:

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -428,8 +428,14 @@ function api_v1_project_pagedetails($method, $data, $query_params)
         }
     }
 
+    $project = $data[":projectid"];
+    $rounds_to_display = get_rounds_to_display($project);
+    if (!is_null($only_rounds)) {
+        $rounds_to_display = array_intersect($rounds_to_display, $only_rounds);
+    }
+
     $return_data = [];
-    foreach (fetch_page_table_data($data[":projectid"], null, null, $only_rounds) as $image) {
+    foreach (fetch_page_table_data($project, null, null, $only_rounds) as $image) {
         $page_rounds_data = [];
         // Remove proofer names and adjust timestamp format
         foreach ($image["pagerounds"] as $round_id => $round_data) {
@@ -438,7 +444,11 @@ function api_v1_project_pagedetails($method, $data, $query_params)
                 $round_data["last_modified"] = date(DATE_ATOM, $round_data["modified_timestamp"]);
                 unset($round_data["modified_timestamp"]);
             }
-            unset($round_data["username"]);
+
+            $proofer_usernames = array_map(fn ($r) => $image["pagerounds"][$r->id]["username"], $rounds_to_display);
+            if (!can_user_see_usernames_for_page($project, $proofer_usernames)) {
+                unset($round_data["username"]);
+            }
             $page_rounds_data[] = $round_data;
         }
         $image["pagerounds"] = $page_rounds_data;
@@ -461,36 +471,44 @@ function api_v1_project_page_round($method, $data, $query_params)
         $user_column = $round->user_column_name;
     }
 
+    $project = $data[":projectid"];
+    $user_cols = array_map(fn ($r) => $r->user_column_name, Rounds::get_all());
+
     $sql = sprintf(
         "
         SELECT
             image,
             %s AS text,
             %s AS user,
+            %s,
             state
         FROM %s
         WHERE image = '%s'
         ",
         $text_column,
         $user_column,
-        $data[":projectid"]->projectid,
+        implode(",", $user_cols),
+        $project->projectid,
         DPDatabase::escape($data[":pagename"])
     );
     $result = DPDatabase::query($sql);
     $row = mysqli_fetch_assoc($result);
-    $row["image_url"] = $data[":projectid"]->url . "/" . $row["image"];
+    $row["image_url"] = $project->url . "/" . $row["image"];
 
-    // We can't show the username here unless the user has proofed the page
-    // in one round or they are an PF/SA. We need to abstract the conditional
-    // logic out of tools/project_manager/page_detail.inc
-    unset($row["user"]);
+    $json = render_project_page_json($row);
 
-    return render_project_page_json($row);
+    $proofer_usernames = array_map(fn ($u) => $row[$u], $user_cols);
+    if (!can_user_see_usernames_for_page($project, $proofer_usernames)) {
+        unset($json["username"]);
+    }
+
+    return $json;
 }
 
 function render_project_page_json($row)
 {
     return [
+        "username" => $row["user"],
         "pagename" => $row["image"],
         "image_url" => $row["image_url"],
         "text" => $row["text"],

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -257,9 +257,6 @@ function echo_page_table(
 
     $can_edit = $project->can_be_managed_by_current_user;
 
-    // want PPers able to see names
-    $can_see_names_for_all_pages = $project->names_can_be_seen_by_current_user;
-
     if ($disable_editing) {
         // Although the user may be allowed to edit the project,
         // this particular page should not let them do so.
@@ -411,20 +408,8 @@ function echo_page_table(
         // --------------------------------------------
         // Per-Round Info
 
-        if ($can_see_names_for_all_pages) {
-            $can_see_names_for_this_page = true;
-        } else {
-            // The user can see the names of all the proofreaders for this page
-            // only if they are one of those proofreaders.
-            $can_see_names_for_this_page = false;
-            foreach ($rounds_to_display as $round) {
-                $proofer_name = $page_res["pagerounds"][$round->id]["username"];
-                if ($proofer_name != '' && $proofer_name == $pguser) {
-                    $can_see_names_for_this_page = true;
-                    break;
-                }
-            }
-        }
+        $proofer_usernames = array_map(fn ($r) => $page_res["pagerounds"][$r->id]["username"], $rounds_to_display);
+        $can_see_names_for_this_page = can_user_see_usernames_for_page($project, $proofer_usernames);
 
         $prev_rn = 0;
         foreach ($rounds_to_display as $round) {
@@ -546,6 +531,35 @@ function changeSelection(sel) {
         // We can't easily do a multipage mark-as-bad,
         // because it requires a per-page reason.
     }
+}
+
+/**
+ * Can the currently logged in user see the usernames of users who have
+ * worked on a particular page in a project?
+ *
+ * @param Project $project
+ * @param string[] $proofer_usernames
+ *   List of users who have proofed a page
+ *
+ * @return bool
+ */
+function can_user_see_usernames_for_page(Project $project, array $proofer_usernames): bool
+{
+    // want PPers able to see names
+    if ($project->names_can_be_seen_by_current_user) {
+        return true;
+    }
+
+    $user = User::current_username();
+
+    // The user can see the names of all the proofreaders for this page
+    // only if they are one of those proofreaders.
+    foreach ($proofer_usernames as $u) {
+        if ($u != '' && $u == $user) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
...using the same permissions checks that page_detail.php uses for each page, which is now factored out into a shared function.