### PR TITLE
Use a ProjectStates class to avoid global variables. 

### DIFF
--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -104,7 +104,7 @@ class ActivityTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("P3.proj_bad", ProjectStates::get_states()[11]);
         $this->assertEquals('PP', ProjectStates::get_all()[PROJ_POST_SECOND_AVAILABLE]->phase);
         $this->assertEquals("P1: Waiting", ProjectStates::get_medium_label(PROJ_P1_WAITING_FOR_RELEASE));
-        $this->assertEquals("Proofreading Round 1: Waiting for Release", ProjectStates::text(PROJ_P1_WAITING_FOR_RELEASE));
+        $this->assertEquals("Proofreading Round 1: Waiting for Release", ProjectStates::get_label(PROJ_P1_WAITING_FOR_RELEASE));
     }
 
     public function test_project_state_functions()

--- a/SETUP/tests/RoundTest.php
+++ b/SETUP/tests/RoundTest.php
@@ -99,6 +99,14 @@ class ActivityTest extends PHPUnit\Framework\TestCase
     //------------------------------------------------------------------------
     // test project state functions
 
+    public function test_project_states_class()
+    {
+        $this->assertEquals("P3.proj_bad", ProjectStates::get_states()[11]);
+        $this->assertEquals('PP', ProjectStates::get_all()[PROJ_POST_SECOND_AVAILABLE]->phase);
+        $this->assertEquals("P1: Waiting", ProjectStates::get_medium_label(PROJ_P1_WAITING_FOR_RELEASE));
+        $this->assertEquals("Proofreading Round 1: Waiting for Release", ProjectStates::text(PROJ_P1_WAITING_FOR_RELEASE));
+    }
+
     public function test_project_state_functions()
     {
         global $PROJECT_STATES_IN_ORDER, $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx;

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -798,8 +798,6 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
  */
 function _get_project_state_selector($which, $desired_states = null)
 {
-    global $project_states;
-
     if (null == $desired_states) {
         $desired_states = ["unavailable", "waiting", "bad", "available", "complete"];
     } elseif (!is_array($desired_states)) {
@@ -822,7 +820,7 @@ function _get_project_state_selector($which, $desired_states = null)
 
     // it may be a pool or stage so look at the stage's phase
     $states = [];
-    foreach ($project_states as $state => $project_state) {
+    foreach (ProjectStates::get_all() as $state => $project_state) {
         if ($project_state->phase == $which) {
             array_push($states, $state);
         }

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -44,24 +44,9 @@ class ProjectStates
 {
     private static $states = [];
 
-    private static function declare_project_state(
-        $constant_name,
-        $constant_value,
-        $medium_label,
-        $long_label,
-        $forum,
-        $phase,
-        $star_metal
-    ) {
-        define($constant_name, $constant_value);
-
-        self::$states[$constant_value] = new ProjectState(
-            $medium_label,
-            $long_label,
-            $forum,
-            $phase,
-            $star_metal
-        );
+    public static function add_state($state_name, $state)
+    {
+        self::$states[$state_name] = $state;
     }
 
     public static function get_states()
@@ -93,203 +78,196 @@ class ProjectStates
     {
         return self::$states[$state]->phase ?? 'NONE';
     }
+}
 
-    // Note that the order in which these project states are declared
-    // is the order in which they will be displayed in various contexts
-    // (via ProjectStates::get_states()).
+// Note that the order in which these project states are declared
+// is the order in which they will be displayed in various contexts
+// (via ProjectStates::get_states()).
+function declare_project_states($rounds, $pools)
+{
+    global $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
+    $completed_projects_forum_idx, $deleted_projects_forum_idx;
 
-    public static function declare_project_states($rounds, $pools)
-    {
-        global $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
-        $completed_projects_forum_idx, $deleted_projects_forum_idx;
+    // for the initial creation of a project
+    define("PROJ_NEW", "project_new");
+    ProjectStates::add_state(PROJ_NEW, new ProjectState(
+        _("New Project"),
+        _("New Project"),
+        $waiting_projects_forum_idx,
+        'NEW',
+        ''
+    ));
 
-        // for the initial creation of a project
-        self::declare_project_state(
-            "PROJ_NEW",
-            "project_new",
-            _("New Project"),
-            _("New Project"),
-            $waiting_projects_forum_idx,
-            'NEW',
+    foreach ($rounds as $round) {
+        // Populate $round->project_states with all project states that apply
+        // to this round for lookup later.
+        $round->project_states[] = $round->project_bad_state = "{$round->id}.proj_bad";
+        $round->project_states[] = $round->project_unavailable_state = "{$round->id}.proj_unavail";
+        $round->project_states[] = $round->project_waiting_state = "{$round->id}.proj_waiting";
+        $round->project_states[] = $round->project_available_state = "{$round->id}.proj_avail";
+        $round->project_states[] = $round->project_complete_state = "{$round->id}.proj_done";
+
+        define("PROJ_{$round->id}_BAD_PROJECT", $round->project_bad_state);
+        ProjectStates::add_state($round->project_bad_state, new ProjectState(
+            "$round->id: " .  _("Bad Project"),
+            "$round->name: " . _("Bad Project"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
             ''
-        );
+        ));
 
-        foreach ($rounds as $round) {
-            // Populate $round->project_states with all project states that apply
-            // to this round for lookup later.
-            $round->project_states[] = $round->project_bad_state = "{$round->id}.proj_bad";
-            $round->project_states[] = $round->project_unavailable_state = "{$round->id}.proj_unavail";
-            $round->project_states[] = $round->project_waiting_state = "{$round->id}.proj_waiting";
-            $round->project_states[] = $round->project_available_state = "{$round->id}.proj_avail";
-            $round->project_states[] = $round->project_complete_state = "{$round->id}.proj_done";
-
-            self::declare_project_state(
-                "PROJ_{$round->id}_BAD_PROJECT",
-                $round->project_bad_state,
-                "$round->id: " .  _("Bad Project"),
-                "$round->name: " . _("Bad Project"),
-                $projects_forum_idx,
-                'PAGE_EDITING',
-                ''
-            );
-
-            self::declare_project_state(
-                "PROJ_{$round->id}_UNAVAILABLE",
-                $round->project_unavailable_state,
-                "$round->id: " . _("Unavailable"),
-                "$round->name: " . _("Unavailable"),
-                ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-                'PAGE_EDITING',
-                ''
-            );
-            self::declare_project_state(
-                "PROJ_{$round->id}_WAITING_FOR_RELEASE",
-                $round->project_waiting_state,
-                "$round->id: " . _("Waiting"),
-                "$round->name: " . _("Waiting for Release"),
-                ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-                'PAGE_EDITING',
-                ''
-            );
-            self::declare_project_state(
-                "PROJ_{$round->id}_AVAILABLE",
-                $round->project_available_state,
-                "$round->id: " . _("Available"),
-                "$round->name: " . _("Available"),
-                $projects_forum_idx,
-                'PAGE_EDITING',
-                'BRONZE'
-            );
-            self::declare_project_state(
-                "PROJ_{$round->id}_COMPLETE",
-                $round->project_complete_state,
-                "$round->id: " . _("Completed"),
-                "$round->name: " . _("Completed"),
-                $projects_forum_idx,
-                'PAGE_EDITING',
-                ''
-            );
-        }
-
-        // POST
-        self::declare_project_state(
-            "PROJ_POST_FIRST_UNAVAILABLE",
-            "proj_post_first_unavailable",
-            _("Unavailable for PP"),
-            _("Unavailable for Post-Processing"),
-            $pp_projects_forum_idx,
-            'PP',
-            'SILVER'
-        );
-
-        foreach ($pools as $pool) {
-            switch ($pool->id) {
-                case 'PP':
-                    $pool->project_available_state = "proj_post_first_available";
-                    $pool->project_checkedout_state = "proj_post_first_checked_out";
-                    break;
-                case 'PPV':
-                    $pool->project_available_state = "proj_post_second_available";
-                    $pool->project_checkedout_state = "proj_post_second_checked_out";
-                    break;
-            }
-
-            $pool->states[] = $pool->project_available_state;
-            $pool->states[] = $pool->project_checkedout_state;
-
-            self::declare_project_state(
-                strtoupper($pool->project_available_state),
-                $pool->project_available_state,
-                "$pool->id: " . _("Available"),
-                "$pool->name: " . _("Available"),
-                $pp_projects_forum_idx,
-                'PP',
-                'SILVER'
-            );
-
-            self::declare_project_state(
-                strtoupper($pool->project_checkedout_state),
-                $pool->project_checkedout_state,
-                "$pool->id: " . _("Checked out"),
-                "$pool->name: " . _("Checked out"),
-                $pp_projects_forum_idx,
-                'PP',
-                'SILVER'
-            );
-        }
-
-        self::declare_project_state(
-            "PROJ_POST_COMPLETE",
-            "proj_post_complete",
-            _("Completed Post"),
-            _("Completed Post-Processing"),
-            $pp_projects_forum_idx,
-            'PP',
-            'SILVER'
-        );
-
-        // SUBMIT (was GB)
-        self::declare_project_state(
-            "PROJ_SUBMIT_PG_POSTED",
-            "proj_submit_pgposted",
-            _("Posted to PG"),
-            _("Completed and Posted to Project Gutenberg"),
-            $posted_projects_forum_idx,
-            'GB',
-            'GOLD'
-        );
-
-        // for complete project
-        self::declare_project_state(
-            "PROJ_COMPLETE",
-            "project_complete",
-            _("Project Complete"),
-            _("Project Complete"),
-            $completed_projects_forum_idx,
-            'COMPLETE',
+        define("PROJ_{$round->id}_UNAVAILABLE", $round->project_unavailable_state);
+        ProjectStates::add_state($round->project_unavailable_state, new ProjectState(
+            "$round->id: " . _("Unavailable"),
+            "$round->name: " . _("Unavailable"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
             ''
-        );
+        ));
 
-        // for the 'deletion' of a project
-        self::declare_project_state(
-            "PROJ_DELETE",
-            "project_delete",
-            _("Delete Project"),
-            _("Delete Project"),
-            $deleted_projects_forum_idx,
-            'NONE',
+        define("PROJ_{$round->id}_WAITING_FOR_RELEASE", $round->project_waiting_state);
+        ProjectStates::add_state($round->project_waiting_state, new ProjectState(
+            "$round->id: " . _("Waiting"),
+            "$round->name: " . _("Waiting for Release"),
+            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+            'PAGE_EDITING',
             ''
-        );
+        ));
 
-        self::construct_star_metal_sql();
+        define("PROJ_{$round->id}_AVAILABLE", $round->project_available_state);
+        ProjectStates::add_state($round->project_available_state, new ProjectState(
+            "$round->id: " . _("Available"),
+            "$round->name: " . _("Available"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            'BRONZE'
+        ));
+
+        define("PROJ_{$round->id}_COMPLETE", $round->project_complete_state);
+        ProjectStates::add_state($round->project_complete_state, new ProjectState(
+            "$round->id: " . _("Completed"),
+            "$round->name: " . _("Completed"),
+            $projects_forum_idx,
+            'PAGE_EDITING',
+            ''
+        ));
     }
 
-    /**
-    * construct constants for use in SQL queries:
-    * SQL_CONDITION_BRONZE
-    * SQL_CONDITION_SILVER
-    * SQL_CONDITION_GOLD
-    */
-    private static function construct_star_metal_sql()
-    {
-        foreach (self::$states as $state_name => $project_state) {
-            if ($project_state->star_metal) {
-                $project_states_for_star_metal_[$project_state->star_metal][] = $state_name;
-            }
-        }
-        foreach ($project_states_for_star_metal_ as $star_metal => $states) {
-            $sql_constant_name = "SQL_CONDITION_$star_metal";
-            $sql_condition = '(';
-            foreach ($states as $project_state) {
-                if ($sql_condition != '(') {
-                    $sql_condition .= ' OR ';
-                }
-                $sql_condition .= "state='$project_state'";
-            }
-            $sql_condition .= ')';
+    // POST
 
-            define($sql_constant_name, $sql_condition);
+    define("PROJ_POST_FIRST_UNAVAILABLE", "proj_post_first_unavailable");
+    ProjectStates::add_state(PROJ_POST_FIRST_UNAVAILABLE, new ProjectState(
+        _("Unavailable for PP"),
+        _("Unavailable for Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    ));
+
+    foreach ($pools as $pool) {
+        switch ($pool->id) {
+            case 'PP':
+                $pool->project_available_state = "proj_post_first_available";
+                $pool->project_checkedout_state = "proj_post_first_checked_out";
+                break;
+            case 'PPV':
+                $pool->project_available_state = "proj_post_second_available";
+                $pool->project_checkedout_state = "proj_post_second_checked_out";
+                break;
         }
+
+        $pool->states[] = $pool->project_available_state;
+        $pool->states[] = $pool->project_checkedout_state;
+
+        define(strtoupper($pool->project_available_state), $pool->project_available_state);
+        ProjectStates::add_state($pool->project_available_state, new ProjectState(
+            "$pool->id: " . _("Available"),
+            "$pool->name: " . _("Available"),
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        ));
+
+        define(strtoupper($pool->project_checkedout_state), $pool->project_checkedout_state);
+        ProjectStates::add_state($pool->project_checkedout_state, new ProjectState(
+            "$pool->id: " . _("Checked out"),
+            "$pool->name: " . _("Checked out"),
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        ));
+    }
+
+    define("PROJ_POST_COMPLETE", "proj_post_complete");
+    ProjectStates::add_state(PROJ_POST_COMPLETE, new ProjectState(
+        _("Completed Post"),
+        _("Completed Post-Processing"),
+        $pp_projects_forum_idx,
+        'PP',
+        'SILVER'
+    ));
+
+    // SUBMIT (was GB)
+
+    define("PROJ_SUBMIT_PG_POSTED", "proj_submit_pgposted");
+    ProjectStates::add_state(PROJ_SUBMIT_PG_POSTED, new ProjectState(
+        _("Posted to PG"),
+        _("Completed and Posted to Project Gutenberg"),
+        $posted_projects_forum_idx,
+        'GB',
+        'GOLD'
+    ));
+
+    // for complete project
+
+    define("PROJ_COMPLETE", "project_complete");
+    ProjectStates::add_state(PROJ_COMPLETE, new ProjectState(
+        _("Project Complete"),
+        _("Project Complete"),
+        $completed_projects_forum_idx,
+        'COMPLETE',
+        ''
+    ));
+
+    // for the 'deletion' of a project
+
+    define("PROJ_DELETE", "project_delete");
+    ProjectStates::add_state(PROJ_DELETE, new ProjectState(
+        _("Delete Project"),
+        _("Delete Project"),
+        $deleted_projects_forum_idx,
+        'NONE',
+        ''
+    ));
+
+    construct_star_metal_sql();
+}
+
+/**
+* construct constants for use in SQL queries:
+* SQL_CONDITION_BRONZE
+* SQL_CONDITION_SILVER
+* SQL_CONDITION_GOLD
+*/
+function construct_star_metal_sql()
+{
+    foreach (ProjectStates::get_all() as $state_name => $project_state) {
+        if ($project_state->star_metal) {
+            $project_states_for_star_metal_[$project_state->star_metal][] = $state_name;
+        }
+    }
+    foreach ($project_states_for_star_metal_ as $star_metal => $states) {
+        $sql_constant_name = "SQL_CONDITION_$star_metal";
+        $sql_condition = '(';
+        foreach ($states as $project_state) {
+            if ($sql_condition != '(') {
+                $sql_condition .= ' OR ';
+            }
+            $sql_condition .= "state='$project_state'";
+        }
+        $sql_condition .= ')';
+
+        define($sql_constant_name, $sql_condition);
     }
 }
 

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -326,10 +326,9 @@ function get_phase_containing_project_state($state)
  */
 function sql_collater_for_project_state($state_column)
 {
-    global $PROJECT_STATES_IN_ORDER;
     return sprintf(
         "FIELD($state_column, %s)",
-        surround_and_join($PROJECT_STATES_IN_ORDER, "'", "'", ",")
+        surround_and_join(ProjectStates::get_states(), "'", "'", ",")
     );
 }
 

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -46,7 +46,7 @@ class ProjectStates
 {
     private static $states = [];
 
-    public static function add_state($state)
+    public static function add_state(&$state)
     {
         self::$states[$state->name] = $state;
     }

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -46,7 +46,7 @@ class ProjectStates
 {
     private static $states = [];
 
-    public static function add_state(&$state)
+    public static function add_state($state)
     {
         self::$states[$state->name] = $state;
     }

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -26,14 +26,16 @@ include_once($relPath.'site_vars.php');
 class ProjectState
 {
     public function __construct(
+        $name,
         $medium_label,
-        $long_label,
+        $label,
         $forum,
         $phase,
         $star_metal
     ) {
+        $this->name = $name;
         $this->medium_label = $medium_label;
-        $this->long_label = $long_label;
+        $this->label = $label;
         $this->forum = $forum;
         $this->phase = $phase;
         $this->star_metal = $star_metal;
@@ -44,9 +46,9 @@ class ProjectStates
 {
     private static $states = [];
 
-    public static function add_state($state_name, $state)
+    public static function add_state($state)
     {
-        self::$states[$state_name] = $state;
+        self::$states[$state->name] = $state;
     }
 
     public static function get_states()
@@ -64,9 +66,9 @@ class ProjectStates
         return self::$states[$state]->medium_label ?? '';
     }
 
-    public static function text($state)
+    public static function get_label($state)
     {
-        return self::$states[$state]->long_label ?? '';
+        return self::$states[$state]->label ?? '';
     }
 
     public static function get_forum($state)
@@ -90,7 +92,8 @@ function declare_project_states($rounds, $pools)
 
     // for the initial creation of a project
     define("PROJ_NEW", "project_new");
-    ProjectStates::add_state(PROJ_NEW, new ProjectState(
+    ProjectStates::add_state(new ProjectState(
+        PROJ_NEW,
         _("New Project"),
         _("New Project"),
         $waiting_projects_forum_idx,
@@ -108,7 +111,8 @@ function declare_project_states($rounds, $pools)
         $round->project_states[] = $round->project_complete_state = "{$round->id}.proj_done";
 
         define("PROJ_{$round->id}_BAD_PROJECT", $round->project_bad_state);
-        ProjectStates::add_state($round->project_bad_state, new ProjectState(
+        ProjectStates::add_state(new ProjectState(
+            $round->project_bad_state,
             "$round->id: " .  _("Bad Project"),
             "$round->name: " . _("Bad Project"),
             $projects_forum_idx,
@@ -117,7 +121,8 @@ function declare_project_states($rounds, $pools)
         ));
 
         define("PROJ_{$round->id}_UNAVAILABLE", $round->project_unavailable_state);
-        ProjectStates::add_state($round->project_unavailable_state, new ProjectState(
+        ProjectStates::add_state(new ProjectState(
+            $round->project_unavailable_state,
             "$round->id: " . _("Unavailable"),
             "$round->name: " . _("Unavailable"),
             ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
@@ -126,7 +131,8 @@ function declare_project_states($rounds, $pools)
         ));
 
         define("PROJ_{$round->id}_WAITING_FOR_RELEASE", $round->project_waiting_state);
-        ProjectStates::add_state($round->project_waiting_state, new ProjectState(
+        ProjectStates::add_state(new ProjectState(
+            $round->project_waiting_state,
             "$round->id: " . _("Waiting"),
             "$round->name: " . _("Waiting for Release"),
             ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
@@ -135,7 +141,8 @@ function declare_project_states($rounds, $pools)
         ));
 
         define("PROJ_{$round->id}_AVAILABLE", $round->project_available_state);
-        ProjectStates::add_state($round->project_available_state, new ProjectState(
+        ProjectStates::add_state(new ProjectState(
+            $round->project_available_state,
             "$round->id: " . _("Available"),
             "$round->name: " . _("Available"),
             $projects_forum_idx,
@@ -144,7 +151,8 @@ function declare_project_states($rounds, $pools)
         ));
 
         define("PROJ_{$round->id}_COMPLETE", $round->project_complete_state);
-        ProjectStates::add_state($round->project_complete_state, new ProjectState(
+        ProjectStates::add_state(new ProjectState(
+            $round->project_complete_state,
             "$round->id: " . _("Completed"),
             "$round->name: " . _("Completed"),
             $projects_forum_idx,
@@ -156,7 +164,8 @@ function declare_project_states($rounds, $pools)
     // POST
 
     define("PROJ_POST_FIRST_UNAVAILABLE", "proj_post_first_unavailable");
-    ProjectStates::add_state(PROJ_POST_FIRST_UNAVAILABLE, new ProjectState(
+    ProjectStates::add_state(new ProjectState(
+        PROJ_POST_FIRST_UNAVAILABLE,
         _("Unavailable for PP"),
         _("Unavailable for Post-Processing"),
         $pp_projects_forum_idx,
@@ -180,7 +189,8 @@ function declare_project_states($rounds, $pools)
         $pool->states[] = $pool->project_checkedout_state;
 
         define(strtoupper($pool->project_available_state), $pool->project_available_state);
-        ProjectStates::add_state($pool->project_available_state, new ProjectState(
+        ProjectStates::add_state(new ProjectState(
+            $pool->project_available_state,
             "$pool->id: " . _("Available"),
             "$pool->name: " . _("Available"),
             $pp_projects_forum_idx,
@@ -189,7 +199,8 @@ function declare_project_states($rounds, $pools)
         ));
 
         define(strtoupper($pool->project_checkedout_state), $pool->project_checkedout_state);
-        ProjectStates::add_state($pool->project_checkedout_state, new ProjectState(
+        ProjectStates::add_state(new ProjectState(
+            $pool->project_checkedout_state,
             "$pool->id: " . _("Checked out"),
             "$pool->name: " . _("Checked out"),
             $pp_projects_forum_idx,
@@ -199,7 +210,8 @@ function declare_project_states($rounds, $pools)
     }
 
     define("PROJ_POST_COMPLETE", "proj_post_complete");
-    ProjectStates::add_state(PROJ_POST_COMPLETE, new ProjectState(
+    ProjectStates::add_state(new ProjectState(
+        PROJ_POST_COMPLETE,
         _("Completed Post"),
         _("Completed Post-Processing"),
         $pp_projects_forum_idx,
@@ -210,7 +222,8 @@ function declare_project_states($rounds, $pools)
     // SUBMIT (was GB)
 
     define("PROJ_SUBMIT_PG_POSTED", "proj_submit_pgposted");
-    ProjectStates::add_state(PROJ_SUBMIT_PG_POSTED, new ProjectState(
+    ProjectStates::add_state(new ProjectState(
+        PROJ_SUBMIT_PG_POSTED,
         _("Posted to PG"),
         _("Completed and Posted to Project Gutenberg"),
         $posted_projects_forum_idx,
@@ -221,7 +234,8 @@ function declare_project_states($rounds, $pools)
     // for complete project
 
     define("PROJ_COMPLETE", "project_complete");
-    ProjectStates::add_state(PROJ_COMPLETE, new ProjectState(
+    ProjectStates::add_state(new ProjectState(
+        PROJ_COMPLETE,
         _("Project Complete"),
         _("Project Complete"),
         $completed_projects_forum_idx,
@@ -232,7 +246,8 @@ function declare_project_states($rounds, $pools)
     // for the 'deletion' of a project
 
     define("PROJ_DELETE", "project_delete");
-    ProjectStates::add_state(PROJ_DELETE, new ProjectState(
+    ProjectStates::add_state(new ProjectState(
+        PROJ_DELETE,
         _("Delete Project"),
         _("Delete Project"),
         $deleted_projects_forum_idx,
@@ -280,7 +295,7 @@ function get_medium_label_for_project_state($state)
 
 function project_states_text($state)
 {
-    return ProjectStates::text($state);
+    return ProjectStates::get_label($state);
 }
 
 function get_forum_id_for_project_state($state)

--- a/pinc/project_states.inc
+++ b/pinc/project_states.inc
@@ -40,262 +40,282 @@ class ProjectState
     }
 }
 
-global $project_states;
+class ProjectStates
+{
+    private static $states = [];
 
-function declare_project_state(
-    $constant_name,
-    $constant_value,
-    $medium_label,
-    $long_label,
-    $forum,
-    $phase,
-    $star_metal
-) {
-    global $project_states;
-
-    define($constant_name, $constant_value);
-
-    $project_states[$constant_value] = new ProjectState(
+    private static function declare_project_state(
+        $constant_name,
+        $constant_value,
         $medium_label,
         $long_label,
         $forum,
         $phase,
         $star_metal
-    );
-}
+    ) {
+        define($constant_name, $constant_value);
 
-function get_medium_label_for_project_state($state)
-{
-    global $project_states;
-    return $project_states[$state]->medium_label ?? '';
-}
-
-function project_states_text($state)
-{
-    global $project_states;
-    return $project_states[$state]->long_label ?? '';
-}
-
-function get_forum_id_for_project_state($state)
-{
-    global $project_states;
-    return $project_states[$state]->forum ?? -1;
-}
-
-function get_phase_containing_project_state($state)
-{
-    global $project_states;
-    return $project_states[$state]->phase ?? 'NONE';
-}
-
-// -----------------------------------------------
-
-// Note that the order in which these project states are declared
-// is the order in which they will be displayed in various contexts
-// (via $PROJECT_STATES_IN_ORDER).
-
-function declare_project_states($rounds, $pools)
-{
-    global $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
-    $completed_projects_forum_idx, $deleted_projects_forum_idx, $project_states_for_star_metal_;
-    global $PROJECT_STATES_IN_ORDER, $project_states;
-
-    // for the initial creation of a project
-    declare_project_state(
-        "PROJ_NEW",
-        "project_new",
-        _("New Project"),
-        _("New Project"),
-        $waiting_projects_forum_idx,
-        'NEW',
-        ''
-    );
-
-    foreach ($rounds as $round) {
-        // Populate $round->project_states with all project states that apply
-        // to this round for lookup later.
-        $round->project_states[] = $round->project_bad_state = "{$round->id}.proj_bad";
-        $round->project_states[] = $round->project_unavailable_state = "{$round->id}.proj_unavail";
-        $round->project_states[] = $round->project_waiting_state = "{$round->id}.proj_waiting";
-        $round->project_states[] = $round->project_available_state = "{$round->id}.proj_avail";
-        $round->project_states[] = $round->project_complete_state = "{$round->id}.proj_done";
-
-        declare_project_state(
-            "PROJ_{$round->id}_BAD_PROJECT",
-            $round->project_bad_state,
-            "$round->id: " .  _("Bad Project"),
-            "$round->name: " . _("Bad Project"),
-            $projects_forum_idx,
-            'PAGE_EDITING',
-            ''
-        );
-
-        declare_project_state(
-            "PROJ_{$round->id}_UNAVAILABLE",
-            $round->project_unavailable_state,
-            "$round->id: " . _("Unavailable"),
-            "$round->name: " . _("Unavailable"),
-            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-            'PAGE_EDITING',
-            ''
-        );
-        declare_project_state(
-            "PROJ_{$round->id}_WAITING_FOR_RELEASE",
-            $round->project_waiting_state,
-            "$round->id: " . _("Waiting"),
-            "$round->name: " . _("Waiting for Release"),
-            ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
-            'PAGE_EDITING',
-            ''
-        );
-        declare_project_state(
-            "PROJ_{$round->id}_AVAILABLE",
-            $round->project_available_state,
-            "$round->id: " . _("Available"),
-            "$round->name: " . _("Available"),
-            $projects_forum_idx,
-            'PAGE_EDITING',
-            'BRONZE'
-        );
-        declare_project_state(
-            "PROJ_{$round->id}_COMPLETE",
-            $round->project_complete_state,
-            "$round->id: " . _("Completed"),
-            "$round->name: " . _("Completed"),
-            $projects_forum_idx,
-            'PAGE_EDITING',
-            ''
+        self::$states[$constant_value] = new ProjectState(
+            $medium_label,
+            $long_label,
+            $forum,
+            $phase,
+            $star_metal
         );
     }
 
-    // POST
-    declare_project_state(
-        "PROJ_POST_FIRST_UNAVAILABLE",
-        "proj_post_first_unavailable",
-        _("Unavailable for PP"),
-        _("Unavailable for Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
+    public static function get_states()
+    {
+        return array_keys(self::$states);
+    }
 
-    foreach ($pools as $pool) {
-        switch ($pool->id) {
-            case 'PP':
-                $pool->project_available_state = "proj_post_first_available";
-                $pool->project_checkedout_state = "proj_post_first_checked_out";
-                break;
-            case 'PPV':
-                $pool->project_available_state = "proj_post_second_available";
-                $pool->project_checkedout_state = "proj_post_second_checked_out";
-                break;
+    public static function get_all()
+    {
+        return self::$states;
+    }
+
+    public static function get_medium_label($state)
+    {
+        return self::$states[$state]->medium_label ?? '';
+    }
+
+    public static function text($state)
+    {
+        return self::$states[$state]->long_label ?? '';
+    }
+
+    public static function get_forum($state)
+    {
+        return self::$states[$state]->forum ?? -1;
+    }
+
+    public static function get_phase($state)
+    {
+        return self::$states[$state]->phase ?? 'NONE';
+    }
+
+    // Note that the order in which these project states are declared
+    // is the order in which they will be displayed in various contexts
+    // (via ProjectStates::get_states()).
+
+    public static function declare_project_states($rounds, $pools)
+    {
+        global $waiting_projects_forum_idx, $projects_forum_idx, $pp_projects_forum_idx, $posted_projects_forum_idx,
+        $completed_projects_forum_idx, $deleted_projects_forum_idx;
+
+        // for the initial creation of a project
+        self::declare_project_state(
+            "PROJ_NEW",
+            "project_new",
+            _("New Project"),
+            _("New Project"),
+            $waiting_projects_forum_idx,
+            'NEW',
+            ''
+        );
+
+        foreach ($rounds as $round) {
+            // Populate $round->project_states with all project states that apply
+            // to this round for lookup later.
+            $round->project_states[] = $round->project_bad_state = "{$round->id}.proj_bad";
+            $round->project_states[] = $round->project_unavailable_state = "{$round->id}.proj_unavail";
+            $round->project_states[] = $round->project_waiting_state = "{$round->id}.proj_waiting";
+            $round->project_states[] = $round->project_available_state = "{$round->id}.proj_avail";
+            $round->project_states[] = $round->project_complete_state = "{$round->id}.proj_done";
+
+            self::declare_project_state(
+                "PROJ_{$round->id}_BAD_PROJECT",
+                $round->project_bad_state,
+                "$round->id: " .  _("Bad Project"),
+                "$round->name: " . _("Bad Project"),
+                $projects_forum_idx,
+                'PAGE_EDITING',
+                ''
+            );
+
+            self::declare_project_state(
+                "PROJ_{$round->id}_UNAVAILABLE",
+                $round->project_unavailable_state,
+                "$round->id: " . _("Unavailable"),
+                "$round->name: " . _("Unavailable"),
+                ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+                'PAGE_EDITING',
+                ''
+            );
+            self::declare_project_state(
+                "PROJ_{$round->id}_WAITING_FOR_RELEASE",
+                $round->project_waiting_state,
+                "$round->id: " . _("Waiting"),
+                "$round->name: " . _("Waiting for Release"),
+                ($round->id == 'P1' ? $waiting_projects_forum_idx : $projects_forum_idx),
+                'PAGE_EDITING',
+                ''
+            );
+            self::declare_project_state(
+                "PROJ_{$round->id}_AVAILABLE",
+                $round->project_available_state,
+                "$round->id: " . _("Available"),
+                "$round->name: " . _("Available"),
+                $projects_forum_idx,
+                'PAGE_EDITING',
+                'BRONZE'
+            );
+            self::declare_project_state(
+                "PROJ_{$round->id}_COMPLETE",
+                $round->project_complete_state,
+                "$round->id: " . _("Completed"),
+                "$round->name: " . _("Completed"),
+                $projects_forum_idx,
+                'PAGE_EDITING',
+                ''
+            );
         }
 
-        $pool->states[] = $pool->project_available_state;
-        $pool->states[] = $pool->project_checkedout_state;
-
-        declare_project_state(
-            strtoupper($pool->project_available_state),
-            $pool->project_available_state,
-            "$pool->id: " . _("Available"),
-            "$pool->name: " . _("Available"),
+        // POST
+        self::declare_project_state(
+            "PROJ_POST_FIRST_UNAVAILABLE",
+            "proj_post_first_unavailable",
+            _("Unavailable for PP"),
+            _("Unavailable for Post-Processing"),
             $pp_projects_forum_idx,
             'PP',
             'SILVER'
         );
 
-        declare_project_state(
-            strtoupper($pool->project_checkedout_state),
-            $pool->project_checkedout_state,
-            "$pool->id: " . _("Checked out"),
-            "$pool->name: " . _("Checked out"),
-            $pp_projects_forum_idx,
-            'PP',
-            'SILVER'
-        );
-    }
-
-    declare_project_state(
-        "PROJ_POST_COMPLETE",
-        "proj_post_complete",
-        _("Completed Post"),
-        _("Completed Post-Processing"),
-        $pp_projects_forum_idx,
-        'PP',
-        'SILVER'
-    );
-
-    // SUBMIT (was GB)
-    declare_project_state(
-        "PROJ_SUBMIT_PG_POSTED",
-        "proj_submit_pgposted",
-        _("Posted to PG"),
-        _("Completed and Posted to Project Gutenberg"),
-        $posted_projects_forum_idx,
-        'GB',
-        'GOLD'
-    );
-
-    // for complete project
-    declare_project_state(
-        "PROJ_COMPLETE",
-        "project_complete",
-        _("Project Complete"),
-        _("Project Complete"),
-        $completed_projects_forum_idx,
-        'COMPLETE',
-        ''
-    );
-
-    // for the 'deletion' of a project
-    declare_project_state(
-        "PROJ_DELETE",
-        "project_delete",
-        _("Delete Project"),
-        _("Delete Project"),
-        $deleted_projects_forum_idx,
-        'NONE',
-        ''
-    );
-
-    construct_star_metal_sql();
-
-    $PROJECT_STATES_IN_ORDER = array_keys($project_states);
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-/**
- * construct constants for use in SQL queries:
- * SQL_CONDITION_BRONZE
- * SQL_CONDITION_SILVER
- * SQL_CONDITION_GOLD
- */
-function construct_star_metal_sql()
-{
-    global $project_states;
-
-    foreach ($project_states as $state_name => $project_state) {
-        if ($project_state->star_metal) {
-            $project_states_for_star_metal_[$project_state->star_metal][] = $state_name;
-        }
-    }
-    foreach ($project_states_for_star_metal_ as $star_metal => $states) {
-        $sql_constant_name = "SQL_CONDITION_$star_metal";
-        $sql_condition = '(';
-        foreach ($states as $project_state) {
-            if ($sql_condition != '(') {
-                $sql_condition .= ' OR ';
+        foreach ($pools as $pool) {
+            switch ($pool->id) {
+                case 'PP':
+                    $pool->project_available_state = "proj_post_first_available";
+                    $pool->project_checkedout_state = "proj_post_first_checked_out";
+                    break;
+                case 'PPV':
+                    $pool->project_available_state = "proj_post_second_available";
+                    $pool->project_checkedout_state = "proj_post_second_checked_out";
+                    break;
             }
-            $sql_condition .= "state='$project_state'";
-        }
-        $sql_condition .= ')';
 
-        define($sql_constant_name, $sql_condition);
+            $pool->states[] = $pool->project_available_state;
+            $pool->states[] = $pool->project_checkedout_state;
+
+            self::declare_project_state(
+                strtoupper($pool->project_available_state),
+                $pool->project_available_state,
+                "$pool->id: " . _("Available"),
+                "$pool->name: " . _("Available"),
+                $pp_projects_forum_idx,
+                'PP',
+                'SILVER'
+            );
+
+            self::declare_project_state(
+                strtoupper($pool->project_checkedout_state),
+                $pool->project_checkedout_state,
+                "$pool->id: " . _("Checked out"),
+                "$pool->name: " . _("Checked out"),
+                $pp_projects_forum_idx,
+                'PP',
+                'SILVER'
+            );
+        }
+
+        self::declare_project_state(
+            "PROJ_POST_COMPLETE",
+            "proj_post_complete",
+            _("Completed Post"),
+            _("Completed Post-Processing"),
+            $pp_projects_forum_idx,
+            'PP',
+            'SILVER'
+        );
+
+        // SUBMIT (was GB)
+        self::declare_project_state(
+            "PROJ_SUBMIT_PG_POSTED",
+            "proj_submit_pgposted",
+            _("Posted to PG"),
+            _("Completed and Posted to Project Gutenberg"),
+            $posted_projects_forum_idx,
+            'GB',
+            'GOLD'
+        );
+
+        // for complete project
+        self::declare_project_state(
+            "PROJ_COMPLETE",
+            "project_complete",
+            _("Project Complete"),
+            _("Project Complete"),
+            $completed_projects_forum_idx,
+            'COMPLETE',
+            ''
+        );
+
+        // for the 'deletion' of a project
+        self::declare_project_state(
+            "PROJ_DELETE",
+            "project_delete",
+            _("Delete Project"),
+            _("Delete Project"),
+            $deleted_projects_forum_idx,
+            'NONE',
+            ''
+        );
+
+        self::construct_star_metal_sql();
+    }
+
+    /**
+    * construct constants for use in SQL queries:
+    * SQL_CONDITION_BRONZE
+    * SQL_CONDITION_SILVER
+    * SQL_CONDITION_GOLD
+    */
+    private static function construct_star_metal_sql()
+    {
+        foreach (self::$states as $state_name => $project_state) {
+            if ($project_state->star_metal) {
+                $project_states_for_star_metal_[$project_state->star_metal][] = $state_name;
+            }
+        }
+        foreach ($project_states_for_star_metal_ as $star_metal => $states) {
+            $sql_constant_name = "SQL_CONDITION_$star_metal";
+            $sql_condition = '(';
+            foreach ($states as $project_state) {
+                if ($sql_condition != '(') {
+                    $sql_condition .= ' OR ';
+                }
+                $sql_condition .= "state='$project_state'";
+            }
+            $sql_condition .= ')';
+
+            define($sql_constant_name, $sql_condition);
+        }
     }
 }
 
 // -----------------------------------------------------------------------------
+// these functions can be removed later
+function get_medium_label_for_project_state($state)
+{
+    return ProjectStates::get_medium_label($state);
+}
+
+function project_states_text($state)
+{
+    return ProjectStates::text($state);
+}
+
+function get_forum_id_for_project_state($state)
+{
+    return ProjectStates::get_forum($state);
+}
+
+function get_phase_containing_project_state($state)
+{
+    return ProjectStates::get_phase($state);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 /**
  * Return SQL segment that can be used to sort project states

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -362,7 +362,7 @@ new Activity(
 
 // -----------------------------------------------------------------------------
 
-ProjectStates::declare_project_states(Rounds::get_all(), Pools::get_all());
+declare_project_states(Rounds::get_all(), Pools::get_all());
 
 // -----------------------------------------------------------------------------
 

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -362,7 +362,7 @@ new Activity(
 
 // -----------------------------------------------------------------------------
 
-declare_project_states(Rounds::get_all(), Pools::get_all());
+ProjectStates::declare_project_states(Rounds::get_all(), Pools::get_all());
 
 // -----------------------------------------------------------------------------
 
@@ -400,3 +400,5 @@ foreach (Rounds::get_all() as $round) {
         $PAGE_STATES_IN_ORDER[] = $page_state;
     }
 }
+global $PROJECT_STATES_IN_ORDER;
+$PROJECT_STATES_IN_ORDER = ProjectStates::get_states();


### PR DESCRIPTION
The global variables are $project_states which is only used in one place and has been removed.
$PROJECT_STATES_IN_ORDER is used in many places but only those in project_states.inc have been replaced so far (by ProjectStates::get_states();).
There are some functions which can also be replaced later.

Best viewed on here with whitespace hidden although it gets a bit mixed up even then.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/project_states_class
