### PR TITLE
Collapse Activities in navbar based on avail space (& preference)

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,6 +7,9 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
+## R??????
+Scripts supporting this upgrade are in `SETUP/upgrade/21`
+
 ## R202403
 Scripts supporting this upgrade are in `SETUP/upgrade/20`
 

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -669,6 +669,7 @@ CREATE TABLE `users` (
   `u_intlang` varchar(25) default '',
   `u_privacy` tinyint(1) default '0',
   `api_key` varchar(38) DEFAULT NULL,
+  `navbar_activity_menu` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`username`),
   UNIQUE KEY `api_key` (`api_key`),
   KEY `u_id` (`u_id`),

--- a/SETUP/smoketests/test_tables.sql
+++ b/SETUP/smoketests/test_tables.sql
@@ -10,8 +10,8 @@ REPLACE INTO `projects` VALUES ('An Empty Project','Fletcher, Jessica','English'
 /* `users` rows populated by INSERTs in accounts/activate.php.
  * Can't do this programatically yet.
  */
-REPLACE INTO `users` VALUES ('userID1234567890abc', 'Adam Adminston', 'admin', 'a@example.com', 1234567890, 1234567890, 1234567890, 1, '', '', '', 10, 0, 'project_gutenberg', 1, 110, '', 0, 'admin_key');
-REPLACE INTO `users` VALUES ('userID460b20a8a8a71','BKeir','teststeel','teststeel@localhost',1175134376,1175134406,1175134457,1,'','','',10,0,'project_gutenberg',110,119,'en_US',0,NULL);
+REPLACE INTO `users` VALUES ('userID1234567890abc', 'Adam Adminston', 'admin', 'a@example.com', 1234567890, 1234567890, 1234567890, 1, '', '', '', 10, 0, 'project_gutenberg', 1, 110, '', 0, 'admin_key', 1);
+REPLACE INTO `users` VALUES ('userID460b20a8a8a71','BKeir','teststeel','teststeel@localhost',1175134376,1175134406,1175134457,1,'','','',10,0,'project_gutenberg',110,119,'en_US',0,NULL,1);
 
 /* $up = new UserProfile(); $up->foo = bar; $up->save(); does not allow new
  * profiles to be created with programmatic control of id.

--- a/SETUP/upgrade/21/20240403_update_user_table.php
+++ b/SETUP/upgrade/21/20240403_update_user_table.php
@@ -1,0 +1,18 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Adding users.navbar_activity_menu\n";
+$sql = "
+    ALTER TABLE users ADD COLUMN navbar_activity_menu tinyint NOT NULL DEFAULT 1
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/faq/pophelp/prefs/prefs_pophelp.inc
+++ b/faq/pophelp/prefs/prefs_pophelp.inc
@@ -127,6 +127,12 @@ _("<p>This setting controls who is able to see your statistics.</p>
             'content' => _("<p>This setting determines which site theme is used as your default.</p>"),
         ],
 
+    'set_navbar_activity_menu' =>
+        [
+            'title' => _("My Activities Menu"),
+            'content' => _("<p>This setting determines if the My Activities menu in the navigation bar is always collapsed, never collapsed, or automatically collapsed based on the width of the window.</p>"),
+        ],
+
     'set_project_detail' =>
         [
             'title' => _("Project Detail"),

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -22,17 +22,20 @@ include_once($relPath.'graph_data.inc'); // get_round_backlog_stats()
  * Retrieve the number of pages proofread by the current user.
  *
  * For demo purposes, allow the user (via the URL parameter 'numofpages')
- * to pretend to have a different number of pages,
- * as long as it's less than their actual number.
+ * to pretend to have a different number of pages. In production only allow
+ * users to adjust down; during testing allow adjusting higher or lower.
  */
 function get_pages_proofed_maybe_simulated($username = null)
 {
+    global $testing;
+
     if ($username === null) {
         $username = User::current_username();
     }
 
     $pagesproofed = user_get_ELR_page_tally($username);
-    $pagesproofed = get_integer_param($_GET, 'numofpages', $pagesproofed, 0, $pagesproofed);
+    $max_pagesproofed = $testing ? null : $pagesproofed;
+    $pagesproofed = get_integer_param($_GET, 'numofpages', $pagesproofed, 0, $max_pagesproofed);
 
     return $pagesproofed;
 }

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -93,6 +93,7 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
     $js_files = [
         "$code_url/pinc/3rdparty/jquery/jquery-3.5.1.min.js",
         "$code_url/scripts/api.js",
+        "$code_url/scripts/navbar_menu.js",
     ];
 
     // Per-page JS

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -91,7 +91,7 @@ function output_footer($nameofpage, $show_statsbar = true)
     echo "<p>\n";
     echo "<small>\n";
 
-    echo "&copy;$site_name";
+    echo "&copy;" . html_safe($site_name);
 
     echo "<span id='buildtime'>";
     echo " &middot; ";
@@ -119,30 +119,96 @@ function html_logobar()
 {
     global $code_url, $site_name;
     global $maintenance, $testing, $alert_message;
+    global $blog_url, $wiki_url;
 
     echo "\n<div id='header'>\n";
-    echo "<a href='$code_url'>\n";
+
     echo "<div id='logo'>\n";
-    echo "<img src='$code_url/graphics/dp-logo.svg' alt='$site_name'>\n";
-    echo "</div>\n";
+    echo "<a href='$code_url'>\n";
+    echo "<img id='logo-img' src='$code_url/graphics/dp-logo.svg' alt='" . attr_safe($site_name) . "'>\n";
     echo "</a>\n";
+    echo "</div>\n"; // logo
 
-    echo "<div id='titles-preserved'><p>\n";
+    echo "<div id='logo-right'>";
+    $user = User::load_current();
+    if (!$user) {
+        // show number of books posted to PG
+        // (takes into account that some books are processed as several projects)
+        echo "<div id='titles-preserved'>\n";
+        echo "<span id='x-preserved'>";
+        echo sprintf(
+            _('%s titles preserved for the world!'),
+            number_format(total_completed_projects())
+        );
+        echo "</span>\n";
+        echo "<span id='month-preserved-summary'>";
+        show_completed_projects(true);
+        echo "</span>";
+        echo "</div>\n";
+    } else {
+        $icon_links = [];
+        if (get_url_for_forum()) {
+            $icon_links[] = [
+                "name" => _("Inbox"),
+                "class" => "fas fa-envelope fa-2x",
+                "url" => get_url_for_inbox(),
+            ];
 
-    // show number of books posted to PG
-    // (takes into account that some books are processed as several projects)
-    echo "<span id='x-preserved'>";
-    echo sprintf(
-        _('%s titles preserved for the world!'),
-        number_format(total_completed_projects())
-    );
-    echo "</span>\n";
-    echo "<span id='month-preserved-summary'>";
-    show_completed_projects(true);
-    echo "</span>";
+            $icon_links[] = [
+                "name" => _("Forums"),
+                "class" => "fas fa-comments fa-2x",
+                "url" => get_url_for_forum(),
+            ];
+        }
+        if (!empty($wiki_url)) {
+            $icon_links[] = [
+                "name" => _("Wiki"),
+                "class" => "fas fa-scroll fa-2x",
+                "url" => $wiki_url,
+            ];
+        }
+        if (!empty($blog_url)) {
+            $icon_links[] = [
+                "name" => _("Blog"),
+                "class" => "fab fa-wordpress fa-2x",
+                "url" => $blog_url,
+            ];
+        }
+        $icon_links[] = [
+            "name" => _("Help"),
+            "class" => "fas fa-question fa-2x",
+            "url" => get_faq_url("faq_central.php"),
+        ];
+        $links = [];
+        foreach ($icon_links as $data) {
+            $name = attr_safe($data["name"]);
+            $class = $data["class"];
+            $url = $data["url"] ?? "";
+            $text = "<div class='icon-menu-item'>";
+            if ($url) {
+                $text .= "<a href='$url' aria-label='$name'>";
+            }
+            $text .= "<i aria-hidden='true' class='$class' title='$name'></i>";
+            if ($url) {
+                $text .= "</a>";
+            }
+            if ($data["name"] == _("Inbox")) {
+                $numofPMs = get_number_of_unread_messages($user->username);
+                if ($numofPMs > 0) {
+                    $text .= "<span class='inbox-badge'>$numofPMs</span>";
+                }
+            }
+            $text .= "<br><span class='icon-menu-item-name'>$name</span>";
+            $text .= "</div>";
+            $links[] = $text;
+        }
 
-    echo "</p></div>\n";
-    echo "</div>\n";
+        echo "<div id='icon-menu'>";
+        echo join("", $links);
+        echo "</div>"; // icon-menu
+    }
+    echo "</div>"; // logo-right
+    echo "</div>\n"; // header
 
     html_navbar();
 
@@ -174,7 +240,7 @@ function html_logobar()
  */
 function html_navbar()
 {
-    global $code_url, $site_abbreviation, $blog_url, $wiki_url;
+    global $code_url, $blog_url, $wiki_url;
 
     echo "<div id='navbar-outer'>";
     echo "<div id='navbar'>";
@@ -183,13 +249,16 @@ function html_navbar()
     $user = User::load_current();
     if (!$user) {
         $links = [];
-        $links[] = ['text' => $site_abbreviation, 'url' => "default.php"];
         if (!empty($blog_url)) {
             $links[] = ['text' => _("Blog"), 'url' => $blog_url];
+        }
+        if (!empty($wiki_url)) {
+            $links[] = ['text' => _("Wiki"), 'url' => $wiki_url];
         }
         if (get_url_for_forum()) {
             $links[] = ['text' => _("Forums"), 'url' => get_url_for_forum()];
         }
+        $links[] = ['text' => _('Help'), 'url' => get_faq_url("faq_central.php")];
         echo "<span id='navbar-left'>";
         echo headerbar_text_array($links);
         echo "</span>\n";
@@ -230,7 +299,6 @@ function html_navbar()
         $links = [];
         $links[] = ['text' => $login_form];
         $links[] = ['text' => _('Register'), 'url' => "accounts/addproofer.php"];
-        $links[] = ['text' => _('Help'), 'url' => get_faq_url("faq_central.php")];
         echo headerbar_text_array($links);
         echo "</div>\n";
     } else {
@@ -238,21 +306,58 @@ function html_navbar()
 
         // left side
         echo "<span id='navbar-left'>";
-        echo headerbar_text_array([['text' => $site_abbreviation, 'url' => "default.php"]]);
-
-        echo " | ";
 
         $links = [];
         $links[] = ['text' => _("Activity Hub"), 'url' => "activity_hub.php"];
 
-        // use white-space: nowrap; to keep the rounds within []s together
-        $activities_string = "<span style='white-space: nowrap;'>[ ";
-        if (get_pages_proofed_maybe_simulated() < 100) {
-            $activities_string .= "<span class='text'>" . _("Activities") . ": </span>";
+        // We create 2 different ways of showing the activities, one with them
+        // all visible in one string and one with with them collapsed behind a menu.
+        // We show/hide them based on the user's navbar_activity_menu preference.
+        //   0 - always collapse
+        //   1 - automatically collapse
+        //   2 - never collapse
+        // Furthermore, in auto mode never collapse the menu for new users or
+        // users with fewer than 4 activities.
+        $activity_links = get_activity_links();
+
+        $is_new_user = get_pages_proofed_maybe_simulated() < 100;
+
+        // Calculate style-level CSS that will override the classes
+        // 2 - never collapse
+        if ($user->navbar_activity_menu == 2) {
+            $string_style = "style='display: inline;'";
+            $menu_style = "style='display: none;'";
+        }
+        // 0 - always collapse
+        elseif ($user->navbar_activity_menu == 0) {
+            $string_style = "style='display: none;'";
+            $menu_style = "style='display: inline;'";
+        }
+        // 1 - auto collapse
+        else {
+            $string_style = "";
+            $menu_style = "";
+
+            // don't collapse for new users in auto mode
+            if ($is_new_user || count($activity_links) <= 3) {
+                $string_style = "style='display: inline;'";
+                $menu_style = "style='display: none;'";
+            }
         }
 
-        $activities_string .= headerbar_text_array(get_activity_links());
-        $activities_string .= " ]</span>";
+        // non-collapsed
+        $activities_string = "<div id='my-activities-string' $string_style>[ ";
+        if ($is_new_user) {
+            $activities_string .= "<span class='text'>" . _("My Activities") . ": </span>";
+        }
+        $activities_string .= headerbar_text_array($activity_links);
+        $activities_string .= " ]</div>";
+
+        // collapsed
+        $activities_string .= "<div id='my-activities-menu' $menu_style>";
+        $activities_string .= headerbar_menu(_("My Activities"), [['text' => headerbar_text_array($activity_links)]]);
+        $activities_string .= "</div>";
+
         $links[] = ['text' => $activities_string];
 
         $links[] = ['text' => _("My Projects"), 'url' => "tools/proofers/my_projects.php"];
@@ -270,34 +375,19 @@ function html_navbar()
         // on the same line.
         echo "<span id='navbar-right'>";
         $links = [];
-        if (get_url_for_inbox()) {
-            $inbox_text = _("Inbox");
-
-            $numofPMs = get_number_of_unread_messages($user->username);
-            if ($numofPMs > 0) {
-                $inbox_text .= " " . sprintf(_("(%s unread)"), $numofPMs);
-            }
-            $links[] = ['text' => $inbox_text, 'url' => get_url_for_inbox()];
-        }
-
-        if (get_url_for_forum()) {
-            $links[] = ['text' => _("Forums"), 'url' => get_url_for_forum()];
-        }
-
-        if (!empty($blog_url)) {
-            $links[] = ['text' => _("Blog"), 'url' => $blog_url];
-        }
-
-        if (!empty($wiki_url)) {
-            $links[] = ['text' => _("Wiki"), 'url' => $wiki_url];
-        }
-
         $links[] = ['text' => _("Stats"), 'url' => "stats/stats_central.php"];
-        $links[] = ['text' => _("Prefs"), 'url' => "userprefs.php"];
-        $links[] = ['text' => _('Help'), 'url' => get_faq_url("faq_central.php")];
-        $links[] = ['text' => sprintf(_("Log Out (%s)"), $user->username), 'url' => "accounts/logout.php"];
 
         echo headerbar_text_array($links);
+        echo "  &#183; ";
+
+        $account_links = [
+            ['text' => _("Profile"), 'url' => "stats/members/mdetail.php"],
+            ['text' => _("Preferences"), 'url' => "userprefs.php"],
+            ['text' => _("Log Out"), 'url' => "accounts/logout.php"],
+        ];
+
+        echo headerbar_menu($user->username, $account_links, true);
+
         echo "</span>";
     }
 
@@ -305,8 +395,34 @@ function html_navbar()
     echo "</div>\n";
 }
 
+function headerbar_menu(string $menu_title, array $links, bool $align_right = false): string
+{
+    $menu_style = "";
+    $menu_contents_style = "";
+    if ($align_right) {
+        $menu_style = "style='padding-right: 0.5em;'";
+        $menu_contents_style = "style='right: 0;'";
+    }
+
+    $menu_id = 'menu' . md5($menu_title);
+    $output = [
+        "<div id='$menu_id' class='menu' $menu_style>",
+        "<div class='menu-selector' onclick='toggleMenu(\"$menu_id\")'>",
+        "<i class='menu-icon fas fa-caret-right'></i>",
+        " " . html_safe($menu_title),
+        "</div>",
+        "<div class='menu-contents invisible transparent' $menu_contents_style>",
+    ];
+    foreach (resolve_headerbar_entries($links) as $entry) {
+        $output[] = "<div class='menu-item'>$entry</div>";
+    }
+    $output[] = "</div>"; // menu-contents
+    $output[] = "</div>"; // menu
+    return join("", $output);
+}
+
 /**
- * Outputs entries in the navbar contained within $entries.
+ * Resolve navbar entries to full links or current page
  *
  * Each $entry is an associative array containing either:
  * - 'text' - text to display as-is without changes, can include HTML
@@ -317,7 +433,7 @@ function html_navbar()
  * current page is one of the urls and if so it doesn't create the link but
  * instead wraps the text in a span.currentpage tag.
  */
-function headerbar_text_array($entries)
+function resolve_headerbar_entries(array $entries): array
 {
     global $code_url;
 
@@ -368,12 +484,21 @@ function headerbar_text_array($entries)
 
         $output_entries[] = $entry_string;
     }
+    return $output_entries;
+}
 
+/**
+ * Outputs entries in the navbar contained within $entries.
+ *
+ * See resolve_headerbar_entries() for $entries format.
+ */
+function headerbar_text_array(array $entries): string
+{
     // set the divider
     // &#183; == &middot; == middle-dot
     $divider = " &#183; ";
 
-    return implode($divider, $output_entries);
+    return implode($divider, resolve_headerbar_entries($entries));
 }
 
 function html_statsbar($nameofpage)

--- a/scripts/navbar_menu.js
+++ b/scripts/navbar_menu.js
@@ -1,0 +1,33 @@
+/* exported toggleMenu */
+
+// Toggle a menu contents to visible and rotate the menu icon
+function toggleMenu(menuId) {
+    let menu = document.getElementById(menuId);
+    for (const element of menu.getElementsByClassName('menu-contents')) {
+        element.classList.toggle("invisible");
+        element.classList.toggle("transparent");
+    }
+    for (const element of menu.getElementsByClassName('menu-icon')) {
+        element.classList.toggle("rotate");
+    }
+}
+
+// Close all dropdown menus if the user clicks outside of one
+document.addEventListener("click", function (event) {
+    let inMenu = false;
+    document.querySelectorAll(".menu").forEach(element => {
+        if (element.contains(event.target) || element == event.target) {
+            inMenu = true;
+        }
+    });
+
+    if (!inMenu) {
+        document.querySelectorAll(".menu-contents").forEach(element => {
+            element.classList.add('invisible');
+            element.classList.add('transparent');
+        });
+        document.querySelectorAll(".menu-icon").forEach(element => {
+            element.classList.remove('rotate');
+        });
+    }
+});

--- a/styles/global.less
+++ b/styles/global.less
@@ -116,6 +116,10 @@
     visibility: hidden;
 }
 
+.transparent {
+    opacity: 0;
+}
+
 .nodisp {
     display: none;
 }
@@ -138,6 +142,10 @@
     bottom: 0;
     left: 0;
     right: 0;
+}
+
+.rotate {
+    transform: rotate(90deg);
 }
 
 /* ------------------------------------------------------------------------ */

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -206,8 +206,9 @@ header, #header {
     display: table;
     background-color: @header-background;
     color: @header-text;
