### PR TITLE
Fix translation-related typos in master

### DIFF
--- a/credits.php
+++ b/credits.php
@@ -12,7 +12,7 @@ echo "<p>" . sprintf(_("This site is powered by the <a href='%s'>dproofreaders</
 
 echo "<h2>" . _("Developers") . "</h2>";
 
-echo "<p>" . sprintf(_("This software brought to you by many volunteer developers across the world over many years. Recent developer contributions after the move to git can be seen on the project's <a href='%s'>Github Contributors page</a>."), "https://github.com/DistributedProofreaders/dproofreaders/graphs/contributors"). "</p>";
+echo "<p>" . sprintf(_("This software is brought to you by many volunteer developers across the world over many years. Recent developer contributions after the move to git can be seen on the project's <a href='%s'>Github Contributors page</a>."), "https://github.com/DistributedProofreaders/dproofreaders/graphs/contributors"). "</p>";
 
 echo "<h2>" . _("Bundled Software"). "</h2>";
 

--- a/faq/pophelp/prefs/prefs_pophelp.inc
+++ b/faq/pophelp/prefs/prefs_pophelp.inc
@@ -181,7 +181,7 @@ _("<p>This setting determines which proofreading interface you prefer.</p>
 browser requirements.</p>
 
 <p>The Enhanced Interface has additional tools and features which are not present in the 
-Standard Interface and may require more a recent browser for complete functionality.</p>
+Standard Interface and may require a more recent browser for complete functionality.</p>
 
 <p>Both interfaces require a frames and JavaScript enabled browser as a minimum.</p>"),
         ],
@@ -353,7 +353,7 @@ _("<p>This setting specifies if colors used to indicate special projects should 
             'title' => _("Profile Name"),
             'content' =>
 _("<p>This field displays the name of the current profile, and can be edited to create a new profile.</p>
-<p>Entering a new name and and clicking 'Save as New Profile' will save a new profile with that name.</p>
+<p>Entering a new name and clicking 'Save as New Profile' will save a new profile with that name.</p>
 <p>A maximum of 10 profiles can be saved.</p>"),
         ],
 

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -264,11 +264,11 @@ function show_text_update_form($projectid, $image, $prev_text, $text_column, $mo
     echo "<div id='proofdiv'>";
     if ($modify == 'current_text') {
         // TRANSLATORS: %s is the image name.
-        echo sprintf(_("The textarea below contains the text from the previous round  (%1\$s) for %2\$s."), $round_id, $image) . "<br>";
+        echo sprintf(_("The text area below contains the text from the previous round  (%1\$s) for %2\$s."), $round_id, $image) . "<br>";
         echo _("You may use it as-is, or insert other replacement text for this page:") . "<br>";
     } else {
         // TRANSLATORS: %1$s is the round ID; %2$ss is the image name.
-        echo sprintf(_("The textarea below contains the text from round <b>%1\$s</b> for %2\$s."), $round_id, $image) . "<br>";
+        echo sprintf(_("The text area below contains the text from round <b>%1\$s</b> for %2\$s."), $round_id, $image) . "<br>";
     }
 
     echo "<form action='handle_bad_page.php' method='post'>";

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -159,7 +159,7 @@ if (!$imso_code) {
 
     if ($imso && can_user_see_image_source($imso)) {
         $base_link = "<a href='show_image_sources.php?name=%s&amp;which=%s'>%s</a>";
-        $all_link = sprintf($base_link, $imso_code, "ALL", pgettext("all sources", "All"));
+        $all_link = sprintf($base_link, $imso_code, "ALL", pgettext("all ebooks", "All"));
         $inprog_link = sprintf($base_link, $imso_code, "INPROG", _("In Progress"));
         $done_link = sprintf($base_link, $imso_code, "DONE", _("Completed"));
 

--- a/tools/proofers/preview.inc
+++ b/tools/proofers/preview.inc
@@ -28,7 +28,7 @@ function get_preview_messages()
         "scNoCap" => _("Small caps must contain at least one upper case character"),
         "charBeforeStart" => _("Character or punctuation before inline start tag"),
         "charAfterEnd" => _("Character after inline end tag"),
-        "puncBEnd" => _(",; or : before end tag"),
+        "puncBEnd" => _(", ; or : before end tag"),
         "noCloseBrack" => _("No matching closing bracket"),
         "footnoteId" => _("Footnote identifier should be a letter or number"),
         "starAnchor" => _("Footnote anchor should be an upper-case letter"),

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -438,7 +438,7 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     echo "<div id='wc_header' $header_style>";
     if (count($messages) != 0) {
         // warnings or errors were raised, print them out
-        echo "<p class='warning'>" . _("The following warnings/errors were raised:") . "<br>\n";
+        echo "<p class='warning'>" . _("The following warnings/errors were raised") . ":<br>\n";
         foreach ($messages as $message) {
             echo html_safe($message) . "<br>\n";
         }
@@ -455,7 +455,7 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     $used_project_languages = array_intersect($languages, $project_languages);
     if (count($used_project_languages) > 0) {
         echo "<div class='dict-section'>";
-        echo "<div class='dict-section-title'>" . _("Project-based dictionaries:") . "</div>$spacer";
+        echo "<div class='dict-section-title'>" . _("Project-based dictionaries") . ":</div>$spacer";
         output_wordcheck_language_buttons($used_project_languages);
         echo "</div>";
     }
@@ -463,7 +463,7 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     $aux_languages = array_diff($languages, $project_languages);
     if (count($aux_languages) > 0) {
         echo "<div class='dict-section'>";
-        echo "<div class='dict-section-title'>" . _("Additional dictionaries: ") . "</div>$spacer";
+        echo "<div class='dict-section-title'>" . _("Additional dictionaries") . ":</div>$spacer";
         output_wordcheck_language_buttons($aux_languages);
         echo "</div>";
     }
@@ -472,7 +472,7 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     if (count($languages) < 5) {
         // output the code allowing the user to select another language
         echo "<select name='aux_language'>";
-        echo "<option value=''>" . _("Select additional language...") . "</option>\n";
+        echo "<option value=''>" . _("Select additional language") . "...</option>\n";
 
         // get a list of languages with dictionaries installed on the system
         $dict_list = get_languages_with_dictionaries();
@@ -505,7 +505,7 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     // text highlight legend
     if ($highlights) {
         echo "<p>";
-        echo _("The following highlights have been used:") . $spacer;
+        echo _("The following highlights have been used") . ":" . $spacer;
         foreach ($highlights as $hl_class => $message) {
             echo "<span class='$hl_class'>$message</span>" . $spacer;
         }


### PR DESCRIPTION
There should be no functional changes. Some of these are errors in the English strings that one of our translators found while updating translated strings, others are tweaking punctuation and spacing that I found while poking through the PO file to see if there were other things I could identify easily.

Sandbox at [https://www.pgdp.org/~srjfoo/c.branch/string-cleanup](https://www.pgdp.org/~srjfoo/c.branch/string-cleanup).