### PR TITLE
Issue warning if the project CTF was generated pre-Unicode

### DIFF
--- a/project.php
+++ b/project.php
@@ -1654,6 +1654,11 @@ function echo_download_zip($link_text, $discriminator)
     echo "</a>";
     echo_byte_size($filesize_b);
     echo_last_modified($last_modified);
+    // output a warning if the file was generated before the UTF-8 cutover.
+    // timestamp is midnight May 18 2020
+    if ($discriminator == "" && $last_modified && $last_modified < 1589785200) {
+        echo "<br><span class='warning'>" . _("This file was generated before the Unicode conversion. If you are just starting to PP this project, please ask a site administrator to regenerate the file.") . "</span>";
+    }
     echo "</li>";
     echo "\n";
 }


### PR DESCRIPTION
_Note: this is going into `pgdp-production`._

PP artifacts that were generated before the Unicode conversion still have their contents in Latin-1. There aren't many of these but we periodically stumble over some that are reclaimed.

Luckily, we just so happen to have have a project in TEST in this state: https://www.pgdp.org/~cpeel/c.branch/pgdp-warn-old-pp-artifacts/project.php?id=projectID44dda73a86096&expected_state=proj_post_first_available