### PR TITLE
Simplify dealing with "OCR" round

### DIFF
--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -572,12 +572,13 @@ function is_formatting_round($round)
  * @param string $key
  * @param Round|null $default
  * @param bool $allownull
+ * @param bool $allowOCR
  *
  * @return Round|null
  *
  * @throws InvalidArgumentException
  */
-function get_round_param(array $arr, string $key, ?Round $default = null, bool $allownull = false): ?Round
+function get_round_param(array $arr, string $key, ?Round $default = null, bool $allownull = false, bool $allowOCR = false)
 {
     // sanity checks on the args
     if (!is_null($default) && $allownull) {
@@ -600,6 +601,8 @@ function get_round_param(array $arr, string $key, ?Round $default = null, bool $
         $round = Rounds::get_by_id($s);
         if ($round) {
             return $round;
+        } elseif ($allowOCR && $s === "OCR") {
+            return get_OCR_pseudoround();
         } else {
             throw new InvalidArgumentException(sprintf(
                 _("Parameter '%1\$s' ('%2\$s') is not a valid round ID"),
@@ -619,4 +622,14 @@ function get_round_param(array $arr, string $key, ?Round $default = null, bool $
             return $default;
         }
     }
+}
+
+function get_OCR_pseudoround()
+{
+    $round = new stdClass();
+    $round->round_number = 0;
+    $round->id = "OCR";
+    $round->text_column_name = 'master_text';
+    $round->user_column_name = "'none'";  // string literal, not column name
+    return $round;
 }

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -426,10 +426,10 @@ function echo_page_table(
             }
         }
 
-        $prev_rn = 0;
+        $prev_round = get_OCR_pseudoround();
         foreach ($rounds_to_display as $round) {
-            echo_cells_for_round($round, $prev_rn, $page_res, $projectid, $can_see_names_for_this_page);
-            $prev_rn = $round->round_number;
+            echo_cells_for_round($round, $prev_round, $page_res, $projectid, $can_see_names_for_this_page);
+            $prev_round = $round;
         }
 
         // (It's annoying that we have to pass all those args,
@@ -595,7 +595,7 @@ function get_rounds_with_data($projectid)
 
 function echo_cells_for_round(
     $round,
-    $diff_round_num, // <- These are the only "real" params.
+    $diff_round, // <- These are the only "real" params.
     $page_res,
     $projectid,
     $can_see_names_for_this_page
@@ -605,7 +605,6 @@ function echo_cells_for_round(
     $imagename = $page_res['image'];
     $page_state = $page_res['state'];
 
-    $round_num = $round->round_number;
     $round_data = $page_res["pagerounds"][$round->id];
     $R_username = $round_data["username"];
 
@@ -637,7 +636,7 @@ function echo_cells_for_round(
     echo "<td>";
     if ($page_state != $round->page_avail_state) {
         if ($round_data["is_diff"]) {
-            echo "<a href='$code_url/tools/project_manager/diff.php?project=$projectid&amp;image=$imagename&amp;L_round_num=$diff_round_num&amp;R_round_num=$round_num'>"._("Diff")."</a>";
+            echo "<a href='$code_url/tools/project_manager/diff.php?project=$projectid&amp;image=$imagename&amp;L_round=$diff_round->id&amp;R_round=$round->id'>"._("Diff")."</a>";
         } else {
             echo _("No diff");
         }

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -23,7 +23,6 @@ $bb_diffs = (@$_GET['bb_diffs'] === 'on' and user_can_mentor_in_any_round());
 $project = new Project($projectid);
 $state = $project->state;
 $project_title = $project->nameofwork;
-$navigation_text = "";
 
 if (!$project->pages_table_exists) {
     // This shouldn't normally happen --
@@ -127,7 +126,7 @@ output_header("$title: $project_title", NO_STATSBAR, $extra_args);
 echo "<h1>" . html_safe($project_title) . "</h1>\n";
 echo "<h2>$image_link</h2>\n";
 
-do_navigation(
+$navigation_text = get_navigation(
     $projectid,
     $image,
     $L_round_num,
@@ -200,7 +199,7 @@ if ($L_text != $R_text) {
  * Build up the text for the navigation bit, so we can repeat it
  * again at the bottom of the page
  */
-function do_navigation(
+function get_navigation(
     $projectid,
     $image,
     $L_round_num,
@@ -213,7 +212,7 @@ function do_navigation(
     $only_nonempty_diffs,
     $bb_diffs
 ) {
-    global $navigation_text;
+    $navigation_text = "";
     $jump_to_js = "this.form.image.value=this.form.jumpto[this.form.jumpto.selectedIndex].value; this.form.submit();";
 
     $navigation_text .= "\n<form method='get' action='diff.php'>";
@@ -303,6 +302,8 @@ function do_navigation(
     $navigation_text .= "\n<input type='checkbox' name='only_nonempty_diffs' $checked_attribute id='only_nonempty_diffs' onclick='this.form.submit()'>\n";
     $navigation_text .= "\n<label for='only_nonempty_diffs'>" . html_safe(_('Skip empty diffs')) . "</label>\n";
     $navigation_text .= "\n</form>\n";
+
+    return $navigation_text;
 }
 
 /**

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -79,10 +79,6 @@ class Comparator
 
         $L_round = get_Round_for_round_id($this->L_round_id);
         $R_round = get_Round_for_round_id($this->R_round_id);
-        $L_text_column_name = $L_round->text_column_name;
-        $R_text_column_name = $R_round->text_column_name;
-        $L_round_num = $L_round->round_number;
-        $R_round_num = $R_round->round_number;
 
         $username = $pguser;
         switch ($this->page_set) {
@@ -110,7 +106,7 @@ class Comparator
 
         validate_projectID($this->projectid);
         $sql = "
-            SELECT image, $L_text_column_name, $R_text_column_name
+            SELECT image, $L_round->text_column_name, $R_round->text_column_name
             FROM $this->projectid
             WHERE $condition
             ORDER BY image ASC
@@ -130,8 +126,8 @@ class Comparator
         $un_formatter = new PageUnformatter();
         while ($page_res = mysqli_fetch_assoc($res)) {
             // also unwrap
-            $L_text = $un_formatter->remove_formatting($page_res[$L_text_column_name], true);
-            $R_text = $un_formatter->remove_formatting($page_res[$R_text_column_name], true);
+            $L_text = $un_formatter->remove_formatting($page_res[$L_round->text_column_name], true);
+            $R_text = $un_formatter->remove_formatting($page_res[$R_round->text_column_name], true);
             if (0 != strcmp($L_text, $R_text)) {
                 $diff_pages[] = $page_res['image'];
             }
@@ -146,7 +142,7 @@ class Comparator
         echo "<p>", _("Clicking on a link will show the differences in a new window or tab."), "</p>\n";
         echo "<p>";
         foreach ($diff_pages as $imagename) {
-            echo "<a href='$code_url/tools/project_manager/diff.php?project=$this->projectid&amp;image=$imagename&amp;L_round_num=$L_round_num&amp;R_round_num=$R_round_num&amp;format=remove' target='_blank'>$imagename</a>\n";
+            echo "<a href='$code_url/tools/project_manager/diff.php?project=$this->projectid&amp;image=$imagename&amp;L_round=$L_round->id&amp;R_round=$R_round->id&amp;format=remove' target='_blank'>$imagename</a>\n";
         }
         echo "</p>";
     }

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -438,7 +438,7 @@ while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save]
         $result = DPDatabase::query($query);
         $diffLinkString = "";
         while ([$image] = mysqli_fetch_row($result)) {
-            $diffLinkString .= "<a href='../project_manager/diff.php?project=$projectid&amp;image=$image&amp;L_round_num=$work_round->round_number&amp;R_round_num=$review_round->round_number'>$image</a> ";
+            $diffLinkString .= "<a href='../project_manager/diff.php?project=$projectid&amp;image=$image&amp;L_round=$work_round->id&amp;R_round=$review_round->id'>$image</a> ";
         }
         mysqli_free_result($result);
     }


### PR DESCRIPTION
Instead of doing gymnastics with round numbers when dealing with the "OCR" round, create a pseudoround object for it with the important details for the diff page (and other uses) and use that instead.

Now we can pass round IDs (and "OCR") into the diff page.

Testable in https://www.pgdp.org/~cpeel/c.branch/diff-by-round-id/

Old `diff.php` URLs should work just fine, but new ones will use the round IDs instead of round numbers.

This was further yak shaving while working towards fixing Task 2000.