### PR TITLE
include navbar_menu.js only if needed

### DIFF
--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -95,7 +95,7 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
         "$code_url/scripts/api.js",
     ];
 
-    if($show_logobar) {
+    if ($show_logobar) {
         $js_files[] = "$code_url/scripts/navbar_menu.js";
     }
 

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -12,7 +12,7 @@ define('SHOW_STATSBAR', true);
  * Output the opening HTML page code, including pulling in common styles,
  * page title, etc.
  */
-function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true)
+function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true, $show_logobar = false)
 {
     global $code_url, $site_abbreviation;
     global $charset;
@@ -93,8 +93,11 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
     $js_files = [
         "$code_url/pinc/3rdparty/jquery/jquery-3.5.1.min.js",
         "$code_url/scripts/api.js",
-        "$code_url/scripts/navbar_menu.js",
     ];
+
+    if($show_logobar) {
+        $js_files[] = "$code_url/scripts/navbar_menu.js";
+    }
 
     // Per-page JS
     if (isset($extra_args['js_files'])) {

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -29,7 +29,7 @@ function output_header($nameofpage, $show_statsbar = true, $extra_args = [])
 
     // All our themes begin with the initial markup, logo and navbar, and open a
     // table for further layout.
-    output_html_header($nameofpage, $extra_args, $show_statsbar);
+    output_html_header($nameofpage, $extra_args, $show_statsbar, true);
     html_logobar();
     echo "\n<div id='page-container'>\n";
     echo "<div id='page-body-container'>\n";


### PR DESCRIPTION
Avoids js exception on pages without a dp header.

I haven't made a sandbox. This follows on from Casey's search function and he might want to fix it another way.