### PR TITLE
Update release tooling

### DIFF
--- a/SETUP/check_db_schema.template
+++ b/SETUP/check_db_schema.template
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Stop on undefined variables or errors
-set -u
-set -e
+set -euo pipefail
 
 # Compare the db-schema of the current installation
 # to the db-schema you get by taking an installation of the previous release

--- a/SETUP/check_db_schema.template
+++ b/SETUP/check_db_schema.template
@@ -12,26 +12,25 @@ set -e
 # or did we sneak a db-schema change into the current installation,
 # and are perhaps now depending on it?)
 
-prev_tag=R202102
-curr_tag=production
-upgrade_number=16
+prev_tag=R202309
+curr_tag=master
+upgrade_number=20
 
-setup_dir=`dirname $0`
+setup_dir=$(realpath $(dirname $0))
 testing_dir=/tmp/dp_schema_check
 testing_code_dir=$testing_dir/c
 testing_db_name=temp_dp_schema_check
 
+db_server='<<DB_SERVER>>'
+db_user='<<DB_USER>>'
+db_password='<<DB_PASSWORD>>'
 php_cli_exec='<<PHP_CLI_EXECUTABLE>>'
 
 mkdir -p $testing_dir
 
 echo ""
 echo "Dumping the schema of the current database..."
-$setup_dir/dump_db_schema --table-list-from-code > $testing_dir/current_schema_dump
-# Use --table-list-from-code because a real DP database will typically have
-# a) a full complement of phpbb tables, and
-# b) some adhoc tables,
-# neither of which are pertinent to this check.
+$setup_dir/dump_db_schema --table-list-from-db > $testing_dir/current_schema_dump
 
 echo ""
 echo "Creating a config file for a test install..."
@@ -42,9 +41,9 @@ echo "
 
     _CODE_DIR=$testing_code_dir
     _DB_NAME=$testing_db_name
-    _DB_SERVER=<<DB_SERVER>>
-    _DB_USER=<<DB_USER>>
-    _DB_PASSWORD='<<DB_PASSWORD>>'
+    _DB_SERVER=$db_server
+    _DB_USER=$db_user
+    _DB_PASSWORD='$db_password'
 
     # Need to set booleans/integers, otherwise site_vars.php will raise syntax errors.
     _TESTING=true
@@ -60,6 +59,7 @@ echo "
     _API_RATE_LIMIT_SECONDS_IN_WINDOW=0
 
     # String values
+    _FORUM_TYPE='phpbb3'
     _DEFAULT_CHAR_SUITES='[ \"basic-latin\" ]'
     _PHPMAILER_SMTP_CONFIG='[]'
 
@@ -93,12 +93,12 @@ cd $testing_code_setup_dir
 
 echo ""
 echo "Creating and/or cleaning out the test database..."
-mysql -h <<DB_SERVER>> -u <<DB_USER>> -p'<<DB_PASSWORD>>' -e "DROP   DATABASE $testing_db_name"
-mysql -h <<DB_SERVER>> -u <<DB_USER>> -p'<<DB_PASSWORD>>' -e "CREATE DATABASE $testing_db_name"
+mysql -h $db_server -u $db_user -p"$db_password" -e "DROP   DATABASE $testing_db_name"
+mysql -h $db_server -u $db_user -p"$db_password" -e "CREATE DATABASE $testing_db_name"
 if [ $? != 0 ]; then
     echo "CREATE DATABASE failed."
     echo "Probably some sufficiently powerful MySQL user will have to invoke:"
-    echo "    GRANT ALL ON $testing_db_name.* TO <<DB_USER>>@<<DB_SERVER>> IDENTIFIED BY '<<DB_PASSWORD>>'"
+    echo "    GRANT ALL ON $testing_db_name.* TO $db_user@$db_server IDENTIFIED BY '$db_password'"
     exit 1
 fi
 
