### PR TITLE
Improve performance of calculating moving average

### DIFF
--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -624,15 +624,17 @@ class TallyBoard
 
     /**
      * Return all tally deltas recorded for the given holder
-     * since $min_timestamp.
+     * since $min_timestamp and optionally before $max_timestamp
      *
      * Specifically, the result is an array of key => value pairs,
      * where key is the ascribed time of a snapshot,
      * and value is the tally delta recorded for that time.
      * (The items are sorted by timestamp.)
      */
-    public function get_deltas($holder_id, $min_timestamp)
+    public function get_deltas($holder_id, $min_timestamp, $max_timestamp = null)
     {
+        $addl_where = $max_timestamp === null ? "" : sprintf("AND timestamp < %d", $max_timestamp);
+
         $sql = sprintf(
             "
             SELECT timestamp, tally_delta
@@ -642,6 +644,7 @@ class TallyBoard
                 AND holder_type = '%s'
                 AND holder_id   = %d
                 AND timestamp  >= $min_timestamp
+                $addl_where
             ORDER BY timestamp ASC
             ",
             DPDatabase::escape($this->tally_name),

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -574,10 +574,8 @@ function array_accumulate($arr)
     return $result;
 }
 
-function pages_daily($tally_name, $c_or_i, $timeframe)
+function pages_daily(string $tally_name, string $c_or_i, string $timeframe)
 {
-    $site_tallyboard = new TallyBoard($tally_name, 'S');
-
     $now_timestamp = time();
     $now_assoc = getdate($now_timestamp);
 
@@ -620,131 +618,25 @@ function pages_daily($tally_name, $c_or_i, $timeframe)
             die("bad 'cori' value: '$c_or_i'");
     }
 
-    // -----------------------------------------------------------------------------
+    $days_to_average = 21;
 
-    $data = get_site_tally_grouped($tally_name, 'date', $start_timestamp, $end_timestamp);
-    $datax = array_column($data, 0);
-    $datay1 = array_column($data, 1);
-    $datay2 = array_column($data, 2);
-
-    if ($c_or_i == 'cumulative') {
-        $datay1 = array_accumulate($datay1);
-        $datay2 = array_accumulate($datay2);
-
-        // The accumulated 'actual' for today and subsequent days is bogus,
-        // so delete it.
-        $date_today = date('Y-m-d', $now_timestamp);
-        for ($i = 0; $i < count($datax); $i++) {
-            if ($datax[$i] >= $date_today) {
-                unset($datay1[$i]);
-            }
-        }
-    }
-
-    if (empty($datay1)) {
-        $datay1[0] = 0;
-    }
-
-
-    // Calculate a simple moving average for 'increments' graphs
-    if ($c_or_i == 'increments') {
-        $days_to_average = 21;
-
-        // to ensure we have enough data to use, go back $days_to_average
-        // days before the start date
-        $where_start_timestamp = $start_timestamp - ($days_to_average * 60 * 60 * 24);
-
-        // Unless it's for all_time when start_timestamp==0. For this case we need
-        // $days_to_average days after the timestamp is zero to ensure the average
-        // is correct.
-        if ($start_timestamp == 0) {
-            $where_start_timestamp = $start_timestamp + ($days_to_average * 60 * 60 * 24);
-        }
-
-        $sql = "
-            SELECT t1.timestamp,
-                (SELECT round(sum(t2.tally_delta)/count(t2.tally_delta))
-                FROM past_tallies as t2
-                WHERE t2.holder_type = 'S'
-                    AND t2.holder_id = '1'
-                    AND t2.tally_name = '$tally_name'
-                    AND datediff(from_unixtime(t1.timestamp), from_unixtime(t2.timestamp)) between 0 and $days_to_average )
-                as 'sma'
-            FROM past_tallies as t1
-            WHERE t1.holder_type = 'S'
-                AND t1.tally_name = '$tally_name'
-                AND t1.holder_id = '1'
-                AND t1.timestamp > $where_start_timestamp
-            ORDER BY t1.timestamp asc
-        ";
-        $res = DPDatabase::query($sql);
-
-        // Get the earliest start date to use in our population of $moving_average
-        // Because the results are sorted ascending by timestamp, the first one
-        // is the one we want.
-        $earliest_timestamp = null;
-
-        // store the results in a date-based array we can use to populate the
-        // graph's data array
-        while ($result = mysqli_fetch_assoc($res)) {
-            if ($earliest_timestamp === null) {
-                $earliest_timestamp = $result["timestamp"];
-            }
-
-            $average_lookup[date("Y-m-d", $result["timestamp"])] = $result["sma"];
-        }
-        mysqli_free_result($res);
-
-        // Don't start before the earliest timestamp
-        $start_timestamp = max($start_timestamp, $earliest_timestamp);
-        // don't go past the current date
-        $end_timestamp = min($end_timestamp, time());
-
-        // loop through each day in the graph and pull in the SMA if it exists
-        for ($dateTimestamp = $start_timestamp; $dateTimestamp <= $end_timestamp; $dateTimestamp += (60 * 60 * 24)) {
-            $day = date('Y-m-d', $dateTimestamp);
-            if (isset($average_lookup[$day])) {
-                $moving_average[] = $average_lookup[$day];
-            } else {
-                $moving_average[] = 0;
-            }
-        }
-
-        // Ensure we don't have more SMA data points than we do $datax points.
-        // This can happen if the statistics use to be kept but aren't any longer.
-        for ($index = count($moving_average) - count($datax); $index > 0; $index--) {
-            array_pop($moving_average);
-        }
-    } else {
-        $moving_average = null;
-        $days_to_average = 0;
-    }
-
-    // if no data was returned from the SELECT, create an empty dataset
-    if (empty($datax)) {
-        // set arrays to empty before populating them
-        $datax = $datay1 = [];
-        $datay2 = null;
-
-        // don't go past the current date
-        $end_timestamp = min($end_timestamp, time());
-
-        // iterate through the days of the specified month
-        for ($dateTimestamp = $start_timestamp; $dateTimestamp <= $end_timestamp; $dateTimestamp += (60 * 60 * 24)) {
-            $datax[] = date('Y-m-d', $dateTimestamp);
-            $datay1[] = 0;
-        }
-    }
+    [$datax, $pages, $goal, $moving_average] = get_site_tally_cumulative_or_incremental(
+        $tally_name,
+        $c_or_i,
+        $start_timestamp,
+        $end_timestamp,
+        $days_to_average
+    );
 
     $data = [
         _("Actual") => [
             "x" => $datax,
-            "y" => $datay1,
+            "y" => $pages,
             "type" => "bar",
         ],
         _("Goal") => [
             "x" => $datax,
-            "y" => $datay2 ?? [],
+            "y" => $goal ?? [],
             "type" => "line",
         ],
     ];

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -436,6 +436,124 @@ function get_site_tally_grouped(
     return $rows;
 }
 
+/**
+ * Return either the cumulative or the incremental daily page stats for
+ * a site tally with optional simple moving average for the incremental.
+ *
+ * @param string $tally_name
+ *   Tally name
+ * @param string $c_or_i
+ *   One of: cumulative, increment
+ * @param int $start_timestamp
+ *   Earliest timestamp to evaluate
+ * @param int $end_timestamp
+ *   Latest timestamp to evaluate
+ * @param int $days_to_average
+ *   If using 'increment', number of days to calculate simple moving average
+ *
+ * @return array
+ */
+function get_site_tally_cumulative_or_incremental(
+    string $tally_name,
+    string $c_or_i,
+    int $start_timestamp,
+    int $end_timestamp,
+    int $days_to_average = 21
+): array {
+    global $SECONDS_TO_YESTERDAY;
+
+    // get_site_tally_grouped() handles the ascribed-vs-actual time difference
+    $data = get_site_tally_grouped($tally_name, 'date', $start_timestamp, $end_timestamp);
+    $datax = array_column($data, 0);
+    $datay1 = array_column($data, 1);
+    $datay2 = array_column($data, 2);
+
+    if ($c_or_i == 'cumulative') {
+        $datay1 = array_accumulate($datay1);
+        $datay2 = array_accumulate($datay2);
+
+        // The accumulated 'actual' for today and subsequent days is bogus,
+        // so delete it.
+        $date_today = date('Y-m-d');
+        for ($i = 0; $i < count($datax); $i++) {
+            if ($datax[$i] >= $date_today) {
+                unset($datay1[$i]);
+            }
+        }
+    }
+
+    if (empty($datay1)) {
+        $datay1[0] = 0;
+    }
+
+
+    // Calculate a simple moving average for 'increments' graphs
+    if ($c_or_i == 'increments') {
+        // To calculate a simple moving average over $days_to_average we need
+        // to have at least that many days worth of data before $start_timestamp.
+        $sma_start_timestamp = max($start_timestamp - ($days_to_average * 60 * 60 * 24), 0);
+        $sma_end_timestamp = $end_timestamp + 60 * 60 * 24;
+
+        $site_tallyboard = new TallyBoard($tally_name, 'S');
+        $deltas = $site_tallyboard->get_deltas(1, $sma_start_timestamp, $sma_end_timestamp);
+
+        $smas = calculate_tally_sma($deltas, $days_to_average);
+
+        // store the results in a date-based array we can use to populate the
+        // graph's data array; we need to account for ascribed-vs-actual diff
+        foreach ($smas as $timestamp => $average) {
+            $average_lookup[date("Y-m-d", $timestamp - $SECONDS_TO_YESTERDAY)] = $average;
+        }
+
+        // pull out the smas just for the dates in the data we're going to return
+        $moving_average = [];
+        foreach ($datax as $date) {
+            $moving_average[] = $average_lookup[$date] ?? 0;
+        }
+    } else {
+        $moving_average = null;
+    }
+
+    // if no data was returned from the SELECT, create an empty dataset
+    if (empty($datax)) {
+        // set arrays to empty before populating them
+        $datax = $datay1 = [];
+        $datay2 = null;
+
+        // don't go past the current date
+        $end_timestamp = min($end_timestamp, time());
+
+        // iterate through the days of the specified month
+        for ($dateTimestamp = $start_timestamp; $dateTimestamp <= $end_timestamp; $dateTimestamp += (60 * 60 * 24)) {
+            $datax[] = date('Y-m-d', $dateTimestamp);
+            $datay1[] = 0;
+        }
+    }
+
+    return [$datax, $datay1, $datay2, $moving_average];
+}
+
+/**
+ * Given an array of numbers and a window, calculate the moving average over
+ * the window.
+ */
+function calculate_tally_sma(array $array, int $window): array
+{
+    // We calculate the simple moving average from the $window of days leading
+    // up to, and including, a given date. If there are fewer than $window days
+    // before the date, we average the available data up to $window.
+    $timestamps = array_keys($array);
+    $values = array_values($array);
+    $results = [];
+    for ($i = 0; $i < count($values); $i++) {
+        $start_range = max($i - ($window - 1), 0);
+        $length = min($window, $i + 1);
+        $results[$timestamps[$i]] = array_sum(array_slice($values, $start_range, $length)) / $length;
+    }
+    return $results;
+}
+
+
 // -----------------------------------------------------------------------------
 
 /**


### PR DESCRIPTION
This is, frankly, embarrassing.

The thing that takes _so long_ to generate the stats graphs is calculating the moving average due to some complex SQL that joins `past_tallies` against itself. If we calculate the SMA in the code it's more than 10x faster on TEST -- probably even faster on PROD. It also removes another direct use of `past_tallies` which is needed for moving to the future sparse format.

Note that the old code only generated integer-based averages (I don't know why) whereas the new one will generate floating point averages, so the graphs will look slightly different.

Compare:
* https://www.pgdp.org/c/stats/pages_proofed_graphs.php?tally_name=P1
* https://www.pgdp.org/~cpeel/c.branch/improve-sma/stats/pages_proofed_graphs.php?tally_name=P1

Both of the above have graph caching disabled to show both the speed difference and to ensure we're seeing the actual results of the code and not a cached copy.