### PR TITLE
api/v1_projects.inc: Return an error if client requests invalid field

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -12,36 +12,39 @@ include_once("api_common.inc");
 //===========================================================================
 // projects/
 
+/**
+ * Get an array of the fields to be returned to the client.
+ * @param ?array<string,string> $query_params the HTTP query
+ * @param ?Project $project
+ *   If we're querying a single project, what is it? (Certain fields
+ *   aren't queryable or viewable by most users.)
+ * @return ?array<string>
+ * @throws InvalidValue if any of the filter arguments aren't recognized
+ */
+function get_return_fields(?array $query_params, ?Project $project)
+{
+    $return_fields = array_get_as_array($query_params, "field", null);
+    if (is_null($return_fields)) {
+        return null;
+    }
+    $valid_render_fields = array_keys(get_project_fields_with_attr(null, $project));
+    $invalid_fields = array_diff($return_fields, $valid_render_fields);
+    if (!empty($invalid_fields)) {
+        throw new InvalidValue("Invalid filter args: " . implode(", ", $invalid_fields));
+    }
+    return $return_fields;
+}
+
 function api_v1_projects($method, $data, $query_params)
 {
     // set which fields are queryable and their column names
-    $valid_fields = [
-        "projectid" => "projectid",
-        "state" => "state",
-        "title" => "nameofwork",
-        "author" => "authorsname",
-        "languages" => "language",
-        "genre" => "genre",
-        "difficulty" => "difficulty",
-        "special_day" => "special_day",
-        "project_manager" => "username",
-        "pg_ebook_number" => "postednum",
-        "pages_available" => "n_pages_available",
-        "pages_total" => "n_pages",
-    ];
+    $valid_fields = get_project_fields_with_attr("queryable", null);
 
     // parameters in the query where the value can be "false", "true" or absent (==true)
     // When true, a WHERE clause is added to the SQL query.
     $valid_flags = [
         "in_smoothreading" => "smoothread_deadline > UNIX_TIMESTAMP()",
     ];
-
-    // Allow SAs and PFs to search on clearance. We can't allow PMs to do so
-    // without opening up the ability for value-fishing as PMs can only see
-    // clearances for their own projects.
-    if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
-        $valid_fields["clearance"] = "clearance";
-    }
 
     // pull out the query parameters
     $query = [];
@@ -125,7 +128,7 @@ function api_v1_projects($method, $data, $query_params)
     api_send_pagination_header($query_params, $total_rows, $per_page, $page);
 
     // restrict to list of desired fields, if set
