### PR TITLE
Add many property declarations to classes so PHPStan can type check, part 2

### DIFF
--- a/SETUP/tests/ProjectTest.php
+++ b/SETUP/tests/ProjectTest.php
@@ -137,14 +137,6 @@ class ProjectTest extends ProjectUtils
         $this->assertStringContainsString("required", $errors[0]);
     }
 
-    public function test_validate_nameofwork_wrong_type()
-    {
-        $project = new Project($this->valid_project_data);
-        $project->nameofwork = [];
-        $errors = $project->validate();
-        $this->assertStringContainsString("should be of type", $errors[0]);
-    }
-
     public function test_validate_authorsname_missing()
     {
         $project = new Project($this->valid_project_data);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,8 +18,6 @@ parameters:
         - Stage
         - Round
 
-        - ProjectTransition
-
         - DifficultyElement
         - GenreColumn
         - GenreElement

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,9 +20,6 @@ parameters:
 
         - ProjectTransition
 
-        - LPage
-        - PPage
-
         - DifficultyElement
         - GenreColumn
         - GenreElement

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,33 +23,17 @@ parameters:
         - LPage
         - PPage
 
-        - Column
-        - ColumnData
-        - ColumnSelector
         - DifficultyElement
         - GenreColumn
         - GenreElement
         - HoldWidget
-        - LanguageElement
-        - LinkColumn
         - Loader
-        - OptionData
-        - OptionSelector
         - PageTally
         - PageTally_Neighbor
-        - ProjectFilterElement
         - ProjectInfoHolder
-        - ProjectSearchElement
-        - ProjectSearchForm
-        - ProjectSearchResults
-        - ProjectSearchResults
-        - ProjectSearchWidget
         - ProjectWordListHolder
         - Ranker
-        - Selector
-        - SpecialDayElement
         - TallyBoard
-        - TimeColumn
 
     # https://phpstan.org/user-guide/rule-levels
     # We want to gradually ratchet up the level here.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,8 +32,6 @@ parameters:
         - PageTally_Neighbor
         - ProjectInfoHolder
         - ProjectWordListHolder
-        - Ranker
-        - TallyBoard
 
     # https://phpstan.org/user-guide/rule-levels
     # We want to gradually ratchet up the level here.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,12 +14,6 @@ parameters:
         - SETUP/phpstan_bootstrap.inc
         - pinc/bootstrap.inc
     universalObjectCratesClasses:
-        - DifficultyElement
-        - GenreColumn
-        - GenreElement
-        - HoldWidget
-        - PageTally
-        - PageTally_Neighbor
         - ProjectWordListHolder
 
     # https://phpstan.org/user-guide/rule-levels

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,7 +30,6 @@ parameters:
         - Loader
         - PageTally
         - PageTally_Neighbor
-        - ProjectInfoHolder
         - ProjectWordListHolder
 
     # https://phpstan.org/user-guide/rule-levels
@@ -50,6 +49,3 @@ parameters:
         - message: '#Call to an undefined method#'
         - message: '#Variable .* might not be defined#'
         - message: '#Constant .* not found#'
-
-        # Allow references where we don't know the type of an object
-        - message: '#Access to an undefined property object::#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,8 +13,6 @@ parameters:
     bootstrapFiles:
         - SETUP/phpstan_bootstrap.inc
         - pinc/bootstrap.inc
-    universalObjectCratesClasses:
-        - ProjectWordListHolder
 
     # https://phpstan.org/user-guide/rule-levels
     # We want to gradually ratchet up the level here.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,7 +18,6 @@ parameters:
         - Stage
         - Round
 
-        - Project
         - ProjectTransition
 
         - LPage

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,7 +27,6 @@ parameters:
         - GenreColumn
         - GenreElement
         - HoldWidget
-        - Loader
         - PageTally
         - PageTally_Neighbor
         - ProjectWordListHolder

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,10 +14,6 @@ parameters:
         - SETUP/phpstan_bootstrap.inc
         - pinc/bootstrap.inc
     universalObjectCratesClasses:
-        - Activity
-        - Stage
-        - Round
-
         - DifficultyElement
         - GenreColumn
         - GenreElement

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -94,6 +94,14 @@ class Activities
 
 class Activity
 {
+    public string $id;
+    public string $name;
+    /** @var array<string,int> */
+    public array $access_minima;
+    public string $after_satisfying_minima;
+    public string $evaluation_criteria;
+    public ?string $access_change_callback;
+
     /**
      * Activity constructor
      *
@@ -119,7 +127,7 @@ class Activity
      *   ```
      * @param string $evaluation_criteria
      *   A brief description of what the evaluation criteria are.
-     * @param string $access_change_callback
+     * @param ?string $access_change_callback
      *   A callback function that will be called when a user's access for this
      *   round has changed. The function will be passed a User object representing
      *   the user with the access change in addition to the access change itself, eg:

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -283,6 +283,13 @@ class RoundInfo
  */
 class LPage
 {
+    public Project $project;
+    public string $projectid;
+    public string $imagefile;
+    public string $page_state;
+    public int $reverting_to_orig;
+    public Round $round;
+
     public function __construct($project, $imagefile, $page_state, $reverting_to_orig)
     {
         $this->project = $project;

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -15,18 +15,23 @@ class Pools extends Stages
 
 class Pool extends Stage
 {
+    public string $foo_Header;
+    public string $foo_field_name;
+    /** @var string[] */
+    public array $blather;
+
     /**
      * Pool constructor
      *
      * A container for various constants relating to a particular pool.
      *
-     * @param $foo_Header
-     * @param $foo_field_name
+     * @param string $foo_Header
+     * @param string $foo_field_name
      *   The relevant person to display in pool listings, both
      *   as shown to the user and as a field in the projects table
      *   (e.g. "postprocessor" when listing books available for PPV).
      *   Used by `pinc/showavailablebooks.inc`
-     * @param $blather
+     * @param string[] $blather
      *   An array of strings to echo on the pool's home page.
      */
     public function __construct(

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -121,11 +121,66 @@ class ProjectNoMorePagesException extends ProjectException
     }
 }
 
+/**
+ * @property-read string $url
+ * @property-read string $dir
+ * @property-read string $page_url
+ * @property-read bool $is_utf8
+ * @property-read bool $dir_exists
+ * @property-read bool $pages_table_exists
+ * @property-read string $credits_line
+ * @property string[] $languages
+ * @property-read string $image_source_name
+ * @property-read bool $can_be_managed_by_current_user
+ * @property-read bool $user_can_delete_nonpage_images
+ * @property-read bool $names_can_be_seen_by_current_user
+ * @property-read string $PPer
+ * @property-read string $PPVer
+ * @property-read bool $PPer_is_current_user
+ * @property-read bool $PPVer_is_current_user
+ */
 class Project
 {
     use CharSuiteSet;
 
     private $_create_source = null;
+    public string $nameofwork;
+    public ?string $state;
+    public string $special_code;
+    public int $smoothread_deadline;
+    public ?string $projectid;
+    public string $custom_chars;
+    public bool $archived;
+    public string $authorsname;
+    public string $genre;
+    public string $checkedoutby;
+    public string $difficulty;
+    public string $username;
+    public ?string $postednum; // TODO: Should be int
+    public ?string $topic_id; // TODO: Should be int
+    public float $days_checkedout;
+    public int $n_available_pages;
+    public int $n_pages;
+    public int $modifieddate;
+    public int $t_last_edit;
+    public int $t_last_change_comments;
+    public int $t_last_page_done;
+    public string $image_source;
+    public ?string $image_source_credit;
+    public string $_image_source_name;
+    public string $image_preparer;
+    public string $text_preparer;
+    public string $clearance;
+    public string $language;
+    public string $title;
+    public string $postproofer;
+    public ?string $ppverifier;
+    public string $deletion_reason;
+    public string $postcomments;
+    public string $comment_format;
+    public string $comments;
+    public string $scannercredit;
+    public string $extra_credits;
 
     public function __construct($arg = null)
     {
@@ -594,7 +649,7 @@ class Project
                 return self::decode_language($this->language);
             case "image_source_name":
                 $this->_load_image_source();
-                return $this->image_source_name;
+                return $this->_image_source_name;
             case "can_be_managed_by_current_user":
                 return $this->can_be_managed_by_user($pguser);
             case "user_can_delete_nonpage_images":
@@ -636,7 +691,7 @@ class Project
 
     private function _load_image_source()
     {
-        $this->image_source_name = '';
+        $this->_image_source_name = '';
         $this->image_source_credit = '';
 
         if (!isset($this->image_source)) {
@@ -646,7 +701,7 @@ class Project
         $image_sources = load_image_sources();
         $imso_res = array_get($image_sources, (string)$this->image_source, null);
         if ($imso_res) {
-            $this->image_source_name = $imso_res['full_name'];
+            $this->_image_source_name = $imso_res['full_name'];
             $this->image_source_credit = $imso_res['credit'];
         }
     }

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -4,9 +4,17 @@ include_once($relPath.'genres.inc'); // load_genre_translation_array
 
 class ProjectSearchWidget
 {
-    public $can_be_multiple = false;
-    public $initial_value = '';
-    public $has_invert = false;
+    protected string $id;
+    protected string $label;
+    protected string $invert_label;
+    private array $q_contrib;
+    private string $separator;
+    private bool $can_be_multiple = false;
+    private string $initial_value = '';
+    private bool $has_invert = false;
+    private string $type;
+    private int $size;
+    private array $options;
 
     public function __construct($properties)
     {
@@ -191,6 +199,8 @@ class HoldWidget extends ProjectSearchWidget
 
 class ProjectSearchForm
 {
+    private array $widgets;
+
     public function __construct()
     {
         $this->define_form_widgets();

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -10,6 +10,16 @@ include_once($relPath.'genres.inc');  // maybe_create_temporary_genre_translatio
 
 class Column
 {
+    public string $id;
+    protected string $label;
+    private string $long_label;
+    private string $css_class;
+    private bool $default_display;
+    public bool $sortable;
+    protected string $db_column;
+    private Settings $userSettings;
+    private string $search_origin;
+
     public function __construct($id, $label, $long_label, $css_class, $default_display, $sortable, $db_column)
     {
         $this->id = $id;
@@ -45,7 +55,7 @@ class Column
         return $this->get_long_label();
     }
 
-    public function get_sort_sql()
+    public function get_sort_sql(): ?string
     {
         return $this->db_column; // overridden by state column
     }
@@ -131,6 +141,8 @@ class Column
 
 class TimeColumn extends Column
 {
+    private string $time_format;
+
     public function __construct($id, $label, $long_label, $css_class, $default_display, $sortable, $db_column, $time_format)
     {
         parent::__construct($id, $label, $long_label, $css_class, $default_display, $sortable, $db_column);
@@ -234,7 +246,7 @@ class StateChangeColumn extends TimeColumn
 
 class StateColumn extends Column
 {
-    public function get_sort_sql()
+    public function get_sort_sql(): ?string
     {
         return sql_collator_for_project_state('state');
     }
@@ -390,6 +402,10 @@ class HoldColumn extends Column
 
 class ColumnData
 {
+    protected Settings $userSettings;
+    protected string $search_origin;
+    public array $columns;
+
     public function __construct($userSettings, $search_origin, $time_format = '')
     {
         global $pguser;
@@ -455,6 +471,17 @@ class ColumnData
 
 class ProjectSearchResults
 {
+    private Settings $userSettings;
+    private string $search_origin;
+    private int $page_size;
+    private bool $show_special_colors;
+    /** @var Column[] */
+    private array $active_columns;
+    private string $sort_column_id;
+    private ?string $sort_sql;
+    private string $sql_sort_dir;
+    private string $sec_sort;
+
     public function __construct($search_origin)
     {
         global $pguser;
@@ -505,7 +532,7 @@ class ProjectSearchResults
         }
     }
 
-    private function get_sort_sql($col_id)
+    private function get_sort_sql($col_id): ?string
     {
         foreach ($this->active_columns as $column) {
             if ($column->sortable && ($column->id == $col_id)) {

--- a/pinc/ProjectSearchResultsConfig.inc
+++ b/pinc/ProjectSearchResultsConfig.inc
@@ -3,6 +3,11 @@ include_once($relPath.'metarefresh.inc');
 
 class Selector
 {
+    public string $id;
+    public string $label;
+    protected Settings $userSettings;
+    protected string $search_origin;
+
     public function echo_select_item()
     {
         echo "
@@ -16,6 +21,8 @@ class Selector
 
 class ColumnSelector extends Selector
 {
+    private Column $column;
+
     public function __construct($column, $userSettings, $search_origin)
     {
         $this->column = $column;
@@ -34,6 +41,9 @@ class ColumnSelector extends Selector
 
 class OptionSelector extends Selector
 {
+    private string $def_value;
+    private array $options;
+
     public function __construct($id, $label, $value, $options, $userSettings, $search_origin)
     {
         $this->id = $id;
@@ -81,6 +91,11 @@ class OptionSelector extends Selector
 
 class OptionData
 {
+    public OptionSelector $results_per_page;
+    public OptionSelector $time_format;
+    /** @var OptionSelector[] */
+    public array $options;
+
     public function __construct($userSettings, $search_origin)
     {
         $this->results_per_page = new OptionSelector(
@@ -107,6 +122,9 @@ class OptionData
 
 class ConfigForm extends ColumnData
 {
+    private array $column_selectors;
+    private OptionData $option_data;
+
     public function __construct($userSettings, $search_origin)
     {
         parent::__construct($userSettings, $search_origin);

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -11,6 +11,19 @@ define('PT_AUTO', '[AUTO]');
 
 class ProjectTransition
 {
+    public string $from_state;
+    public string $to_state;
+    public string $who_restriction;
+
+    // Populated from $options
+    private ?string $project_restriction; // callable
+    public ?string $action_name;
+    public ?string $confirmation_question;
+    public ?string $detour;
+    public ?string $settings_template;
+    private ?string $collateral_actions; // callable
+    private ?bool $disabled_during_SR;
+
     /**
      * Project Transition constructor
      *

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -42,10 +42,38 @@ class Rounds extends Stages
 // A container for various constants relating to a particular round of proofreading.
 class Round extends Stage
 {
+    public int $round_number;
+    /** @var array<string, string[]> */
+    public array $pi_tools;
+    public ?int $daily_page_limit;
+    public array $other_rounds_with_visible_usernames;
+    /** @var array<int, string> */
+    private array $honorifics;
+    public string $project_unavailable_state;
+    public string $project_waiting_state;
+    public string $project_bad_state;
+    public string $project_available_state;
+    public string $project_complete_state;
+    /** @var ProjectState[] */
+    public array $project_states;
+    public string $page_avail_state;
+    public string $page_out_state;
+    public string $page_temp_state;
+    public string $page_save_state;
+    public string $page_bad_state;
+    /** @var string[] */
+    public array $page_states;
+    public string $time_column_name;
+    public string $text_column_name;
+    public string $user_column_name;
+    public string $prevtext_column_name;
+    public ?Round $mentor_round;
+    public ?Round $mentee_round;
+
     /**
      * Round constructor
      *
-     * @param array $pi_tools
+     * @param array<string, string[]> $pi_tools
      *   A list of which tools should be available in the proofreading
      *   interface's toolbox when proofreading a page in this round.
      *   The format is:
@@ -67,15 +95,15 @@ class Round extends Stage
      *   ```
      *   See `pinc/ProofreadingToolbox.inc` for which tools are available
      *   and their names.
-     * @param $daily_page_limit
+     * @param ?int $daily_page_limit
      *   This is either NULL (indicating no daily page limit for this round)
      *   or a non-negative (though likely positive) integer.
-     * @param array $other_rounds_with_visible_usernames
+     * @param string[] $other_rounds_with_visible_usernames
      *   An array of round_ids.
      *   If user X worked on a page in this round, they can see the
      *   username of another user Y who worked on the page *if* user Y
      *   worked on the page in a round that appears in this parameter.
-     * @param array $honorifics
+     * @param array<int, string> $honorifics
      *   An array of integer => string items that determine a user's
      *   "title" on the basis of their page tally in this round.
      *   In each item:

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -20,16 +20,20 @@ class Stages extends Activities
 
 class Stage extends Activity
 {
+    public string $description;
+    public ?string $document;
+    public string $relative_url;
+
     /**
      * Stage constructor
      *
-     * @param $description
+     * @param string $description
      *   A sentence or two explaining what happens in this stage.
-     * @param $document
+     * @param ?string $document
      *   The path (relative to `$code_url/faq/`) of a document that tells you
      *   everything you need to know about working in this stage.
      *   Or NULL if there is no such document.
-     * @param $relative_url
+     * @param string $relative_url
      *   The "home" location (relative to `$code_url/`) of the stage.
      */
     public function __construct(

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -29,6 +29,8 @@
 /**
  * Return an array of TallyBoard objects, representing all
  * boards on which there is some tally explicitly recorded.
+ *
+ * @return TallyBoard[]
  */
 function get_all_current_tallyboards()
 {
@@ -48,7 +50,10 @@ function get_all_current_tallyboards()
 
 class TallyBoard
 {
-    public function __construct($tally_name, $holder_type)
+    public string $tally_name;
+    public string $holder_type;
+
+    public function __construct(string $tally_name, string $holder_type)
     {
         $this->tally_name = $tally_name;
         $this->holder_type = $holder_type;
@@ -56,7 +61,7 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
-    public function add_to_tally($holder_id, $amount)
+    public function add_to_tally(string $holder_id, int $amount)
     {
         $sql = sprintf(
             "
@@ -106,6 +111,7 @@ class TallyBoard
      *   String containing an SQL expression (typically just a column name)
      *   that yields the holder_ids of the holders for whom you want to extract
      *   tally data.
+     * @return string[]
      */
     public function get_sql_joinery_for_current_tallies($holder_id_expr)
     {
@@ -129,7 +135,7 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
-    public function get_num_holders_with_positive_tally()
+    public function get_num_holders_with_positive_tally(): int
     {
         $sql = sprintf(
             "
@@ -156,7 +162,7 @@ class TallyBoard
      * Note that if you want tallies for multiple holders, it's probably
      * more efficient to use SQL-joinery supplied by the previous method.
      */
-    public function get_current_tally($holder_id)
+    public function get_current_tally(string $holder_id): int
     {
         $sql = sprintf(
             "
@@ -747,6 +753,10 @@ class TallyBoard
 
 class Ranker
 {
+    private bool $zero_begets_zero;
+    private int $n;
+    private int $prev_rank;
+    private int $prev_value;
     /**
      * Ranker constructor
      *

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -14,6 +14,13 @@ include_once($relPath.'Project.inc'); // get_project_difficulties()
 
 class ProjectFilterElement
 {
+    private string $id;
+    public string $label;
+    private bool $active;
+    protected $data;
+    protected string $state_sql;
+    public array $selected_options;
+
     public function __construct($id, $label, $data, $state_sql, $active_fields)
     {
         $this->id = $id;
@@ -275,6 +282,9 @@ function process_and_display_project_filter_form($username, $filter_type, $filte
 
 class ProjectSearchElement
 {
+    private string $id;
+    protected $data;
+
     public function __construct($id, $data)
     {
         $this->id = $id;

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -172,8 +172,8 @@ function user_get_page_tally_neighborhood($tally_name, $username, $radius)
 class PageTally_Neighbor
 {
     private bool $is_anonymized;
-    private string $username;
-    private int $date_joined;
+    private ?string $username;
+    private ?int $date_joined;
     private int $u_id;
     private int $current_page_tally;
     private int $current_page_tally_rank;

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -119,10 +119,11 @@ function user_get_ELR_page_tally($username)
 
 /**
  * Get the user's page tally neighborhood
- *
+ * @param string $tally_name
+ * @param string $username
  * @param int $radius
  *   (maximum) number of neighbors (on each side) to include in
- *   the neighborhood. (It will include fewer that the maximum iff the target
+ *   the neighborhood. (It will include fewer than the maximum iff the target
  *   user is within $radius of the corresponding end of the ranked list.)
  *
  * Return the page-tally neighborhood of $username.
@@ -131,6 +132,8 @@ function user_get_ELR_page_tally($username)
  * (So key=0 refers to the target user.)
  * For a given key, the corresponding value is a PageTally_Neighbor object
  * supplying various information about the page-tally neighbor.
+ *
+ * @return PageTally_Neighbor[]
  */
 function user_get_page_tally_neighborhood($tally_name, $username, $radius)
 {
@@ -154,7 +157,6 @@ function user_get_page_tally_neighborhood($tally_name, $username, $radius)
 
         $neighbors[$rel_posn] =
             new PageTally_Neighbor(
-                $tallyboard,
                 $neighbor_is_anonymized,
                 $neighbor_username,
                 $neighbor_date_joined,
@@ -169,9 +171,15 @@ function user_get_page_tally_neighborhood($tally_name, $username, $radius)
 
 class PageTally_Neighbor
 {
-    public function __construct($tallyboard, $is_anonymized, $username, $date_joined, $u_id, $current_page_tally, $current_page_tally_rank)
+    private bool $is_anonymized;
+    private string $username;
+    private int $date_joined;
+    private int $u_id;
+    private int $current_page_tally;
+    private int $current_page_tally_rank;
+
+    public function __construct($is_anonymized, $username, $date_joined, $u_id, $current_page_tally, $current_page_tally_rank)
     {
-        $this->tallyboard = $tallyboard;
         $this->is_anonymized = $is_anonymized;
         $this->username = $username;
         $this->date_joined = $date_joined;

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -180,6 +180,24 @@ echo return_to_project_page_link($projectid) . "\n";
 
 class Loader
 {
+    private string $source_project_dir;
+    private string $dest_project_dir;
+    private string $projectid;
+    private bool $dry_run;
+    private bool $adding_pages;
+    private int $image_field_len;
+    /** @var array<string, string> */
+    private array $ignored_files;
+    /** @var string[] */
+    private array $non_page_files;
+    /** @var array<string, array<string, array<string, string>>> */
+    private array $page_file_table;
+    /** @var array<string, string> */
+    private array $db_text_for_base;
+    private int $n_ops;
+    private int $n_warnings;
+    private int $n_errors;
+
     public function __construct($source_project_dir, $dest_project_dir, $projectid)
     {
         $this->source_project_dir = $source_project_dir;

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -78,6 +78,14 @@ $pwlh->show_form();
 
 class ProjectWordListHolder
 {
+    public string $projectid;
+    public Project $project;
+    public string $bad_words;
+    public string $good_words;
+    public int $bwl_timestamp;
+    public int $gwl_timestamp;
+
+
     public function __construct($projectid)
     {
         $this->projectid = $projectid;

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -125,6 +125,15 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
 
 class ProjectInfoHolder
 {
+    public Project $project;
+    /** @var string[] */
+    private array $charsuites;
+    public ?string $original_marc_array_encd;
+    private string $clone_projectid;
+    private bool $posted = false;
+    /** @var string[] */
+    private array $hold_states;
+
     public function set_from_nothing()
     {
         global $pguser, $default_project_char_suites;
@@ -202,7 +211,7 @@ class ProjectInfoHolder
         }
 
         // ProjectTransition routes users here when a project is posted to PG
-        $this->posted = @$_GET['posted'];
+        $this->posted = (bool) @$_GET['posted'];
 
         $this->charsuites = [];
         foreach ($this->project->get_charsuites(false) as $project_charsuite) {
@@ -228,7 +237,7 @@ class ProjectInfoHolder
             }
 
             if (!$this->project->can_be_managed_by_current_user) {
-                return _("You are not authorized to manage this project.").": '$this->projectid'";
+                return _("You are not authorized to manage this project.").": '{$this->project->projectid}'";
             }
         } elseif (isset($_POST['clone_projectid'])) {
             // we're creating a clone; initialize our object with the original
@@ -271,7 +280,7 @@ class ProjectInfoHolder
             if ($_POST["postednum"] == "") {
                 $this->project->postednum = null;
             } else {
-                $this->project->postednum = (int)$_POST["postednum"];
+                $this->project->postednum = sprintf("%d", $_POST["postednum"]);
             }
         }
 
@@ -323,7 +332,7 @@ class ProjectInfoHolder
             $errors[] = _("At least one Character Suite is required.");
         }
 
-        $this->posted = @$_POST['posted'];
+        $this->posted = (bool) @$_POST['posted'];
         if ($this->posted) {
             // We are in the process of marking this project as posted.
             if (!$this->project->postednum) {
@@ -444,7 +453,7 @@ class ProjectInfoHolder
         if (!empty($this->original_marc_array_encd)) {
             echo "<input type='hidden' name='rec' value='$this->original_marc_array_encd'>";
         }
-        if (!empty($this->posted)) {
+        if ($this->posted) {
             echo "<input type='hidden' name='posted' value='1'>";
         }
         if (!empty($this->project->projectid)) {

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -45,7 +45,7 @@ function url_for_pi_do_particular_page($projectid, $proj_state, $imagefile, $pag
 
 // -----------------------------------------------------------------------------
 
-function get_requested_PPage($request_params)
+function get_requested_PPage(array $request_params): PPage
 {
     $projectid = get_projectID_param($request_params, 'projectid');
     $proj_state = get_enumerated_param($request_params, 'proj_state', null, ProjectStates::get_states());
@@ -69,6 +69,9 @@ function get_requested_PPage($request_params)
 // The initial 'P' is for 'Presentation' (i.e., user interface).
 class PPage
 {
+    public LPage $lpage;
+    private string $proj_state;
+
     public function __construct(&$lpage, $proj_state)
     {
         $this->lpage = & $lpage;


### PR DESCRIPTION
Cherry picking the remainder of the class property declarations from #1112 so they can be submitted separately.

There were lots of merge conflicts doing this, so it turned out to be easier to cherry pick everything into a new PR. I'll close #1112.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/property-2/ (changed to cpeel's sandbox to pick up a small fix)