### PR TITLE
api/v1/projects/:id: Allow endpoint to return selected fields

### DIFF
--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -393,6 +393,13 @@ paths:
         required: true
         schema:
           type: string
+      - name: field
+        description: Field to return, if not set all fields are returned.
+          To request multiple fields, append with [] and pass one per desired
+          field (e.g. field[]=projectid&field[]=author).
+        in: query
+        schema:
+          type: string
       responses:
         200:
           description: project response

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -253,7 +253,9 @@ function create_or_update_project($project)
 function api_v1_project($method, $data, $query_params)
 {
     if ($method == "GET") {
-        return render_project_json($data[":projectid"]);
+        // restrict to list of desired fields, if set
+        $return_fields = array_get_as_array($query_params, "field", null);
+        return render_project_json($data[":projectid"], $return_fields);
     } elseif ($method == "PUT") {
         $project = $data[":projectid"];
         return render_project_json(create_or_update_project($project));


### PR DESCRIPTION
Clients can already access a subset of fields when listing projects with `api/v1/projects` so it makes sense to allow this for individual projects too. And in particular clients may want to avoid the `comments` field because it can be very large.