### PR TITLE
Fix round backlog graphs

### DIFF
--- a/stats/round_backlog.php
+++ b/stats/round_backlog.php
@@ -34,7 +34,7 @@ $stats = query_graph_cache("_get_round_backlog_data", [], 60 * 60 * 24);
 $stats_total = array_sum($stats);
 
 // calculate the goal percent as 100 / number_of_phases
-$goal_percent = ceil(100 / min(1, count($stats)));
+$goal_percent = ceil(100 / max(1, count($stats)));
 
 // colors
 $barColors = [];

--- a/stats/round_backlog_days.php
+++ b/stats/round_backlog_days.php
@@ -55,7 +55,7 @@ $stats = query_graph_cache("_get_round_backlog_days_data", [], 60 * 60 * 24);
 $stats_total = array_sum($stats);
 
 // calculate the goal percent as 100 / number_of_phases
-$goal_percent = ceil(100 / min(1, count($stats)));
+$goal_percent = ceil(100 / max(1, count($stats)));
 
 // colors
 $barColors = [];


### PR DESCRIPTION
61c6b1438 inadvertently used `min()` when we really want `max()`