### PR TITLE
Remove last uses of $PROJECT_STATES_IN_ORDER global

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -499,4 +499,13 @@ class ProjectTest extends ProjectUtils
         $this->expectExceptionCode(113);
         get_available_proof_page_array($project, $round, $pguser);
     }
+
+    public function test_project_has_entered_formatting_round()
+    {
+        $project = $this->_create_project();
+        $project->state = "P1.proj_avail";
+        $this->assertFalse($project->has_entered_formatting_round());
+        $project->state = "F1.proj_avail";
+        $this->assertTrue($project->has_entered_formatting_round());
+    }
 }

--- a/api/v1_stats.inc
+++ b/api/v1_stats.inc
@@ -57,8 +57,7 @@ function api_v1_stats_site_projects_states($method, $data, $query_params)
 {
     // Make sure all project state statistics are provided.
     $output = [];
-    global $PROJECT_STATES_IN_ORDER;
-    foreach ($PROJECT_STATES_IN_ORDER as $s) {
+    foreach (ProjectStates::get_states() as $s) {
         $output[$s] = 0;
     }
 

--- a/crontab/log_project_states.php
+++ b/crontab/log_project_states.php
@@ -34,7 +34,7 @@ if ($row["count"]) {
 // to zero for every currently-defined state.
 $num_projects_in_state_ = [];
 $num_pages_in_state_ = [];
-foreach ($PROJECT_STATES_IN_ORDER as $state) {
+foreach (ProjectStates::get_states() as $state) {
     $num_projects_in_state_[$state] = 0;
     $num_pages_in_state_[$state] = 0;
 }

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1715,10 +1715,10 @@ class Project
      */
     public function has_entered_formatting_round()
     {
-        global $PROJECT_STATES_IN_ORDER;
-        $state_index = array_search($this->state, $PROJECT_STATES_IN_ORDER);
-        for ($i = $state_index; $i >= 0; $i--) {
-            $round = get_Round_for_project_state($PROJECT_STATES_IN_ORDER[$i]);
+        $project_states = ProjectStates::get_states();
+        $completed_states = array_slice($project_states, 0, array_search($this->state, $project_states) + 1);
+        foreach (array_reverse($completed_states) as $state) {
+            $round = get_Round_for_project_state($state);
             if ($round && is_formatting_round($round)) {
                 return true;
             }

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -237,10 +237,8 @@ class ProjectSearchForm
 
     public static function state_options()
     {
-        global $PROJECT_STATES_IN_ORDER;
-
         $state_options[''] = _('Any state');
-        foreach ($PROJECT_STATES_IN_ORDER as $proj_state) {
+        foreach (ProjectStates::get_states() as $proj_state) {
             $state_options[$proj_state] = project_states_text($proj_state);
         }
         return $state_options;

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -462,7 +462,7 @@ function get_transition($from_state, $to_state)
 
 function create_project_transitions()
 {
-    global $code_url, $PROJECT_STATES_IN_ORDER;
+    global $code_url;
 
     $project_transitions[] = new ProjectTransition(
         PROJ_NEW,
@@ -1155,7 +1155,7 @@ function create_project_transitions()
     // -----------------------------------------------------------------------------
     // Transitions to PROJ_DELETE.
 
-    foreach ($PROJECT_STATES_IN_ORDER as $from_state) {
+    foreach (ProjectStates::get_states() as $from_state) {
         // Don't bother creating a transition for Delete -> Delete.
         if ($from_state == PROJ_DELETE) {
             continue;

--- a/project.php
+++ b/project.php
@@ -33,7 +33,7 @@ $userSettings = Settings::get_Settings(User::current_username());
 
 // Validate all the input
 $projectid = get_projectID_param($_GET, 'id');
-$expected_state = get_enumerated_param($_GET, 'expected_state', null, $PROJECT_STATES_IN_ORDER, true);
+$expected_state = get_enumerated_param($_GET, 'expected_state', null, ProjectStates::get_states(), true);
 $detail_levels = get_project_detail_levels();
 $detail_level = get_enumerated_param($_GET, 'detail_level', $userSettings->get_value('project_detail', 2), array_keys($detail_levels));
 

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -14,8 +14,8 @@ header("Content-Type: text/html; charset=$charset");
 
 // Get Passed parameters to code
 $projectid = get_projectID_param($_POST, 'projectid');
-$curr_state = get_enumerated_param($_POST, 'curr_state', null, $PROJECT_STATES_IN_ORDER);
-$next_state = get_enumerated_param($_POST, 'next_state', null, array_merge($PROJECT_STATES_IN_ORDER, ['automodify']));
+$curr_state = get_enumerated_param($_POST, 'curr_state', null, ProjectStates::get_states());
+$next_state = get_enumerated_param($_POST, 'next_state', null, array_merge(ProjectStates::get_states(), ['automodify']));
 $confirmed = get_enumerated_param($_POST, 'confirmed', null, ['yes'], true);
 $return_uri = @$_POST['return_uri'];
 

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -86,7 +86,7 @@ if ($show_view == "user_all") {
     $condition = "$PROJECT_IS_ACTIVE_sql AND username = '$user->username'";
     $_GET = array_merge($_GET, [
         'project_manager' => $user->username,
-        'state' => array_diff($PROJECT_STATES_IN_ORDER, [PROJ_SUBMIT_PG_POSTED, PROJ_DELETE]),
+        'state' => array_diff(ProjectStates::get_states(), [PROJ_SUBMIT_PG_POSTED, PROJ_DELETE]),
     ]);
 } else { // $show_view == 'search'
     $search_form = new ProjectSearchForm();

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -1,5 +1,5 @@
 <?php
-include_once($relPath.'Project.inc');         // $PROJECT_STATES_IN_ORDER
+include_once($relPath.'Project.inc');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'prefs_options.inc'); // get_user_proofreading_font()
 include_once($relPath.'LPage.inc');
@@ -48,9 +48,8 @@ function url_for_pi_do_particular_page($projectid, $proj_state, $imagefile, $pag
 
 function get_requested_PPage($request_params)
 {
-    global $PROJECT_STATES_IN_ORDER;
     $projectid = get_projectID_param($request_params, 'projectid');
-    $proj_state = get_enumerated_param($request_params, 'proj_state', null, $PROJECT_STATES_IN_ORDER);
+    $proj_state = get_enumerated_param($request_params, 'proj_state', null, ProjectStates::get_states());
     $imagefile = get_page_image_param($request_params, 'imagefile');
     $page_state = get_enumerated_param($request_params, 'page_state', null, Rounds::get_page_states());
     $reverting = get_integer_param($request_params, 'reverting', 0, 0, 1);

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'abort.inc');
-include_once($relPath.'Project.inc'); // $PROJECT_STATES_IN_ORDER
+include_once($relPath.'Project.inc');
 include_once('PPage.inc');
 include_once('proof_frame.inc');
 include_once('text_frame_std.inc');
@@ -21,7 +21,7 @@ $_POST:
 */
 
 $projectid = get_projectID_param($_POST, 'projectid');
-$proj_state = get_enumerated_param($_POST, 'proj_state', null, $PROJECT_STATES_IN_ORDER);
+$proj_state = get_enumerated_param($_POST, 'proj_state', null, ProjectStates::get_states());
 $imagefile = get_page_image_param($_POST, 'imagefile');
 $text_data = array_get($_POST, 'text_data', '');
 

--- a/tools/proofers/proof.php
+++ b/tools/proofers/proof.php
@@ -11,7 +11,7 @@ require_login();
 // one of the links in "Done" or "In Progress" trays.)
 
 $projectid = get_projectID_param($_GET, 'projectid');
-$expected_state = get_enumerated_param($_GET, 'proj_state', null, $PROJECT_STATES_IN_ORDER, true);
+$expected_state = get_enumerated_param($_GET, 'proj_state', null, ProjectStates::get_states(), true);
 
 $project = new Project($projectid);
 


### PR DESCRIPTION
This + https://github.com/DistributedProofreaders/dproofreaders/pull/1124 will remove all instances of `$PROJECT_STATES_IN_ORDER`.

https://www.pgdp.org/~cpeel/c.branch/remove-page-states-global/