-    #logo, #titles-preserved {
+    #logo, #logo-right {
         display: table-cell;
+        .middle-align;
     }
     #logo {
         height: 75px;
@@ -219,11 +220,43 @@ header, #header {
     }
     #titles-preserved {
         .center-align;
-        .middle-align;
         font-size: 0.9em;
         #x-preserved {
             .bold;
             .sans-serif;
+        }
+    }
+    #icon-menu {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+    }
+    .icon-menu-item {
+        position: relative;
+        cursor: pointer;
+        margin-right: 1.5em;
+        .center-align;
+        text-decoration: none;
+        .sans-serif;
+        font-size: 0.7em;
+        color: @navbar-background;
+        .unicolor-link(@navbar-background);
+        .icon-menu-item-name {
+            font-size: 0.9em;
+            color: @heading-color;
+            .unicolor-link(@heading-color);
+        }
+        .inbox-badge {
+          background-color: @text-error;
+          border-radius: 2px;
+          color: @page-background;
+
+          padding: 1px 3px;
+          font-size: 0.9em;
+
+          position: absolute;
+          top: -3px;
+          right: -3px;
         }
     }
 }
@@ -281,6 +314,49 @@ nav, #navbar-outer {
         }
     }
 }
+
+.menu {
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+    color: @navbar-text;
+    text-align: center;
+    min-width: 4em;
+}
+
+.menu-selector {
+    display: inline;
+}
+
+.menu-icon {
+    transition-duration: 0.15s;
+}
+
+.menu-contents {
+    // initially these are invisible & transparent
+    transition: all 0.15s ease-in-out;
+    position: absolute;
+    z-index: 1;
+    .solid-border();
+    color: @header-text;
+    background-color: @navbar-background;
+    text-align: left;
+    padding: 0.5em;
+    margin-top: 0.4em;
+    .menu-item {
+        margin: 0.3em;
+    }
+}
+
+#my-activities-string {
+    display: inline;
+    white-space: nowrap;
+}
+#my-activities-menu {
+    display: none;
+    white-space: nowrap;
+}
+
 
 /* ------------------------------------------------------------------------ */
 /* Alert & Test bar */
