### PR TITLE
Remove select_from_site_past_tallies_and_goals()

### DIFF
--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -533,16 +533,10 @@ function total_pages_by_month_graph($tally_name)
     ///////////////////////////////////////////////////
     //Total pages by month since beginning of stats
 
-    $result = DPDatabase::query(select_from_site_past_tallies_and_goals(
-        $tally_name,
-        "SELECT {year_month}, SUM(tally_delta), SUM(goal)",
-        "",
-        "GROUP BY 1",
-        "ORDER BY 1",
-        ""
-    ));
-
-    [$datax, $datay1, $datay2] = dpsql_fetch_columns($result);
+    $data = get_site_tally_grouped($tally_name, 'year_month');
+    $datax = array_column($data, 0);
+    $datay1 = array_column($data, 1);
+    $datay2 = array_column($data, 2);
 
     return [
         "title" => _("Pages Done Each Month Since the Beginning of Statistics Collection"),
@@ -594,23 +588,18 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
         case 'curr_month':
             $start_timestamp = mktime(0, 0, 0, $curr_m, 1, $curr_y);
             $end_timestamp = mktime(0, 0, 0, $curr_m + 1, 1, $curr_y);
-            $year_month = date('Y-m', $start_timestamp);
-            $where_clause = "WHERE {year_month} = '$year_month'";
             $title_timeframe = icu_date('MMM y', $now_timestamp);
             break;
 
         case 'prev_month':
             $start_timestamp = mktime(0, 0, 0, $curr_m - 1, 1, $curr_y);
             $end_timestamp = mktime(0, 0, 0, $curr_m, 1, $curr_y);
-            $year_month = date('Y-m', $start_timestamp);
-            $where_clause = "WHERE {year_month} = '$year_month'";
             $title_timeframe = icu_date('MMM y', $start_timestamp);
             break;
 
         case 'all_time':
             $start_timestamp = 0;
             $end_timestamp = mktime(0, 0, 0, $curr_m + 1, 1, $curr_y);
-            $where_clause = '';
             $title_timeframe = _('since stats began');
             break;
 
@@ -633,18 +622,10 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
 
     // -----------------------------------------------------------------------------
 
-    $result = DPDatabase::query(
-        select_from_site_past_tallies_and_goals(
-            $tally_name,
-            "SELECT {date}, tally_delta, goal",
-            $where_clause,
-            "",
-            "ORDER BY timestamp",
-            ""
-        )
-    );
-
-    [$datax, $datay1, $datay2] = dpsql_fetch_columns($result);
+    $data = get_site_tally_grouped($tally_name, 'date', $start_timestamp, $end_timestamp);
+    $datax = array_column($data, 0);
+    $datay1 = array_column($data, 1);
+    $datay2 = array_column($data, 2);
 
     if ($c_or_i == 'cumulative') {
         $datay1 = array_accumulate($datay1);

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -329,53 +329,111 @@ function get_site_tally_goal_summed($tally_name, $date_condition)
 // -----------------------------------------------------------------------------
 
 /**
- * Return a string containing an SQL 'select' statement
- * dealing with site-specific rows from the past_tallies table,
- * and corresponding rows from the site_tally_goals table.
+ * Return tally_delta sums over a timeframe grouped into predefined date units.
+ *
+ * The multi-dimensional array returned contains a row for every time unit:
+ * ```
+ * [
+ *     [dateunit, tally_delta, goal],
+ *     [dateunit, tally_delta, goal],
+ *     ...
+ * ]
+ * ```
+ *
+ * @param string $tally_name
+ *   Tally name
+ * @param string $grouped_into
+ *   Which date format to group into, one of: date, year_month, year
+ * @param ?int $min_timestamp
+ *   Earliest timestamp to evaluate
+ * @param ?int $max_timestamp
+ *   Latest timestamp to evaluate
+ * @param ?int $limit
+ *   Limit the number of rows to return
+ * @param ?string $sort
+ *   Field to sort on, one of: dateunit, tally_delta, goal
+ *
+ * @return array
  */
-function select_from_site_past_tallies_and_goals(
-    $tally_name,
-    $select,
-    $where,
-    $groupby,
-    $orderby,
-    $limit
-) {
+function get_site_tally_grouped(
+    string $tally_name,
+    string $grouped_into,
+    ?int $min_timestamp = null,
+    ?int $max_timestamp = null,
+    ?int $limit = null,
+    ?string $sort = null
+): array {
     global $SECONDS_TO_YESTERDAY;
 
-    if (empty($where)) {
-        $where_addition = '';
+    // The date formats below use two %s because they are embedded in an sprintf()
+    $goal_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y-%%m-%%d')";
+
+    if ($grouped_into == "date") {
+        $date_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y-%%m-%%d')";
+    } elseif ($grouped_into == "year_month") {
+        $date_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y-%%m')";
+    } elseif ($grouped_into == "year") {
+        $date_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y')";
     } else {
-        $where_addition =
-            preg_replace('/^\s*WHERE\s+(.*)$/i', 'AND (\1)', $where);
+        throw new InvalidArgumentException("\$grouped_into is an invalid value");
     }
 
-    $s = "
-        $select
+    $where_time = "";
+    if (isset($min_timestamp)) {
+        $where_time .= sprintf("AND timestamp >= %d ", $min_timestamp + $SECONDS_TO_YESTERDAY);
+    }
+    if (isset($max_timestamp)) {
+        $where_time .= sprintf("AND timestamp < %d ", $max_timestamp + $SECONDS_TO_YESTERDAY);
+    }
+
+    $limit_string = "";
+    if (isset($limit)) {
+        $limit_string = sprintf("LIMIT %d", $limit);
+    }
+
+    if (!$sort) {
+        $sort = "dateunit asc";
+    }
+    if (stripos($sort, " ") !== false) {
+        [$sort_column, $sort_direction] = explode(" ", $sort);
+    } else {
+        $sort_column = $sort;
+        $sort_direction = "asc";
+    }
+    if (!in_array($sort_column, ["dateunit", "tally_delta", "goal"])) {
+        throw new InvalidArgumentException("Invalid \$sort column");
+    }
+    if (!in_array(strtolower($sort_direction), ["asc", "desc"])) {
+        throw new InvalidArgumentException("Invalid \$sort direction`");
+    }
+    $sort_string = "ORDER BY $sort_column $sort_direction";
+
+    $sql = sprintf(
+        "
+        SELECT $date_expr as dateunit, sum(tally_delta) as tally_delta, sum(goal) as goal
         FROM past_tallies
             LEFT OUTER JOIN site_tally_goals
             ON (past_tallies.tally_name = site_tally_goals.tally_name
-                AND {date} = site_tally_goals.date
+                AND $goal_expr = site_tally_goals.date
             )
         WHERE
-            past_tallies.tally_name='$tally_name'
-            AND holder_type='S'
-            AND holder_id=1
-            $where_addition
-        $groupby
-        $orderby
-        $limit
-    ";
+            past_tallies.tally_name = '%s'
+            AND holder_type = 'S'
+            AND holder_id = 1
+            $where_time
+        GROUP BY dateunit
+        $sort_string
+        $limit_string
+        ",
+        $tally_name
+    );
+    $result = DPDatabase::query($sql);
+    $rows = [];
+    while ($row = mysqli_fetch_row($result)) {
+        $rows[] = $row;
+    }
 
-    $date_expr = "FROM_UNIXTIME(past_tallies.timestamp - $SECONDS_TO_YESTERDAY, '%Y-%m-%d')";
-    $ym_expr = "FROM_UNIXTIME(past_tallies.timestamp - $SECONDS_TO_YESTERDAY, '%Y-%m')";
-    $y_expr = "FROM_UNIXTIME(past_tallies.timestamp - $SECONDS_TO_YESTERDAY, '%Y')";
-
-    $s = preg_replace('/{date}/', $date_expr, $s);
-    $s = preg_replace('/{year_month}/', $ym_expr, $s);
-    $s = preg_replace('/{year}/', $y_expr, $s);
-
-    return $s;
+    return $rows;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Part of solving https://github.com/DistributedProofreaders/dproofreaders/issues/1190 is going to be decreasing the number of instances where we directly query `past_tallies` where the caller assumes that it has entries for every single day. This PR removes one of the offenders used only in the statistics code. It pulls the DB-ness into a function. Right now that function just queries `past_tallies` directly, but in a future revision it will encode more logic to handle the transition to a sparse format.

This has two functional changes:
* `misc_stats1.php` (what a terrible name for a file, BTW) no longer outputs the top 10 proofreading days this year and it no longer outputs the days above certain thresholds. Supporting these two use-cases required more work for what I think is a pretty small return
* The tables in `misc_stats1.php` do not have a "This Month?" column as that seemed like a pretty poor UI choice to begin with.

Except for those two things, the stats pages and graphs should match what's on TEST.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/reduce-past-tallies-direct-access/stats/stats_central.php

Notes:
* The sandbox has a temporary hack such that graphs are not cached to ease testing.
* `misc_stats1.php` is the "Top Proofreading Days and Months, etc." link on the main statistics page.