@@ -130,7 +130,7 @@ echo "Dumping the schema of the resulting database..."
 if [ -e $testing_dir/upgraded_schema_dump ]; then
     mv $testing_dir/upgraded_schema_dump $testing_dir/upgraded_schema_dump.bak
 fi
-./dump_db_schema --table-list-from-db > $testing_dir/upgraded_schema_dump
+$setup_dir/dump_db_schema --table-list-from-db $testing_db_name > $testing_dir/upgraded_schema_dump
 
 echo ""
 echo "Compare the two schemas, eg:"
@@ -141,5 +141,3 @@ echo ""
 echo "When you're done, don't forget to..."
 echo "    rm -rf $testing_dir"
 echo "    DROP DATABASE $testing_db_name;"
-
-# vim: sw=4 ts=4 expandtab

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -1,12 +1,9 @@
-# Disable foreign key checks to until all tables are created
+-- Disable foreign key checks to until all tables are created
 SET FOREIGN_KEY_CHECKS=0;
 
-#
-# Table structure for table `access_log`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `access_log`
+--
 
 CREATE TABLE `access_log` (
   `timestamp` int(20) NOT NULL default '0',
@@ -16,14 +13,10 @@ CREATE TABLE `access_log` (
   `activity` varchar(32) NOT NULL default '',
   KEY `subject_username` (`subject_username`,`timestamp`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `authors`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `authors`
+--
 
 CREATE TABLE `authors` (
   `author_id` mediumint(8) unsigned NOT NULL auto_increment,
@@ -39,16 +32,12 @@ CREATE TABLE `authors` (
   `dcomments` varchar(20) NOT NULL default '',
   `enabled` tinytext NOT NULL,
   `last_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY  (`author_id`)
+  PRIMARY KEY (`author_id`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `best_tally_rank`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `best_tally_rank`
+--
 
 CREATE TABLE `best_tally_rank` (
   `tally_name` char(2) NOT NULL default '',
@@ -56,16 +45,12 @@ CREATE TABLE `best_tally_rank` (
   `holder_id` int(6) unsigned NOT NULL default '0',
   `best_rank` int(6) NOT NULL default '0',
   `best_rank_timestamp` int(10) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`tally_name`,`holder_type`,`holder_id`)
+  PRIMARY KEY (`tally_name`,`holder_type`,`holder_id`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `biographies`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `biographies`
+--
 
 CREATE TABLE `biographies` (
   `bio_id` int(11) NOT NULL auto_increment,
@@ -73,49 +58,38 @@ CREATE TABLE `biographies` (
   `bio` text NOT NULL,
   `last_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `bio_format` varchar(8) NOT NULL default 'markdown',
-  PRIMARY KEY  (`bio_id`)
+  PRIMARY KEY (`bio_id`)
 ) COMMENT='Contains biographies (see authors)';
-# --------------------------------------------------------
 
-#
-# Table structure for table `current_tallies`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `current_tallies`
+--
 
 CREATE TABLE `current_tallies` (
   `tally_name` char(2) NOT NULL default '',
   `holder_type` char(1) NOT NULL default '',
   `holder_id` int(6) unsigned NOT NULL default '0',
   `tally_value` int(8) NOT NULL default '0',
-  PRIMARY KEY  (`tally_name`,`holder_type`,`holder_id`)
+  PRIMARY KEY (`tally_name`,`holder_type`,`holder_id`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `charsuites`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `charsuites`
+--
 
 CREATE TABLE `charsuites` (
   `name` varchar(64) NOT NULL,
   `enabled` tinyint(4) DEFAULT '1',
   PRIMARY KEY (`name`)
 ) ENGINE=InnoDB;
-# --------------------------------------------------------
+
 
 INSERT INTO charsuites
     SET name='basic-latin';
 
-#
-# Table structure for table `image_sources`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `image_sources`
+--
 
 CREATE TABLE `image_sources` (
   `code_name` varchar(10) NOT NULL default '',
@@ -132,14 +106,10 @@ CREATE TABLE `image_sources` (
   UNIQUE KEY `code_name` (`code_name`),
   UNIQUE KEY `display_name` (`display_name`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `job_logs`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `job_logs`
+--
 
 CREATE TABLE `job_logs` (
   `filename` varchar(40) NOT NULL default ''' ''',
@@ -147,29 +117,21 @@ CREATE TABLE `job_logs` (
   `event` varchar(20) NOT NULL default ''' ''',
   `comments` varchar(255) default NULL
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `marc_records`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `marc_records`
+--
 
 CREATE TABLE `marc_records` (
   `projectid` varchar(22) NOT NULL default '',
   `original_array` text NOT NULL,
   `updated_array` text NOT NULL,
-  PRIMARY KEY  (`projectid`)
+  PRIMARY KEY (`projectid`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `news_items`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `news_items`
+--
 
 CREATE TABLE `news_items` (
   `id` int(11) NOT NULL auto_increment,
@@ -181,31 +143,23 @@ CREATE TABLE `news_items` (
   `locale` varchar(8) NOT NULL DEFAULT '',
   `header` varchar(256) NOT NULL DEFAULT '',
   `item_type` varchar(16) NOT NULL DEFAULT '',
-  PRIMARY KEY  (`id`),
+  PRIMARY KEY (`id`),
   KEY `pageid_locale` (`news_page_id`,`locale`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `news_pages`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `news_pages`
+--
 
 CREATE TABLE `news_pages` (
   `news_page_id` varchar(8) NOT NULL default '',
   `t_last_change` int(11) NOT NULL default '0',
-  PRIMARY KEY  (`news_page_id`)
+  PRIMARY KEY (`news_page_id`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `non_activated_users`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `non_activated_users`
+--
 
 CREATE TABLE `non_activated_users` (
   `id` varchar(50) NOT NULL default '',
@@ -219,17 +173,13 @@ CREATE TABLE `non_activated_users` (
   `http_referrer` varchar(256) NOT NULL DEFAULT '',
   `u_intlang` varchar(25) default '',
   `user_password` varchar(255) NOT NULL default '',
-  PRIMARY KEY  (`username`),
+  PRIMARY KEY (`username`),
   KEY `email` (`email`)
 ) COMMENT='Each row represents a not-yet-activated user, user_password ';
-# --------------------------------------------------------
 
-#
-# Table structure for table `page_events`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `page_events`
+--
 
 CREATE TABLE `page_events` (
   `event_id` int(10) unsigned NOT NULL auto_increment,
@@ -239,18 +189,14 @@ CREATE TABLE `page_events` (
   `event_type` varchar(16) NOT NULL default '',
   `username` varchar(25) NOT NULL default '',
   `round_id` char(2) default NULL,
-  PRIMARY KEY  (`event_id`),
+  PRIMARY KEY (`event_id`),
   KEY `username` (`username`,`round_id`),
   KEY `projectid_username` (`projectid`,`username`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `past_tallies`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `past_tallies`
+--
 
 CREATE TABLE `past_tallies` (
   `timestamp` int(10) unsigned NOT NULL default '0',
@@ -259,31 +205,23 @@ CREATE TABLE `past_tallies` (
   `tally_name` char(2) NOT NULL default '',
   `tally_delta` int(8) NOT NULL default '0',
   `tally_value` int(8) NOT NULL default '0',
-  PRIMARY KEY  (`tally_name`,`holder_type`,`holder_id`,`timestamp`),
+  PRIMARY KEY (`tally_name`,`holder_type`,`holder_id`,`timestamp`),
   KEY `tallyboard_time` (`tally_name`,`holder_type`,`timestamp`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `pg_books`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `pg_books`
+--
 
 CREATE TABLE `pg_books` (
   `etext_number` int(10) unsigned NOT NULL,
   `formats` varchar(255) NOT NULL DEFAULT '',
-  PRIMARY KEY  (`etext_number`)
+  PRIMARY KEY (`etext_number`)
 ) COMMENT='Each row represents a different PG etext';
-# --------------------------------------------------------
 
-#
-# Table structure for table `project_events`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `project_events`
+--
 
 CREATE TABLE `project_events` (
   `event_id` int(10) unsigned NOT NULL auto_increment,
@@ -294,18 +232,14 @@ CREATE TABLE `project_events` (
   `details1` varchar(255) NOT NULL default '',
   `details2` varchar(255) NOT NULL default '',
   `details3` varchar(255) NOT NULL default '',
-  PRIMARY KEY  (`event_id`),
+  PRIMARY KEY (`event_id`),
   KEY `project` (`projectid`),
   KEY `timestamp` (`timestamp`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `project_charsuites`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `project_charsuites`
+--
 
 CREATE TABLE `project_charsuites` (
   `projectid` varchar(22) NOT NULL,
@@ -314,14 +248,10 @@ CREATE TABLE `project_charsuites` (
   KEY `charsuite_fk` (`charsuite_name`),
   CONSTRAINT `charsuite_fk` FOREIGN KEY (`charsuite_name`) REFERENCES `charsuites` (`name`)
 ) ENGINE=InnoDB;
-# --------------------------------------------------------
 
-#
-# Table structure for table `project_holds`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `project_holds`
+--
 
 CREATE TABLE `project_holds` (
   `projectid` varchar(22) NOT NULL,
@@ -329,14 +259,10 @@ CREATE TABLE `project_holds` (
   `notify_time` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`projectid`,`state`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `project_state_stats`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `project_state_stats`
+--
 
 CREATE TABLE `project_state_stats` (
   `date` date NOT NULL default '2003-01-01',
@@ -347,14 +273,10 @@ CREATE TABLE `project_state_stats` (
   KEY `date` (`date`),
   KEY `state` (`state`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `projects`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `projects`
+--
 
 CREATE TABLE `projects` (
   `nameofwork` varchar(255) NOT NULL default '',
@@ -393,19 +315,15 @@ CREATE TABLE `projects` (
   `smoothread_deadline` int(20) NOT NULL default '0',
   `deletion_reason` tinytext NOT NULL,
   `custom_chars` varchar(64) DEFAULT '',
-  PRIMARY KEY  (`projectid`),
+  PRIMARY KEY (`projectid`),
   KEY `special_code` (`special_code`),
   KEY `projectid_archived_state` (`projectid`,`archived`,`state`),
   KEY `state_moddate` (`state`,`modifieddate`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `queue_defns`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `queue_defns`
+--
 
 CREATE TABLE `queue_defns` (
   `id` int(4) NOT NULL auto_increment,
@@ -417,18 +335,14 @@ CREATE TABLE `queue_defns` (
   `projects_target` smallint unsigned NOT NULL,
   `pages_target` mediumint unsigned NOT NULL,
   `comment` text,
-  PRIMARY KEY  (`id`),
+  PRIMARY KEY (`id`),
   UNIQUE KEY `ordering` (`round_id`,`ordering`),
   UNIQUE KEY `name` (`round_id`,`name`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `quiz_passes`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `quiz_passes`
+--
 
 CREATE TABLE `quiz_passes` (
   `username` varchar(25) NOT NULL default '',
@@ -437,14 +351,10 @@ CREATE TABLE `quiz_passes` (
   `result` varchar(10) NOT NULL default '',
   KEY `username` (`username`,`quiz_page`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `rules`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `rules`
+--
 
 CREATE TABLE `rules` (
   `id` int(4) NOT NULL auto_increment,
@@ -453,64 +363,48 @@ CREATE TABLE `rules` (
   `anchor` varchar(255) default NULL,
   `subject` varchar(255) NOT NULL default '',
   `rule` text NOT NULL,
-  PRIMARY KEY  (`id`),
+  PRIMARY KEY (`id`),
   KEY `document_langcode` (`document`,`langcode`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `sessions`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `sessions`
+--
 
 CREATE TABLE `sessions` (
   `sid` varchar(32) NOT NULL default '',
   `expiration` int(11) NOT NULL default '0',
   `value` text NOT NULL,
-  PRIMARY KEY  (`sid`),
+  PRIMARY KEY (`sid`),
   KEY `expiration` (`expiration`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `site_tally_goals`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `site_tally_goals`
+--
 
 CREATE TABLE `site_tally_goals` (
   `date` date NOT NULL default '2000-01-01',
   `tally_name` char(2) NOT NULL default '',
   `goal` int(6) NOT NULL default '0',
-  PRIMARY KEY  (`date`,`tally_name`)
+  PRIMARY KEY (`date`,`tally_name`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `smoothread`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `smoothread`
+--
 
 CREATE TABLE `smoothread` (
   `projectid` varchar(22) NOT NULL default '',
   `user` varchar(25) NOT NULL default '',
   `committed` tinyint(4) NOT NULL default '0',
-  PRIMARY KEY  (`projectid`,`user`),
+  PRIMARY KEY (`projectid`,`user`),
   KEY `user` (`user`)
 ) COMMENT='Each row represents an association between a user and a proj';
-# --------------------------------------------------------
 
-#
-# Table structure for table `special_days`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `special_days`
+--
 
 CREATE TABLE `special_days` (
   `spec_code` varchar(20) NOT NULL default '',
@@ -528,14 +422,10 @@ CREATE TABLE `special_days` (
   `symbol` varchar(2) default '',
   UNIQUE KEY `spec_code` (`spec_code`)
 ) COMMENT='definitions of SPECIAL days';
-# --------------------------------------------------------
 
-#
-# Table structure for table `tasks`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `tasks`
+--
 
 CREATE TABLE `tasks` (
   `task_id` mediumint(9) NOT NULL auto_increment,
@@ -560,14 +450,10 @@ CREATE TABLE `tasks` (
   `related_postings` mediumtext NOT NULL,
   PRIMARY KEY (`task_id`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `tasks_comments`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `tasks_comments`
+--
 
 CREATE TABLE `tasks_comments` (
   `task_id` mediumint(9) NOT NULL default '0',
@@ -576,14 +462,10 @@ CREATE TABLE `tasks_comments` (
   `comment` mediumtext NOT NULL,
   PRIMARY KEY (`task_id`,`u_id`,`comment_date`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `tasks_related_tasks`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `tasks_related_tasks`
+--
 
 CREATE TABLE `tasks_related_tasks` (
   `task_id_1` mediumint(9) NOT NULL,
@@ -591,14 +473,10 @@ CREATE TABLE `tasks_related_tasks` (
   PRIMARY KEY (`task_id_1`,`task_id_2`),
   KEY `task_id_2` (`task_id_2`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `tasks_votes`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `tasks_votes`
+--
 
 CREATE TABLE `tasks_votes` (
   `id` int(11) NOT NULL auto_increment,
@@ -609,14 +487,10 @@ CREATE TABLE `tasks_votes` (
   UNIQUE KEY `id` (`id`),
   KEY `task_id` (`task_id`,`u_id`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `themes`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `themes`
+--
 
 CREATE TABLE `themes` (
   `theme_id` int(10) NOT NULL auto_increment,
@@ -625,11 +499,10 @@ CREATE TABLE `themes` (
   `created_by` varchar(25) NOT NULL default '',
   KEY `theme_id` (`theme_id`)
 );
-# --------------------------------------------------------
 
-#
-# Initial theme data
-#
+--
+-- Initial theme data
+--
 
 INSERT INTO themes SET
     name='Project Gutenberg',
@@ -648,14 +521,11 @@ INSERT INTO themes SET
     unixname='charcoal',
     created_by='srjfoo';
 
-# --------------------------------------------------------
 
-#
-# Table structure for table `user_active_log`
-#
-# Creation:
-# Last update:
-#
+
+--
+-- Table structure for table `user_active_log`
+--
 
 CREATE TABLE `user_active_log` (
   `year` smallint(4) unsigned NOT NULL default '2003',
@@ -674,29 +544,21 @@ CREATE TABLE `user_active_log` (
   `comments` varchar(255) default NULL,
   KEY `timestamp_ndx` (`time_stamp`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `user_filters`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `user_filters`
+--
 
 CREATE TABLE `user_filters` (
   `username` varchar(25) NOT NULL default '',
   `filtertype` varchar(25) NOT NULL default '',
   `value` text NOT NULL,
-  PRIMARY KEY  (`username`,`filtertype`)
+  PRIMARY KEY (`username`,`filtertype`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `user_profiles`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `user_profiles`
+--
 
 CREATE TABLE `user_profiles` (
   `id` int(10) unsigned NOT NULL auto_increment,
@@ -724,17 +586,13 @@ CREATE TABLE `user_profiles` (
   `h_tchars` tinyint(2) unsigned default '70',
   `h_tscroll` tinyint(1) default '1',
   `h_twrap` tinyint(1) default '0',
-  PRIMARY KEY  (`id`),
+  PRIMARY KEY (`id`),
   KEY `u_ref` (`u_ref`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `user_project_info`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `user_project_info`
+--
 
 CREATE TABLE `user_project_info` (
   `username` varchar(25) NOT NULL,
@@ -749,17 +607,13 @@ CREATE TABLE `user_project_info` (
   `iste_ppv_enter` tinyint(1) NOT NULL default '0',
   `iste_posted` tinyint(1) NOT NULL default '0',
   `iste_sr_reported` tinyint(1) NOT NULL default '0',
-  PRIMARY KEY  (`username`,`projectid`),
+  PRIMARY KEY (`username`,`projectid`),
   KEY `projectid` (`projectid`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `user_teams`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `user_teams`
+--
 
 CREATE TABLE `user_teams` (
   `id` int(10) unsigned NOT NULL auto_increment,
@@ -774,17 +628,13 @@ CREATE TABLE `user_teams` (
   `icon` varchar(25) NOT NULL default 'icon_default.png',
   `topic_id` int(10) default NULL,
   `latestUser` mediumint(9) NOT NULL default '0',
-  PRIMARY KEY  (`id`),
+  PRIMARY KEY (`id`),
   UNIQUE KEY `teamname` (`teamname`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `user_teams_membership`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `user_teams_membership`
+--
 
 CREATE TABLE `user_teams_membership` (
   `u_id` int(11) unsigned NOT NULL,
@@ -794,14 +644,10 @@ CREATE TABLE `user_teams_membership` (
   FOREIGN KEY (`u_id`) REFERENCES `users` (`u_id`),
   FOREIGN KEY (`t_id`) REFERENCES `user_teams` (`id`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `users`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `users`
+--
 
 CREATE TABLE `users` (
   `reg_token` varchar(50) NOT NULL default '',
@@ -823,7 +669,7 @@ CREATE TABLE `users` (
   `u_intlang` varchar(25) default '',
   `u_privacy` tinyint(1) default '0',
   `api_key` varchar(38) DEFAULT NULL,
-  PRIMARY KEY  (`username`),
+  PRIMARY KEY (`username`),
   UNIQUE KEY `api_key` (`api_key`),
   KEY `u_id` (`u_id`),
   KEY `last_login` (`last_login`),
@@ -831,14 +677,10 @@ CREATE TABLE `users` (
   KEY `api_key_username` (`api_key`,`username`),
   KEY `email` (`email`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `usersettings`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `usersettings`
+--
 
 CREATE TABLE `usersettings` (
   `username` varchar(25) NOT NULL default '',
@@ -848,14 +690,10 @@ CREATE TABLE `usersettings` (
   KEY `setting` (`setting`,`value`),
   KEY `value` (`value`,`setting`)
 );
-# --------------------------------------------------------
 
-#
-# Table structure for table `wordcheck_events`
-#
-# Creation:
-# Last update:
-#
+--
+-- Table structure for table `wordcheck_events`
+--
 
 CREATE TABLE `wordcheck_events` (
   `check_id` int(10) unsigned NOT NULL auto_increment,
@@ -866,11 +704,10 @@ CREATE TABLE `wordcheck_events` (
   `username` varchar(25) NOT NULL,
   `suggestions` text,
   `corrections` text,
-  PRIMARY KEY  (`check_id`),
+  PRIMARY KEY (`check_id`),
   KEY `pc_compound` (`projectid`,`timestamp`,`image`)
 );
-# --------------------------------------------------------
 
-# Re-enable foreign key checks
+-- Re-enable foreign key checks
 SET FOREIGN_KEY_CHECKS=1;
 

--- a/SETUP/dump_db_schema.template
+++ b/SETUP/dump_db_schema.template
@@ -7,7 +7,7 @@ db_password='<<DB_PASSWORD>>'
 db_name='<<DB_NAME>>'
 code_dir='<<CODE_DIR>>'
 
-setup_dir=`dirname $0`
+setup_dir=$(realpath $(dirname $0))
 
 export LC_ALL=POSIX
 # because on www.pgdp.net, none of the LC_* are defined,
@@ -104,27 +104,15 @@ if true; then
         --no-data --quote-names --add-drop-table=FALSE --force \
         $db_name $tables |
 
-    # Remove column collation specs as those can vary
+    # Remove column collation specs & auto increment as those can vary
     sed -E '
+        s/AUTO_INCREMENT=[0-9]+ //
         s/COLLATE \w+\s*//
         s/ COLLATE=\w+//
     ' |
 
     # Ensure the per-table chunks are in a consistent order:
     php -f  $setup_dir/sort_mysqldump.php |
-
-    # Make it look more like the dump from phpMyAdmin:
-    sed '
-        s/^--/#/
-        s/for table .\(.*\)./for table \`\1\`/
-        /^# Table structure/ a\
-#\
-# Creation:\
-# Last update:
-        s/AUTO_INCREMENT=\([0-9]*\) //
-        /^) ENGINE=/ a\
-# --------------------------------------------------------
-        ' |
 
     # Skip MySQL command sequences as they may be version-specific
     # (and generate a lot of noise in the diffs).

--- a/SETUP/dump_db_schema.template
+++ b/SETUP/dump_db_schema.template
@@ -5,7 +5,7 @@
 db_user='<<DB_USER>>'
 db_password='<<DB_PASSWORD>>'
 db_name='<<DB_NAME>>'
-code_dir=<<CODE_DIR>>
+code_dir='<<CODE_DIR>>'
 
 setup_dir=`dirname $0`
 
@@ -18,6 +18,10 @@ export LC_ALL=POSIX
 # So how will we determine which ones to dump?
 if [ "$1" = '--table-list-from-db' ]; then
     table_list_source='db'
+    # If they've passed in another arg, assume it's the DB name
+    if [ ! -z "$2" ]; then
+        db_name=$2
+    fi
 elif [ "$1" = '--table-list-from-code' ]; then
     table_list_source='code'
 else
@@ -33,14 +37,8 @@ get_table_names()
         grep -v \
             -e '^projectID' \
             -e '^phpbb_' \
-            -e active_users \
-            -e begin_users \
-            -e end_users \
-            -e old_phpbb_users \
-            -e phpwiki \
-            -e projectstemp \
-            -e ranks \
-            -e states |
+            -e pgdptest_voter_info \
+            |
         sort
     elif [ $table_list_source = code ]; then
         find $code_dir -type f \
@@ -105,6 +103,12 @@ if true; then
     mysqldump --user=$db_user --password="$db_password" \
         --no-data --quote-names --add-drop-table=FALSE --force \
         $db_name $tables |
+
+    # Remove column collation specs as those can vary
+    sed -E '
+        s/COLLATE \w+\s*//
+        s/ COLLATE=\w+//
+    ' |
 
     # Ensure the per-table chunks are in a consistent order:
     php -f  $setup_dir/sort_mysqldump.php |

--- a/SETUP/dump_db_schema.template
+++ b/SETUP/dump_db_schema.template
@@ -1,6 +1,7 @@
 #!/bin/bash
-
 # Dump (to stdout) the SQL commands to create DP tables.
+
+set -euo pipefail
 
 db_user='<<DB_USER>>'
 db_password='<<DB_PASSWORD>>'
@@ -16,13 +17,13 @@ export LC_ALL=POSIX
 
 # We don't want to dump schema for *all* tables in the database.
 # So how will we determine which ones to dump?
-if [ "$1" = '--table-list-from-db' ]; then
+if [ "${1-}" = '--table-list-from-db' ]; then
     table_list_source='db'
     # If they've passed in another arg, assume it's the DB name
-    if [ ! -z "$2" ]; then
+    if [ -n "${2-}" ]; then
         db_name=$2
     fi
-elif [ "$1" = '--table-list-from-code' ]; then
+elif [ "${1-}" = '--table-list-from-code' ]; then
     table_list_source='code'
 else
     table_list_source='code'
@@ -41,16 +42,16 @@ get_table_names()
             |
         sort
     elif [ $table_list_source = code ]; then
-        find $code_dir -type f \
+        find $setup_dir/.. -type f \
             \( -name '*.php' -o -name '*.inc' -o -name '*.pl' \) |
 
         xargs grep -E '(FROM|INTO|JOIN) ' |
 
-        # Suppress some non-SQL occurrences of those keywords:
+        # Suppress some non-SQL occurrences of those keywords and vendor code
         grep -v \
+            -e /vendor/ \
             -e 'the FROM clause' \
             -e 'FAR FROM HOME' \
-            -e 'INSERT INTO the same table' \
         |
 
         sed -n -e'
@@ -61,21 +62,15 @@ get_table_names()
             s/^`\([^`]*\)`.*/\1/p
         ' |
 
-        # 'cur' and 'old' are tables referenced in DifferenceEngine.inc,
-        #     by code that we presumably don't execute.
         # 'member_stats', 'user_teams_stats', and 'pagestats' are obsolete
         #     tables that are referenced by some upgrade scripts.
         # The rest are temporary tables.
         grep -v -x \
-            -e cur -e old \
             -e member_stats -e user_teams_stats -e pagestats \
-            -e _page_latest \
             -e access_log_summary \
             -e active_page_counts \
-            -e beginpages \
-            -e newbies \
-            -e test_u \
-            -e user_filters_temp \
+            -e information_schema \
+            -e genre_translations \
             -e project_event_subscriptions_grouped_by_project \
         |
         # Tables with phpbb_ prefix are managed / installed by phpBB.
@@ -91,7 +86,7 @@ get_table_names()
     fi
 }
 
-tables=`get_table_names`
+tables=$(get_table_names)
 
 if true; then
     # The order tables are dumped is not consistent and it's possible to have

--- a/SETUP/install_db.php
+++ b/SETUP/install_db.php
@@ -27,7 +27,9 @@ $db_schema = "db_schema.sql";
 $db_schema = file($db_schema);
 $sql_create_tables = "";
 while ($lines = array_shift($db_schema)) {
-    if (substr($lines, 0, 1) == "#" || substr($lines, 0, 1) == "\n") {
+    if (substr($lines, 0, 1) == "#" ||
+        substr($lines, 0, 2) == "--" ||
+        substr($lines, 0, 1) == "\n") {
         // skip comment and blank lines
     } else {
         $sql_create_tables = $sql_create_tables.$lines." ";


### PR DESCRIPTION
This updates some of the pre-release tooling we use to confirm all database changes we made to the live DB on TEST are represented by the upgrade scripts. Every release I bang my head against subtle differences in the output due to collation (among others) and this time I decided to just fix it.

I've also updated the dump format so it is mostly just what `mysqldump` does rather than mirroring the phpMyAdmin dump format which we haven't used in well over a decade. There are no functional changes in `db_schema.sql`, just changes to comments (mostly format).