@@ -461,6 +537,19 @@ details[open] summary {
 .graph-series-loop(10);
 
 /*
+ If the screen is "narrow enough", collapse the activities into a menu.
+ > 900px allows *all* activities to be displayed for English, French, and German.
+*/
+@media only screen and (max-width: 900px) {
+    #my-activities-string {
+        display: none;
+    }
+    #my-activities-menu {
+        display: inline;
+    }
+}
+
+/*
  If the screen is "narrow enough" we move the statsbar below the page
  content using a flex layout. We don't use a flex layout for the
  regular content because doing so cuts off the project listings on
@@ -490,17 +579,27 @@ details[open] summary {
 }
 
 /* For even smaller screens, change the header and footer */
-@media only screen and (max-width: 481px) {
+@media only screen and (max-width: 600px) {
     #header {
-        #titles-preserved {
-            display: table-row;
-            .right-align;
-            font-size: 0.8em;
-        }
         #logo {
             max-width: 95%;
             img {
                 max-width: 95%;
+            }
+        }
+        #logo-right {
+            display: table-row;
+        }
+        #titles-preserved {
+            .right-align;
+            font-size: 0.8em;
+            padding-bottom: 5px;
+        }
+        .icon-menu-item {
+            font-size: 0.6em;
+            padding-bottom: 5px;
+            .icon-menu-item-name {
+                display: none;
             }
         }
     }

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -84,6 +84,9 @@
 .invisible {
   visibility: hidden;
 }
