### PR TITLE
Check project table exists before fetching pages

### DIFF
--- a/project.php
+++ b/project.php
@@ -577,10 +577,9 @@ function do_project_info_table()
     // For now, we say that guests can't see page details or page browser
     if ($user_is_logged_in) {
 
-        $pages = $project->get_page_names_from_db();
         if ($detail_level >= 4) {
             // We'll call do_page_table later, so we don't need the "Page Detail" link.
-        } elseif ($pages) {
+        } else {
             $detail = "";
             if ($project->check_pages_table_exists($detail)) {
                 $url = "$code_url/tools/project_manager/page_detail.php?project=$projectid&amp;show_image_size=0";
@@ -597,9 +596,11 @@ function do_project_info_table()
             echo_row_a(_("Page Detail"), $detail);
         }
 
-        if ($detail_level >= 3 && $project->pages_table_exists && $pages) {
+        if ($detail_level >= 3 && $project->pages_table_exists) {
+            $pages = $project->get_page_names_from_db();
+            $imageparam = $pages ? ("&amp;imagefile=" . $pages[0]) : "";
             // get the first page image
-            $url = "$code_url/tools/page_browser.php?project=$projectid&amp;imagefile=" . $pages[0];
+            $url = "$code_url/tools/page_browser.php?project=$projectid$imageparam";
             $images_url = "$url&amp;mode=image";
             $text_url = "$url&amp;mode=text";
             $both_url = "$url&amp;mode=imageText";


### PR DESCRIPTION
We need to confirm the project table exists before fetching a list of pages.

Interesting edgecases are new projects with a page table but no pages and projects where the page table has been deleted (eg: deleted projects).

Sandbox: https://www.pgdp.org/~cpeel/c.branch/check-pagetable/