### PR TITLE
Disable autocapitalization of username input fields

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -159,7 +159,7 @@ $csrf_token
 <table class='themed theme_striped' style='width: auto'>
 <tr>
   <th><label for='loginform-userNM'>" . _("ID") . "</label></th>
-  <td><input type='text' id='loginform-userNM' name='userNM' value='".attr_safe($user->username)."' required></td>
+  <td><input type='text' id='loginform-userNM' name='userNM' value='".attr_safe($user->username)."' autocapitalize='none' required></td>
 </tr>
 <tr>
   <th><label for='loginform-userPW'>" . _("Password") . "</label></th>

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -145,7 +145,7 @@ echo "  <th>" . _("Real Name") . ":</th>";
 echo "  <td><input type='text' name='real_name' value='". attr_safe($real_name) ."' maxlength='100' required></td>";
 echo "</tr>\n<tr>";
 echo "  <th>" . _("User Name") . ":</th>";
-echo "  <td><input type='text' name='userNM' value='" . attr_safe($username) . "' required><br><small>$valid_username_chars_statement_for_reg_form</small></td>";
+echo "  <td><input type='text' name='userNM' value='" . attr_safe($username) . "' autocapitalize='none' required><br><small>$valid_username_chars_statement_for_reg_form</small></td>";
 echo "</tr>\n<tr>";
 echo "  <th>" . _("Password") . ":</th>";
 echo "  <td><input type='password' name='userPW' required></td>";

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -221,7 +221,7 @@ function html_navbar()
         // login link text
         // TRANSLATORS: ID is an abbreviation for username in the navbar
         $login_form .= "<label for='loginform-userNM'>" . _("ID") . ":</label> ";
-        $login_form .= "<input type='text' id='loginform-userNM' name='userNM' style='width: 7em;' required>&nbsp;";
+        $login_form .= "<input type='text' id='loginform-userNM' name='userNM' style='width: 7em;' autocapitalize='none' required>&nbsp;";
         $login_form .= "<label for='loginform-userPW'>" . _("Password") . ":</label> ";
         $login_form .= "<input type='password' id='loginform-userPW' name='userPW' style='width: 7em;' required>&nbsp;";
         $login_form .= "<input type='submit' value='" . _("Sign In") ."'>";