+.transparent {
+  opacity: 0;
+}
 .nodisp {
   display: none;
 }
@@ -102,6 +105,9 @@
   bottom: 0;
   left: 0;
   right: 0;
+}
+.rotate {
+  transform: rotate(90deg);
 }
 /* ------------------------------------------------------------------------ */
 /* WEB FONTS */
@@ -1191,9 +1197,10 @@ header,
 }
 header #logo,
 #header #logo,
-header #titles-preserved,
-#header #titles-preserved {
+header #logo-right,
+#header #logo-right {
   display: table-cell;
+  vertical-align: middle;
 }
 header #logo,
 #header #logo {
@@ -1208,13 +1215,61 @@ header #logo img,
 header #titles-preserved,
 #header #titles-preserved {
   text-align: center;
-  vertical-align: middle;
   font-size: 0.9em;
 }
 header #titles-preserved #x-preserved,
 #header #titles-preserved #x-preserved {
   font-weight: bold;
   font-family: Verdana, Helvetica, sans-serif;
+}
+header #icon-menu,
+#header #icon-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+header .icon-menu-item,
+#header .icon-menu-item {
+  position: relative;
+  cursor: pointer;
+  margin-right: 1.5em;
+  text-align: center;
+  text-decoration: none;
+  font-family: Verdana, Helvetica, sans-serif;
+  font-size: 0.7em;
+  color: black;
+}
+header .icon-menu-item a:link,
+#header .icon-menu-item a:link,
+header .icon-menu-item a:visited,
+#header .icon-menu-item a:visited,
+header .icon-menu-item a:active,
+#header .icon-menu-item a:active {
+  color: black;
+}
+header .icon-menu-item .icon-menu-item-name,
+#header .icon-menu-item .icon-menu-item-name {
+  font-size: 0.9em;
+  color: #bcbcbc;
+}
+header .icon-menu-item .icon-menu-item-name a:link,
+#header .icon-menu-item .icon-menu-item-name a:link,
+header .icon-menu-item .icon-menu-item-name a:visited,
+#header .icon-menu-item .icon-menu-item-name a:visited,
+header .icon-menu-item .icon-menu-item-name a:active,
+#header .icon-menu-item .icon-menu-item-name a:active {
+  color: #bcbcbc;
+}
+header .icon-menu-item .inbox-badge,
+#header .icon-menu-item .inbox-badge {
+  background-color: #ff8080;
+  border-radius: 2px;
+  color: #262626;
+  padding: 1px 3px;
+  font-size: 0.9em;
+  position: absolute;
+  top: -3px;
+  right: -3px;
 }
 /* ------------------------------------------------------------------------ */
 /* Navbar */
