### PR TITLE
Add new "site search" page

### DIFF
--- a/pinc/forum_interface_json.inc
+++ b/pinc/forum_interface_json.inc
@@ -350,6 +350,14 @@ function get_url_for_inbox()
     return "";
 }
 
+/**
+ * Return the URL for searching the forums
+ */
+function get_url_for_search($query)
+{
+    return "";
+}
+
 function get_number_of_unread_messages($username)
 // Given a forum username, return the number of unread messages.
 {

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -564,6 +564,14 @@ function get_url_for_inbox()
 }
 
 /**
+ * Return the URL for searching the forums
+ */
+function get_url_for_search(string $query, bool $encode = true)
+{
+    return get_url_for_forum() . "/search.php?keywords=" . ($encode ? urlencode($query) : $query);
+}
+
+/**
  * Given a forum username, return the number of unread messages.
  */
 function get_number_of_unread_messages($username)

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -179,15 +179,19 @@ function html_logobar()
             "class" => "fas fa-question fa-2x",
             "url" => get_faq_url("faq_central.php"),
         ];
+        $icon_links[] = [
+            "name" => _("Search"),
+            "class" => "fas fa-search fa-2x",
+            "onclick" => "showSiteSearch(); return false;",
+        ];
         $links = [];
         foreach ($icon_links as $data) {
             $name = attr_safe($data["name"]);
             $class = $data["class"];
             $url = $data["url"] ?? "";
+            $onclick = isset($data["onclick"]) ? "onclick='" . attr_safe($data["onclick"]) . "'" : "";
             $text = "<div class='icon-menu-item'>";
-            if ($url) {
-                $text .= "<a href='$url' aria-label='$name'>";
-            }
+            $text .= "<a href='$url' aria-label='$name' $onclick>";
             $text .= "<i aria-hidden='true' class='$class' title='$name'></i>";
             if ($data["name"] == _("Inbox")) {
                 $numofPMs = get_number_of_unread_messages($user->username);
@@ -195,10 +199,8 @@ function html_logobar()
                     $text .= "<span class='inbox-badge'>$numofPMs</span>";
                 }
             }
-            $text .= "<br><span class='icon-menu-item-name'>$name</span>";
-            if ($url) {
-                $text .= "</a>";
-            }
+            $text .= "<br><span class='icon-menu-item-name' $onclick>$name</span>";
+            $text .= "</a>";
             $text .= "</div>";
             $links[] = $text;
         }
@@ -206,6 +208,13 @@ function html_logobar()
         echo "<div id='icon-menu'>";
         echo join("", $links);
         echo "</div>"; // icon-menu
+
+        echo "<div id='search-menu' class='nodisp'>";
+        $placeholder = attr_safe(sprintf(_("Search for '%s' to see options"), "help"));
+        echo "<form action='$code_url/tools/site_search.php'>";
+        echo "<input id='search-menu-input' type='text' placeholder='$placeholder' name='q' autocapitalize='none'>&nbsp;<i aria-hidden='true' class='far fa-window-close' onclick='hideSiteSearch()'></i>";
+        echo "</form>";
+        echo "</div>"; // search-menu
     }
     echo "</div>"; // logo-right
     echo "</div>\n"; // header

--- a/scripts/navbar_menu.js
+++ b/scripts/navbar_menu.js
@@ -1,4 +1,4 @@
-/* exported toggleMenu */
+/* exported toggleMenu showSiteSearch hideSiteSearch */
 
 // Toggle a menu contents to visible and rotate the menu icon
 function toggleMenu(menuId) {
@@ -29,5 +29,33 @@ document.addEventListener("click", function (event) {
         document.querySelectorAll(".menu-icon").forEach(element => {
             element.classList.remove('rotate');
         });
+    }
+});
+
+// Show / hide site search input
+function showSiteSearch() {
+    document.getElementById('search-menu').classList.remove('nodisp');
+    document.getElementById('icon-menu').classList.add('nodisp');
+    document.getElementById('search-menu-input').value = '';
+    document.getElementById('search-menu-input').focus();
+}
+
+function hideSiteSearch() {
+    document.getElementById('search-menu').classList.add('nodisp');
+    document.getElementById('icon-menu').classList.remove('nodisp');
+}
+
+window.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('search-menu').addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            hideSiteSearch();
+        }
+    });
+});
+
+document.addEventListener('keydown', (event) => {
+    if (event.key === '/' && document.activeElement.tagName == "BODY") {
+        event.preventDefault();
+        showSiteSearch();
     }
 });

