### PR TITLE
Allow users to select their preferred project detail level

### DIFF
--- a/faq/pophelp/prefs/prefs_pophelp.inc
+++ b/faq/pophelp/prefs/prefs_pophelp.inc
@@ -127,6 +127,12 @@ _("<p>This setting controls who is able to see your statistics.</p>
             'content' => _("<p>This setting determines which site theme is used as your default.</p>"),
         ],
 
+    'set_project_detail' =>
+        [
+            'title' => _("Project Detail"),
+            'content' => _("<p>This setting determines the default detail level shown on a project page.</p>"),
+        ],
+
     // =====================================================================
     // PM Tab Settings
 

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -2109,3 +2109,16 @@ function get_project_difficulties()
         'hard' => _('Hard'),
     ];
 }
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Project page detail level
+
+function get_project_detail_levels()
+{
+    return [
+        1 => _("Minimal"),
+        2 => _("Basic"),
+        3 => _("Advanced"),
+        4 => _("Everything"),
+    ];
+}

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1317,7 +1317,7 @@ class Project
         $post_body = <<<EOS
             This thread is for discussion specific to "$this->nameofwork" by $this->authorsname.
 
-            If you have a question about this project, please review the [url=$code_url/project.php?id={$this->projectid}&detail_level=2]Project Comments[/url], as well as any posts below, as your question may already be answered there.
+            If you have a question about this project, please review the [url=$code_url/project.php?id={$this->projectid}]Project Comments[/url], as well as any posts below, as your question may already be answered there.
 
             If you haven't found the answer to your question, or want to make a comment about this project, click on the [b]Post Reply[/b] button to post your question or comment in this thread.
 

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -179,7 +179,7 @@ class TitleColumn extends Column
     public function print_cell_data($project)
     {
         global $code_url;
-        echo "<a href='$code_url/project.php?id=$project->projectid&amp;detail_level=3'>" . html_safe($project->nameofwork) . "</a>";
+        echo "<a href='$code_url/project.php?id=$project->projectid'>" . html_safe($project->nameofwork) . "</a>";
     }
 }
 

--- a/project.php
+++ b/project.php
@@ -31,14 +31,13 @@ include_once($relPath.'special_colors.inc'); // load_special_days
 // in a list of projects.
 // But there are lots of other less-used pages that link here.
 
-$MIN_DETAIL_LEVEL = 1;
-$MAX_DETAIL_LEVEL = 4;
-$DEFAULT_DETAIL_LEVEL = 3;
+$userSettings = Settings::get_Settings(User::current_username());
 
 // Validate all the input
 $projectid = get_projectID_param($_GET, 'id');
 $expected_state = get_enumerated_param($_GET, 'expected_state', null, $PROJECT_STATES_IN_ORDER, true);
-$detail_level = get_integer_param($_GET, 'detail_level', $DEFAULT_DETAIL_LEVEL, $MIN_DETAIL_LEVEL, $MAX_DETAIL_LEVEL);
+$detail_levels = get_project_detail_levels();
+$detail_level = get_enumerated_param($_GET, 'detail_level', $userSettings->get_value('project_detail', 2), array_keys($detail_levels));
 
 $project = new Project($projectid);
 
