### PR TITLE
Colour block quotes correctly when there is a nested block quote.

### DIFF
--- a/SETUP/tests/jsTests/formatPreviewTests.js
+++ b/SETUP/tests/jsTests/formatPreviewTests.js
@@ -702,6 +702,8 @@ bq
 /#
 bqbq
 #/
+
+bq
 #/`;
         let preview = makePreview(text, false, true, defaultStyles, getMessage);
         assert.strictEqual(preview.ok, true);
@@ -710,6 +712,7 @@ bqbq
         assert.strictEqual(preview.txtout,
             `<div style='margin-left: 1em;' class='para blockquote_color'>bq
 </div><div style='margin-left: 2em;' class='para blockquote_color'>bqbq
+</div><div style='margin-left: 1em;' class='para blockquote_color'>bq
 </div>`);
     });
 });

--- a/tools/proofers/preview.js
+++ b/tools/proofers/preview.js
@@ -1057,7 +1057,7 @@ const makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
         let inBlock = false;
         let indent = 0;
         let blockType = CONT;
-        let blockQuote = false;
+        let blockQuote = 0;
         const noWrapColor = styler.color ? ' nowrap_color' : '';
 
         function terminate() {
@@ -1098,10 +1098,10 @@ const makePreview = function (txt, viewMode, wrapMode, styler, getMessage) {
                 }
                 blanks = 0;
                 if ("/#" === line) {
-                    blockQuote = true;
+                    blockQuote += 1;
                     indent += 1;
                 } else if ("#/" === line) {
-                    blockQuote = false;
+                    blockQuote -= 1;
                     indent -= 1;
                 } else if("/*" === line) {
                     // no wrap


### PR DESCRIPTION
This addresses [task 2077](https://www.pgdp.net/c/tasks.php?action=show&task_id=2077).

Sandbox at: https://www.pgdp.org/~rp31/c.branch/block_colour
