### PR TITLE
Return 404 if project page table doesn't exist

### DIFF
--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -436,12 +436,16 @@ function api_v1_project_pages($method, $data, $query_params)
     $project = $data[":projectid"];
 
     $return_data = [];
-    foreach ($project->get_page_names_from_db() as $image) {
-        $return_data[] = [
-            "image" => $image,
-            "image_url" => "{$project->url}/$image",
-            "image_size" => (int)$project->get_image_file_size($image),
-        ];
+    try {
+        foreach ($project->get_page_names_from_db() as $image) {
+            $return_data[] = [
+                "image" => $image,
+                "image_url" => "{$project->url}/$image",
+                "image_size" => (int)$project->get_image_file_size($image),
+            ];
+        }
+    } catch (NoProjectPageTable $exception) {
+        throw new NotFoundError($exception->getMessage(), $exception->getCode());
     }
     return $return_data;
 }
@@ -470,7 +474,11 @@ function api_v1_project_pagedetails($method, $data, $query_params)
     }
 
     $project = $data[":projectid"];
-    $rounds_to_display = get_rounds_to_display($project);
+    try {
+        $rounds_to_display = get_rounds_to_display($project);
+    } catch (NoProjectPageTable $exception) {
+        throw new NotFoundError($exception->getMessage(), $exception->getCode());
+    }
     if (!is_null($only_rounds)) {
         $rounds_to_display = array_intersect($rounds_to_display, $only_rounds);
     }

--- a/api/v1_validators.inc
+++ b/api/v1_validators.inc
@@ -44,7 +44,7 @@ function validate_page_name($pagename, $data)
             throw new NonexistentPageException("No such page in project");
         }
         return $pagename;
-    } catch (NonexistentPageException $exception) {
+    } catch (NonexistentPageException | NoProjectPageTable $exception) {
         throw new NotFoundError($exception->getMessage(), $exception->getCode());
     }
 }

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -15,7 +15,7 @@ function get_rounds_to_display($project)
     // yet to do, so there may be some round-columns with no data in them.
     // Figure out which ones to display.
     //
-    $rounds_to_display = get_rounds_with_data($project->projectid);
+    $rounds_to_display = get_rounds_with_data($project);
 
     // If the project is in a round, then users expect that round to appear here,
     // even if there's no data in it.
@@ -132,7 +132,7 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         $wordcheck_events = [];
     }
 
-    $rounds_with_data = get_rounds_with_data($project->projectid);
+    $rounds_with_data = get_rounds_with_data($project);
 
     $fields_to_get = "{$project->projectid}.image AS image, length(master_text), state";
     $tables = $project->projectid;
@@ -560,8 +560,13 @@ function can_user_see_usernames_for_page(Project $project, array $proofer_userna
  * Returns an array of Rounds representing those rounds
  * for which the given project has some useful data.
  */
-function get_rounds_with_data($projectid)
+function get_rounds_with_data(Project $project): array
 {
+    $projectid = $project->projectid;
+    if (!$project->pages_table_exists) {
+        throw new NoProjectPageTable(_("Project page table does not exist."));
+    }
+
     $rounds_with_data = [];
 
     // Currently, when a project skips a round, the time and text of the


### PR DESCRIPTION
Instead of return a 500 server error, return a 404 if an API call is querying a project's page table that doesn't exist.

```bash
# current code returns 500
curl -i -H "Accept: application/json" -H "X-API-KEY: review" \
    -X GET "https://www.pgdp.org/api/v1/projects/projectID4b8bc04f5dc7c/pagedetails"

# new code returns 404
curl -i -H "Accept: application/json" -H "X-API-KEY: review" \
    -X GET "https://www.pgdp.org/~cpeel/c.branch/return-404-for-missing-project-table-api/api/v1/projects/projectID4b8bc04f5dc7c/pagedetails"
```

This fixes the following API endpoints that use the page table (using an archived project as an example):
```
/api/v1/projects/projectID4b8bc04f5dc7c/pagedetails
/api/v1/projects/projectID4b8bc04f5dc7c/pages
/api/v1/projects/projectID4b8bc04f5dc7c/pages/001.png/pagerounds/P1
```

Sandbox: https://www.pgdp.org/~cpeel/c.branch/return-404-for-missing-project-table-api/