### PR TITLE
Use project object rather than projectid to construct LPage

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -491,7 +491,7 @@ class ProjectTest extends ProjectUtils
         $pguser = $this->TEST_USERNAME;
         $round = get_Round_for_round_id("P1");
         [$imagefile, $state] = get_available_proof_page_array($project, $round, $pguser);
-        $lpage = new LPage($project->projectid, $imagefile, $state, 0);
+        $lpage = new LPage($project, $imagefile, $state, 0);
         $lpage->checkout($pguser);
         $this->assertEquals("P1.page_out", $lpage->page_state);
 

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -146,7 +146,7 @@ function get_available_page($projectid, $proj_state, $pguser, &$err)
         $err = $exception->getMessage();
         return null;
     }
-    $lpage = new LPage($project->projectid, $imagefile, $state, 0);
+    $lpage = new LPage($project, $imagefile, $state, 0);
 
     $lpage->checkout($pguser);
 
@@ -232,7 +232,7 @@ function get_indicated_LPage(
         throw new ProjectPageException($err);
     }
 
-    return new LPage($projectid, $imagefile, $page_state, $reverting_to_orig);
+    return new LPage($project, $imagefile, $page_state, $reverting_to_orig);
 }
 
 function project_continuity_test($project, $orig_state, $no_more_pages)
@@ -283,9 +283,10 @@ class RoundInfo
  */
 class LPage
 {
-    public function __construct($projectid, $imagefile, $page_state, $reverting_to_orig)
+    public function __construct($project, $imagefile, $page_state, $reverting_to_orig)
     {
-        $this->projectid = $projectid;
+        $this->project = $project;
+        $this->projectid = $project->projectid;
         $this->imagefile = $imagefile;
         $this->page_state = $page_state;
         $this->reverting_to_orig = $reverting_to_orig;
@@ -341,8 +342,7 @@ class LPage
 
     public function get_language()
     {
-        $project = new Project($this->projectid);
-        return langcode2_for_langname($project->languages[0]);
+        return langcode2_for_langname($this->project->languages[0]);
     }
 
     public function get_username_for_round($round)
@@ -432,8 +432,7 @@ class LPage
         Page_markAsBad($this->projectid, $this->imagefile, $this->round, $user, $reason);
 
         // Advise PM that the page has been marked bad.
-        $project = new Project($this->projectid);
-        configure_gettext_for_user($project->username);
+        configure_gettext_for_user($this->project->username);
         $body_blurb_messages[] = sprintf(_('Page %1$s of this project has been marked bad due to %2$s.'), $this->imagefile, $PAGE_BADNESS_REASONS[$reason]);
         // TRANSLATORS: %s is a url
         $body_blurb_messages[] = sprintf(
@@ -443,12 +442,11 @@ class LPage
         $body_blurb_messages[] = _("Until this report has been resolved, the project will not be able to leave the current round.");
         $body_blurb_messages[] = _("If 10 pages are marked bad by at least 3 different users, the project will automatically be made unavailable.");
         $body_blurb = implode("\n\n", $body_blurb_messages);
-        send_mail_project_manager($project, $body_blurb, _("Bad Page Report"));
+        send_mail_project_manager($this->project, $body_blurb, _("Bad Page Report"));
         configure_gettext_for_user();
 
         // Now determine whether the project as a whole should be marked bad.
-        $project = new Project($this->projectid);
-        if (!$project->is_bad_from_pages($this->round)) {
+        if (!$this->project->is_bad_from_pages($this->round)) {
             return false;
         }
 


### PR DESCRIPTION
This should be useful for the API.

Another new project is not now made at line 450 but I think this should not cause any problem. The only reason to make another new project is if we have done something which changes the projects table so the project object could be invalid. The only thing that does this here is project_transition() but that occurs later.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/LP_project


