### PR TITLE
page_detail.php: Don't stretch linkbox with long project titles

### DIFF
--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -63,7 +63,7 @@ output_header("$page_details_str: $title", NO_STATSBAR);
 // `float: right` like the other linkboxes in the codebase do because on
 // this page the inflexible and very wide page details table causes the
 // linkbox to display in ugly locations.
-echo "<div style='display: flex; justify-content: space-between'>";
+echo "<div style='display: flex; align-items: flex-start; justify-content: space-between'>";
 echo "<div>";
 echo "<h1>" . html_safe($title) . "</h1>\n";
 echo "<h2>$page_details_str</h2>\n";


### PR DESCRIPTION
Example in sandbox: https://www.pgdp.org/~bfoley/c.branch/t2049-fix/tools/project_manager/page_detail.php?project=projectID5e26422ab19b5&show_image_size=0