### PR TITLE
Hide errors and charsuites from non-users

### DIFF
--- a/project.php
+++ b/project.php
@@ -511,17 +511,17 @@ function do_project_info_table()
         }
 
         echo_row_a(_("Word Lists"), $links);
-    }
 
-    if ($project->pages_table_exists && !$project->is_utf8) {
-        echo_row_a(_("Encoding"), "<span class='error'>" . _("Project table is not UTF-8.") . "</span>");
-    }
+        if ($project->pages_table_exists && !$project->is_utf8) {
+            echo_row_a(_("Encoding"), "<span class='error'>" . _("Project table is not UTF-8.") . "</span>");
+        }
 
-    $project_charsuites = [];
-    foreach ($project->get_charsuites() as $charsuite) {
-        $project_charsuites[] = "<a href='tools/charsuites.php?projectid=$projectid#" . attr_safe($charsuite->name) . "'>" . html_safe($charsuite->title) . "</a>";
+        $project_charsuites = [];
+        foreach ($project->get_charsuites() as $charsuite) {
+            $project_charsuites[] = "<a href='tools/charsuites.php?projectid=$projectid#" . attr_safe($charsuite->name) . "'>" . html_safe($charsuite->title) . "</a>";
+        }
+        echo_row_a(_("Character Suites"), implode(", ", $project_charsuites));
     }
-    echo_row_a(_("Character Suites"), implode(", ", $project_charsuites));
 
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Users who are not logged in can't see project character suite details, so we shouldn't show them the rows for it. And they also don't need to know if the project isn't in UTF-8. Diff is best viewed ignoring whitespace.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/hide-charsuites-for-nonusers/
 
Logged out, compare
* [A project on TEST](https://www.pgdp.org/c/project.php?id=projectID4c49f39aa829c)
* [A project in the sandbox](https://www.pgdp.org/~cpeel/c.branch/hide-charsuites-for-nonusers/project.php?id=projectID4c49f39aa829c)