### PR TITLE
Remove duplicate definition of rounds in project_states.inc

### DIFF
--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -94,4 +94,38 @@ class ActivityTest extends PHPUnit\Framework\TestCase
         $this->expectExceptionMessage("is required");
         get_round_param([], "round", null);
     }
+
+    //------------------------------------------------------------------------
+    // test project state functions
+
+    public function test_project_state_functions()
+    {
+        global $PROJECT_STATES_IN_ORDER, $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx;
+
+        $this->assertEquals("P3.proj_bad", $PROJECT_STATES_IN_ORDER[11]);
+        $this->assertEquals("project_delete", $PROJECT_STATES_IN_ORDER[34]);
+        $this->assertEquals("(state='proj_submit_pgposted')", SQL_CONDITION_GOLD);
+        $this->assertEquals("(state='P1.proj_avail' OR state='P2.proj_avail' OR state='P3.proj_avail' OR state='F1.proj_avail' OR state='F2.proj_avail')", SQL_CONDITION_BRONZE);
+
+        $this->assertEquals("P1: Waiting", get_medium_label_for_project_state(PROJ_P1_WAITING_FOR_RELEASE));
+        $this->assertEquals("Proofreading Round 1: Waiting for Release", project_states_text(PROJ_P1_WAITING_FOR_RELEASE));
+        $this->assertEquals('PAGE_EDITING', get_phase_containing_project_state(PROJ_P1_WAITING_FOR_RELEASE));
+
+        $this->assertEquals("PP: Available", get_medium_label_for_project_state(PROJ_POST_FIRST_AVAILABLE));
+        $this->assertEquals("PP: Checked out", get_medium_label_for_project_state(PROJ_POST_FIRST_CHECKED_OUT));
+        $this->assertEquals("Post-Processing: Available", project_states_text(PROJ_POST_FIRST_AVAILABLE));
+        $this->assertEquals($waiting_projects_forum_idx, get_forum_id_for_project_state(PROJ_P1_WAITING_FOR_RELEASE));
+        $this->assertEquals($projects_forum_idx, get_forum_id_for_project_state(PROJ_P2_WAITING_FOR_RELEASE));
+        $this->assertEquals($pp_projects_forum_idx, get_forum_id_for_project_state(PROJ_POST_FIRST_AVAILABLE));
+
+        $this->assertEquals("PPV: Available", get_medium_label_for_project_state(PROJ_POST_SECOND_AVAILABLE));
+        $this->assertEquals("Post-Processing Verification: Available", project_states_text(PROJ_POST_SECOND_AVAILABLE));
+    }
+
+    public function test_graph_data_functions()
+    {
+        $this->assertEquals("state IN ('proj_post_first_unavailable','proj_post_first_available','proj_post_first_checked_out','proj_post_second_available','proj_post_second_checked_out','proj_post_complete')", _get_project_state_selector('PP'));
+        $this->assertEquals("state IN ('project_complete')", _get_project_state_selector('COMPLETE'));
+
+    }
 }

--- a/SETUP/tests/phpunit_bootstrap.php
+++ b/SETUP/tests/phpunit_bootstrap.php
@@ -1,5 +1,8 @@
 <?php
 global $relPath, $forum_type, $projects_dir, $aspell_temp_dir;
+global $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
+$completed_projects_forum_idx, $deleted_projects_forum_idx;
+
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'wordcheck_engine.inc');

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -40,8 +40,6 @@ class Pool extends Stage
         $access_change_callback,
         $description,
         $document,
-        $project_checkedout_state,
-        $project_available_state,
         $foo_Header,
         $foo_field_name,
         $blather
@@ -58,16 +56,9 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
-        $this->project_checkedout_state = $project_checkedout_state;
-        $this->project_available_state = $project_available_state;
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;
         $this->blather = $blather;
-
-        $this->states = [
-            $this->project_checkedout_state,
-            $this->project_available_state,
-        ];
     }
 }
 

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -55,8 +55,9 @@ class Pool extends Stage
         );
 
         // The following project-state related attributes are created & set in project_states.inc
-        // $this->project_checkedout_state
-        // $this->project_available_state
+        //     $this->project_checkedout_state
+        //     $this->project_available_state
+        //     $this->states
 
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -20,8 +20,6 @@ class Pool extends Stage
      *
      * A container for various constants relating to a particular pool.
      *