--- a/styles/global.less
+++ b/styles/global.less
@@ -121,7 +121,7 @@
 }
 
 .nodisp {
-    display: none;
+    display: none !important;
 }
 
 .overflow-auto {

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -260,6 +260,18 @@ header, #header {
           right: -3px;
         }
     }
+    #search-menu {
+        text-align: right;
+        padding-right: 1em;
+        font-size: 1.2em;
+        color: @navbar-background;
+    }
+    #search-menu-input {
+        width: 90%;
+        font-size: 1em;
+        border-radius: 8px;
+        border: solid thin @border-color-base-lowc;
+    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -561,9 +573,6 @@ details[open] summary {
 */
 @media only screen and (max-width: 768px) {
     #header {
-        #month-preserved-summary {
-            display: none;
-        }
         p {
             margin: 0.25em 0.5em;
         }
@@ -602,6 +611,9 @@ details[open] summary {
             .icon-menu-item-name {
                 display: none;
             }
+        }
+        #search-menu {
+            font-size: 1em;
         }
     }
 

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -88,7 +88,7 @@
   opacity: 0;
 }
 .nodisp {
-  display: none;
+  display: none !important;
 }
 .overflow-auto {
   overflow: auto;
@@ -1273,6 +1273,20 @@ header .icon-menu-item .inbox-badge,
   top: -3px;
   right: -3px;
 }
+header #search-menu,
+#header #search-menu {
+  text-align: right;
+  padding-right: 1em;
+  font-size: 1.2em;
+  color: black;
+}
+header #search-menu-input,
+#header #search-menu-input {
+  width: 90%;
+  font-size: 1em;
+  border-radius: 8px;
+  border: solid thin #404040;
+}
 /* ------------------------------------------------------------------------ */
 /* Navbar */
 nav,
@@ -1678,9 +1692,6 @@ details[open] summary {
  window gets too narrow
 */
 @media only screen and (max-width: 768px) {
-  #header #month-preserved-summary {
-    display: none;
-  }
   #header p {
     margin: 0.25em 0.5em;
   }
@@ -1717,6 +1728,9 @@ details[open] summary {
   }
   #header .icon-menu-item .icon-menu-item-name {
     display: none;
+  }
+  #header #search-menu {
+    font-size: 1em;
   }
   #buildtime {
     display: none;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -88,7 +88,7 @@
   opacity: 0;
 }
 .nodisp {
-  display: none;
+  display: none !important;
 }
 .overflow-auto {
   overflow: auto;
@@ -1273,6 +1273,20 @@ header .icon-menu-item .inbox-badge,
   top: -3px;
   right: -3px;
 }
+header #search-menu,
+#header #search-menu {
+  text-align: right;
+  padding-right: 1em;
+  font-size: 1.2em;
+  color: #444444;
+}
+header #search-menu-input,
+#header #search-menu-input {
+  width: 90%;
+  font-size: 1em;
+  border-radius: 8px;
+  border: solid thin #d3d3d3;
+}
 /* ------------------------------------------------------------------------ */
 /* Navbar */
 nav,
@@ -1678,9 +1692,6 @@ details[open] summary {
  window gets too narrow
 */
 @media only screen and (max-width: 768px) {
-  #header #month-preserved-summary {
-    display: none;
-  }
   #header p {
     margin: 0.25em 0.5em;
   }
@@ -1717,6 +1728,9 @@ details[open] summary {
   }
   #header .icon-menu-item .icon-menu-item-name {
     display: none;
+  }
+  #header #search-menu {
+    font-size: 1em;
   }
   #buildtime {
     display: none;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -88,7 +88,7 @@
   opacity: 0;
 }
 .nodisp {
-  display: none;
+  display: none !important;
 }
 .overflow-auto {
   overflow: auto;
@@ -1273,6 +1273,20 @@ header .icon-menu-item .inbox-badge,
   top: -3px;
   right: -3px;
 }
+header #search-menu,
+#header #search-menu {
+  text-align: right;
+  padding-right: 1em;
+  font-size: 1.2em;
+  color: #336633;
+}
+header #search-menu-input,
+#header #search-menu-input {
+  width: 90%;
+  font-size: 1em;
+  border-radius: 8px;
+  border: solid thin #d3d3d3;
+}
 /* ------------------------------------------------------------------------ */
 /* Navbar */
 nav,
@@ -1678,9 +1692,6 @@ details[open] summary {
  window gets too narrow
 */
 @media only screen and (max-width: 768px) {
-  #header #month-preserved-summary {
-    display: none;
-  }
   #header p {
     margin: 0.25em 0.5em;
   }
