### PR TITLE
Configure gettext before creating site structure

### DIFF
--- a/SETUP/check_includes.php
+++ b/SETUP/check_includes.php
@@ -47,7 +47,7 @@ $site_structure_includes = [
 
 // List of files that are ok to contain site structure includes
 $ok_includes_site_structure = [
-    "pinc/bootstrap.inc",
+    "pinc/base.inc",
     "pinc/Quiz.inc",
     "pinc/Round.inc",
     "pinc/Stage.inc",
@@ -56,6 +56,7 @@ $ok_includes_site_structure = [
     "pinc/quizzes.inc",
     "pinc/stages.inc",
     "pinc/site_structure.inc",
+    "api/index.php",
 ];
 
 

--- a/api/index.php
+++ b/api/index.php
@@ -1,6 +1,7 @@
 <?php
 $relPath = "../pinc/";
 include_once($relPath.'bootstrap.inc');
+include_once($relPath.'site_structure.inc');
 include_once($relPath.'User.inc');
 include_once('ApiRouter.inc');
 include_once('exceptions.inc');

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -32,6 +32,11 @@ if (DPDatabase::get_connection()) {
 
 configure_gettext($charset, get_desired_language(), $dyn_locales_dir, $system_locales_dir);
 
+// Load the site structure. We do this here and not in bootstrap.inc because
+// it uses _() on some strings but we need to configure_gettext() first
+// or those won't be in the user's language.
+include_once($relPath.'site_structure.inc');
+
 if ($maintenance && !@$maintenance_override) {
     /*
     Including user_is.inc causes a perf impact because it includes

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -63,9 +63,6 @@ include_once($relPath.'dpsession.inc');
 // the pages use in some way.
 include_once($relPath.'misc.inc');
 
-// Load the site structure
-include_once($relPath.'site_structure.inc');
-
 //----------------------------------------------------------------------------
 
 // Autoloading functions for DP classes in pinc/


### PR DESCRIPTION
When rounds/stages/etc are defined we use `_()` to translate strings. If we don't configure gettext first those strings will non-localized. Move site_structure.inc from bootstrap.inc to the two entrypoints: `base.inc` and `api/index.php`.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-site-structure-translation/