### PR TITLE
Fix MediaWiki extensions

### DIFF
--- a/SETUP/MediaWiki_extensions/dpExtensions.php
+++ b/SETUP/MediaWiki_extensions/dpExtensions.php
@@ -97,9 +97,7 @@ function showProjectInfo($input, $argv, $parser)
 {
     global $relPath, $code_url;
     include($relPath.'site_vars.php');
-    include_once($relPath.'misc.inc'); // needed for project_states.inc
     include_once($relPath.'DPDatabase.inc');
-    include_once($relPath.'project_states.inc');
 
     DPDatabase::connect();
 
@@ -123,7 +121,6 @@ function showProjectInfo($input, $argv, $parser)
     }
 
     $project['raw_state'] = $project['state'];
-    $project['state'] = project_states_text($project['state']);
 
     $project['title'] = $project['nameofwork'];
     $project['author'] = $project['authorsname'];

--- a/SETUP/MediaWiki_extensions/hospitalExtensions.php
+++ b/SETUP/MediaWiki_extensions/hospitalExtensions.php
@@ -41,9 +41,7 @@ function listHospitalProjects($input, $argv)
 {
     global $relPath, $code_url;
     include_once($relPath.'site_vars.php');
-    include_once($relPath.'misc.inc'); // needed for project_states.inc
     include_once($relPath.'DPDatabase.inc');
-    include_once($relPath.'project_states.inc');
 
     DPDatabase::connect();
 
@@ -60,7 +58,7 @@ function listHospitalProjects($input, $argv)
         // Get the preformatted remarks from PCs
         $matches = [];
         $problems = preg_match('/<pre>.*?<\/pre>/s', $project->comments, $matches);
-        $pstate = project_states_text($project->state);
+        $pstate = $project->state;
         $puri = "$code_url/project.php?id=$project->projectid";
         $plink = "<a href='$puri'>$project->nameofwork</a>";
 


### PR DESCRIPTION
Because of recent include restructuring we can't include more than site_vars.php and misc.inc without having conflicts with MW objects. The solution to this is going to be moving these to an API, but this unblocks the upcoming release until that is in place.

These are the changes that are currently running on PROD.