### PR TITLE
Pageload smoketest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Static code checks
+name: CI tests
 on: [push, pull_request]
 jobs:
   phpunit:
@@ -97,3 +97,28 @@ jobs:
         run: make -C SETUP lint_css
       - name: Run best practice checks
         run: make -C SETUP best_practice_checks
+  pageload-smoketest:
+    strategy:
+      matrix:
+        cfg:
+          - { os: 'ubuntu-20.04', php: '7.4' }
+          - { os: 'ubuntu-22.04', php: '8.1' }
+    runs-on: ${{ matrix.cfg.os }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup PHP, composer
+        uses: ./.github/actions/setup-php
+        with:
+          php-version: ${{ matrix.cfg.php }}
+      - name: Setup MySQL, install schema
+        uses: ./.github/actions/setup-mysql-db
+      - name: Install aspell dependencies for WordCheck tests
+        run: sudo apt --fix-broken install aspell aspell-en
+      - name: Add smoketest DB entries
+        run: |
+            mysql -uroot -proot < SETUP/smoketests/test_tables.sql
+      - name: Run pageload smoketest
+        run: |
+            SETUP/smoketests/pageload_smoketest.py \
+                -u admin -p admin_pass -k admin_key

--- a/SETUP/smoketests/error.php
+++ b/SETUP/smoketests/error.php
@@ -1,0 +1,3 @@
+<?php
+// To test that errors are detected correctly.
+trigger_error("Yes, it is a problem, sir.", E_USER_ERROR);

--- a/SETUP/smoketests/hello.php
+++ b/SETUP/smoketests/hello.php
@@ -1,0 +1,3 @@
+<?php
+// An 'always suceeds' script to check server liveness.
+echo "Hello world\n";

--- a/SETUP/smoketests/notice.php
+++ b/SETUP/smoketests/notice.php
@@ -1,0 +1,3 @@
+<?php
+// To test that notices are detected correctly.
+trigger_error("Good morning, Mr. Wooster.", E_USER_NOTICE);

--- a/SETUP/smoketests/pageload_smoketest.py
+++ b/SETUP/smoketests/pageload_smoketest.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import signal
+import sys
+import time
+
+from http.cookiejar import CookieJar, DefaultCookiePolicy
+from subprocess import Popen, DEVNULL
+from urllib.error import URLError
+from urllib.parse import urlencode, urlparse
+from urllib.request import build_opener, HTTPCookieProcessor, HTTPErrorProcessor, Request
+
+from typing import List, Optional, Tuple
+
+SERVER_LOG = "server.log"
+
+NOLOGIN_TESTS = [
+    {'path': 'accounts/addproofer.php'},
+    {'path': 'credits.php'},
+    {'path': 'default.php'},
+    {'path': 'list_etexts.php'},
+    {'path': 'sitemap.php'},
+]
+
+BASE_TESTS = [
+    {'path': 'activity_hub.php'},
+    {'path': 'pastnews.php'},
+    {'path': 'pophelp.php?category=teams&name=edit_teamname'},
+    {'path': 'project.php?id=projectID5e23a810ef693'},
+    {'path': 'tasks.php'},
+    {'path': 'userprefs.php'},
+    {'path': 'accounts/login_failure.php', 'expect_status': 302},
+    {'path': 'accounts/require_login.php'},
+]
+
+API_TESTS = [
+    {'path': 'api/index.php?url=v1/projects'},
+    {'path': 'api/index.php?url=v1/projects/projectID5e23a810ef693'},
+    {'path': 'api/index.php?url=v1/projects/projectID5e23a810ef693/wordlists/good'},
+    {'path': 'api/index.php?url=v1/projects/projectID5e23a810ef693/holdstates'},
+    {'path': 'api/index.php?url=v1/projects/projectID5e23a810ef693/pages'},
+    {'path': 'api/index.php?url=v1/projects/projectID5e23a810ef693/pagedetails'},
+    {'path': 'api/index.php?url=v1/projects/projectID5e23a810ef693/pages/001.png/pagerounds/P1'},
+    {'path': 'api/index.php?url=v1/projects/projectID5e23a810ef693/transitions'},
+    {'path': 'api/index.php?url=v1/projects/difficulties'},
+    {'path': 'api/index.php?url=v1/projects/genres'},
+    {'path': 'api/index.php?url=v1/projects/states'},
+    {'path': 'api/index.php?url=v1/projects/pagerounds'},
+    {'path': 'api/index.php?url=v1/projects/charsuites'},
+    {'path': 'api/index.php?url=v1/projects/specialdays'},
+    {'path': 'api/index.php?url=v1/projects/imagesources'},
+    {'path': 'api/index.php?url=v1/projects/holdstates'},
+
+    {'path': 'api/index.php?url=v1/queues'},
+    {'path': 'api/index.php?url=v1/queues/500'},
+    {'path': 'api/index.php?url=v1/queues/500/stats'},
+    {'path': 'api/index.php?url=v1/queues/500/projects'},
+
+    {'path': 'api/index.php?url=v1/stats/site'},
+    {'path': 'api/index.php?url=v1/stats/site/projects/stages'},
+    {'path': 'api/index.php?url=v1/stats/site/projects/states'},
+    {'path': 'api/index.php?url=v1/stats/site/rounds'},
+    {'path': 'api/index.php?url=v1/stats/site/rounds/P3'},
+]
+
+FAQ_TESTS = [
+    {'path': 'faq/doc-copy.php'},
+    {'path': 'faq/feeds_sdk/index.php'},
+    {'path': 'faq/font_sample.php'},
+    {'path': 'faq/privacy.php'},
+    {'path': 'faq/prooffacehelp.php'},
+    {'path': 'faq/simple_proof_rules.php'},
+    {'path': 'faq/site_progress_snapshot_legend.php'},
+    {'path': 'faq/translate.php'},
+]
+
+MISC_TESTS = [
+    # 'feeds/backend.php' # Disabled. It writes to a file
+    {'path': 'locale/debug_ui_language.php'},
+    {'path': 'locale/translators/index.php'},
+]
+
+QUIZ_TESTS = [
+    {'path': 'quiz/start.php'},
+    {'path': 'quiz/generic/hints.php?quiz_page_id=p_greek_4&error=G_n_u&number=1'},
+    {'path': 'quiz/generic/main.php?quiz_page_id=p_greek_1'},
+    {'path': 'quiz/generic/orig.php?quiz_page_id=p_greek_2'},
+    {'path': 'quiz/generic/proof.php?quiz_page_id=p_greek_3'},
+    {'path': 'quiz/generic/returnfeed.php?quiz_page_id=p_thorn'},
+    {'path': 'quiz/generic/right.php?quiz_page_id=p_fraktur'},
+    {'path': 'quiz/generic/wizard/default_messages.php'},
+    {'path': 'quiz/generic/wizard/start.php'},
+    {'path': 'quiz/generic/wizard/new_quiz.php'},
+    # TODO: Needs SESSION data
+    #'quiz/generic/wizard/general.php',
+    #'quiz/generic/wizard/checks.php',
+    #'quiz/generic/wizard/messages.php',
+    #'quiz/generic/wizard/output.php',
+    #'quiz/generic/wizard/output_quiz.php',
+    #'quiz/generic/wizard/quiz_pages.php',
+
+    {'path': 'quiz/tuts/tut_p_aeoe_1.php'},
+    {'path': 'quiz/tuts/tut_p_aeoe_2.php'},
+    {'path': 'quiz/tuts/tut_p_basic_1.php'},
+    {'path': 'quiz/tuts/tut_p_basic_2.php'},
+    {'path': 'quiz/tuts/tut_p_basic_3.php'},
+    {'path': 'quiz/tuts/tut_p_basic_4.php'},
+    {'path': 'quiz/tuts/tut_p_basic_5.php'},
+    {'path': 'quiz/tuts/tut_p_fraktur.php'},
+    {'path': 'quiz/tuts/tut_p_greek_1.php'},
+    {'path': 'quiz/tuts/tut_p_greek_2.php'},
+    {'path': 'quiz/tuts/tut_p_greek_3.php'},
+    {'path': 'quiz/tuts/tut_p_greek_4.php'},
+    {'path': 'quiz/tuts/tut_p_greek_5.php'},
+    {'path': 'quiz/tuts/tut_p_mod1_1.php'},
+    {'path': 'quiz/tuts/tut_p_mod1_2.php'},
+    {'path': 'quiz/tuts/tut_p_mod1_3.php'},
+    {'path': 'quiz/tuts/tut_p_mod1_4.php'},
+    {'path': 'quiz/tuts/tut_p_mod1_5.php'},
+    {'path': 'quiz/tuts/tut_p_mod2_1.php'},
+    {'path': 'quiz/tuts/tut_p_mod2_2.php'},
+    {'path': 'quiz/tuts/tut_p_mod2_3.php'},
+    {'path': 'quiz/tuts/tut_p_mod2_4.php'},
+    {'path': 'quiz/tuts/tut_p_mod2_5.php'},
+    {'path': 'quiz/tuts/tut_p_old_1.php'},
+    {'path': 'quiz/tuts/tut_p_old_2.php'},
+    {'path': 'quiz/tuts/tut_p_old_3.php'},
+    {'path': 'quiz/tuts/tut_p_thorn.php'},
+]
+
+TEAMS_TESTS = [
+    # NB performs an action
+    {'path': 'stats/members/jointeam.php?tid=44', 'expect_status': [200, 302]},
+    # NB performs an action
+    {'path': 'stats/members/quitteam.php?tid=44', 'expect_status': [200, 302]},
+    # Adds a forum post!
+    {'path': 'stats/teams/team_topic.php?team=44', 'expect_status': 302},
+    {'path': 'stats/members/mbr_list.php?tid=44'},
+    {'path': 'stats/members/mbr_xml.php?username=teststeel'},
+    {'path': 'stats/members/mdetail.php?id=1'},
+    {'path': 'stats/teams/new_team.php'},
+    {'path': 'stats/teams/tdetail.php?tid=44'},
+    {'path': 'stats/teams/teams_xml.php?tid=44'},
+    {'path': 'stats/teams/tedit.php?tid=44'},
+    {'path': 'stats/teams/tlist.php'},
+]
+
+STATS_TESTS = [
+    {'path': 'stats/PP_unknown.php'},
+    {'path': 'stats/equilibria.php'},
+    {'path': 'stats/misc_stats1.php?tally_name=F1&start=2024-01&end=2024-02'},
+    {'path': 'stats/misc_user_graphs.php'},
+    {'path': 'stats/pages_in_states.php'},
+    {'path': 'stats/pages_proofed_graphs.php?tally_name=P3'}, # Slow to evaluate!
+    {'path': 'stats/percent_users_who_proof.php'},
+    {'path': 'stats/pm_stats.php'},
+    {'path': 'stats/pp_stage_goal.php'},
+    {'path': 'stats/pp_stats.php'},
+    {'path': 'stats/ppv_stats.php'},
+    {'path': 'stats/projects_Xed_graphs.php?which=posted'},
+    {'path': 'stats/proof_stats.php?tally_name=F2'},
+    {'path': 'stats/release_queue.php'},
+    {'path': 'stats/requested_books.php'},
+    {'path': 'stats/round_backlog.php'},
+    {'path': 'stats/round_backlog_days.php'},
+    {'path': 'stats/stats_central.php'},
+    {'path': 'stats/user_logon_graphs.php'},
+]
+
+STYLES_TESTS = [
+    {'path': 'styles/design_philosophy.php'},
+    {'path': 'styles/style_demo.php'},
+]
+
+TOOLS_TESTS = [
+    {
+        'method': 'POST',
+        'path': 'tools/change_sr_commitment.php',
+        'data': {'projectid': 'projectID5e23a810ef693','action': 'commit'}
+    },
+    {
+        'method': 'POST',
+        'path': 'tools/changestate.php',
+        'data': {
+            'projectid': 'projectID5e23a810ef693',
+            'curr_state': 'P3.proj_avail',
+            'next_state': 'P3.proj_unavail',
+            'confirmed': 'yes',
+        },
+    },
+    {'path': 'tools/charsuites.php'},
+    {'path': 'tools/download_images.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/extend_sr.php?project=projectID5e23a810ef693&days=10'},
+    {
+        'method': 'POST',
+        'path': 'tools/modify_access.php',
+        'data': {
+            'subject_username': 'admin',
+            'F2|grant': 'on',
+        },
+    },
+    {
+        'method': 'POST',
+        'path': 'tools/modify_access.php',
+        'data': {
+            'subject_username': 'admin',
+            'F2|revoke': 'on',
+        },
+    },
+    {'path': 'tools/page_browser.php?project=projectID5e23a810ef693&imagefile=001.png'},
+    {'path': 'tools/pending_access_requests.php'},
+    {'path': 'tools/pool.php?pool_id=PP'},
+    {
+        'method': 'POST',
+        'path': 'tools/remove_project_hold.php',
+        'data': {
+            'projectid': 'projectID5e23a810ef693',
+            'curr_state': 'P3.proj_avail',
+            'return_uri': '',
+        },
+        'expect_status': 302,
+    },
+    {'path': 'tools/request_access.php?stage_id=F2'},
+    {'path': 'tools/search.php?show=search&title=A'},
+    {
+        'method': 'POST',
+        'path': 'tools/set_project_event_subs.php',
+        'data': {'projectid': 'projectID5e23a810ef693', 'posted': 'on'},
+    },
+    {
+        'method': 'POST',
+        'path': 'tools/set_project_holds.php',
+        'data': {
+            'projectid': 'projectID5e23a810ef693',
+            'P3_proj_avail': 'on',
+            'return_uri': ''
+        },
+    },
+    {
+        'method': 'POST',
+        'path': 'tools/setlangcookie.php',
+        'data': {'lang': 'en-US'},
+        'expect_status': 302,
+    },
+]
+
+TOOLS_AUTHORS_TESTS = [
+    # Show form
+    {'path': 'tools/authors/add.php'},
+    {
+        'method': 'POST',
+        'path': 'tools/authors/add.php',
+        'data': {
+            'last_name': 'Franklin',
+            'bday': 17,
+            'bmonth': 1,
+            'byear': 1706,
+            'byearRadio': 1,
+            'dday': 17,
+            'dmonth': 4,
+            'dyear': 1790,
+            'dyearRadio': 1,
+        },
+    },
+    {'path': 'tools/authors/addbio.php?bio_id=1&author_id=1'},
+    # Disabled until #1140 is committed.
+    #{'path': 'tools/authors/author.php?author_id=1'},
+    {'path': 'tools/authors/authorxml.php'},
+    {'path': 'tools/authors/bio.php'},
+    {'path': 'tools/authors/bio.php?bio_id=1'},
+    {'path': 'tools/authors/bioxml.php'},
+    {'path': 'tools/authors/listing.php'},
+    {'path': 'tools/authors/listing.php?last_name=Smith&other_names'},
+    {'path': 'tools/authors/manage.php'},
+    {'path': 'tools/authors/manage.php?last_name=Smith&other_names'},
+]
+
+TOOLS_POST_PROOFERS_TESTS = [
+    {
+        'method': 'POST',
+        'path': 'tools/post_proofers/postcomments.php',
+        'data': {
+            'projectid': 'projectID5e23a810ef693',
+            'comments': 'It was a dark and stormy night',
+        },
+    },
+    {'path': 'tools/post_proofers/ppv_report.php?project=projectID5e23a810ef693'},
+    {'path': 'tools/post_proofers/smooth_reading.php'},
+]
+
+TOOLS_PROJECT_MANAGER_TESTS = [
+    # TODO add project in P1.unavail
+    {'path': 'tools/project_manager/add_files.php?project=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/automodify.php'},
+    {'path': 'tools/project_manager/bad_bytes_explainer.php'},
+    {'path': 'tools/project_manager/clearance_check.php'},
+    {'path': 'tools/project_manager/diff.php?project=projectID5e23a810ef693&L_round=P1&R_round=P2&image=001.png'},
+    # (deliberately) not clicking 'Confirm'...
+    {'path': 'tools/project_manager/edit_pages.php?projectid=projectID5e23a810ef693&operation=clear&selected_pages[001.png]=on'},
+    # TODO project dir doesn't exist
+    {'path': 'tools/project_manager/edit_project_word_lists.php?projectid=projectID5e23a810ef693'},
+    # TODO other actions
+    {'path': 'tools/project_manager/editproject.php?project=projectID5e23a810ef693&action=edit'},
+    {'path': 'tools/project_manager/external_catalog_search.php?action=show_query_form'},
+    # TODO yaz
+    #{'path': 'tools/project_manager/external_catalog_search.php?action=do_search_and_show_hits'},
+    {'path': 'tools/project_manager/generate_post_files.php?projectid=projectID5e23a810ef693&round_id=P3&which_text=EQ'},
+    {'path': 'tools/project_manager/handle_bad_page.php?projectid=projectID5e23a810ef693&image=001.png'},
+    {'path': 'tools/project_manager/manage_image_sources.php?action=show_sources'},
+    {'path': 'tools/project_manager/marc_inspector.php?rec=H4sIAAAAAAAAA23QwQrCMAwG4FcJPSmI_Enbrc0uvko2PQgq4rzJ3t2uQ2GwXpo0_b9CTVv9XBWdqSzFqAx1O3-4Xex8ee1dd1UupxLUATnkh93JRABJmYxCBFw3zZdM-We0lQB4X2ey8uU_LNvp_0LJeJ9ahtSM3_Li4oVNL649btRxTgmRBTmKyDHXdNyS0yI3m3Jay6H8UHE9p5Fzw1TW-CTrh1L0cweAQIO9iYo6fQG-RwV6ZgEAAA'},
+    {'path': 'tools/project_manager/page_compare.php?project=projectID5e23a810ef693&L_round=P1&R_round=P2'},
+    {'path': 'tools/project_manager/page_detail.php?project=projectID5e23a810ef693'},
+    # Needs project dir and pngcheck
+    #{'path': 'tools/project_manager/project_quick_check.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/projectmgr.php?show=user_avail'},
+    {'path': 'tools/project_manager/projectmgr.php?show=user_active'},
+    {'path': 'tools/project_manager/projectmgr.php?show=user_all'},
+    {'path': 'tools/project_manager/projectmgr.php?show=search_form'},
+    {'path': 'tools/project_manager/remote_file_manager.php'},
+    {'path': 'tools/project_manager/show_adhoc_word_details.php?projectid=projectID5e23a810ef693'},
+    {
+        'method': 'POST',
+        'path': 'tools/project_manager/show_adhoc_word_details.php',
+        'data': {
+            'projectid': 'projectID5e23a810ef693',
+            'queryWordText': 'the\nwho',
+            'freqCutoff': 1
+        },
+    },
+    {'path': 'tools/project_manager/show_all_good_word_suggestions.php'},
+    # TODO add word lists to project to exercise this better
+    {'path': 'tools/project_manager/show_current_flagged_words.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_good_word_suggestions.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_good_word_suggestions_detail.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_project_possible_bad_words.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_project_stealth_scannos.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_project_wordcheck_stats.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_project_wordcheck_usage.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_word_context.php?projectid=projectID5e23a810ef693'},
+    {'path': 'tools/project_manager/show_image_sources.php'},
+    {'path': 'tools/project_manager/show_specials.php'},
+    # TODO Needs a projects dir to work.
+    #{'path': 'tools/project_manager/update_illos.php?projectid=projectID5e23a810ef693&image=001.png'},
+]
+
+TESTS = (
+    NOLOGIN_TESTS +
+    BASE_TESTS +
+    API_TESTS +
+    FAQ_TESTS +
+    MISC_TESTS +
+    QUIZ_TESTS +
+    TEAMS_TESTS +
+    STATS_TESTS +
+    STYLES_TESTS +
+    TOOLS_TESTS +
+    TOOLS_AUTHORS_TESTS +
+    TOOLS_POST_PROOFERS_TESTS +
+    TOOLS_PROJECT_MANAGER_TESTS
+)
+
+# {'path': 'tools/proofers/ctrl_frame.php'},
+# {'path': 'tools/proofers/for_mentors.php'},
+# {'path': 'tools/proofers/greek2ascii.php'},
+# {'path': 'tools/proofers/hiero/index.php'},
+# {'path': 'tools/proofers/image_frame_std.php'},
+# {'path': 'tools/proofers/images_index.php'},
+# {'path': 'tools/proofers/mktable.php'},
+# {'path': 'tools/proofers/my_projects.php'},
+# {'path': 'tools/proofers/my_suggestions.php'},
+# {'path': 'tools/proofers/processtext.php'},
+# {'path': 'tools/proofers/project_topic.php'},
+# {'path': 'tools/proofers/proof.php'},
+# {'path': 'tools/proofers/proof_frame.php'},
+# {'path': 'tools/proofers/report_bad_page.php'},
+# {'path': 'tools/proofers/review_work.php'},
+# {'path': 'tools/proofers/round.php'},
+# {'path': 'tools/proofers/srchrep.php'},
+# {'path': 'tools/proofers/text_frame_std.php'},
+#
+# {'path': 'tools/site_admin/convert_project_table_utf8.php'},
+# {'path': 'tools/site_admin/copy_pages.php'},
+# {'path': 'tools/site_admin/delete_pages.php'},
+# {'path': 'tools/site_admin/displayrandrules.php'},
+# {'path': 'tools/site_admin/edit_mail_address_for_non_activated_user.php'},
+# {'path': 'tools/site_admin/index.php'},
+# {'path': 'tools/site_admin/manage_random_rules.php'},
+# {'path': 'tools/site_admin/manage_site_access_privileges.php'},
+# {'path': 'tools/site_admin/manage_site_charsuites.php'},
+# {'path': 'tools/site_admin/manage_site_word_lists.php'},
+# {'path': 'tools/site_admin/manage_special_days.php'},
+# {'path': 'tools/site_admin/project_jump.php'},
+# {'path': 'tools/site_admin/projects_with_odd_values.php'},
+# {'path': 'tools/site_admin/rename_pages.php'},
+# {'path': 'tools/site_admin/shared_postednums.php'},
+# {'path': 'tools/site_admin/show_access_log.php'},
+# {'path': 'tools/site_admin/show_common_words_from_project_word_lists.php'},
+# {'path': 'tools/site_admin/sitenews.php'},
+
+def get_site_config() -> dict:
+    config = {}
+    with open('pinc/site_vars.php', 'r') as site_vars:
+        for l in site_vars:
+            m = re.match(r"\$site_url\s*=\s*'(.*?)';", l)
+            if m:
+                u = urlparse(m[1])
+                config.update({
+                    'site_url': m[1].rstrip('/'),
+                    'scheme': u.scheme,
+                    'netloc': u.netloc, # hostname:port
+                })
+                continue
+    return config
+
+def start_server(host_port: str):
+    """Start a PHP server in the background outputting to a log file.
+    Return the Popen object."""
+    # NB In theory we could use a pipe for stderr and just read from it
+    # after every HTTP request, but in practice, Python's readline() API
+    # is blocking, so there's no easy way to find the end of the log
+    # output (because the last readline() will just block waiting for more
+    # log entries). Just writing to a file on disc and manipulating that
+    # is less elegant, but easier in practice.
+    with open(SERVER_LOG, "w+") as logfile:
+        return Popen(
+            ['php', '-S', host_port],
+            bufsize=1,
+            stdin=DEVNULL,
+            stdout=DEVNULL,
+            stderr=logfile,
+        )
+
+def server_ready(site_url: str) -> bool:
+    """Returns False if server doesn't respond correctly
+    within 5 seconds & 10 retries"""
+    for i in range(10):
+        time.sleep(.5)
+        url = f'{site_url}/SETUP/smoketests/hello.php?i={i}'
+        try:
+            data, _, _, _ = request(Request(url))
+            return data == b'Hello world\n'
+        except URLError:
+            pass
+    return False
+
+# For local debugging run the following in a terminal window
+# php -S 127.0.0.1:12345 2> >(tee -a server.log >&2)
+
+class NoRedirect(HTTPErrorProcessor):
+    def http_response(self, request, response):
+        return response
+    def https_response(self, request, response):
+        return response
+
+class AllowInsecureCookiePolicy(DefaultCookiePolicy):
+    def return_ok_secure(self, cookie, request):
+        return True
+
+# Create a URL handler that:
+# 1 doesn't follow redirects
+# 2 stores session cookies in memory
+# 3 allows secure cookies to be sent over an insecure HTTP connection
+jar = CookieJar(AllowInsecureCookiePolicy())
+opener = build_opener(NoRedirect, HTTPCookieProcessor(jar))
+
+def request(req: Request, data=None) -> Tuple[
+        Optional[bytes],
+        Optional[int],
+        List[Tuple[str, str]],
+        List[str]]:
+    """Make an HTTP request to the server.
+       Return the body, status, headers, and PHP logs"""
+    # Truncate log so we only see logs that are in response to the next request
+    with open(SERVER_LOG, 'w') as log:
+        pass
+    # Read from the log after the server responds
+    with open(SERVER_LOG, 'r') as log:
+        try:
+            jar.add_cookie_header(req)
+            response = opener.open(req, data=data)
+            data = response.read()
+            status = response.code
+            headers = response.getheaders()
+            jar.extract_cookies(response, req)
+        except URLError:
+            data, status, headers = None, None, []
+        log_lines = log.readlines()
+        return data, status, headers, log_lines
+
+def test_failed(logs: List[str]) -> bool:
+    """Are there are any PHP messages in the logs?"""
+    return any(re.search('PHP (Notice|Warning|Fatal error)', l) for l in logs)
+
+def login(config, username: str, password: str) -> bool:
+    """Try to log in to the website and save the session cookie
+    in the in-memory cookie jar."""
+    req = Request(
+        f'{config["site_url"]}/accounts/login.php',
+        method='POST'
+    )
+
+    login_data = urlencode({'userNM': username, 'userPW': password})
+    data, _, _, _ = request(req, login_data.encode())
+
+    # We need to scrape the body to check if the login succeeded :(
+    return b'Unable to authenticate' not in data
+
+def check_error_detect(config) -> bool:
+    """Does the log parsing correctly detect PHP notices, warnings, errors?"""
+    url_base = config['site_url'] + '/SETUP/smoketests/'
+    for script in ['notice.php', 'warning.php', 'error.php']:
+        _, _, _, logs = request(Request(url_base + script))
+        if not test_failed(logs):
+            print(f"{script} PHP log wasn't detected!")
+            print("\n".join(logs))
+            return False
+    return True
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument('-n', '--no-server', action='store_true')
+    p.add_argument('-v', '--verbose', action='store_true')
+    p.add_argument('-u', '--username', type=str, required=True)
+    p.add_argument('-p', '--password', type=str, required=True)
+    p.add_argument('-k', '--api-key', type=str, required=True)
+    p.add_argument('-s', '--site-url', type=str)
+    args = p.parse_args()
+
+    ret = 0
+    config = get_site_config()
+
+    if not args.no_server:
+        print("Starting php server...")
+        php_server = start_server(config['netloc'])
+        if not server_ready(config['site_url']):
+            return 1
+        print(f"php server ready pid={php_server.pid}")
+
+        if not check_error_detect(config):
+            return 1
+        print("Log parsing OK")
+
+    if args.site_url:
+        config['site_url'] = args.site_url
+
+    if not login(config, args.username, args.password):
+        print("Failed to get session cookie. Check username/password.")
+        return 1
+    print("Login succeeded. Cookie jar contents:")
+    for c in jar:
+        print(f"    {c}")
+
+    for test in TESTS:
+        method = test.get('method', 'GET')
+        req_data = test.get('data')
+        path = test['path']
+        expect_status = test.get('expect_status', 200)
+        if isinstance(expect_status, int):
+            expect_status = [expect_status]
+
+        req = Request(
+            config['site_url'] + '/' + path,
+            method=method,
+            headers={'X-API-KEY': args.api_key},
+        )
+        if req_data is not None:
+            print(f"{method} {path} {req_data}")
+        else:
+            print(f"{method} {path}")
+
+        if req_data is not None:
+            req_data = urlencode(req_data).encode()
+        data, status, _, logs = request(req, req_data)
+        if args.verbose:
+            print(data.decode())
+        if status not in expect_status or test_failed(logs):
+            print(f'Status: {status}')
+            print('\n'.join(logs))
+            ret = 1
+            break
+
+    if not args.no_server:
+        php_server.send_signal(signal.SIGINT)
+
+    return ret
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/SETUP/smoketests/posts.json
+++ b/SETUP/smoketests/posts.json
@@ -1,0 +1,9 @@
+[
+    {
+        "topic_id": 417,
+        "poster": "BEGIN",
+        "subject": "The Man Who Married the Moon",
+        "text": "Project discussion",
+        "created": 1234567890
+    }
+]

--- a/SETUP/smoketests/test_tables.sql
+++ b/SETUP/smoketests/test_tables.sql
@@ -1,0 +1,75 @@
+USE dp_db;
+SET FOREIGN_KEY_CHECKS=0;
+
+/* $p = new Project(); $p->foo = bar; $p->save() does not allow new projects
+ * to be created with programmatic control of the project_id.
+ */
+REPLACE INTO `projects` VALUES ('*UTF-8 Practice','Lummis, Charles Fletcher','English','admin','notes','html','projectID5e23a810ef693','','',1704080514,1579564017,1579395673,1708309119,'','P3.proj_avail',NULL,'20200118BEGIN001','',417,1,0,'Folklore','beginner',0,'','',15,6,NULL,'TESTING','admin','admin','',0,'','');
+
+/* `users` rows populated by INSERTs in accounts/activate.php.
+ * Can't do this programatically yet.
+ */
+REPLACE INTO `users` VALUES ('userID1234567890abc', 'Adam Adminston', 'admin', 'a@example.com', 1234567890, 1234567890, 1234567890, 1, '', '', '', 10, 0, 'project_gutenberg', 1, 110, '', 0, 'admin_key');
+REPLACE INTO `users` VALUES ('userID460b20a8a8a71','BKeir','teststeel','teststeel@localhost',1175134376,1175134406,1175134457,1,'','','',10,0,'project_gutenberg',110,119,'en_US',0,NULL);
+
+/* $up = new UserProfile(); $up->foo = bar; $up->save(); does not allow new
+ * profiles to be created with programmatic control of id.
+ */
+REPLACE INTO `user_profiles` VALUES (110,105,'default',4,1,1,0,0,1,5,6,'',50,40,65,1,0,5,6,'',35,20,70,1,0);
+
+/* This can be done with $s = new Settings('admin'); $s->set_true('sitemanager');
+ * But there's not much point until we can do some of the rest with code.
+ */
+REPLACE INTO `usersettings` SET username='admin', setting='PP.access', value='yes';
+REPLACE INTO `usersettings` SET username='admin', setting='PPV.access', value='yes';
+REPLACE INTO `usersettings` SET username='admin', setting='sitemanager', value='yes';
+
+/* `user_teams` rows populated by INSERTs in stats/teams/new_team.php
+ * Can't do this programatically yet.
+ */
+REPLACE INTO `user_teams` VALUES (44,'%','','http://webpage.org','wickedcoder256',1,1532715008,34,'avatar_605f6ae3e7386.png','icon_5f9490f9bf32b.png',509,151);
+
+/* There's no code in dproofers to INSERT into queue_defns yet. */
+REPLACE INTO `queue_defns` VALUES (500,'P3',3155,1,'Esperanto','language like \'Esperanto%\' and not (genre = \'Mathematics\' and difficulty = \'hard\')',4,400,'Have Esperanto available when possible (special case artificial language: \"with\" titles more common)');
+
+/* The table can be created with DPage.inc project_allow_pages, and in theory
+ * can be populated (via intermediate text files) using project_add_page,
+ * and Page_modifyText, but it's clunky and annoying at the moment.
+ */
+DROP TABLE IF EXISTS `projectID5e23a810ef693`;
+CREATE TABLE `projectID5e23a810ef693` (
+  fileid varchar(20) NOT NULL DEFAULT '', UNIQUE (fileid),
+  image varchar(12) NOT NULL DEFAULT '', UNIQUE (image),
+  master_text longtext NOT NULL,
+  round1_time int NOT NULL DEFAULT '0',
+  round1_user varchar(25) NOT NULL DEFAULT '',
+  round1_text longtext NOT NULL,
+  round2_time int NOT NULL DEFAULT '0',
+  round2_user varchar(25) NOT NULL DEFAULT '',
+  round2_text longtext COLLATE utf8mb4_general_ci NOT NULL,
+  round3_time int NOT NULL DEFAULT '0',
+  round3_user varchar(25) NOT NULL DEFAULT '',
+  round3_text longtext NOT NULL,
+  round4_time int NOT NULL DEFAULT '0',
+  round4_user varchar(25) NOT NULL DEFAULT '',
+  round4_text longtext NOT NULL,
+  round5_time int NOT NULL DEFAULT '0',
+  round5_user varchar(25) NOT NULL DEFAULT '',
+  round5_text longtext NOT NULL,
+  state varchar(50) NOT NULL DEFAULT '',
+  b_user varchar(25) NOT NULL DEFAULT '',
+  b_code int NOT NULL DEFAULT '0',
+  orig_page_num varchar(6) NOT NULL DEFAULT '',
+  KEY round1_user (round1_user),
+  KEY round2_user (round2_user),
+  KEY round3_user (round3_user),
+  KEY round4_user (round4_user),
+  KEY round5_user (round5_user),
+  KEY state (state)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
+
+REPLACE INTO `projectID5e23a810ef693` VALUES ('001','001.png','THE BOY IN THE IIOL\'SE OF THE TRUES. (SEE PAGE 115.)',1579633527,'sanspeur43','THE BOY IN THE HOUSE OF THE TRUES. (SEE PAGE 115.)',1579652671,'jjz','\r\nTHE BOY IN THE HOUSE OF THE TRUES. (SEE PAGE 115.)',1708294896,'bfoley','\r\nTHE BOY IN THE HOUSE OF THE TRUES. (SEE PAGE 115.)',0,'','',0,'','','P3.page_saved','',0,'');
+REPLACE INTO `projectID5e23a810ef693` VALUES ('002','002.png','THE MAN WHO MARRIED\r\nTHE MOON\r\n\r\nAND OTHER PUEBLO INDIAN FOLK -- STORIES\r\n\r\nBY\r\n\r\nCHARLES E. LUMMIS\r\n\r\n(AUYHOR \'OF SOME STRANGE CORNERS OF OUR COUNTRY\"\r\n\"A IVEW MEX/CO DAVID,\" ETC.\r\n\r\n\r\n\r\nNEW YORK\r\nTHE CENIURY CO.\r\n1894',1579633637,'sanspeur43','THE MAN WHO MARRIED\r\nTHE MOON\r\n\r\nAND OTHER PUEBLO INDIAN FOLK-STORIES\r\n\r\nBY\r\n\r\nCHARLES E. LUMMIS\r\n\r\n(AUTHOR \'OF SOME STRANGE CORNERS OF OUR COUNTRY\"\r\n\"A NEW MEXICO DAVID,\" ETC.\r\n\r\n\r\n\r\nNEW YORK\r\nTHE CENTURY CO.\r\n1894',1579651078,'jjz','\r\nTHE MAN WHO MARRIED\r\nTHE MOON\r\n\r\nAND OTHER PUEBLO INDIAN FOLK-STORIES\r\n\r\nBY\r\n\r\nCHARLES E. LUMMIS\r\n\r\n(AUTHOR OF \"SOME STRANGE CORNERS OF OUR COUNTRY[**,]\"\r\n\"A NEW MEXICO DAVID,\" ETC.\r\n\r\nNEW YORK\r\nTHE CENTURY CO.\r\n1894',1708308780,'srjfoo','\r\nTHE MAN WHO MARRIED\r\nTHE MOON\r\n\r\nAND OTHER PUEBLO INDIAN FOLK-STORIES\r\n\r\nBY\r\n\r\nCHARLES E. LUMMIS\r\n\r\n(AUTHOR OF \"SOME STRANGE CORNERS OF OUR COUNTRY[**,]\"\r\n\"A NEW MEXICO DAVID,\" ETC.\r\n\r\nNEW YORK\r\n\r\nTHE CENTURY CO.\r\n\r\n1894',0,'','',0,'','','P3.page_saved','',0,'');
+REPLACE INTO `projectID5e23a810ef693` VALUES ('003','003.png','Copyright, 1891, 1892, 1894,\r\n\r\nBy THE CENTURY C0.\r\n\r\n\r\n\r\nTHE DEVINNE PREss;',1579633720,'sanspeur43','Copyright, 1891, 1892, 1894,\r\nBy THE CENTURY Co.\r\n\r\n\r\n\r\nTHE DE VINNE PREss.',1579651130,'jjz','\r\nCopyright, 1891, 1892, 1894,\r\nBy THE CENTURY Co.\r\n\r\nTHE DE VINNE PREss.',1708308890,'srjfoo','\r\nCopyright, 1891, 1892, 1894,\r\nBy THE CENTURY Co.\r\n\r\nThe De Vinne Press.',0,'','',0,'','','P3.page_saved','',0,'');
+REPLACE INTO `projectID5e23a810ef693` VALUES ('004','004.png','To\r\nTHE FAIRY TALE THAT CAME TRUE IN\r\nTHE HOME OF THE TEE-WAHN\r\nMY WIFE AND CHILD',1579633808,'sanspeur43','To\r\nTHE FAIRY TALE THAT CAME TRUE IN\r\nTHE HOME OF THE TEE-WAHN\r\nMY WIFE AND CHILD',1579651187,'jjz','\r\nTo\r\nTHE FAIRY TALE THAT CAME TRUE IN\r\nTHE HOME OF THE TEE-WAHN\r\nMY WIFE AND CHILD',1708308955,'srjfoo','\r\nTo\r\nTHE FAIRY TALE THAT CAME TRUE IN\r\nTHE HOME OF THE TEE-WAHN\r\nMY WIFE AND CHILD',0,'','',0,'','','P3.page_saved','',0,'');
+REPLACE INTO `projectID5e23a810ef693` VALUES ('005','005.png','',1579633830,'sanspeur43','[Blank Page]',1579651201,'jjz','[Blank Page]',1708308967,'srjfoo','[Blank Page]',0,'','',0,'','','P3.page_saved','',0,'');

--- a/SETUP/smoketests/users.json
+++ b/SETUP/smoketests/users.json
@@ -1,0 +1,4 @@
+{
+    "admin": {"id": 1, "password": "$argon2id$v=19$m=65536,t=4,p=1$bElGVnhFNXpOZXZONUdaOA$gazVDNwh/og8aFAvtKCizQkFw3k2Q6l5E2WV26UxAaA", "email": "a@example.com"},
+    "teststeel": {"id": 110, "password": "", "email": ""}
+}

--- a/SETUP/smoketests/warning.php
+++ b/SETUP/smoketests/warning.php
@@ -1,0 +1,3 @@
+<?php
+// To test that warnings are detected correctly.
+trigger_error("I fear so, sir.", E_USER_WARNING);

--- a/SETUP/tests/ci_configuration.sh
+++ b/SETUP/tests/ci_configuration.sh
@@ -9,15 +9,14 @@ _DB_PASSWORD=dp_password
 _DB_NAME=dp_db
 _ARCHIVE_DB_NAME=dp_archive
 
-_CODE_DIR=$HOME
-_CODE_URL='http://localhost'
-_DYN_DIR=$HOME
-_DYN_URL='http://localhost'
+_CODE_DIR=$PWD
+_CODE_URL='http://127.0.0.1:12345'
+_DYN_DIR=$PWD
+_DYN_URL='http://127.0.0.1:12345'
 
-_FORUM_TYPE=phpbb3
-_PHPBB_TABLE_PREFIX=phpbb3.phpbb
-_PHPBB_DIR=$HOME/phpBB3
-_PHPBB_URL='http://localhost/phpBB3'
+_FORUM_TYPE=json
+_JSON_USERS=$PWD/SETUP/smoketests/users.json
+_JSON_POSTS=$PWD/SETUP/smoketests/posts.json
 
 _DEFAULT_CHAR_SUITES='["basic-latin"]'
 
@@ -36,11 +35,11 @@ _UPLOADS_PASSWORD=PICK_A_PASSWORD
 _ANTIVIRUS_EXECUTABLE=
 
 _PROJECTS_DIR=$HOME/projects
-_PROJECTS_URL='http://localhost/projects'
+_PROJECTS_URL='http://127.0.0.1:12345/projects'
 
 _ARCHIVE_PROJECTS_DIR=$HOME/projects.archive
 
-_API_ENABLED=false
+_API_ENABLED=true
 _API_RATE_LIMIT=false
 _API_RATE_LIMIT_REQUESTS_PER_WINDOW=3600
 _API_RATE_LIMIT_SECONDS_IN_WINDOW=3600

--- a/api/index.php
+++ b/api/index.php
@@ -178,7 +178,13 @@ function api_send_pagination_header($query_params, $total_rows, $per_page, $page
 
     // If the URI doesn't include the url param (because the Apache config
     // hasn't been updated) we need to include it here to make valid links.
-    $link_base = $_SERVER["SCRIPT_URI"] . "?";
+
+    // NB We don't use $_SERVER['SCRIPT_URI'] because not all servers set
+    // it. Most notably, the `php -S` CLI server we use for testing.
+    // See https://www.php.net/manual/en/reserved.variables.server.php
+    $proto = !empty(array_get($_SERVER, 'HTTPS', '')) ? 'https://' : 'http://';
+    $script_uri = $proto . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+    $link_base = $script_uri . "?";
     if (stripos($link_base, $_GET["url"]) === false) {
         $link_base .= "url=" . $_GET["url"] . "&";
     }

--- a/stats/pages_in_states.php
+++ b/stats/pages_in_states.php
@@ -31,7 +31,7 @@ $progordone_n_pages = [];
 // ---------------
 
 $stage_labels[] = 'New';
-$unavail_n_pages[] = $n_pages_[PROJ_NEW];
+$unavail_n_pages[] = $n_pages_[PROJ_NEW] ?? 0;
 $waiting_n_pages[] = 0;
 $available_n_pages[] = 0;
 $progordone_n_pages[] = 0;

--- a/stats/round_backlog.php
+++ b/stats/round_backlog.php
@@ -34,7 +34,7 @@ $stats = query_graph_cache("_get_round_backlog_data", [], 60 * 60 * 24);
 $stats_total = array_sum($stats);
 
 // calculate the goal percent as 100 / number_of_phases
-$goal_percent = ceil(100 / count($stats));
+$goal_percent = ceil(100 / min(1, count($stats)));
 
 // colors
 $barColors = [];

--- a/stats/round_backlog_days.php
+++ b/stats/round_backlog_days.php
@@ -55,7 +55,7 @@ $stats = query_graph_cache("_get_round_backlog_days_data", [], 60 * 60 * 24);
 $stats_total = array_sum($stats);
 
 // calculate the goal percent as 100 / number_of_phases
-$goal_percent = ceil(100 / count($stats));
+$goal_percent = ceil(100 / min(1, count($stats)));
 
 // colors
 $barColors = [];


### PR DESCRIPTION
A smoketest that sets up `site_vars.php` and a minimal set of database tables so that PGDP can be served from the `php -S` command line web server.

Then it loads many pages (soon to be every page) with representative parameters and checks if there are any PHP errors, warnings, or notices in the server logs.

Useful for, e.g., catching variables that happen not to be defined at runtime, and other issues that PHPStan and the PHP linter can't find.

This is deliberately not an exhaustive test of all possible inputs -- smoke tests are meant to be fast and to weed out obvious brokenness.  That said, we probably should check each of, e.g. `task.php`'s `action=` parameters so we get reasonable code coverage.

This is incomplete, but is good enough to be useful as is.

Next steps:
1. Add all the remaining pages, and any necessary database tables needed.