### PR TITLE
sitemap.php: Fix error caused by PROJECT_STATES_IN_ORDER

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -1,7 +1,7 @@
 <?php
 $relPath = "pinc/";
 include_once($relPath."base.inc");
-include_once($relPath."project_states.inc");
+include_once($relPath."stages.inc"); // For PROJECT_STATES_IN_ORDER
 
 // fixed, non-project pages to include in the listing with their
 // change frequency

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'User.inc');
-include_once($relPath.'project_states.inc');
+include_once($relPath.'stages.inc'); // For PROJECT_STATES_IN_ORDER
 
 require_login();
 


### PR DESCRIPTION
2b97d677d2 caused the initialization of PROJECT_STATES_IN_ORDER to move from project_states.inc to stages.inc (it's done by the call to declare_project_states in stages.inc)

sql_collater_for_project_state() (defined in project_states.inc) requires PROJECT_STATES_IN_ORDER to be defined.

(I'm not confident this is the correct fix, but I thought I'd put it up to advance the discussion)