@@ -1274,6 +1329,42 @@ nav,
 }
 #navbar form div {
   display: inline;
+}
+.menu {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  color: #cdcdcd;
+  text-align: center;
+  min-width: 4em;
+}
+.menu-selector {
+  display: inline;
+}
+.menu-icon {
+  transition-duration: 0.15s;
+}
+.menu-contents {
+  transition: all 0.15s ease-in-out;
+  position: absolute;
+  z-index: 1;
+  border: thin solid #565656;
+  color: #d5d5d5;
+  background-color: black;
+  text-align: left;
+  padding: 0.5em;
+  margin-top: 0.4em;
+}
+.menu-contents .menu-item {
+  margin: 0.3em;
+}
+#my-activities-string {
+  display: inline;
+  white-space: nowrap;
+}
+#my-activities-menu {
+  display: none;
+  white-space: nowrap;
 }
 /* ------------------------------------------------------------------------ */
 /* Alert & Test bar */
@@ -1564,6 +1655,18 @@ details[open] summary {
   stroke: #80b3ff;
 }
 /*
+ If the screen is "narrow enough", collapse the activities into a menu.
+ > 900px allows *all* activities to be displayed for English, French, and German.
+*/
+@media only screen and (max-width: 900px) {
+  #my-activities-string {
+    display: none;
+  }
+  #my-activities-menu {
+    display: inline;
+  }
+}
+/*
  If the screen is "narrow enough" we move the statsbar below the page
  content using a flex layout. We don't use a flex layout for the
  regular content because doing so cuts off the project listings on
@@ -1591,17 +1694,27 @@ details[open] summary {
   }
 }
 /* For even smaller screens, change the header and footer */
-@media only screen and (max-width: 481px) {
-  #header #titles-preserved {
-    display: table-row;
-    text-align: right;
-    font-size: 0.8em;
-  }
+@media only screen and (max-width: 600px) {
   #header #logo {
     max-width: 95%;
   }
   #header #logo img {
     max-width: 95%;
+  }
+  #header #logo-right {
+    display: table-row;
+  }
+  #header #titles-preserved {
+    text-align: right;
+    font-size: 0.8em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item {
+    font-size: 0.6em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item .icon-menu-item-name {
+    display: none;
   }
   #buildtime {
     display: none;
@@ -2826,13 +2939,25 @@ header,
      * https://caniuse.com/mdn-css_properties_content_element_replacement
      */
 }
-header #logo,
-#header #logo {
+header #logo-img,
+#header #logo-img {
   content: url('../../graphics/dp-logo-dark.svg');
 }
-#logo,
-#titles-preserved {
-  display: table-cell;
+header #search-menu,
+#header #search-menu {
+  color: #cdcdcd;
+}
+header .icon-menu-item,
+#header .icon-menu-item {
+  color: #bcbcbc;
+}
+header .icon-menu-item a:link,
+#header .icon-menu-item a:link,
+header .icon-menu-item a:visited,
+#header .icon-menu-item a:visited,
+header .icon-menu-item a:active,
+#header .icon-menu-item a:active {
+  color: #bcbcbc;
 }
 /* 
  * Image treatment. This is primarily aimed at proofing

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -33,13 +33,18 @@ header, #header {
      * FF 62 and earlier due to lack of content: element-replacement support
      * https://caniuse.com/mdn-css_properties_content_element_replacement
      */
-    #logo {
+    #logo-img {
         content: url('../../graphics/dp-logo-dark.svg');
     }
+    #search-menu {
+        color: @navbar-text;
+    }
+    .icon-menu-item {
+        color: @heading-color;
+        .unicolor-link(@heading-color);
+    }
 }
-#logo, #titles-preserved {
-    display: table-cell;
-}
+
 
 /* 
  * Image treatment. This is primarily aimed at proofing

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -84,6 +84,9 @@
 .invisible {
   visibility: hidden;
 }
+.transparent {
+  opacity: 0;
+}
 .nodisp {
   display: none;
 }
@@ -102,6 +105,9 @@
   bottom: 0;
   left: 0;
   right: 0;
+}
+.rotate {
+  transform: rotate(90deg);
 }
 /* ------------------------------------------------------------------------ */
 /* WEB FONTS */
@@ -1191,9 +1197,10 @@ header,
 }
 header #logo,
 #header #logo,
