### PR TITLE
member.inc: Don't try to show forum info if the user doesn't have an account

### DIFF
--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -198,6 +198,13 @@ function showForumProfile($username)
     global $site_abbreviation;
 
     $bb_user = get_forum_user_details($username);
+    if (is_null($bb_user)) {
+        echo "<p class='error'>";
+        echo sprintf(_("User '%s' has no forum account"), html_safe($username));
+        echo "</p>";
+        return;
+    }
+
 
     $view_url = attr_safe(get_url_to_view_profile($bb_user["id"]));
     $text = _('View');
@@ -276,26 +283,26 @@ function showForumProfile($username)
         ],
         [
             "AIM",
-            $bb_user["aim"],
+            @$bb_user["aim"],
             null,
             '',
         ],
         [
             "MSN",
-            $bb_user["msnm"],
+            @$bb_user["msnm"],
             null,
             '',
         ],
         [
             _("Yahoo Message"),
-            $bb_user["yim"],
-            "ymsgr:sendim?" . $bb_user["yim"],
+            @$bb_user["yim"],
+            "ymsgr:sendim?" . @$bb_user["yim"],
             '',
         ],
         [
             "ICQ",
-            $bb_user["icq"],
-            "https://www.icq.com/people/" . $bb_user["icq"] . "/",
+            @$bb_user["icq"],
+            "https://www.icq.com/people/" . @$bb_user["icq"] . "/",
             "_new",
         ],
         [


### PR DESCRIPTION
Because of how account creation is done, this isn't ordinarily possible in PROD, but occurs on TEST.

While here, allow any of the user's contact fields (apart from the username) to be undefined, not just a random subset of them.

Test sandbox at https://www.pgdp.org/~bfoley/c.branch/memberless/stats/members/mdetail.php?id=575