### PR TITLE
Set initial project_detail selection to 2

### DIFF
--- a/userprefs.php
+++ b/userprefs.php
@@ -396,7 +396,7 @@ function echo_general_tab($user)
         _('Default Project Detail Level'),
         'project_detail',
         'project_detail',
-        $userSettings->get_value('project_detail', 1),
+        $userSettings->get_value('project_detail', 2),
         'dropdown',
         $page_detail_options
     );


### PR DESCRIPTION
For the default form selection in preferences, correctly set the `project_detail` value to 2. It works as-is because 1 is not a valid option so the select shows the first option which is 2, but we should reflect what we actually want. Because of this the behavior of the sandbox won't look any different than what's on TEST, but here it is anyway: https://www.pgdp.org/~cpeel/c.branch/fix-project-detail-form-default/