-     * @param string $project_checkedout_state
-     * @param string $project_available_state
      * @param $foo_Header
      * @param $foo_field_name
      *   The relevant person to display in pool listings, both

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -54,6 +54,10 @@ class Pool extends Stage
             "tools/pool.php?pool_id=$id"
         );
 
+        // The following project-state related attributes are created & set in project_states.inc
+        // $this->project_checkedout_state
+        // $this->project_available_state
+
         $this->foo_Header = $foo_Header;
         $this->foo_field_name = $foo_field_name;
         $this->blather = $blather;

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -115,20 +115,6 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
-        $this->project_unavailable_state = constant("PROJ_{$round_id}_UNAVAILABLE");
-        $this->project_waiting_state = constant("PROJ_{$round_id}_WAITING_FOR_RELEASE");
-        $this->project_bad_state = constant("PROJ_{$round_id}_BAD_PROJECT");
-        $this->project_available_state = constant("PROJ_{$round_id}_AVAILABLE");
-        $this->project_complete_state = constant("PROJ_{$round_id}_COMPLETE");
-
-        // Populate $this->project_states with all project states that apply
-        // to this round for lookup later.
-        $this->project_states = [];
-        foreach (["unavailable", "waiting", "bad", "available", "complete"] as $state) {
-            $attribute = "project_{$state}_state";
-            $this->project_states[] = $this->$attribute;
-        }
-
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -115,6 +115,14 @@ class Round extends Stage
         $this->honorifics = $honorifics;
         krsort($this->honorifics);
 
