### PR TITLE
Remove use of MAX_NUM_PAGE_EDITING_ROUNDS

### DIFF
--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -20,6 +20,7 @@ class ActivityTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("P3", Rounds::get_by_id("P3")->id);
         $this->assertEquals("P2.page_saved", Rounds::get_page_states()[8]);
         $this->assertEquals("P2", Rounds::get_by_project_state("P2.proj_waiting")->id);
+        $this->assertEquals("F2", Rounds::get_last()->id);
     }
 
     public function test_rounds_functions()

--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -19,8 +19,7 @@ function project_allow_pages($projectid)
 {
     validate_projectID($projectid);
     $columns_for_rounds = "";
-    for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-        $round = get_Round_for_round_number($rn);
+    foreach (Rounds::get_all() as $round) {
         $columns_for_rounds .= "
             {$round->time_column_name}   int(20)     NOT NULL default '0',
             {$round->user_column_name}   varchar(25) NOT NULL default '',
@@ -115,8 +114,7 @@ function project_add_page(
     $page_state = $round->page_avail_state;
 
     $columns_for_rounds = [];
-    for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-        $round = get_Round_for_round_number($rn);
+    foreach (Rounds::get_all() as $round) {
         $columns_for_rounds[] = "{$round->text_column_name} = ''";
     }
     $columns_for_rounds = join(", ", $columns_for_rounds);

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -487,8 +487,7 @@ function create_project_transitions()
 
     // -----------------------------------------------------------------------------
 
-    for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-        $round = get_Round_for_round_number($rn);
+    foreach (Rounds::get_all() as $round) {
 
         // setting modifieddate:
         //
@@ -666,8 +665,8 @@ function create_project_transitions()
             ]
         );
 
-        if ($rn < MAX_NUM_PAGE_EDITING_ROUNDS) {
-            $next_round = get_Round_for_round_number($rn + 1);
+        if ($round->round_number < Rounds::get_last()->round_number) {
+            $next_round = get_Round_for_round_number($round->round_number + 1);
 
             $project_transitions[] = new ProjectTransition(
                 $round->project_complete_state,
@@ -721,8 +720,8 @@ function create_project_transitions()
             ];
 
             foreach ($from_states as $from_state) {
-                if ($rn < MAX_NUM_PAGE_EDITING_ROUNDS) {
-                    $next_round = get_Round_for_round_number($rn + 1);
+                if ($round->round_number < Rounds::get_last()->round_number) {
+                    $next_round = get_Round_for_round_number($round->round_number + 1);
 
                     $project_transitions[] = new ProjectTransition(
                         $from_state,

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -32,6 +32,11 @@ class Rounds extends Stages
     {
         return self::_get("page_states", $state);
     }
+
+    public static function get_last()
+    {
+        return self::get_by_id(array_key_last(self::get_all()));
+    }
 }
 
 // A container for various constants relating to a particular round of proofreading.

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -701,8 +701,7 @@ function page_state_is_a($page_state, $desired_state)
     }
 
     $state_cache[$desired_state][$page_state] = false;
-    for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-        $round = get_Round_for_round_number($rn);
+    foreach (Rounds::get_all() as $round) {
         if ($page_state == $round->$desired_state) {
             $state_cache[$desired_state][$page_state] = true;
             break;

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -237,10 +237,6 @@ new Round(
 
 // After creating all rounds:
 
-define('MAX_NUM_PAGE_EDITING_ROUNDS', count(Rounds::get_all()));
-
-// ---------------------------
-
 declare_mentoring_pair('P1', 'P2');
 
 // -----------------------------------------------------------------------------
@@ -371,6 +367,8 @@ new Activity(
 // -----------------------------------------------------------------------------
 
 // recreate globals until they are replaced in the codebase
+
+define('MAX_NUM_PAGE_EDITING_ROUNDS', count(Rounds::get_all()));
 
 function _globals_builder($objects, $field)
 {

--- a/stats/equilibria.php
+++ b/stats/equilibria.php
@@ -19,8 +19,7 @@ function display_graph($d)
     if ($d == 0) {
         $title = _("Net pages saved so far today");
 
-        for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-            $round = get_Round_for_round_number($rn);
+        foreach (Rounds::get_all() as $round) {
             $site_stats = get_site_page_tally_summary($round->id);
             $data[] = $pages = $site_stats->curr_day_actual;
             $labels[] = "$round->id ($pages)";
@@ -30,8 +29,7 @@ function display_graph($d)
         $title = sprintf(_("Net pages saved in preceding %s days"), $d);
 
         $now = time();
-        for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-            $round = get_Round_for_round_number($rn);
+        foreach (Rounds::get_all() as $round) {
             $tallyboard = new TallyBoard($round->id, 'S');
             $data[] = $pages = $tallyboard->get_delta_sum(1, $now - (60 * 60 * 24 * $d), $now);
             $labels[] = "$round->id ($pages)";

--- a/stats/requested_books.php
+++ b/stats/requested_books.php
@@ -30,8 +30,7 @@ $comments_url3 = DPDatabase::escape("</a>");
 // Instead, custom-build a project-state condition that includes the
 // WAITING and AVAILABLE states from each round.
 $state_condition = '0';
-for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-    $round = get_Round_for_round_number($rn);
+foreach (Rounds::get_all() as $round) {
     $state_condition .= "
         OR state='{$round->project_waiting_state}'
         OR state='{$round->project_available_state}'

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -252,11 +252,11 @@ while ([$projectid] = mysqli_fetch_row($allprojects)) {
     if ($state == $round->project_complete_state) {
         // The project is ready to exit this round.
 
-        if ($round->round_number < MAX_NUM_PAGE_EDITING_ROUNDS) {
+        if ($round->round_number < Rounds::get_last()->round_number) {
             // It goes to the next round.
             $next_round = get_Round_for_round_number(1 + $round->round_number);
             $new_state = $next_round->project_waiting_state;
-        } elseif ($round->round_number == MAX_NUM_PAGE_EDITING_ROUNDS) {
+        } elseif ($round->round_number == Rounds::get_last()->round_number) {
             // It goes into post-processing.
             if (is_null(project_get_auto_PPer($projectid))) {
                 $new_state = PROJ_POST_FIRST_AVAILABLE;
@@ -264,7 +264,7 @@ while ([$projectid] = mysqli_fetch_row($allprojects)) {
                 $new_state = PROJ_POST_FIRST_CHECKED_OUT;
             }
         } else {
-            die("round_number is {$round->round_number}???\n");
+            throw new ValueError("round_number is {$round->round_number}???");
         }
 
         if ($verbose) {

--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -13,8 +13,7 @@ function autorelease()
     echo "<pre>\n";
     echo "Starting autorelease\n";
 
-    for ($rn = 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
-        $round = get_Round_for_round_number($rn);
+    foreach (Rounds::get_all() as $round) {
         autorelease_for_round($round);
     }
 

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -13,8 +13,8 @@ require_login();
 
 $projectid = get_projectID_param($_GET, 'project');
 $image = get_page_image_param($_GET, 'image', true);
-$L_round_num = get_integer_param($_GET, 'L_round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
-$R_round_num = get_integer_param($_GET, 'R_round_num', null, 0, MAX_NUM_PAGE_EDITING_ROUNDS);
+$L_round_num = get_integer_param($_GET, 'L_round_num', null, 0, Rounds::get_last()->round_number);
+$R_round_num = get_integer_param($_GET, 'R_round_num', null, 0, Rounds::get_last()->round_number);
 $format = get_enumerated_param($_GET, "format", null, ["keep", "remove"], true);
 $only_nonempty_diffs = @$_GET['only_nonempty_diffs'] === 'on';
 $bb_diffs = (@$_GET['bb_diffs'] === 'on' and user_can_mentor_in_any_round());

--- a/tools/project_manager/show_adhoc_word_details.php
+++ b/tools/project_manager/show_adhoc_word_details.php
@@ -153,8 +153,7 @@ function _get_word_list($projectid, $queryWords)
     $messages = [];
 
     // get the latest project text of all pages up to last possible round
-    $last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-    $pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
     $page_texts = get_page_texts($pages_res);
 
     // now run it through WordCheck

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -227,8 +227,7 @@ function _get_word_list($projectid, $suggestions)
     $project_bad_words = load_project_bad_words($projectid);
 
     // get the latest project text of all pages up to last possible round
-    $last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-    $pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
     $all_words_w_freq = get_distinct_words_in_text(get_page_texts($pages_res));
 
     // array to hold all words

--- a/tools/project_manager/show_current_flagged_words.php
+++ b/tools/project_manager/show_current_flagged_words.php
@@ -140,8 +140,7 @@ function _get_word_list($projectid)
     $messages = [];
 
     // get the latest project text of all pages up to last possible round
-    $last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-    $pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
     $page_texts = get_page_texts($pages_res);
 
     // now run it through WordCheck

--- a/tools/project_manager/show_good_word_suggestions.php
+++ b/tools/project_manager/show_good_word_suggestions.php
@@ -258,8 +258,7 @@ function _get_word_list($projectid, $timeCutoff)
     $project_bad_words = load_project_bad_words($projectid);
 
     // get the latest project text of all pages up to last possible round
-    $last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-    $pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
     $all_words_w_freq = get_distinct_words_in_text(get_page_texts($pages_res));
 
     // array to hold all words

--- a/tools/project_manager/show_project_possible_bad_words.php
+++ b/tools/project_manager/show_project_possible_bad_words.php
@@ -123,8 +123,7 @@ function _get_word_list($projectid)
     $messages = [];
 
     // get the latest project text of all pages up to last possible round
-    $last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-    $pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
     $all_words_w_freq = get_distinct_words_in_text(get_page_texts($pages_res));
 
     // load site word lists for project languages

--- a/tools/project_manager/show_project_stealth_scannos.php
+++ b/tools/project_manager/show_project_stealth_scannos.php
@@ -182,8 +182,7 @@ function _get_word_list($projectid)
     file_put_contents($ocr_filename, $all_page_text);
 
     // get the latest project text of all pages up to last possible round
-    $last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-    $pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
     $all_page_text = get_page_texts($pages_res);
     // remove any formatting tags and add a final \r\n to each page-text
     // to ensure that there is whitespace between pages so they don't run together

--- a/tools/project_manager/show_project_wordcheck_stats.php
+++ b/tools/project_manager/show_project_wordcheck_stats.php
@@ -26,9 +26,7 @@ $proj_bad_words = load_project_bad_words($projectid);
 // load bad words for the site for this project
 $site_bad_words = load_site_bad_words_given_project($projectid);
 
-// get the latest possible round
-$last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-$pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+$pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
 
 // get the entire text
 $page_texts = get_page_texts($pages_res);
@@ -61,7 +59,7 @@ $total["num_pages"] = $project->n_pages;
 
 // now run it again except we're going to count the words per page
 // this time through
-$pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+$pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
 $page_stats = [];
 // iterate through all the pages gathering stats
 while ([$page_text, $page, $proofer_names] = page_info_fetch($pages_res)) {

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -72,9 +72,7 @@ echo "</select>";
 echo "</form>";
 
 
-// get the latest possible round
-$last_possible_round = get_Round_for_round_number(MAX_NUM_PAGE_EDITING_ROUNDS);
-$pages_res = page_info_query($projectid, $last_possible_round->id, 'LE');
+$pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
 // iterate through all the pages until we find $wordInstances of the word
 // we're looking for
 $foundInstances = 0;

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -196,7 +196,7 @@ echo "</h2>";
 // ---------------------------------------------
 // snippets for use in queries
 $state_builder = [];
-for ($rn = $review_round->round_number + 1; $rn <= MAX_NUM_PAGE_EDITING_ROUNDS; $rn++) {
+for ($rn = $review_round->round_number + 1; $rn <= Rounds::get_last()->round_number; $rn++) {
     $round = get_Round_for_round_number($rn);
     // this will be used in sprintf()s below so for the final query to have a
     // single % in it, we need to make it 4x here


### PR DESCRIPTION
Replace numeric iteration of the rounds by a more natural foreach over the objects. This ultimately removes `MAX_NUM_PAGE_EDITING_ROUNDS`.

Testable in https://www.pgdp.org/~cpeel/c.branch/remove-max-rounds-const/

Aside: This started as work on Task 2000 but it got into a bit of yak shaving.