--- a/quiz/start.php
+++ b/quiz/start.php
@@ -73,7 +73,7 @@ elseif (
         echo "<form action='#' method='get'><p>";
         echo _("See results for another user") . "<br>";
         echo "<input type='hidden' name='show_only' value='$activity_type' required>";
-        echo "<input type='text' name='username' value='$username' required>";
+        echo "<input type='text' name='username' value='$username' autocapitalize='none' required>";
         echo "<input type='submit' value='" . attr_safe(_("Refresh")) . "'>";
         echo "</p></form>\n";
         echo "</div>";

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -40,7 +40,7 @@ if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
     echo "<div id='linkbox'>";
     echo "<form action='#' method='get'><p>";
     echo _("See projects for another user") . "<br>";
-    echo "<input type='text' name='username' value='$username' required>";
+    echo "<input type='text' name='username' value='$username' autocapitalize='none' required>";
     echo "<input type='submit' value='" . attr_safe(_("Refresh")) . "'>";
     echo "</p></form>\n";
     echo "<p><a href='?username='>" . _("See all projects with suspect clearances") . "</a></p>";

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -95,7 +95,7 @@ function echo_filter_box(string $projectid, int $show_image_size, ?string $usern
     echo "<tr><td colspan=2>", _("Filter pages by:"), "</td></tr>";
     echo "<tr>";
     echo "<td class='bold'><label for='sbu'>", _("Username"), "</label></td>";
-    echo "<td><input type='text' id='sbu' name='select_by_user' value='" . attr_safe($username) . "' required></td>";
+    echo "<td><input type='text' id='sbu' name='select_by_user' value='" . attr_safe($username) . "' autocapitalize='none' required></td>";
     echo "</tr>";
     echo "<tr>";
     echo "<td class='bold'><label for='sbr'>", _("User in round"), "</label></td>";

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -314,7 +314,7 @@ function output_link_box($username)
     if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
         echo "<form action='#' method='get'><p>";
         echo _("See projects for another user") . "<br>";
-        echo "<input type='text' name='username' value='" . attr_safe($username) . "' required>";
+        echo "<input type='text' name='username' value='" . attr_safe($username) . "' autocapitalize='none' required>";
         echo "<input type='submit' value='" . attr_safe(_("Refresh")) . "'>";
         echo "</p></form>\n";
         echo "<hr>";

--- a/tools/proofers/my_suggestions.php
+++ b/tools/proofers/my_suggestions.php
@@ -102,7 +102,7 @@ function output_link_box($username, $verbose)
     if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
         echo "<form method='get'><p>";
         echo _("See projects for another user") . "<br>";
-        echo "<input type='text' name='username' value='" . attr_safe($username) . "' required>";
+        echo "<input type='text' name='username' value='" . attr_safe($username) . "' autocapitalize='none' required>";
         echo "<input type='submit' value='" . attr_safe(_("Refresh")) . "'>";
         $checked = $verbose ? "checked" : "";
         echo "<input type='checkbox' name='verbose' value='1' $checked>";

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -54,7 +54,7 @@ if ($user_can_review_others) {
     // only let site admins or reviewers to access non-self records and eval query
     echo  "<tr>";
     echo   "<th>" . _("Username") . "</th>";
-    echo   "<td><input name='username' type='text' size='26' value='" . attr_safe($username) . "' required></td>";
+    echo   "<td><input name='username' type='text' size='26' value='" . attr_safe($username) . "' autocapitalize='none' required></td>";
     echo  "</tr>";
     echo  "<tr>";
     echo   "<th>" . _("Use Evaluation Query") . "</th>";

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -36,7 +36,7 @@ if ($action == 'default') {
 
     echo "<form method='get'>";
     echo "<input type='hidden' name='action' value='get_user'>";
-    echo _("Username") . ": <input type='text' name='username' required>";
+    echo _("Username") . ": <input type='text' name='username' autocapitalize='none' required>";
     echo  " <input type='submit' value='" . attr_safe(_("Continue")) . "'>";
     echo "</form>";
     echo "<br>";

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -82,7 +82,7 @@ function show_username_form($username)
 {
     echo "<form method='GET'>\n";
     echo "<p>" . _("Username") . ": ";
-    echo "<input name='username' type='text' value='$username' size='20' required>\n";
+    echo "<input name='username' type='text' value='$username' size='20' autocapitalize='none' required>\n";
     echo "</p>";
     echo "<input type='submit' value='" . attr_safe(_("Look up this user")) . "'>\n";
     echo "</form>\n";

--- a/tools/site_admin/show_access_log.php
+++ b/tools/site_admin/show_access_log.php
@@ -32,7 +32,7 @@ echo "<form method='GET'>";
 echo "<table class='basic'>";
 echo "<tr>";
 echo "  <th>" . _("Username") . "</th>";
-echo "  <td><input name='username' type='text' value='" . attr_safe($username) . "'></td>";
+echo "  <td><input name='username' type='text' value='" . attr_safe($username) . "' autocapitalize='none'></td>";
 echo "</tr>";
 echo "<tr>";
 echo "  <th>" . _("Action") . "</th>";


### PR DESCRIPTION
The autocapitalize attribute is standard HTML5, but the default behavior when it isn't explicitly set differs across browsers.

In particular we have some users using iPads, and in Safari, autocapitalize is on by default.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize#usage_notes

Support goes back to iOS Safari 5 (2012); Chrome 43 (2015); Opera 30 (2015); but not until Firefox 111 (2023). However the Firefox non-support is harmless as it defaults to autocapitalize off anyway.