@@ -149,21 +148,20 @@ if ($detail_level == 1) {
 
 function do_detail_level_switch()
 {
-    global $project, $detail_level, $MIN_DETAIL_LEVEL, $MAX_DETAIL_LEVEL;
+    global $project, $detail_level, $detail_levels;
 
-    echo "<p>";
-    echo sprintf(
-        _('This page is being presented at detail level %d.'),
-        $detail_level
-    );
-    echo "\n";
-    echo _('Switch to:'), "\n";
-    for ($v = $MIN_DETAIL_LEVEL; $v <= $MAX_DETAIL_LEVEL; $v++) {
-        if ($v != $detail_level) {
-            $url = "project.php?id={$project->projectid}&amp;expected_state={$project->state}&amp;detail_level=$v";
-            echo "<a href='$url'>$v</a>\n";
+    $level_links = [];
+    foreach ($detail_levels as $level => $label) {
+        if ($level == $detail_level) {
+            $level_links[] = "<b>$label</b>";
+        } else {
+            $url = "?id={$project->projectid}&amp;expected_state={$project->state}&amp;detail_level=$level";
+            $level_links[] = "<a href='$url'>$label</a>";
         }
     }
+    echo "<p>";
+    echo _("Detail level: ");
+    echo implode(" | ", $level_links);
     echo "</p>\n";
 }
 

--- a/project.php
+++ b/project.php
@@ -579,9 +579,10 @@ function do_project_info_table()
     // For now, we say that guests can't see page details or page browser
     if ($user_is_logged_in) {
 
+        $pages = $project->get_page_names_from_db();
         if ($detail_level >= 4) {
             // We'll call do_page_table later, so we don't need the "Page Detail" link.
-        } else {
+        } elseif ($pages) {
             $detail = "";
             if ($project->check_pages_table_exists($detail)) {
                 $url = "$code_url/tools/project_manager/page_detail.php?project=$projectid&amp;show_image_size=0";
@@ -598,9 +599,8 @@ function do_project_info_table()
             echo_row_a(_("Page Detail"), $detail);
         }
 
-        if ($detail_level >= 3 && $project->pages_table_exists) {
+        if ($detail_level >= 3 && $project->pages_table_exists && $pages) {
             // get the first page image
-            $pages = $project->get_page_names_from_db();
             $url = "$code_url/tools/page_browser.php?project=$projectid&amp;imagefile=" . $pages[0];
             $images_url = "$url&amp;mode=image";
             $text_url = "$url&amp;mode=text";

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -173,7 +173,7 @@ if (!@$_POST['confirmed']) {
 }
 
 echo "<hr>\n";
-echo return_to_project_page_link($projectid, ["detail_level=4"]) . "\n";
+echo return_to_project_page_link($projectid) . "\n";
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -637,7 +637,7 @@ class Loader
         echo "<br>\n";
         echo _("Please review the information, and use the link at the bottom of the page to proceed with the load.");
         echo "<br>\n";
-        $project_url = project_page_link_url($projectid, ["detail_level=4"]);
+        $project_url = project_page_link_url($projectid);
         echo sprintf(_("If there's a problem, return to the <a %s>project page</a> without loading the files."), "href='$project_url'");
         echo "</p>\n";
 

--- a/tools/project_manager/edit_pages.php
+++ b/tools/project_manager/edit_pages.php
@@ -62,7 +62,7 @@ if (@$_REQUEST['confirmed'] == 'yes') {
         echo "<br>\n";
         echo "<br>\n";
     }
-    echo return_to_project_page_link($projectid, ["detail_level=4"]) . "<br>\n";
+    echo return_to_project_page_link($projectid) . "<br>\n";
 } else {
     // Obtain confirmation
 

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -129,8 +129,7 @@ class PPage
             . "id={$this->lpage->projectid}"
             . $amp
             . "expected_state={$this->proj_state}"
-            . $amp
-            . "detail_level=1#project-comments";
+            . "#project-comments";
     }
 
     public function urlencoded($escape_amp = false)

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -254,7 +254,6 @@ $projects_done = []; // the projects that we've done rows for
 // go through the list of projects with pages saved in the work round, according
 // to the page_events table
 while ([$projectid, $state, $nameofwork, $deletion_reason, $time_of_latest_save] = mysqli_fetch_row($res2)) {
-    // $url = "$code_url/project.php?id=$projectid&amp;detail_level=4";
     $url = "$code_url/tools/project_manager/page_detail.php?project=$projectid&amp;select_by_user=$username&amp;select_by_round=" . $work_round->id;
 
     // if the project has been deleted, find out whether it was merged into another one

--- a/userprefs.php
+++ b/userprefs.php
@@ -11,6 +11,7 @@ include_once($relPath.'Settings.inc');
 include_once($relPath.'js_newpophelp.inc');
 include_once($relPath.'forum_interface.inc'); // get_forum_user_details(), get_url_to_edit_profile()
 include_once($relPath.'User.inc');
+include_once($relPath.'Project.inc');
 
 require_login();
 
@@ -379,7 +380,26 @@ function echo_general_tab($user)
         'credit_name_adhoc',
         null
     );
-    show_blank();
+
+    foreach (get_project_detail_levels() as $level => $label) {
+        // We don't allow users to select level 1 and 4 because:
+        // * Level 1 doesn't include Start Proofreading and will confuse people
+        // * Level 4 includes the page detail which is resource intensive
+        //   and can produce a Very Large Page (>35MB)
+        if ($level == 1 || $level == 4) {
+            continue;
+        }
+
+        $page_detail_options[$level] = sprintf("%s (%d)", $label, $level);
+    }
+    show_preference(
+        _('Default Project Detail Level'),
+        'project_detail',
+        'project_detail',
+        $userSettings->get_value('project_detail', 1),
+        'dropdown',
+        $page_detail_options
+    );
     echo "</tr>\n";
 
     echo_bottom_button_row();
@@ -422,6 +442,8 @@ function save_general_tab($user)
     }
 
     $userSettings->set_boolean('hide_special_colors', $_POST["show_special_colors"] == 'no');
+
+    $userSettings->set_value('project_detail', $_POST["project_detail"]);
 }
 
 function echo_proofreading_tab($user)


### PR DESCRIPTION
Give project detail levels meaningful descriptors and allow users to select which one they want to see by default. This also removes all of the bits in the code that override the `detail_level` via URL.

Note that we change the default level back to 2 (it was changed from 2 to 3 in 2014). This present users with a smaller set of data to hopefully be less confusing. Subsequent PRs could further pair down the data shown at level 2 to improve the new user experience.

Testable in https://www.pgdp.org/~cpeel/c.branch/project-detail-level/

[Task 669](https://www.pgdp.net/c/tasks.php?task_id=669)