### PR TITLE
Centralize Parsedown code, and suppress Notices generated by the parser

### DIFF
--- a/pinc/authors.inc
+++ b/pinc/authors.inc
@@ -17,9 +17,7 @@ function get_biography($id)
         return sprintf(_("An error has occurred somewhere. The project manager of this project has requested that a biography be automatically inserted here, but no biography is known by the id provided: <b>%s</b>.<br><br>You may wish to contact the project manager so that the problem can be resolved."), $id);
     } else {
         if ($row["bio_format"] === 'markdown') {
-            $Parsedown = new ParsedownExtra();
-            $Parsedown->setSafeMode(true);
-            $bio_text = $Parsedown->text($row["bio"]);
+            $bio_text = render_markdown_as_html($row["bio"]);
         } else {
             $bio_text = sanitize_html($row["bio"], 'td');
         }

--- a/pinc/comment_inclusions.inc
+++ b/pinc/comment_inclusions.inc
@@ -11,7 +11,7 @@ include_once($relPath.'authors.inc');
  * This markup should always be replaced with the proper biography before the
  * project comments are displayed, zipped up for the post-processor, etc.
  *
- * @param object $project Project object
+ * @param Project $project Project object
  *
  * @return string
  */
@@ -22,9 +22,7 @@ function parse_project_comments($project)
     if ($project->comment_format == 'html') {
         $comments = sanitize_html($project->comments, 'td');
     } else {
-        $Parsedown = new ParsedownExtra();
-        $Parsedown->setSafeMode(true);
-        $comments = $Parsedown->text($project->comments);
+        $comments = render_markdown_as_html($project->comments);
     }
 
     // insert biographies instead of [biography=123]-markup

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -651,6 +651,27 @@ function sanitize_html($html, $parent_tag = 'div')
     return $purifier->purify($html);
 }
 
+/* Parse markdown text string using Parsedown library and output HTML
+ * @param $message Markdown text
+ * @return string HTML content
+ */
+function render_markdown_as_html(string $message): string
+{
+    $parser = new ParsedownExtra();
+    $parser->setSafeMode(true);
+    // NB Parsedown's parser code routinely uses $str[index] on
+    // substrings of the user provided input without checking if
+    // the string is long enough first, which generates PHP Notices.
+    // The result is an empty string which is what the parser code
+    // tends to mean in the places I've checked, so it's safe, but
+    // we get PHP Notices in the logs as a side effect.
+    // There's an open issue for this since 2020, so I suspect it's
+    // not going to be fixed anytime soon, so for now just suppress
+    // the notice.
+    // See https://github.com/erusev/parsedown/issues/784
+    return @$parser->text($message);
+}
+
 // -----------------------------------------------------------------------------
 
 /**

--- a/pinc/send_mail.inc
+++ b/pinc/send_mail.inc
@@ -49,9 +49,7 @@ function send_mail($to, $subject, $message, $from = null, $reply_to = null)
 
     $text_message = $message . $text_footer;
 
-    $Parsedown = new ParsedownExtra();
-    $Parsedown->setSafeMode(true);
-    $html_message = $Parsedown->text($message) . $html_footer;
+    $html_message = render_markdown_as_html($message) . $html_footer;
 
     if ($testing) {
         echo "\n<hr style='border-style:double;'>\n";

--- a/tasks.php
+++ b/tasks.php
@@ -1476,8 +1476,6 @@ function TaskComments($tid, $action)
     $result = DPDatabase::query($sql);
 
     echo "<h2>" . _("Comments") . "</h2>";
-    $Parsedown = new ParsedownExtra();
-    $Parsedown->setSafeMode(true);
     while ($row = mysqli_fetch_assoc($result)) {
         $comment_id = create_anchor_for_comment($row['u_id'], $row['comment_date']);
 
@@ -1505,7 +1503,7 @@ function TaskComments($tid, $action)
             echo "<input type='hidden' name='action' value='save_edit_comment'>";
             echo "<input type='submit' value='" . attr_safe(_("Save Comment")) . "'>";
         } else {
-            echo $Parsedown->text($row['comment']);
+            echo render_markdown_as_html($row['comment']);
         }
         echo "</div>";
         echo "</div>";
@@ -1857,9 +1855,7 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
             break;
 
         case 'task_details':
-            $Parsedown = new Parsedown();
-            $Parsedown->setSafeMode(true);
-            return $Parsedown->text($raw_value);
+            return render_markdown_as_html($raw_value);
 
             // The raw value is an integer denoting state of progress:
         case 'percent_complete':


### PR DESCRIPTION
These were visible in comments on the task center such as "&type c:\windows\win.ini&"

They rendered OK, but also emitted PHP Notice messages into the web page.

Example in sandbox at https://www.pgdp.org/~bfoley/c.branch/quell-parsedown-notices/tasks.php?action=show&task_id=2296