@@ -1717,6 +1728,9 @@ details[open] summary {
   }
   #header .icon-menu-item .icon-menu-item-name {
     display: none;
+  }
+  #header #search-menu {
+    font-size: 1em;
   }
   #buildtime {
     display: none;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -88,7 +88,7 @@
   opacity: 0;
 }
 .nodisp {
-  display: none;
+  display: none !important;
 }
 .overflow-auto {
   overflow: auto;
@@ -1273,6 +1273,20 @@ header .icon-menu-item .inbox-badge,
   top: -3px;
   right: -3px;
 }
+header #search-menu,
+#header #search-menu {
+  text-align: right;
+  padding-right: 1em;
+  font-size: 1.2em;
+  color: #000099;
+}
+header #search-menu-input,
+#header #search-menu-input {
+  width: 90%;
+  font-size: 1em;
+  border-radius: 8px;
+  border: solid thin #d3d3d3;
+}
 /* ------------------------------------------------------------------------ */
 /* Navbar */
 nav,
@@ -1678,9 +1692,6 @@ details[open] summary {
  window gets too narrow
 */
 @media only screen and (max-width: 768px) {
-  #header #month-preserved-summary {
-    display: none;
-  }
   #header p {
     margin: 0.25em 0.5em;
   }
@@ -1717,6 +1728,9 @@ details[open] summary {
   }
   #header .icon-menu-item .icon-menu-item-name {
     display: none;
+  }
+  #header #search-menu {
+    font-size: 1em;
   }
   #buildtime {
     display: none;