-header #titles-preserved,
-#header #titles-preserved {
+header #logo-right,
+#header #logo-right {
   display: table-cell;
+  vertical-align: middle;
 }
 header #logo,
 #header #logo {
@@ -1208,13 +1215,61 @@ header #logo img,
 header #titles-preserved,
 #header #titles-preserved {
   text-align: center;
-  vertical-align: middle;
   font-size: 0.9em;
 }
 header #titles-preserved #x-preserved,
 #header #titles-preserved #x-preserved {
   font-weight: bold;
   font-family: Verdana, Helvetica, sans-serif;
+}
+header #icon-menu,
+#header #icon-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+header .icon-menu-item,
+#header .icon-menu-item {
+  position: relative;
+  cursor: pointer;
+  margin-right: 1.5em;
+  text-align: center;
+  text-decoration: none;
+  font-family: Verdana, Helvetica, sans-serif;
+  font-size: 0.7em;
+  color: #444444;
+}
+header .icon-menu-item a:link,
+#header .icon-menu-item a:link,
+header .icon-menu-item a:visited,
+#header .icon-menu-item a:visited,
+header .icon-menu-item a:active,
+#header .icon-menu-item a:active {
+  color: #444444;
+}
+header .icon-menu-item .icon-menu-item-name,
+#header .icon-menu-item .icon-menu-item-name {
+  font-size: 0.9em;
+  color: #333333;
+}
+header .icon-menu-item .icon-menu-item-name a:link,
+#header .icon-menu-item .icon-menu-item-name a:link,
+header .icon-menu-item .icon-menu-item-name a:visited,
+#header .icon-menu-item .icon-menu-item-name a:visited,
+header .icon-menu-item .icon-menu-item-name a:active,
+#header .icon-menu-item .icon-menu-item-name a:active {
+  color: #333333;
+}
+header .icon-menu-item .inbox-badge,
+#header .icon-menu-item .inbox-badge {
+  background-color: red;
+  border-radius: 2px;
+  color: #ffffff;
+  padding: 1px 3px;
+  font-size: 0.9em;
+  position: absolute;
+  top: -3px;
+  right: -3px;
 }
 /* ------------------------------------------------------------------------ */
 /* Navbar */
@@ -1274,6 +1329,42 @@ nav,
 }
 #navbar form div {
   display: inline;
+}
+.menu {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  color: #ffffff;
+  text-align: center;
+  min-width: 4em;
+}
+.menu-selector {
+  display: inline;
+}
+.menu-icon {
+  transition-duration: 0.15s;
+}
+.menu-contents {
+  transition: all 0.15s ease-in-out;
+  position: absolute;
+  z-index: 1;
+  border: thin solid #000000;
+  color: #000000;
+  background-color: #444444;
+  text-align: left;
+  padding: 0.5em;
+  margin-top: 0.4em;
+}
+.menu-contents .menu-item {
+  margin: 0.3em;
+}
+#my-activities-string {
+  display: inline;
+  white-space: nowrap;
+}
+#my-activities-menu {
+  display: none;
+  white-space: nowrap;
 }
 /* ------------------------------------------------------------------------ */
 /* Alert & Test bar */
@@ -1564,6 +1655,18 @@ details[open] summary {
   stroke: #1f77b4;
 }
 /*
+ If the screen is "narrow enough", collapse the activities into a menu.
+ > 900px allows *all* activities to be displayed for English, French, and German.
+*/
+@media only screen and (max-width: 900px) {
+  #my-activities-string {
+    display: none;
+  }
+  #my-activities-menu {
+    display: inline;
+  }
+}
+/*
  If the screen is "narrow enough" we move the statsbar below the page
  content using a flex layout. We don't use a flex layout for the
  regular content because doing so cuts off the project listings on
@@ -1591,17 +1694,27 @@ details[open] summary {
   }
 }
 /* For even smaller screens, change the header and footer */
-@media only screen and (max-width: 481px) {
-  #header #titles-preserved {
-    display: table-row;
-    text-align: right;
-    font-size: 0.8em;
-  }
+@media only screen and (max-width: 600px) {
   #header #logo {
     max-width: 95%;
   }
   #header #logo img {
     max-width: 95%;
+  }
+  #header #logo-right {
+    display: table-row;
+  }
+  #header #titles-preserved {
+    text-align: right;
+    font-size: 0.8em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item {
+    font-size: 0.6em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item .icon-menu-item-name {
+    display: none;
   }
   #buildtime {
     display: none;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -84,6 +84,9 @@
 .invisible {
   visibility: hidden;
 }
+.transparent {
+  opacity: 0;
+}
 .nodisp {
   display: none;
 }
@@ -102,6 +105,9 @@
   bottom: 0;
   left: 0;
   right: 0;
+}
+.rotate {
+  transform: rotate(90deg);
 }
 /* ------------------------------------------------------------------------ */
 /* WEB FONTS */
@@ -1191,9 +1197,10 @@ header,
 }
 header #logo,
 #header #logo,
-header #titles-preserved,
-#header #titles-preserved {
+header #logo-right,
+#header #logo-right {
   display: table-cell;
+  vertical-align: middle;
 }
 header #logo,
 #header #logo {
@@ -1208,13 +1215,61 @@ header #logo img,
 header #titles-preserved,
 #header #titles-preserved {
   text-align: center;
-  vertical-align: middle;
   font-size: 0.9em;
 }
 header #titles-preserved #x-preserved,
 #header #titles-preserved #x-preserved {
   font-weight: bold;
   font-family: Verdana, Helvetica, sans-serif;