+        // The following project-state related attributes are created & set in project_states.inc
+        //     $this->project_unavailable_state
+        //     $this->project_waiting_state
+        //     $this->project_bad_state
+        //     $this->project_available_state
+        //     $this->project_complete_state
+        //     $this->project_states
+
         $this->page_avail_state = "{$round_id}.page_avail";
         $this->page_out_state = "{$round_id}.page_out";
         $this->page_temp_state = "{$round_id}.page_temp";

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -798,7 +798,7 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
  */
 function _get_project_state_selector($which, $desired_states = null)
 {
-    global $project_state_phase_;
+    global $project_states;
 
     if (null == $desired_states) {
         $desired_states = ["unavailable", "waiting", "bad", "available", "complete"];
@@ -822,8 +822,8 @@ function _get_project_state_selector($which, $desired_states = null)
 
     // it may be a pool or stage so look at the stage's phase
     $states = [];
-    foreach ($project_state_phase_ as $state => $phase) {
-        if ($phase == $which) {
+    foreach ($project_states as $state => $project_state) {
+        if ($project_state->phase == $which) {
             array_push($states, $state);
         }
     }

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -23,16 +23,22 @@ include_once($relPath.'site_vars.php');
   (Actually, the naming convention is in transition.)
 */
 
-$PROJECT_STATES_IN_ORDER = [];
-$project_state_medium_label_ = [];
-$project_state_long_label_ = [];
-$project_state_forum_ = [];
-$project_state_phase_ = [];
-$project_states_for_star_metal_ = [
-    'BRONZE' => [],
-    'SILVER' => [],
-    'GOLD' => [],
-];
+class ProjectState
+{
+    public function __construct(
+        $medium_label,
+        $long_label,
+        $forum,
+        $phase
+    ) {
+        $this->medium_label = $medium_label;
+        $this->long_label = $long_label;
+        $this->forum = $forum;
+        $this->phase = $phase;
+    }
+}
+
+global $project_states;
 
 function declare_project_state(
     $constant_name,
@@ -43,19 +49,18 @@ function declare_project_state(
     $phase,
     $star_metal
 ) {
-    global $PROJECT_STATES_IN_ORDER;
-    global $project_state_medium_label_;
-    global $project_state_long_label_;
-    global $project_state_forum_;
-    global $project_state_phase_;
+    global $project_states;
     global $project_states_for_star_metal_;
 
     define($constant_name, $constant_value);
-    $PROJECT_STATES_IN_ORDER[] = $constant_value;
-    $project_state_medium_label_[$constant_value] = $medium_label;
-    $project_state_long_label_[$constant_value] = $long_label;
-    $project_state_forum_[$constant_value] = $forum;
-    $project_state_phase_[$constant_value] = $phase;
+
+    $project_states[$constant_value] = new ProjectState(
+        $medium_label,
+        $long_label,
+        $forum,
+        $phase
+    );
+
     if ($star_metal) {
         $project_states_for_star_metal_[$star_metal][] = $constant_value;
     }
@@ -63,80 +68,26 @@ function declare_project_state(
 
 function get_medium_label_for_project_state($state)
 {
-    global $project_state_medium_label_;
-    return array_get($project_state_medium_label_, $state, '');
+    global $project_states;
+    return $project_states[$state]->medium_label ?? '';
 }
 
 function project_states_text($state)
 {
-    global $project_state_long_label_;
-    return array_get($project_state_long_label_, $state, '');
+    global $project_states;
+    return $project_states[$state]->long_label ?? '';
 }
 
 function get_forum_id_for_project_state($state)
 {
-    global $project_state_forum_;
-    return array_get($project_state_forum_, $state, -1);
+    global $project_states;
+    return $project_states[$state]->forum ?? -1;
 }
 
 function get_phase_containing_project_state($state)
 {
-    global $project_state_phase_;
-    return array_get($project_state_phase_, $state, 'NONE');
-}
-
-// -----------------------------------------------
-
-function declare_project_states_for_round($round_id, $round_name)
-{
-    global $projects_forum_idx;
-    global $waiting_projects_forum_idx;
-
-    declare_project_state(
-        "PROJ_{$round_id}_BAD_PROJECT",
-        "$round_id.proj_bad",
-        "$round_id: " .  _("Bad Project"),
-        "$round_name: " . _("Bad Project"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_UNAVAILABLE",
-        "$round_id.proj_unavail",
-        "$round_id: " . _("Unavailable"),
-        "$round_name: " . _("Unavailable"),
-        ($round_id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_WAITING_FOR_RELEASE",
-        "$round_id.proj_waiting",
-        "$round_id: " . _("Waiting"),
-        "$round_name: " . _("Waiting for Release"),
-        ($round_id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-        'PAGE_EDITING',
-        ''
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_AVAILABLE",
-        "$round_id.proj_avail",
-        "$round_id: " . _("Available"),
-        "$round_name: " . _("Available"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        'BRONZE'
-    );
-    declare_project_state(
-        "PROJ_{$round_id}_COMPLETE",
-        "$round_id.proj_done",
-        "$round_id: " . _("Completed"),
-        "$round_name: " . _("Completed"),
-        $projects_forum_idx,
-        'PAGE_EDITING',
-        ''
-    );
+    global $project_states;
+    return $project_states[$state]->phase ?? 'NONE';
 }
 
 // -----------------------------------------------
@@ -145,145 +96,198 @@ function declare_project_states_for_round($round_id, $round_name)
 // is the order in which they will be displayed in various contexts
 // (via $PROJECT_STATES_IN_ORDER).
 
+function declare_project_states($rounds, $pools)
+{
+    global $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
+    $completed_projects_forum_idx, $deleted_projects_forum_idx, $project_states_for_star_metal_;
+    global $PROJECT_STATES_IN_ORDER, $project_states;
 
-// PR
+    $project_states_for_star_metal_ = [
+        'BRONZE' => [],
+        'SILVER' => [],
+        'GOLD' => [],
+    ];
 
+    // for the initial creation of a project
+    declare_project_state(
+        "PROJ_NEW",
+        "project_new",
+        _("New Project"),
+        _("New Project"),
+        $waiting_projects_forum_idx,
+        'NEW',
+        ''
+    );
 
-// for the initial creation of a project
-declare_project_state(
-    "PROJ_NEW",
-    "project_new",
-    _("New Project"),
-    _("New Project"),
-    $waiting_projects_forum_idx,
-    'NEW',
-    ''
-);
+    foreach ($rounds as $round) {
+        // Populate $round->project_states with all project states that apply
+        // to this round for lookup later.
+        $round->project_states[] = $round->project_bad_state = "{$round->id}.proj_bad";
+        $round->project_states[] = $round->project_unavailable_state = "{$round->id}.proj_unavail";
+        $round->project_states[] = $round->project_waiting_state = "{$round->id}.proj_waiting";
+        $round->project_states[] = $round->project_available_state = "{$round->id}.proj_avail";
+        $round->project_states[] = $round->project_complete_state = "{$round->id}.proj_done";
 
+        declare_project_state(
+            "PROJ_{$round->id}_BAD_PROJECT",
+            $round->project_bad_state,
+            "$round->id: " .  _("Bad Project"),
+            "$round->name: " . _("Bad Project"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            ''
+        );
 
-// PROOF
-declare_project_states_for_round('P1', _('Proofreading Round 1'));
-declare_project_states_for_round('P2', _('Proofreading Round 2'));
-declare_project_states_for_round('P3', _('Proofreading Round 3'));
-
-// FORMAT
-declare_project_states_for_round('F1', _('Formatting Round 1'));
-declare_project_states_for_round('F2', _('Formatting Round 2'));
-
-
-// POST
-declare_project_state(
-    "PROJ_POST_FIRST_UNAVAILABLE",
-    "proj_post_first_unavailable",
-    _("Unavailable for PP"),
-    _("Unavailable for Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-declare_project_state(
-    "PROJ_POST_FIRST_AVAILABLE",
-    "proj_post_first_available",
-    _("Available for PP"),
-    _("Available for Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_FIRST_CHECKED_OUT",
-    "proj_post_first_checked_out",
-    _("In PP"),
-    _("In Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_SECOND_AVAILABLE",
-    "proj_post_second_available",
-    _("Available for PPV"),
-    _("Available for Verifying Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-declare_project_state(
-    "PROJ_POST_SECOND_CHECKED_OUT",
-    "proj_post_second_checked_out",
-    _("In PPV"),
-    _("Verifying Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-declare_project_state(
-    "PROJ_POST_COMPLETE",
-    "proj_post_complete",
-    _("Completed Post"),
-    _("Completed Post-Processing"),
-    $pp_projects_forum_idx,
-    'PP',
-    'SILVER'
-);
-
-
-
-// SUBMIT (was GB)
-declare_project_state(
-    "PROJ_SUBMIT_PG_POSTED",
-    "proj_submit_pgposted",
-    _("Posted to PG"),
-    _("Completed and Posted to Project Gutenberg"),
-    $posted_projects_forum_idx,
-    'GB',
-    'GOLD'
-);
-
-// for complete project
-declare_project_state(
-    "PROJ_COMPLETE",
-    "project_complete",
-    _("Project Complete"),
-    _("Project Complete"),
-    $completed_projects_forum_idx,
-    'COMPLETE',
-    ''
-);
-
-// for the 'deletion' of a project
-declare_project_state(
-    "PROJ_DELETE",
-    "project_delete",
-    _("Delete Project"),
-    _("Delete Project"),
-    $deleted_projects_forum_idx,
-    'NONE',
-    ''
-);
-
-// -----------------------------------------------------------------------------
-
-// Define constants for use in SQL queries:
-// SQL_CONDITION_BRONZE
-// SQL_CONDITION_SILVER
-// SQL_CONDITION_GOLD
-
-foreach ($project_states_for_star_metal_ as $star_metal => $project_states) {
-    $sql_constant_name = "SQL_CONDITION_$star_metal";
-    $sql_condition = '(';
-    foreach ($project_states as $project_state) { /** @phpstan-ignore-line Fixed in https://github.com/phpstan/phpstan/issues/9403 */
-        if ($sql_condition != '(') {
-            $sql_condition .= ' OR ';
-        }
-        $sql_condition .= "state='$project_state'";
+        declare_project_state(
+            "PROJ_{$round->id}_UNAVAILABLE",
+            $round->project_unavailable_state,
+            "$round->id: " . _("Unavailable"),
+            "$round->name: " . _("Unavailable"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
+            ''
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_WAITING_FOR_RELEASE",
+            $round->project_waiting_state,
+            "$round->id: " . _("Waiting"),
+            "$round->name: " . _("Waiting for Release"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
+            ''
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_AVAILABLE",
+            $round->project_available_state,
+            "$round->id: " . _("Available"),
+            "$round->name: " . _("Available"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            'BRONZE'
+        );
+        declare_project_state(
+            "PROJ_{$round->id}_COMPLETE",
+            $round->project_complete_state,
+            "$round->id: " . _("Completed"),
+            "$round->name: " . _("Completed"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            ''
+        );
     }
-    $sql_condition .= ')';
 
-    define($sql_constant_name, $sql_condition);
+    // POST
+    declare_project_state(
+        "PROJ_POST_FIRST_UNAVAILABLE",
+        "proj_post_first_unavailable",
+        _("Unavailable for PP"),
+        _("Unavailable for Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    foreach ($pools as $pool) {
+        switch ($pool->id) {
+            case 'PP':
+                $pool->project_available_state = "proj_post_first_available";
+                $pool->project_checkedout_state = "proj_post_first_checked_out";
+                break;
+            case 'PPV':
+                $pool->project_available_state = "proj_post_second_available";
+                $pool->project_checkedout_state = "proj_post_second_checked_out";
+                break;
+        }
+
+        $pool->states[] = $pool->project_available_state;
+        $pool->states[] = $pool->project_checkedout_state;
+
+        declare_project_state(
+            strtoupper($pool->project_available_state),
+            $pool->project_available_state,
+            "$pool->id: " . _("Available"),
+            "$pool->name: " . _("Available"),
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
+
+        declare_project_state(
+            strtoupper($pool->project_checkedout_state),
+            $pool->project_checkedout_state,
+            "$pool->id: " . _("Checked out"),
+            "$pool->name: " . _("Checked out"),
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
+    }
+
+    declare_project_state(
+        "PROJ_POST_COMPLETE",
+        "proj_post_complete",
+        _("Completed Post"),
+        _("Completed Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    );
+
+    // SUBMIT (was GB)
+    declare_project_state(
+        "PROJ_SUBMIT_PG_POSTED",
+        "proj_submit_pgposted",
+        _("Posted to PG"),
+        _("Completed and Posted to Project Gutenberg"),
+        $posted_projects_forum_idx,
+        'GB',
+        'GOLD'
+    );
+
+    // for complete project
+    declare_project_state(
+        "PROJ_COMPLETE",
+        "project_complete",
+        _("Project Complete"),
+        _("Project Complete"),
+        $completed_projects_forum_idx,
+        'COMPLETE',
+        ''
+    );
+
+    // for the 'deletion' of a project
+    declare_project_state(
+        "PROJ_DELETE",
+        "project_delete",
+        _("Delete Project"),
+        _("Delete Project"),
+        $deleted_projects_forum_idx,
+        'NONE',
+        ''
+    );
+
+    // -----------------------------------------------------------------------------
+
+    // Define constants for use in SQL queries:
+    // SQL_CONDITION_BRONZE
+    // SQL_CONDITION_SILVER
+    // SQL_CONDITION_GOLD
+
+    foreach ($project_states_for_star_metal_ as $star_metal => $states) {
+        $sql_constant_name = "SQL_CONDITION_$star_metal";
+        $sql_condition = '(';
+        foreach ($states as $project_state) { /** @phpstan-ignore-line Fixed in https://github.com/phpstan/phpstan/issues/9403 */
+            if ($sql_condition != '(') {
+                $sql_condition .= ' OR ';
+            }
+            $sql_condition .= "state='$project_state'";
+        }
+        $sql_condition .= ')';
+
+        define($sql_constant_name, $sql_condition);
+    }
+
+    $PROJECT_STATES_IN_ORDER = array_keys($project_states);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -283,7 +283,7 @@ function construct_star_metal_sql()
     foreach ($project_states_for_star_metal_ as $star_metal => $states) {
         $sql_constant_name = "SQL_CONDITION_$star_metal";
         $sql_condition = '(';
-        foreach ($states as $project_state) { /** @phpstan-ignore-line Fixed in https://github.com/phpstan/phpstan/issues/9403 */
+        foreach ($states as $project_state)
             if ($sql_condition != '(') {
                 $sql_condition .= ' OR ';
             }

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -29,12 +29,14 @@ class ProjectState
         $medium_label,
         $long_label,
         $forum,
-        $phase
+        $phase,
+        $star_metal
     ) {
         $this->medium_label = $medium_label;
         $this->long_label = $long_label;
         $this->forum = $forum;
         $this->phase = $phase;
+        $this->star_metal = $star_metal;
     }
 }
 
@@ -50,7 +52,6 @@ function declare_project_state(
     $star_metal
 ) {
     global $project_states;
-    global $project_states_for_star_metal_;
 
     define($constant_name, $constant_value);
 
@@ -58,12 +59,9 @@ function declare_project_state(
         $medium_label,
         $long_label,
         $forum,
-        $phase
+        $phase,
+        $star_metal
     );
-
-    if ($star_metal) {
-        $project_states_for_star_metal_[$star_metal][] = $constant_value;
-    }
 }
 
 function get_medium_label_for_project_state($state)
@@ -101,12 +99,6 @@ function declare_project_states($rounds, $pools)
     global $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
     $completed_projects_forum_idx, $deleted_projects_forum_idx, $project_states_for_star_metal_;
     global $PROJECT_STATES_IN_ORDER, $project_states;
-
-    $project_states_for_star_metal_ = [
-        'BRONZE' => [],
-        'SILVER' => [],
-        'GOLD' => [],
-    ];
 
     // for the initial creation of a project
     declare_project_state(
@@ -266,13 +258,28 @@ function declare_project_states($rounds, $pools)
         ''
     );
 
-    // -----------------------------------------------------------------------------
+    construct_star_metal_sql();
 
-    // Define constants for use in SQL queries:
-    // SQL_CONDITION_BRONZE
-    // SQL_CONDITION_SILVER
-    // SQL_CONDITION_GOLD
+    $PROJECT_STATES_IN_ORDER = array_keys($project_states);
+}
 
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+/**
+ * construct constants for use in SQL queries:
+ * SQL_CONDITION_BRONZE
+ * SQL_CONDITION_SILVER
+ * SQL_CONDITION_GOLD
+ */
+function construct_star_metal_sql()
+{
+    global $project_states;
+
+    foreach ($project_states as $state_name => $project_state) {
+        if ($project_state->star_metal) {
+            $project_states_for_star_metal_[$project_state->star_metal][] = $state_name;
+        }
+    }
     foreach ($project_states_for_star_metal_ as $star_metal => $states) {
         $sql_constant_name = "SQL_CONDITION_$star_metal";
         $sql_condition = '(';
@@ -286,11 +293,9 @@ function declare_project_states($rounds, $pools)
 
         define($sql_constant_name, $sql_condition);
     }
-
-    $PROJECT_STATES_IN_ORDER = array_keys($project_states);
 }
 
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// -----------------------------------------------------------------------------
 
 /**
  * Return SQL segment that can be used to sort project states

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -283,7 +283,7 @@ function construct_star_metal_sql()
     foreach ($project_states_for_star_metal_ as $star_metal => $states) {
         $sql_constant_name = "SQL_CONDITION_$star_metal";
         $sql_condition = '(';
-        foreach ($states as $project_state)
+        foreach ($states as $project_state) {
             if ($sql_condition != '(') {
                 $sql_condition .= ' OR ';
             }

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -272,8 +272,6 @@ new Pool(
     null, // access_change_callback
     _('After going through various rounds of proofreading and formatting, the books need to be massaged into a final e-text.'),
     'post_proof.php',
-    PROJ_POST_FIRST_CHECKED_OUT,
-    PROJ_POST_FIRST_AVAILABLE,
     _("Manager"),
     'username',
     [
@@ -322,8 +320,6 @@ new Pool(
     null, // access_change_callback
     _('Once a PPer has submitted a final e-text, it needs to be checked by a PPVer before it is posted to PG.'),
     'ppv.php',
-    PROJ_POST_SECOND_CHECKED_OUT,
-    PROJ_POST_SECOND_AVAILABLE,
     _("Post-Processor"),
     'postproofer',
     [
@@ -367,6 +363,10 @@ new Activity(
     '',
     null // access_change_callback
 );
+
+// -----------------------------------------------------------------------------
+
+declare_project_states(Rounds::get_all(), Pools::get_all());
 
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This is the first part of the process, using a ProjectState object to hold the $medium_label, $long_label, $forum and $phase and a global $project_states array to associate the state names with the project states.

This has been remade with conficts resolved.

The next part will be to use a static class to remove globals.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/project_states_3
