### PR TITLE
Replace hard-coded faq/*-referenced URLs

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -504,7 +504,7 @@ function activity_descriptions()
         echo _("Providing Content");
         echo "</dt>";
         echo "<dd>";
-        echo sprintf(_("Want to help out the site by providing material for us to proofread? <a href='%s'>Find out how!</a>"), "$code_url/faq/cp.php");
+        echo sprintf(_("Want to help out the site by providing material for us to proofread? <a href='%s'>Find out how!</a>"), get_faq_url("cp.php"));
         echo "</dd>\n";
     }
 

--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -402,6 +402,8 @@ if ($i_type == 0) {
     echo "</dl>\n";
     echo "</form>\n";
 } else {
+    $faq_url = get_faq_url("ProoferFAQ.php");
+    $guidelines_url = get_faq_url("proofreading_guidelines.php");
     ?>
 
 <DIV ALIGN="CENTER"><TABLE
@@ -414,9 +416,9 @@ COLSPAN="2">
 <p><A HREF="#proofing_toolbox"><B>Help for Proofreading Toolbox</B></A></p>
 <p><B>Additional Help Files</B>
 <BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <A HREF="ProoferFAQ.php">Proofreader's Frequently Asked Questions</A>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <A HREF="<?php echo $faq_url; ?>">Proofreader's Frequently Asked Questions</A>
 <BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <A HREF="proofreading_guidelines.php">Proofreading Guidelines</A></p>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <A HREF="<?php echo $guidelines_url; ?>">Proofreading Guidelines</A></p>
 </TD></TR>
 <TR><TD ALIGN="CENTER" COLSPAN="2">
 <p class='large'><A NAME="ibtns"> </A>Button and Selection Menu</p></TD></TR>

--- a/pinc/quizzes.inc
+++ b/pinc/quizzes.inc
@@ -2,6 +2,7 @@
 // This file creates quiz objects for each quiz with data in CVS
 include_once($relPath."Quiz.inc");
 include_once($relPath."forum_interface.inc");
+include_once($relPath."faq.inc");
 
 define('SIX_MONTHS_IN_SECONDS', 15778463);
 
@@ -25,7 +26,7 @@ new QuizLevel(
     "P_BASIC",
     _("Basic Proofreading Quizzes and Tutorials"),
     "proof",
-    "<p>" . _("This section is designed as an overview of the most important and frequently used <a href='../faq/proofreading_guidelines.php'>proofreading guidelines</a>. The pages cover items that you are likely to see when proofreading BEGINNERS ONLY and EASY projects.") .
+    "<p>" . sprintf(_("This section is designed as an overview of the most important and frequently used <a href='%s'>proofreading guidelines</a>. The pages cover items that you are likely to see when proofreading BEGINNERS ONLY and EASY projects."), get_faq_url("proofreading_guidelines.php")) .
         "</p>\n<p>" .
         _("These tutorials and quizzes only address the standard guidelines. Some projects have special instructions, particularly for books in non-English languages or with unusual features, so be sure to read the Project Comments carefully on each project you proofread.") .
         "</p>\n<p>" .
@@ -75,7 +76,7 @@ new QuizLevel(
     "P_MOD",
     _("Moderate Proofreading Quizzes and Tutorials"),
     "proof",
-    "<p>" . _("This section covers other aspects of the <a href='../faq/proofreading_guidelines.php'>proofreading guidelines</a>, beyond what is in the Basic section. The pages include items that you are likely to see when proofreading Average projects.") . "</p>",
+    "<p>" . sprintf(_("This section covers other aspects of the <a href='%s'>proofreading guidelines</a>, beyond what is in the Basic section. The pages include items that you are likely to see when proofreading Average projects."), get_faq_url("proofreading_guidelines.php")) . "</p>",
     [
 
         new Quiz(
@@ -123,7 +124,7 @@ new QuizLevel(
     "P_SPECIAL",
     _("Specialized Proofreading Quizzes and Tutorials"),
     "proof",
-    "<p>" . _("This section covers topics that are not addressed in the <a href='../faq/proofreading_guidelines.php'>proofreading guidelines</a>. The pages include items that you are likely to see when proofreading HARD (and some Average) projects.") .
+    "<p>" . sprintf(_("This section covers topics that are not addressed in the <a href='%s'>proofreading guidelines</a>. The pages include items that you are likely to see when proofreading HARD (and some Average) projects."), get_faq_url("proofreading_guidelines.php")) .
         "</p>\n<p>" .
         _("If you are not yet familiar with a topic, you can learn about it by using the tutorial mode or following the \"Information\" link for that topic.") .
         "</p>",
@@ -190,7 +191,7 @@ new QuizLevel(
     "F_ONLY",
     _("Formatting Quizzes"),
     "format",
-    "<p>" . _("The formatting quizzes cover topics addressed in the <a href='../faq/formatting_guidelines.php'>formatting guidelines</a>.") . "</p>",
+    "<p>" . sprintf(_("The formatting quizzes cover topics addressed in the <a href='%s'>formatting guidelines</a>."), get_faq_url("formatting_guidelines.php")) . "</p>",
     [
 
         new Quiz(

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -8,6 +8,7 @@ include_once($relPath.'Round.inc');
 include_once($relPath.'Pool.inc');
 include_once($relPath.'ProjectState.inc');
 include_once($relPath.'forum_interface.inc'); // get_url_to_view_forum()
+include_once($relPath.'faq.inc');
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -273,7 +274,7 @@ new Pool(
         "<b>" . _("First Time Here?") . "</b>",
         sprintf(
             _("Please read the <a href='%s'>Post-Processing FAQ</a> as it covers all the steps needed to post-process an e-text."),
-            "$code_url/faq/post_proof.php"
+            get_faq_url("post_proof.php")
         ),
         _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
         sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum($post_processing_forum_idx)),
@@ -321,7 +322,7 @@ new Pool(
         _("In this pool, experienced volunteers verify texts that have already been Post-Processed, and mentor new Post-Processors."),
         sprintf(
             _("<b>Before working in this pool</b>, please make sure you read the <a href='%s'>Post-Processing Verification Guidelines</a>."),
-            "$code_url/faq/ppv.php"
+            get_faq_url("ppv.php")
         ),
         sprintf(
             _("The PPV reporting form is <a href='%s'>here</a>."),

--- a/quiz/generic/wizard/messages.php
+++ b/quiz/generic/wizard/messages.php
@@ -2,6 +2,7 @@
 $relPath = '../../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath."faq.inc");
 include_once('../quiz_defaults.inc'); // $default_*
 
 require_login();
@@ -137,7 +138,12 @@ echo _("HTML allowed. This field is optional. If you leave it empty there will b
 
 echo "<p>" . _("Theoretically you can add more hints, but again you have to manually edit the final file for this.") . "</p>\n<hr>\n";
 
-echo "<p>" . sprintf(_("If you want you can also provide a link to a relevant section of the guidelines.  If you choose one of these, a sentence such as this will appear: \"See the <a href='%s' target='_blank'>Page Headers/Page Footers</a> section of the Proofreading Guidelines for details.\" (with a different section name and \"Proofreading\" or \"Formatting\" as appropriate)."), "../../../faq/proofreading_guidelines.php#page_hf") . "</p>\n";
+echo "<p>";
+echo sprintf(
+    _("If you want you can also provide a link to a relevant section of the guidelines.  If you choose one of these, a sentence such as this will appear: \"See the <a href='%s' target='_blank'>Page Headers/Page Footers</a> section of the Proofreading Guidelines for details.\" (with a different section name and \"Proofreading\" or \"Formatting\" as appropriate)."),
+    get_faq_url("proofreading_guidelines.php") . "#page_hf"
+);
+echo "</p>\n";
 
 echo "<p>" . _("Proofreading Guidelines section:") . "<br>\n";
 echo "<select size='1' name='P_guideline'>\n<option></option>\n";

--- a/quiz/tuts/tut_p_aeoe_1.php
+++ b/quiz/tuts/tut_p_aeoe_1.php
@@ -2,6 +2,7 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath."faq.inc");
 
 require_login();
 
@@ -14,6 +15,12 @@ echo "<table class='basic'>\n<tr><th>œ</th><th>æ</th></tr>\n";
 echo "<tr><td><img src='../generic/images/oelig_ital.png' alt='oe ligature' width='33' height='30'></td>\n";
 echo "<td><img src='../generic/images/aelig_ital_teardrop.png' alt='ae ligature' width='34' height='32'></td>\n</tr></table>\n";
 
-echo "<p>" . sprintf(_("You can insert each of these characters using the character picker in the proofreading interface or using keyboard shortcuts. Tables for <a href='%1\$s' target='_blank'>Windows</a> and <a href='%2\$s' target='_blank'>Macintosh</a> which list these shortcuts are in the Proofreading Guidelines."), "../../faq/proofreading_guidelines.php#a_chars_win", "../../faq/proofreading_guidelines.php#a_chars_mac") . "</p>\n";
+echo "<p>";
+echo sprintf(
+    _("You can insert each of these characters using the character picker in the proofreading interface or using keyboard shortcuts. Tables for <a href='%1\$s' target='_blank'>Windows</a> and <a href='%2\$s' target='_blank'>Macintosh</a> which list these shortcuts are in the Proofreading Guidelines."),
+    get_faq_url("proofreading_guidelines.php") . "#a_chars_win",
+    get_faq_url("proofreading_guidelines.php") . "#a_chars_mac"
+);
+echo "</p>\n";
 
 echo "<p><a href='../generic/main.php?quiz_page_id=p_aeoe_1'>" . _("Continue to quiz page") . "</a></p>\n";

--- a/quiz/tuts/tut_p_mod1_3.php
+++ b/quiz/tuts/tut_p_mod1_3.php
@@ -2,6 +2,7 @@
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
+include_once($relPath."faq.inc");
 
 require_login();
 
@@ -16,8 +17,18 @@ echo "<p>" . _("If they are not on your keyboard, there are several ways to inpu
 echo "<ul>\n";
 echo "<li>" . _("The character picker at the bottom of the proofreading interface.") . "</li>\n";
 echo "<li>" . _("Keyboard shortcuts.") . "<br>\n";
-echo sprintf(_("Tables for <a href='%1\$s' target='_blank'>Windows</a> and <a href='%2\$s' target='_blank'>Macintosh</a> which list these shortcuts are in the Proofreading Guidelines."), "../../faq/proofreading_guidelines.php#a_chars_win", "../../faq/proofreading_guidelines.php#a_chars_mac") . "</li>\n";
-echo "<li>" . sprintf(_("Other methods described in the <a href='%s' target='_blank'>guidelines</a>."), "../../faq/proofreading_guidelines.php#insert_char") . "</li>\n";
+echo sprintf(
+    _("Tables for <a href='%1\$s' target='_blank'>Windows</a> and <a href='%2\$s' target='_blank'>Macintosh</a> which list these shortcuts are in the Proofreading Guidelines."),
+    get_faq_url("proofreading_guidelines.php") . "#a_chars_win",
+    get_faq_url("proofreading_guidelines.php") . "#a_chars_mac"
+);
+echo "</li>\n";
+echo "<li>";
+echo sprintf(
+    _("Other methods described in the <a href='%s' target='_blank'>guidelines</a>."),
+    get_faq_url("proofreading_guidelines.php") . "#insert_char"
+);
+echo "</li>\n";
 echo "</ul>\n";
 
 echo "<h3>" . _("Fractions") . "</h3>\n";

--- a/tools/project_manager/projectmgr.inc
+++ b/tools/project_manager/projectmgr.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath.'user_is.inc');
 include_once($relPath.'project_edit.inc');
+include_once($relPath."faq.inc");
 
 function abort_if_not_manager()
 {
@@ -62,8 +63,10 @@ function echo_manager_links()
     }
     echo "<li><a href='$code_url/stats/release_queue.php'>"._("Show All Release Queues")."</a></li>\n";
     echo "<li><a href='https://www.pgdp.net/wiki/DP_Official_Documentation:CP_and_PM'>"._("PM Official Documentation")."</a></li>\n";
-    echo "<li><a href='$code_url/faq/proofreading_guidelines.php'>"._("Proofreading Guidelines")."</a></li>\n";
-    echo "<li><a href='$code_url/faq/formatting_guidelines.php'>"._("Formatting Guidelines")."</a></li>\n";
+    $url = get_faq_url("proofreading_guidelines.php");
+    echo "<li><a href='$url'>"._("Proofreading Guidelines")."</a></li>\n";
+    $url = get_faq_url("formatting_guidelines.php");
+    echo "<li><a href='$url'>"._("Formatting Guidelines")."</a></li>\n";
 
     echo "</ul>\n";
     echo "</div>\n";


### PR DESCRIPTION
Replace the hard-coded `faq/*` URLs with the ones that take the user directly to the wiki rather than relying on the redirects inside the `faq/*` pages to redirect them there. This is the first step in removing the the `faq/*` files that have been moved to the wiki.

Sandbox at https://www.pgdp.org/~cpeel/c.branch/replace-hardcoded-faq-urls/