+}
+header #icon-menu,
+#header #icon-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+header .icon-menu-item,
+#header .icon-menu-item {
+  position: relative;
+  cursor: pointer;
+  margin-right: 1.5em;
+  text-align: center;
+  text-decoration: none;
+  font-family: Verdana, Helvetica, sans-serif;
+  font-size: 0.7em;
+  color: #336633;
+}
+header .icon-menu-item a:link,
+#header .icon-menu-item a:link,
+header .icon-menu-item a:visited,
+#header .icon-menu-item a:visited,
+header .icon-menu-item a:active,
+#header .icon-menu-item a:active {
+  color: #336633;
+}
+header .icon-menu-item .icon-menu-item-name,
+#header .icon-menu-item .icon-menu-item-name {
+  font-size: 0.9em;
+  color: #234523;
+}
+header .icon-menu-item .icon-menu-item-name a:link,
+#header .icon-menu-item .icon-menu-item-name a:link,
+header .icon-menu-item .icon-menu-item-name a:visited,
+#header .icon-menu-item .icon-menu-item-name a:visited,
+header .icon-menu-item .icon-menu-item-name a:active,
+#header .icon-menu-item .icon-menu-item-name a:active {
+  color: #234523;
+}
+header .icon-menu-item .inbox-badge,
+#header .icon-menu-item .inbox-badge {
+  background-color: red;
+  border-radius: 2px;
+  color: #ffffff;
+  padding: 1px 3px;
+  font-size: 0.9em;
+  position: absolute;
+  top: -3px;
+  right: -3px;
 }
 /* ------------------------------------------------------------------------ */
 /* Navbar */
@@ -1274,6 +1329,42 @@ nav,
 }
 #navbar form div {
   display: inline;
+}
+.menu {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  color: #ffffff;
+  text-align: center;
+  min-width: 4em;
+}
+.menu-selector {
+  display: inline;
+}
+.menu-icon {
+  transition-duration: 0.15s;
+}
+.menu-contents {
+  transition: all 0.15s ease-in-out;
+  position: absolute;
+  z-index: 1;
+  border: thin solid #000000;
+  color: #000000;
+  background-color: #336633;
+  text-align: left;
+  padding: 0.5em;
+  margin-top: 0.4em;
+}
+.menu-contents .menu-item {
+  margin: 0.3em;
+}
+#my-activities-string {
+  display: inline;
+  white-space: nowrap;
+}
+#my-activities-menu {
+  display: none;
+  white-space: nowrap;
 }
 /* ------------------------------------------------------------------------ */
 /* Alert & Test bar */
@@ -1564,6 +1655,18 @@ details[open] summary {
   stroke: #1f77b4;
 }
 /*
+ If the screen is "narrow enough", collapse the activities into a menu.
+ > 900px allows *all* activities to be displayed for English, French, and German.
+*/
+@media only screen and (max-width: 900px) {
+  #my-activities-string {
+    display: none;
+  }
+  #my-activities-menu {
+    display: inline;
+  }
+}
+/*
  If the screen is "narrow enough" we move the statsbar below the page
  content using a flex layout. We don't use a flex layout for the
  regular content because doing so cuts off the project listings on
@@ -1591,17 +1694,27 @@ details[open] summary {
   }
 }
 /* For even smaller screens, change the header and footer */
-@media only screen and (max-width: 481px) {
-  #header #titles-preserved {
-    display: table-row;
-    text-align: right;
-    font-size: 0.8em;
-  }
+@media only screen and (max-width: 600px) {
   #header #logo {
     max-width: 95%;
   }
   #header #logo img {
     max-width: 95%;
+  }
+  #header #logo-right {
+    display: table-row;
+  }
+  #header #titles-preserved {
+    text-align: right;
+    font-size: 0.8em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item {
+    font-size: 0.6em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item .icon-menu-item-name {
+    display: none;
   }
   #buildtime {
     display: none;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -84,6 +84,9 @@
 .invisible {
   visibility: hidden;
 }
+.transparent {
+  opacity: 0;
+}
 .nodisp {
   display: none;
 }
@@ -102,6 +105,9 @@
   bottom: 0;
   left: 0;
   right: 0;
+}
+.rotate {
+  transform: rotate(90deg);
 }
 /* ------------------------------------------------------------------------ */
 /* WEB FONTS */
@@ -1191,9 +1197,10 @@ header,
 }
 header #logo,
 #header #logo,
-header #titles-preserved,
-#header #titles-preserved {
+header #logo-right,
+#header #logo-right {
   display: table-cell;
+  vertical-align: middle;
 }
 header #logo,
 #header #logo {
@@ -1208,13 +1215,61 @@ header #logo img,
 header #titles-preserved,
 #header #titles-preserved {
   text-align: center;
-  vertical-align: middle;
   font-size: 0.9em;
 }
 header #titles-preserved #x-preserved,
 #header #titles-preserved #x-preserved {
   font-weight: bold;
   font-family: Verdana, Helvetica, sans-serif;
+}
+header #icon-menu,
+#header #icon-menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+header .icon-menu-item,
+#header .icon-menu-item {
+  position: relative;
+  cursor: pointer;
+  margin-right: 1.5em;
+  text-align: center;
+  text-decoration: none;
+  font-family: Verdana, Helvetica, sans-serif;
+  font-size: 0.7em;
+  color: #000099;
+}
+header .icon-menu-item a:link,
+#header .icon-menu-item a:link,
+header .icon-menu-item a:visited,
+#header .icon-menu-item a:visited,
+header .icon-menu-item a:active,
+#header .icon-menu-item a:active {
+  color: #000099;
+}
+header .icon-menu-item .icon-menu-item-name,
+#header .icon-menu-item .icon-menu-item-name {
+  font-size: 0.9em;
+  color: #000066;
+}
+header .icon-menu-item .icon-menu-item-name a:link,
+#header .icon-menu-item .icon-menu-item-name a:link,
+header .icon-menu-item .icon-menu-item-name a:visited,
+#header .icon-menu-item .icon-menu-item-name a:visited,
+header .icon-menu-item .icon-menu-item-name a:active,
+#header .icon-menu-item .icon-menu-item-name a:active {
+  color: #000066;
+}
+header .icon-menu-item .inbox-badge,
+#header .icon-menu-item .inbox-badge {
+  background-color: red;
+  border-radius: 2px;
+  color: #ffffff;
+  padding: 1px 3px;
+  font-size: 0.9em;
+  position: absolute;
+  top: -3px;
+  right: -3px;
 }
 /* ------------------------------------------------------------------------ */
 /* Navbar */
