### PR TITLE
Don't include navbar JS if there's no navbar

### DIFF
--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -93,7 +93,6 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
     $js_files = [
         "$code_url/pinc/3rdparty/jquery/jquery-3.5.1.min.js",
         "$code_url/scripts/api.js",
-        "$code_url/scripts/navbar_menu.js",
     ];
 
     // Per-page JS

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -17,6 +17,8 @@ include_once($relPath.'faq.inc');
  */
 function output_header($nameofpage, $show_statsbar = true, $extra_args = [])
 {
+    global $code_url;
+
     $user = User::load_current();
 
     // Display stats bar on left (1) or right (0)
@@ -29,6 +31,7 @@ function output_header($nameofpage, $show_statsbar = true, $extra_args = [])
 
     // All our themes begin with the initial markup, logo and navbar, and open a
     // table for further layout.
+    $extra_args['js_files'][] = "$code_url/scripts/navbar_menu.js";
     output_html_header($nameofpage, $extra_args, $show_statsbar);
     html_logobar();
     echo "\n<div id='page-container'>\n";

--- a/scripts/navbar_menu.js
+++ b/scripts/navbar_menu.js
@@ -46,16 +46,19 @@ function hideSiteSearch() {
 }
 
 window.addEventListener('DOMContentLoaded', function() {
-    document.getElementById('search-menu').addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-            hideSiteSearch();
-        }
-    });
-});
+    // if the page has the search menu, add some listeners for it
+    if (document.getElementById('search-menu')) {
+        document.getElementById('search-menu').addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                hideSiteSearch();
+            }
+        });
 
-document.addEventListener('keydown', (event) => {
-    if (event.key === '/' && document.activeElement.tagName == "BODY") {
-        event.preventDefault();
-        showSiteSearch();
+        document.addEventListener('keydown', (event) => {
+            if (event.key === '/' && document.activeElement.tagName == "BODY") {
+                event.preventDefault();
+                showSiteSearch();
+            }
+        });
     }
 });


### PR DESCRIPTION
Don't include the navbar JS when there is no navbar. In addition add some checks to see if the search menu exists before adding listeners for it. A slightly different approach than Ray's https://github.com/DistributedProofreaders/dproofreaders/pull/1193. Diff best viewed ignoring whitespace.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-navbar-js-error/

Testing notes: The new search menu should still function. On page without a header, like the Image Browser, there should be no error in the JS console.