--- a/tools/site_search.php
+++ b/tools/site_search.php
@@ -1,0 +1,352 @@
+<?php
+$relPath = "./../pinc/";
+include_once($relPath.'base.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath.'Project.inc');
+include_once($relPath.'User.inc');
+
+require_login();
+
+$query = trim(array_get($_GET, "q", "help"));
+
+// "help" is just a string to get us here, but we don't want to keep it
+if ($query == "help") {
+    $query = "";
+}
+
+if ($query !== "") {
+    // try a jump search first, as we want to prefer the built-in jump
+    // search strings over usernames that might conflict
+    jump_search($query);
+
+    // try a smart search -- usernames can't contain ':' so these will
+    // never conflict
+    smart_search($query);
+
+    try {
+        // try a prefix search
+        prefix_search($query);
+
+        $message = sprintf(_("Not sure what to do with '%s', maybe try one of the prefixes below."), $query);
+    } catch (Exception $exception) {
+        $message = sprintf(_("The input for your prefix search was invalid: %s"), $exception->getMessage());
+    }
+}
+
+$title = _("Site Search");
+output_header($title, NO_STATSBAR);
+
+echo "<h1>$title</h1>";
+
+if (@$message) {
+    echo "<p class='warning'>" . html_safe($message) . "</p>";
+}
+
+echo "<form>";
+echo "<input type='text' name='q' value='" . attr_safe($query) . "'> ";
+echo "<input type='submit' value='" . attr_safe(_("Search")) . "'>";
+echo "</form>";
+
+echo "<p>" . _("Site search attempts to figure out what you're looking for and get you to it quickly.") . "</p>";
+
+echo "<ul>";
+echo "<li>" . _("Enter a projectID to go to the project's page.") . "</li>";
+echo "<li>" . _("Enter a username to go to the user's statistics page.") . "</li>";
+echo "<li>" . sprintf(
+    _("Enter an activity (%s) to go to the activity's page."),
+    surround_and_join(array_keys(get_activity_jumps()), "<kbd>", "</kbd>", ", ")
+) . "</li>";
+echo "</ul>";
+
+echo "<p>" . _("The following prefixes can be used to search across various categories.") . "</p>";
+
+echo "<ul>";
+foreach (get_prefix_searches() as $prefix => $data) {
+    echo "<li>";
+    echo "<kbd>$prefix:</kbd> - " . $data["desc"];
+    if (@$data["alias"]) {
+        echo " (" . sprintf(_("alias: %s"), "<kbd>" . $data["alias"] . ":</kbd>") . ")";
+    }
+    echo "</li>";
+}
+echo "</ul>";
+
+echo "<p>" . _("In addition, the following words can be used to jump to specific site pages.") . "</p>";
+
+echo "<ul>";
+foreach (get_jump_words() as $prefix => $data) {
+    echo "<li>";
+    echo "<kbd>$prefix</kbd> - " . $data["desc"];
+    if (@$data["alias"]) {
+        echo " (" . sprintf(_("alias: %s"), "<kbd>" . $data["alias"] . "</kbd>") . ")";
+    }
+    echo "</li>";
+}
+echo "</ul>";
+
+echo "<hr>";
+
+echo "<p>" . _("You can access site search in three ways:") . "</p>";
+echo "<ul>";
+echo "<li>" . _("Use the search icon (the magnifying glass) in the header to start a site search. You can cancel it with the escape key.") . "</li>";
+echo "<li>" . _("When on any page with the logo in the header, typing the <kbd>/</kbd> key on your keyboard will bring up the search field as long as an input field doesn't already have focus.") . "</li>";
+echo "<li>" . sprintf(
+    _("Add this page to your browser's custom search feature (eg <a href='%s'>smart keywords</a> in Firefox, <a href='%s'>site shortcuts</a> in Chrome).<br>The URL to use in searching is <kbd>%s</kbd>"),
+    "https://support.mozilla.org/en-US/kb/how-search-from-address-bar",
+    "https://support.google.com/chrome/answer/95426",
+    "$code_url/tools/site_search.php?q=%s"
+) . "</li>";
+echo "</ul>";
+
+//----------------------------------------------------------------------------
+
+function get_prefix_searches(bool $flatten_aliases = false): array
+{
+    global $code_url, $wiki_url;
+
+    $prefix_searches = [
+        "title" => [
+            "url" => "$code_url/tools/search.php?show=search&title=%s",
+            "desc" => _("Project search for this in the title"),
+            "alias" => "t",
+        ],
+        "author" => [
+            "url" => "$code_url/tools/search.php?show=search&author=%s",
+            "desc" => _("Project search for this in the author"),
+            "alias" => "a",
+        ],
+        "pm" => [
+            "url" => "$code_url/tools/search.php?show=search&project_manager=%s",
+            "desc" => _("Project search for this project manager"),
+        ],
+        "user" => [
+            "url" => "$code_url/stats/members/mbr_list.php?uname=%s",
+            "desc" => _("Search for this username or part of a username"),
+            "alias" => "u",
+        ],
+        "team" => [
+            "url" => "$code_url/stats/teams/tlist.php?tname=%s",
+            "desc" => _("Search for this team name or part of a team name"),
+        ],
+        "task" => [
+            "url" => "$code_url/tasks.php?task_id=%s",
+            "desc" => _("Jump to this task ID"),
+            "validator" => "_validate_integer",
+        ],
+    ];
+
+    if (get_url_for_forum()) {
+        $prefix_searches["forum"] = [
+            "url" => get_url_for_search("%s", false),
+            "desc" => _("Search for this in forum posts"),
+            "alias" => "f",
+        ];
+    }
+
+    if (!empty($wiki_url)) {
+        $prefix_searches["wiki"] = [
+            "url" => "$wiki_url/Special:Search/Index.php?profile=all&search=%s",
+            "desc" => _("Search for this in the wiki"),
+            "alias" => "w",
+        ];
+    }
+
+    if ($flatten_aliases) {
+        foreach ($prefix_searches as $key => &$data) {
+            if (isset($data["alias"])) {
+                $alias = $data["alias"];
+                unset($data["alias"]);
+                $prefix_searches[$alias] = $data;
+            }
+        }
+    }
+
+    return $prefix_searches;
+}
+
+function get_jump_words(bool $flatten_aliases = false): array
+{
+    global $code_url, $wiki_url, $blog_url;
+
+    $jump_words = [
+        "activityhub" => [
+            "url" => "$code_url/activity_hub.php",
+            "desc" => _("Activity Hub"),
+            "alias" => "ah",
+        ],
+        "home" => [
+            "url" => "$code_url/default.php",
+            "desc" => _("Home Page"),
+        ],
+        "myprojects" => [
+            "url" => "$code_url/tools/proofers/my_projects.php",
+            "desc" => _("My Projects"),
+            "alias" => "myproj",
+        ],
+        "mysuggestions" => [
+            "url" => "$code_url/tools/proofers/my_suggestions.php",
+            "desc" => _("My Suggestions"),
+            "alias" => "mysugg",
+        ],
+        "preferences" => [
+            "url" => "$code_url/userprefs.php",
+            "desc" => _("Personal Preferences"),
+            "alias" => "prefs",
+        ],
+        "quizzes" => [
+            "url" => "$code_url/quiz/start.php",
+            "desc" => _("Interactive Quizzes and Tutorials"),
+            "alias" => "quiz",
+        ],
+        "statistics" => [
+            "url" => "$code_url/stats/stats_central.php",
+            "desc" => _("Statistics Central"),
+            "alias" => "stats",
+        ],
+        "tasks" => [
+            "url" => "$code_url/tasks.php",
+            "desc" => _("Task Center"),
+        ],
+    ];
+
+    if (get_url_for_forum()) {
+        $jump_words["forum"] = [
+            "url" => get_url_for_forum(),
+            "desc" => _("Forums"),
+        ];
+        $jump_words["inbox"] = [
+            "url" => get_url_for_inbox(),
+            "desc" => _("Inbox"),
+        ];
+    }
+
+    if (!empty($wiki_url)) {
+        $jump_words["wiki"] = [
+            "url" => $wiki_url,
+            "desc" => _("Wiki"),
+        ];
+    }
+
+    if (!empty($blog_url)) {
+        $jump_words["blog"] = [
+            "url" => $blog_url,
+            "desc" => _("Blog"),
+        ];
+    }
+
+    if (user_is_PM()) {
+        $jump_words["pm"] = [
+            "url" => "$code_url/tools/project_manager/projectmgr.php",
+            "desc" => _("Project Management"),
+        ];
+        $jump_words["rfm"] = [
+            "url" => "$code_url/tools/project_manager/remote_file_manager.php",
+            "desc" => _("Remote File Manager"),
+        ];
+    }
+
+    if (user_is_a_sitemanager()) {
+        $jump_words["sa"] = [
+            "url" => "$code_url/tools/site_admin/index.php",
+            "desc" => _("Site Administration"),
+        ];
+    }
+
+    if ($flatten_aliases) {
+        foreach ($jump_words as $key => &$data) {
+            if (isset($data["alias"])) {
+                $alias = $data["alias"];
+                unset($data["alias"]);
+                $jump_words[$alias] = $data;
+            }
+        }
+    }
+
+    ksort($jump_words);
+    return $jump_words;
+}
+
+function get_activity_jumps(): array
+{
+    global $code_url;
+
+    $activity_jumps = [];
+    foreach (Activities::get_all() as $activity) {
+        if ($activity instanceof Round) {
+            $activity_jumps[$activity->id] = "$code_url/tools/proofers/round.php?round_id=$activity->id";
+        } elseif ($activity instanceof Pool) {
+            $activity_jumps[$activity->id] = "$code_url/tools/pool.php?pool_id=$activity->id";
+        } elseif ($activity->id === "SR") {
+            // SR is such a special snowflake
+            $activity_jumps[$activity->id] = "$code_url/tools/post_proofers/smooth_reading.php";
+        }
+    }
+
+    return $activity_jumps;
+}
+
+function jump_search(string $query)
+{
+    $query = strtolower($query);
+    $jump_words = get_jump_words(true);
+    if (isset($jump_words[$query])) {
+        metarefresh(0, $jump_words[$query]["url"], "", "", true);
+    }
+}
+
+function smart_search(string $query)
+{
+    global $code_url;
+
+    // is it a valid projectID?
+    try {
+        new Project($query);
+        metarefresh(0, "$code_url/project.php?id=$query");
+    } catch (NonexistentProjectException $e) {
+        // pass
+    }
+
+    // is it a valid username?
+    try {
+        $user = new User($query);
+        metarefresh(0, "$code_url/stats/members/mdetail.php?id=$user->u_id");
+    } catch (NonexistentUserException $e) {
+        // pass
+    }
+
+    // is it an Activity?
+    $activity_jumps = get_activity_jumps();
+    if (isset($activity_jumps[strtoupper($query)])) {
+        metarefresh(0, $activity_jumps[strtoupper($query)]);
+    }
+}
+
+function prefix_search(string $query)
+{
+    $matches = [];
+    if (!preg_match('/^(\w+):\s*(.*)$/', $query, $matches)) {
+        return;
+    }
+
+    $prefix_searches = get_prefix_searches(true);
+    $data = $prefix_searches[strtolower($matches[1])] ?? null;
+    if (!$data) {
+        return;
+    }
+
+    $query = $matches[2];
+
+    // if there's a validator for the prefix, validate it
+    if (@$data["validator"]) {
+        $data["validator"]($query);
+    }
+
+    metarefresh(0, sprintf($data["url"], urlencode($query)), "", "", true);
+}
+
+function _validate_integer(string $value)
+{
+    if (!preg_match("/^\d+$/", $value)) {
+        throw new Exception("Not a valid integer");
+    }
+}


### PR DESCRIPTION
This adds a new "site search" page. Users can either click on the search icon in the header or use the `/` hotkey in any non-input field on a site page. This has been available for public preview & discussion in the [New site search feature](https://www.pgdp.net/phpBB3/viewtopic.php?f=4&t=81458) forum.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/site-search/