### PR TITLE
Generalise round options

### DIFF
--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -16,18 +16,25 @@ class Comparator
 {
     public function __construct()
     {
-        global $PROJECT_STATES_IN_ORDER;
+        $all_rounds = Rounds::get_all();
+        $all_ids = Rounds::get_ids();
 
-        $this->L_round_options = ['P1', 'P2', 'P3', 'F1'];
-        $this->R_round_options = ['F1', 'F2'];
-        $this->state_index = array_flip($PROJECT_STATES_IN_ORDER);
+        // L_round_options are all rounds except the last
+        $this->L_round_options =  array_slice($all_ids, 0, count($all_ids) - 1);
+        // R_round_options are all formatting rounds
+        $this->R_round_options = array_keys(array_filter($all_rounds, 'is_formatting_round'));
+        // default R_round is first R-round
+        $this->default_R_round_id = $this->R_round_options[0];
+        // default L_round is the preceding one
+        $this->default_L_round_id = $all_ids[array_search($this->default_R_round_id, $all_ids) -1];
+        $this->state_index = array_flip(ProjectStates::get_states());
     }
 
     public function get_data()
     {
         $this->projectid = get_projectID_param($_GET, 'project');
-        $this->L_round_id = get_enumerated_param($_GET, "L_round_id", "P3", $this->L_round_options);
-        $this->R_round_id = get_enumerated_param($_GET, "R_round_id", "F1", $this->R_round_options);
+        $this->L_round_id = get_enumerated_param($_GET, "L_round_id", $this->default_L_round_id, $this->L_round_options);
+        $this->R_round_id = get_enumerated_param($_GET, "R_round_id", $this->default_R_round_id, $this->R_round_options);
         $this->page_set = get_enumerated_param($_GET, "page_set", "all", ['left', 'right', 'all']);
         $this->go_compare = isset($_GET['compare']);
     }

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -28,15 +28,15 @@ class Comparator
 
         $this->state_index = array_flip(ProjectStates::get_states());
 
-        $this->projectid = get_projectID_param($_GET, 'project');
+        $projectid = get_projectID_param($_GET, 'project');
         $L_round = get_round_param($_GET, "L_round_id", $default_L_round);
         $R_round = get_round_param($_GET, "R_round_id", $default_R_round);
         $this->page_set = get_enumerated_param($_GET, "page_set", "all", ['left', 'right', 'all']);
-        $this->go_compare = isset($_GET['compare']);
+        $go_compare = isset($_GET['compare']);
 
         global $pguser, $code_url;
 
-        $this->project = new Project($this->projectid);
+        $this->project = new Project($projectid);
 
         $title = _('Compare pages with formatting removed');
         $sub_title = $this->project->nameofwork;
@@ -46,7 +46,7 @@ class Comparator
         echo "<h2>" . html_safe($sub_title) . "</h2>\n";
 
         $state = $this->project->state;
-        echo "<p>" . return_to_project_page_link($this->projectid, ["expected_state=$state"]) . "</p>\n";
+        echo "<p>" . return_to_project_page_link($projectid, ["expected_state=$state"]) . "</p>\n";
 
         if (!$this->project->check_pages_table_exists($warn_message)) {
             echo "<p class='warning'>$warn_message</p>\n";
@@ -55,7 +55,7 @@ class Comparator
 
         // draw the round selectors
         echo "<form action='page_compare.php' method='GET'>
-            <input type='hidden' name='project' value='$this->projectid'>
+            <input type='hidden' name='project' value='$projectid'>
             <input type='hidden' name='compare'>",
         "<div>", _("Compare rounds:"), "</div>\n",
         "<div class='grid-wrapper'>\n",
@@ -69,7 +69,7 @@ class Comparator
         "<input type='submit' value=", attr_safe(_('Go')), "></form>\n";
 
         // if this is first entry don't do anything else
-        if (!$this->go_compare) {
+        if (!$go_compare) {
             exit();
         }
 
@@ -101,10 +101,10 @@ class Comparator
             $condition .= sprintf(" AND state='%s'", $R_round->page_save_state);
         }
 
-        validate_projectID($this->projectid);
+        validate_projectID($projectid);
         $sql = "
             SELECT image, $L_round->text_column_name, $R_round->text_column_name
-            FROM $this->projectid
+            FROM $projectid
             WHERE $condition
             ORDER BY image ASC
         ";
@@ -139,7 +139,7 @@ class Comparator
         echo "<p>", _("Clicking on a link will show the differences in a new window or tab."), "</p>\n";
         echo "<p>";
         foreach ($diff_pages as $imagename) {
-            echo "<a href='$code_url/tools/project_manager/diff.php?project=$this->projectid&amp;image=$imagename&amp;L_round=$L_round->id&amp;R_round=$R_round->id&amp;format=remove' target='_blank'>$imagename</a>\n";
+            echo "<a href='$code_url/tools/project_manager/diff.php?project=$projectid&amp;image=$imagename&amp;L_round=$L_round->id&amp;R_round=$R_round->id&amp;format=remove' target='_blank'>$imagename</a>\n";
         }
         echo "</p>";
     }

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -20,13 +20,13 @@ class Comparator
         $all_ids = Rounds::get_ids();
 
         // L_round_options are all rounds except the last
-        $this->L_round_options =  array_slice($all_ids, 0, count($all_ids) - 1);
+        $this->L_round_options = array_slice($all_ids, 0, count($all_ids) - 1);
         // R_round_options are all formatting rounds
         $this->R_round_options = array_keys(array_filter($all_rounds, 'is_formatting_round'));
         // default R_round is first R-round
         $this->default_R_round_id = $this->R_round_options[0];
         // default L_round is the preceding one
-        $this->default_L_round_id = $all_ids[array_search($this->default_R_round_id, $all_ids) -1];
+        $this->default_L_round_id = $all_ids[array_search($this->default_R_round_id, $all_ids) - 1];
         $this->state_index = array_flip(ProjectStates::get_states());
     }
 

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -13,8 +13,10 @@ $comparator->render();
 
 class Comparator
 {
-    public function render()
+    public function render(): void
     {
+        global $pguser, $code_url;
+
         $all_rounds = Rounds::get_all();
 
         // L_round_options are all rounds except the last
@@ -33,8 +35,6 @@ class Comparator
         $R_round = get_round_param($_GET, "R_round_id", $default_R_round);
         $this->page_set = get_enumerated_param($_GET, "page_set", "all", ['left', 'right', 'all']);
         $go_compare = isset($_GET['compare']);
-
-        global $pguser, $code_url;
 
         $this->project = new Project($projectid);
 
@@ -101,7 +101,6 @@ class Comparator
             $condition .= sprintf(" AND state='%s'", $R_round->page_save_state);
         }
 
-        validate_projectID($projectid);
         $sql = "
             SELECT image, $L_round->text_column_name, $R_round->text_column_name
             FROM $projectid
@@ -144,7 +143,7 @@ class Comparator
         echo "</p>";
     }
 
-    public function selector_string($selected_round, $name, $rounds)
+    private function selector_string(Round $selected_round, string $name, array $rounds): string
     {
         $sel_str = "<select name=$name>";
         foreach ($rounds as $round) {
@@ -158,7 +157,7 @@ class Comparator
         return $sel_str;
     }
 
-    public function radio_string($value, $label)
+    private function radio_string(string $value, string $label): string
     {
         $checked = ($this->page_set === $value) ? " checked" : "";
         return "<input type='radio' name='page_set' value='$value'$checked>" . html_safe($label);


### PR DESCRIPTION
This removes the hard-coded round ids, addressing issue #1005 

The compare without formatting link on the project page should comtinue to work as before.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/no_hard_code_rounds