@@ -1274,6 +1329,42 @@ nav,
 }
 #navbar form div {
   display: inline;
+}
+.menu {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  color: #ffffff;
+  text-align: center;
+  min-width: 4em;
+}
+.menu-selector {
+  display: inline;
+}
+.menu-icon {
+  transition-duration: 0.15s;
+}
+.menu-contents {
+  transition: all 0.15s ease-in-out;
+  position: absolute;
+  z-index: 1;
+  border: thin solid #000000;
+  color: #000000;
+  background-color: #000099;
+  text-align: left;
+  padding: 0.5em;
+  margin-top: 0.4em;
+}
+.menu-contents .menu-item {
+  margin: 0.3em;
+}
+#my-activities-string {
+  display: inline;
+  white-space: nowrap;
+}
+#my-activities-menu {
+  display: none;
+  white-space: nowrap;
 }
 /* ------------------------------------------------------------------------ */
 /* Alert & Test bar */
@@ -1564,6 +1655,18 @@ details[open] summary {
   stroke: #1f77b4;
 }
 /*
+ If the screen is "narrow enough", collapse the activities into a menu.
+ > 900px allows *all* activities to be displayed for English, French, and German.
+*/
+@media only screen and (max-width: 900px) {
+  #my-activities-string {
+    display: none;
+  }
+  #my-activities-menu {
+    display: inline;
+  }
+}
+/*
  If the screen is "narrow enough" we move the statsbar below the page
  content using a flex layout. We don't use a flex layout for the
  regular content because doing so cuts off the project listings on
@@ -1591,17 +1694,27 @@ details[open] summary {
   }
 }
 /* For even smaller screens, change the header and footer */
-@media only screen and (max-width: 481px) {
-  #header #titles-preserved {
-    display: table-row;
-    text-align: right;
-    font-size: 0.8em;
-  }
+@media only screen and (max-width: 600px) {
   #header #logo {
     max-width: 95%;
   }
   #header #logo img {
     max-width: 95%;
+  }
+  #header #logo-right {
+    display: table-row;
+  }
+  #header #titles-preserved {
+    text-align: right;
+    font-size: 0.8em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item {
+    font-size: 0.6em;
+    padding-bottom: 5px;
+  }
+  #header .icon-menu-item .icon-menu-item-name {
+    display: none;
   }
   #buildtime {
     display: none;

--- a/userprefs.php
+++ b/userprefs.php
@@ -256,7 +256,14 @@ function echo_general_tab($user)
         ['100%', 'required', '']
         // About 98% of pgdp.net's users have length(real_name) <= 20
     );
-    show_blank();
+    show_preference(
+        _('Interface Language'),
+        'u_intlang',
+        'intlang',
+        $user->u_intlang,
+        'dropdown',
+        $u_intlang_options
+    );
     echo "</tr>\n";
 
     // Check for DP/forum email mismatch, warn user if not the same
@@ -277,25 +284,6 @@ function echo_general_tab($user)
         'emailfield',
         ['100%', 'required', $email_warning]
     );
-    show_preference(
-        _('Interface Language'),
-        'u_intlang',
-        'intlang',
-        $user->u_intlang,
-        'dropdown',
-        $u_intlang_options
-    );
-    echo "</tr>\n";
-
-    echo "<tr>\n";
-    show_preference(
-        _('E-mail Updates'),
-        'email_updates',
-        'updates',
-        $user->email_updates,
-        'radio_group',
-        [1 => _("Yes"), 0 => _("No")]
-    );
     $theme_options = [];
     $result = DPDatabase::query("SELECT * FROM themes");
     while ($row = mysqli_fetch_array($result)) {
@@ -310,6 +298,30 @@ function echo_general_tab($user)
         $user->i_theme,
         'dropdown',
         $theme_options
+    );
+    echo "</tr>\n";
+
+    echo "<tr>\n";
+    show_preference(
+        _('E-mail Updates'),
+        'email_updates',
+        'updates',
+        $user->email_updates,
+        'radio_group',
+        [1 => _("Yes"), 0 => _("No")]
+    );
+    $navbar_options = [
+        0 => _("Always collapse"),
+        1 => _("Auto collapse"),
+        2 => _("Never collapse"),
+    ];
+    show_preference(
+        _('My Activities Menu'),
+        'navbar_activity_menu',
+        'navbar_activity_menu',
+        $user->navbar_activity_menu,
+        'dropdown',
+        $navbar_options
     );
     echo "</tr>\n";
 
@@ -411,7 +423,7 @@ function save_general_tab($user)
 
     // set users values
     $input_string_fields = ["real_name", "email", "email_updates", "i_theme", "u_intlang"];
-    $input_numeric_fields = ["u_align", "u_neigh", "u_privacy"];
+    $input_numeric_fields = ["u_align", "u_neigh", "u_privacy", "navbar_activity_menu"];
 
     // pull only specific data out of $_POST
     $data = [];


### PR DESCRIPTION
Introduce the idea of drop-down menu options to group like things together and make better use of the top header space. Much to my chagrin we use the new menu based on a user preference; if the preference is set to "auto" (the default) dynamically use the menu based on the width of the window.

This is available for testing in https://www.pgdp.org/~cpeel/c.branch/refine-navbar/

See also the discussion in the [Proposed changes to the navigation bar - 2024 edition](https://www.pgdp.net/phpBB3/viewtopic.php?f=4&t=81413) forum.

Testing notes: In addition to confirming this works in all our minimum browsers, we should make sure this looks good in all themes -- including having an unread message in the forums which will add an "unread messages" number to the new Inbox icon -- and on various mobile devices.