### PR TITLE
Patch erusev/parsedown to avoid a PHP Notice on malformed input

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "erusev/parsedown": "1.8.0-beta-7",
         "erusev/parsedown-extra": "0.8.0",
         "voku/portable-utf8": "^6.0",
-        "phpmailer/phpmailer": "^6.8"
+        "phpmailer/phpmailer": "^6.8",
+        "cweagans/composer-patches": "^1.7.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -29,5 +30,18 @@
         "symfony/polyfill-intl-grapheme": "*",
         "symfony/polyfill-intl-normalizer": "*",
         "symfony/polyfill-mbstring": "*"
+    },
+    "extra": {
+        "composer-exit-on-patch-failure": true,
+        "patches": {
+            "erusev/parsedown": {
+                "Parser PHP Notice on invalid HTML attribute": "patches/composer/parsedown-1.diff"
+            }
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "cweagans/composer-patches": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,56 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2beb8627fe22d90bfc893dca894525ce",
+    "content-hash": "061e935521760746c8b927cd7fd3c408",
     "packages": [
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
+        },
         {
             "name": "erusev/parsedown",
             "version": "1.8.0-beta-7",

--- a/patches/composer/parsedown-1.diff
+++ b/patches/composer/parsedown-1.diff
@@ -1,0 +1,11 @@
+--- a/Parsedown.php	2024-03-07 03:41:04.428494261 +0000
++++ b/Parsedown.php	2024-03-07 03:42:55.857437607 +0000
+@@ -1490,7 +1490,7 @@
+ 
+     protected function inlineSpecialCharacter($Excerpt)
+     {
+-        if ($Excerpt['text'][1] !== ' ' and strpos($Excerpt['text'], ';') !== false
++        if (@$Excerpt['text'][1] !== ' ' and strpos($Excerpt['text'], ';') !== false
+             and preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches)
+         ) {
+             return array(


### PR DESCRIPTION
The notice is for indexing beyond the end of a string, and PHP's result (an empty string) has logically the right effect in the parser code, it just outputs an annoying notice which is visible on the web page.

This is far from exhaustive. It would need to be done in a lot of other places too, but serves as an interesting example of how to patch vendored dependencies if we need to. The `cwegans/composer-patches` composer plugin adds only 164kB to `vendor/` so is pretty lightweight too.

Sandbox here: https://www.pgdp.org/~bfoley/c.branch/parsedown-patch/tasks.php?action=show&task_id=2296

