### PR TITLE
Don't autocap usernames in stats searches

### DIFF
--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -23,7 +23,7 @@ $direction = get_enumerated_param(
     ['asc', 'desc']
 );
 $mstart = get_integer_param($_GET, 'mstart', 0, 0, null);
-$uname = normalize_whitespace(array_get($_GET, 'uname', ''));
+$uname = normalize_whitespace(array_get($_GET, 'uname', array_get($_GET, 'username', '')));
 $uexact = array_get($_GET, 'uexact', '') == 'yes';
 
 if ($uname) {

--- a/stats/stats_central.php
+++ b/stats/stats_central.php
@@ -32,7 +32,7 @@ show_news_for_page("STATS");
 <tr>
     <td>
     <form action='<?php echo $code_url; ?>/stats/members/mbr_list.php' method='get'>
-        <input type='text' name='uname' size='20' style='margin-left: 0;' required>
+        <input type='text' name='username' size='20' style='margin-left: 0;' autocapitalize='none' required>
         <input type='submit' value='<?php echo attr_safe(_("Member Search")); ?>'>
         <br>
         <input type='checkbox' name='uexact' value='yes' style='margin-left: 0;'> <?php echo _("Exact match"); ?>


### PR DESCRIPTION
Also make the field name 'username' to match the rest of the site.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/no-autocap-user-stats/