-    $return_fields = array_get_as_array($query_params, "field", null);
+    $return_fields = get_return_fields($query_params, null);
 
     $output = [];
     while ($row = mysqli_fetch_assoc($result)) {
@@ -139,33 +142,73 @@ function api_v1_projects($method, $data, $query_params)
 //---------------------------------------------------------------------------
 // projects/:projectid
 
+function get_project_fields_with_attr(?string $attr, ?Project $project): array
+{
+    // A list of all the fields that can be rendered by render_project_json
+    // and the corresponding name of the SQL column.
+    // In addition, fields with the "queryable" attribute can be used
+    // as query term for api/v1/projects, and fields with the "updatable"
+    // attribute can be set by a POST request.
+    $fields = [
+        "projectid" => ["sql_name" => "projectid", "queryable" => true],
+        "title" => ["sql_name" => "nameofwork", "updatable" => true, "queryable" => true],
+        "author" => ["sql_name" => "authorsname", "updatable" => true, "queryable" => true],
+        "languages" => ["sql_name" => "languages",  "updatable" => true, "queryable" => true],
+        "genre" => ["sql_name" => "genre", "updatable" => true, "queryable" => true],
+        "difficulty" => ["sql_name" => "difficulty", "updatable" => true, "queryable" => true],
+        "special_day" => ["sql_name" => "special_code", "updatable" => true, "queryable" => true],
+        "project_manager" => ["sql_name" => "username", "updatable" => true, "queryable" => true],
+        "image_source" => ["sql_name" => "image_source", "updatable" => true],
+        "image_preparer" => ["sql_name" => "image_preparer", "updatable" => true],
+        "text_preparer" => ["sql_name" => "text_preparer", "updatable" => true],
+        "pg_ebook_number" => ["sql_name" => "postednum", "updatable" => true, "queryable" => true],
+        "comments" => ["sql_name" => "comments", "updatable" => true],
+        "comment_format" => ["sql_name" => "comment_format", "updatable" => true],
+        "custom_characters" => ["sql_name" => "custom_chars", "updatable" => true],
+        "pages_available" => ["sql_name" => "n_available_pages", "queryable" => true],
+        "pages_total" => ["sql_name" => "n_pages", "queryable" => true],
+        "post_processor" => ["sql_name" => "postproofer"],
+        "post_process_verifier" => ["sql_name" => "ppverifier"],
+        "state" => ["sql_name" => "state"],
+        "last_state_change_time" => ["sql_name" => "modifieddate"],
+        "last_page_done_time" => ["sql_name" => "t_last_page_done"],
+        "last_edit_time" => ["sql_name" => "t_last_edit"],
+        "smoothread_deadline" => ["sql_name" => "smoothread_deadline"],
+    ];
+
+    // If accessing a single project using the api/v1/projects/:id endpoint,
+    // only allow clearance to be rendered/updated if the user has permission
+    // for that project.
+    $can_render = !is_null($project) && $project->clearance_line_can_be_seen_by_current_user();
+    // If using the api/v1/projects/ endpoint to search for (multiple) projects
+    // allow SAs and PFs to search on clearance. This does have the odd corner
+    // case of forbidding PMs to search for clearances that they can in fact
+    // see in their individual projects, but we don't want to open up the
+    // ability for them to value-fishing on clearances.
+    $can_search = is_null($project) && (user_is_a_sitemanager() || user_is_proj_facilitator());
+    if ($can_search || $can_render) {
+        $fields["clearance"] = ["sql_name" => "clearance", "updatable" => true, "queryable" => true];
+    }
+
+    $r = [];
+    foreach ($fields as $api_name => $attrs) {
+        if (is_null($attr) || @$attrs[$attr] == true) {
+            $r[$api_name] = $attrs["sql_name"];
+        }
+    }
+    return $r;
+}
+
 /**
  * Return a list of updatable project fields mapped from the API names
  * to the Project object names.
  */
-function get_updatable_project_fields()
+function get_updatable_project_fields(Project $project): array
 {
-    return [
-        // API name => Project name
-        "title" => "nameofwork",
-        "author" => "authorsname",
-        "languages" => "languages",
-        "genre" => "genre",
-        "difficulty" => "difficulty",
-        "special_day" => "special_code",
-        "project_manager" => "username",
-        "image_source" => "image_source",
-        "image_preparer" => "image_preparer",
-        "text_preparer" => "text_preparer",
-        "pg_ebook_number" => "postednum",
-        "comments" => "comments",
-        "comment_format" => "comment_format",
-        "clearance" => "clearance",
-        "custom_characters" => "custom_chars",
-    ];
+    return get_project_fields_with_attr("updatable", $project);
 }
 
-function create_or_update_project($project)
+function create_or_update_project(Project $project)
 {
     // can the user use this update API at all?
     if (!user_is_PM()) {
@@ -188,7 +231,7 @@ function create_or_update_project($project)
     // update all updatable fields
     $updates = api_get_request_body();
     try {
-        foreach (get_updatable_project_fields() as $api_key => $project_key) {
+        foreach (get_updatable_project_fields($project) as $api_key => $project_key) {
             // allow partial record updates by only updating specified values
             if (isset($updates[$api_key])) {
                 $project->$project_key = $updates[$api_key];
@@ -254,8 +297,9 @@ function api_v1_project($method, $data, $query_params)
 {
     if ($method == "GET") {
         // restrict to list of desired fields, if set
-        $return_fields = array_get_as_array($query_params, "field", null);
-        return render_project_json($data[":projectid"], $return_fields);
+        $project = $data[":projectid"];
+        $return_fields = get_return_fields($query_params, $project);
+        return render_project_json($project, $return_fields);
     } elseif ($method == "PUT") {
         $project = $data[":projectid"];
         return render_project_json(create_or_update_project($project));
@@ -267,7 +311,7 @@ function api_v1_project($method, $data, $query_params)
     }
 }
 
-function render_project_json($project, $return_fields = null)
+function render_project_json(Project $project, ?array $return_fields = null)
 {
     // We want to explicitly call out the parameters we want to return so
     // callers can know what to expect in this version of the API.
@@ -275,18 +319,13 @@ function render_project_json($project, $return_fields = null)
         "projectid" => $project->projectid,
     ];
 
-    foreach (get_updatable_project_fields() as $api_key => $project_key) {
+    foreach (get_updatable_project_fields($project) as $api_key => $project_key) {
         $return_array[$api_key] = $project->$project_key;
 
         // force pg_ebook_number to an int
         if ($api_key == "pg_ebook_number" && $return_array[$api_key] != null) {
             $return_array[$api_key] = (int)$return_array[$api_key];
         }
-    }
-
-    // prevent clearance from being included for unauthorized users
-    if (!$project->clearance_line_can_be_seen_by_current_user()) {
-        unset($return_array["clearance"]);
     }
 
     $charsuites = [];


### PR DESCRIPTION
As suggested by srjfoo. I agree with her that it's better to fail loudly rather than silent ignore unrecognized fields. If nothing else, it helps when a dev makes typos in client code.

I needed to do some code reorg to avoid repeating a subset of SQL column names and API field names for a third time.

Sandbox at https://www.pgdp.org/~bfoley/c.branch/invalid-field but it doesn't touch any non-API code.

Example call:
```
curl -s -X GET "$ROOT/api/v1/projects&field[]=pages_total&field[]=no_such_field" \
    -H "Accept: application/json" \
    -H "X-API-KEY: $INSERT_YOUR_API_KEY_KEY"
```