### PR TITLE
Remove layout in page exception messages

### DIFF
--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -538,18 +538,12 @@ function _Page_require(
     $res = DPDatabase::query($sql);
     [$curr_page_state, $curr_page_owner] = mysqli_fetch_row($res);
     if (!in_array($curr_page_state, $allowed_states)) {
-        $err = "\n"
-            . "    "
-            . sprintf(
-                _("This operation (%s) requires that the page be in one of the following states:"),
-                $op_name
-            )
-            . "\n"
-            . "        "
-            . implode(' ', $allowed_states)
-            . "\n"
-            . "    "
-            . sprintf(_("But it is in %s"), $curr_page_state);
+        $err = sprintf(
+            _("This operation (%s) requires that the page be in one of the following states: %s. But it is in state %s."),
+            $op_name,
+            implode(', ', $allowed_states),
+            $curr_page_state
+        );
         throw new ProjectPageException($err);
     }
 
@@ -561,12 +555,10 @@ function _Page_require(
         // The operation can only be done by the person who currently
         // "owns" the page.
         if ($requesting_user != $curr_page_owner) {
-            $err = "\n"
-                . "    "
-                . sprintf(
-                    _("This operation (%s) can only be done by the user who has the page checked out, which you are not."),
-                    $op_name
-                );
+            $err = sprintf(
+                _("This operation (%s) can only be done by the user who has the page checked out, which you are not."),
+                $op_name
+            );
             throw new ProjectPageException($err);
         }
     }


### PR DESCRIPTION
While testing Ray's proofreading API PR I saw some weird string layouts in some of the exception messages, this fixes them. Interestingly because we output these in HTML it almost doesn't change the format from the web-perspective because all of the whitespace collapses together but it really improves them from the API perspective.

You can see one of them with: https://www.pgdp.org/~cpeel/c.branch/remove-error-formatting/tools/proofers/proof.php?projectid=projectID4c49f39aa829c&imagefile=190.png&proj_state=F1.proj_avail&page_state=F1.page_avail