### PR TITLE
Make past_tallies a sparse table

### DIFF
--- a/SETUP/check_db_schema.template
+++ b/SETUP/check_db_schema.template
@@ -109,9 +109,10 @@ echo ""
 echo "Applying all upgrade scripts..."
 cd $testing_code_setup_dir/upgrade/$upgrade_number
 for f in *.php; do
-    # comment out any immediate die()s -- we want to continue even if
+    # comment out any immediate die()s or exit()s -- we want to continue even if
     # a user might want to double-check on a real site
     sed -i 's/^die()/#die()/' $f
+    sed -i 's/^exit(/#exit(/' $f
 
     # now run the script
     echo ""

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -70,7 +70,6 @@ CREATE TABLE `current_tallies` (
   `holder_type` char(1) NOT NULL default '',
   `holder_id` int(6) unsigned NOT NULL default '0',
   `tally_value` int(8) NOT NULL default '0',
-  `last_snap_timestamp` int unsigned NOT NULL DEFAULT '0',
   `last_snap_tally_delta` int NOT NULL DEFAULT '0',
   `last_snap_tally_value` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`tally_name`,`holder_type`,`holder_id`)
@@ -420,8 +419,10 @@ CREATE TABLE `special_days` (
 --
 
 CREATE TABLE `tally_snapshot_times` (
+  `tally_name` char(2) NOT NULL default '',
+  `holder_type` char(1) NOT NULL default '',
   `timestamp` int(10) unsigned NOT NULL default '0',
-  PRIMARY KEY (`timestamp`)
+  PRIMARY KEY (`tally_name`, `holder_type`, `timestamp`)
 );
 
 --

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -70,6 +70,9 @@ CREATE TABLE `current_tallies` (
   `holder_type` char(1) NOT NULL default '',
   `holder_id` int(6) unsigned NOT NULL default '0',
   `tally_value` int(8) NOT NULL default '0',
+  `last_snap_timestamp` int unsigned NOT NULL DEFAULT '0',
+  `last_snap_tally_delta` int NOT NULL DEFAULT '0',
+  `last_snap_tally_value` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`tally_name`,`holder_type`,`holder_id`)
 );
 
@@ -411,6 +414,15 @@ CREATE TABLE `special_days` (
   `symbol` varchar(2) default '',
   UNIQUE KEY `spec_code` (`spec_code`)
 ) COMMENT='definitions of SPECIAL days';
+
+--
+-- Table structure for table `tally_snapshot_times`
+--
+
+CREATE TABLE `tally_snapshot_times` (
+  `timestamp` int(10) unsigned NOT NULL default '0',
+  PRIMARY KEY (`timestamp`)
+);
 
 --
 -- Table structure for table `tasks`

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -421,7 +421,7 @@ CREATE TABLE `special_days` (
 CREATE TABLE `tally_snapshot_times` (
   `tally_name` char(2) NOT NULL default '',
   `holder_type` char(1) NOT NULL default '',
-  `timestamp` int(10) unsigned NOT NULL default '0',
+  `timestamp` int unsigned NOT NULL default '0',
   PRIMARY KEY (`tally_name`, `holder_type`, `timestamp`)
 );
 

--- a/SETUP/upgrade/21/20240414_update_current_tallies.php
+++ b/SETUP/upgrade/21/20240414_update_current_tallies.php
@@ -1,0 +1,165 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Altering current_tallies and creating tally_snapshot_times...\n";
+
+$sql = "
+    ALTER TABLE `current_tallies`
+        ADD COLUMN `last_snap_timestamp` int(10) unsigned NOT NULL default '0',
+        ADD COLUMN `last_snap_tally_delta` int(8) NOT NULL default '0',
+        ADD COLUMN `last_snap_tally_value` int(8) NOT NULL default '0'
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// The "IF NOT EXISTS" allows the script to be re-run easily if necessary
+$sql = "
+    CREATE TABLE IF NOT EXISTS `tally_snapshot_times` (
+      `timestamp` int(10) unsigned NOT NULL default '0',
+      PRIMARY KEY (`timestamp`)
+    )
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+echo "Populating new current_tallies fields and tally_snapshot_times table...\n";
+
+echo "Note: Progress will be reported every 100 holders per tallyboard\n";
+
+// iterate through all tallyboards
+foreach (get_all_current_tallyboards() as $tallyboard) {
+    $tally_name = $tallyboard->tally_name;
+    $holder_type = $tallyboard->holder_type;
+    echo "Populating for $holder_type, $tally_name\n";
+
+    // iterate over all of our holders, this should be fast because of the index
+    $sql = sprintf(
+        "
+        SELECT holder_id, tally_value, tally_delta, timestamp
+        FROM past_tallies
+        WHERE tally_name = '%s' AND holder_type = '%s' AND timestamp = %d
+        ORDER BY holder_id
+        ",
+        DPDatabase::escape($tally_name),
+        DPDatabase::escape($holder_type),
+        get_time_of_latest_snapshot($tallyboard)
+    );
+    $res = DPDatabase::query($sql);
+    $progress_index = 0;
+    while ($row = mysqli_fetch_assoc($res)) {
+        $holder_id = intval($row['holder_id']);
+
+        if ($progress_index % 100 == 0) {
+            echo sprintf("    %s: holder_id %d\n", $progress_index, $holder_id);
+        }
+
+        $sql = sprintf(
+            "
+            UPDATE current_tallies
+            SET
+                last_snap_timestamp = %d,
+                last_snap_tally_value = %d,
+                last_snap_tally_delta = %d
+            WHERE
+                tally_name = '%s'
+                AND holder_type = '%s'
+                AND holder_id = %d
+            ",
+            $row['timestamp'],
+            $row['tally_value'],
+            $row['tally_delta'],
+            DPDatabase::escape($tally_name),
+            DPDatabase::escape($holder_type),
+            $row['holder_id']
+        );
+        DPDatabase::query($sql);
+        $progress_index += 1;
+    }
+}
+
+// Keep track of all the timestamps we've seen and inserted into
+// tally_snapshot_times so far.
+$found_timestamps = [];
+
+// Create a list of distinct tally names for holder_type = 'S'
+$tally_names = [];
+foreach (get_all_current_tallyboards() as $tallyboard) {
+    if ($tallyboard->holder_type == 'S') {
+        $tally_names[] = $tallyboard->tally_name;
+    }
+}
+array_unique($tally_names);
+
+foreach ($tally_names as $tally_name) {
+    echo "Finding distinct timestamps for site tally_name $tally_name\n";
+    $holder_type = 'S';
+    $holder_id = 1;
+
+    $sql = sprintf(
+        "
+        SELECT DISTINCT timestamp
+        FROM past_tallies
+        WHERE tally_name = '%s' AND holder_type = '%s' AND holder_id = 1
+        ",
+        DPDatabase::escape($tally_name),
+        DPDatabase::escape($holder_type),
+    );
+
+    $res = DPDatabase::query($sql);
+    while ($row = mysqli_fetch_assoc($res)) {
+        $timestamp = $row['timestamp'];
+        if (isset($found_timestamps[$timestamp])) {
+            continue;
+        }
+
+        // we handle duplicates in case this script was restarted
+        $sql = sprintf(
+            "
+            INSERT INTO tally_snapshot_times
+            SET
+                timestamp = %d
+            ON DUPLICATE KEY UPDATE
+                timestamp = timestamp
+            ",
+            $timestamp
+        );
+        DPDatabase::query($sql);
+
+        $found_timestamps[$timestamp] = 1;
+    }
+}
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";
+
+// We have to use our own function in the upgrade script rather than the one
+// in Tallyboard because it will already be trying to use the table we're
+// trying to populate!
+function get_time_of_latest_snapshot($tallyboard)
+{
+    $sql = sprintf(
+        "
+        SELECT MAX(timestamp) as max_timestamp
+        FROM past_tallies
+        WHERE
+            tally_name      = '%s'
+            AND holder_type = '%s'
+        ",
+        DPDatabase::escape($tallyboard->tally_name),
+        DPDatabase::escape($tallyboard->holder_type)
+    );
+    $result = DPDatabase::query($sql);
+
+    $row = mysqli_fetch_assoc($result);
+    if (!$row) {
+        return null;
+    }
+
+    return $row["max_timestamp"];
+}

--- a/SETUP/upgrade/21/20240420_sparsify_past_tallies.php
+++ b/SETUP/upgrade/21/20240420_sparsify_past_tallies.php
@@ -1,0 +1,75 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+include_once($relPath.'Stopwatch.inc');
+
+header('Content-type: text/plain');
+
+echo <<<EOF
+    WARNING: Do not run this script until 20240414_update_current_tallies.php
+    has completed successfully. This will ensure that the new tally_snapshot_times
+    table is fully-populated before we start removing tally_delta=0 records from
+    past_tallies. Edit this file and comment out the exit() to continue.
+    
+    EOF;
+exit(1);
+
+// ------------------------------------------------------------
+
+echo "Deleting rows from past_tallies where tally_delta=0...\n";
+echo "Note: Progress will be reported every 100 holders per tallyboard\n";
+
+$watch = new Stopwatch();
+
+// iterate through all tallyboards
+foreach (get_all_current_tallyboards() as $tallyboard) {
+    $tally_name = $tallyboard->tally_name;
+    $holder_type = $tallyboard->holder_type;
+    echo "Working on $holder_type, $tally_name\n";
+
+    // iterate over all of our holders, this should be fast because of the index
+    $sql = sprintf(
+        "
+        SELECT DISTINCT holder_id
+        FROM past_tallies
+        WHERE tally_name = '%s' AND holder_type = '%s'
+        ORDER BY holder_id
+        ",
+        DPDatabase::escape($tally_name),
+        DPDatabase::escape($holder_type),
+    );
+    $res = DPDatabase::query($sql);
+    $progress_index = 0;
+    while ($row = mysqli_fetch_assoc($res)) {
+        $holder_id = intval($row['holder_id']);
+
+        if ($progress_index % 100 == 0) {
+            echo "    last holder_id $holder_id\n";
+        }
+
+        // time how long the delete takes and sleep for the same amount of time
+        // to not overwhelm the DB
+        $watch->start();
+        $sql = sprintf(
+            "
+            DELETE FROM past_tallies
+            WHERE
+                tally_name = '%s'
+                AND holder_type = '%s'
+                AND holder_id = %d
+                AND tally_delta = 0
+            ",
+            DPDatabase::escape($tally_name),
+            DPDatabase::escape($holder_type),
+            $row['holder_id'],
+        );
+        DPDatabase::query($sql);
+        $watch->stop();
+        sleep($watch->read());
+        $progress_index += 1;
+    }
+}
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/SETUP/upgrade/21/20240420_sparsify_past_tallies.php
+++ b/SETUP/upgrade/21/20240420_sparsify_past_tallies.php
@@ -44,7 +44,7 @@ foreach (get_all_current_tallyboards() as $tallyboard) {
         $holder_id = intval($row['holder_id']);
 
         if ($progress_index % 100 == 0) {
-            echo "    last holder_id $holder_id\n";
+            echo sprintf("    %s: holder_id %d\n", $progress_index, $holder_id);
         }
 
         // time how long the delete takes and sleep for the same amount of time
@@ -65,7 +65,7 @@ foreach (get_all_current_tallyboards() as $tallyboard) {
         );
         DPDatabase::query($sql);
         $watch->stop();
-        sleep($watch->read());
+        sleep(round($watch->read()));
         $progress_index += 1;
     }
 }

--- a/SETUP/upgrade/21/20240420_sparsify_past_tallies.php
+++ b/SETUP/upgrade/21/20240420_sparsify_past_tallies.php
@@ -16,6 +16,20 @@ exit(1);
 
 // ------------------------------------------------------------
 
+/*
+This whole script could be accomplished with a single command:
+
+    DELETE FROM past_tallies
+    WHERE tally_delta = 0
+
+However, the DELETE command locks the past_tallies table, forcing any other
+queries on the table to wait. On pgdp.net, this wait would be so long that
+we'd have to disable the site to do it. We'd prefer to avoid down-time, so
+instead we take all that deleting and break it into many smaller chunks,
+first by tallyboard and then by holder_id. Each chunk should be fairly quick,
+and after each, we sleep a while to let the DB recover.
+*/
+
 echo "Deleting rows from past_tallies where tally_delta=0...\n";
 echo "Note: Progress will be reported every 100 holders per tallyboard\n";
 

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -21,9 +21,21 @@
 
 // If a holder isn't explicitly recorded in a TallyBoard,
 // then it is implicitly recorded with a tally of zero.
-// So  the TallyBoard is prepared to answer questions about
+// So the TallyBoard is prepared to answer questions about
 // holders it has never heard of before.
 
+// TallyBoards store and access data in 4 tables, 2 of which treat the
+// holder_type/holder_id/tally_name tuple as a primary key:
+// * current_tallies - stores the current tally and tallies from the last
+//                     snapshot, one per tuple
+// * best_tally_rank - stores the highest achieved tally per tuple
+//
+// One that adds timestamp to that tuple for the primary key:
+// * past_tallies - stores historical tallies of deltas, one row per tuple
+//                  per snapshot with a non-zero tally_delta
+//
+// And one table to track all of the snapshot times:
+// * tally_snapshot_times - records all the snapshot times
 // -----------------------------------------------------------------------------
 
 /**
@@ -352,7 +364,6 @@ class TallyBoard
     {
         $prev_ascribe_time = $this->get_time_of_latest_snapshot();
 
-        $prev_tally_for_ = [];
         $best_rank_for_ = [];
         if (is_null($prev_ascribe_time)) {
             // No previous snapshot on this TallyBoard.
@@ -364,24 +375,6 @@ class TallyBoard
                 if ($prev_ascribe_time == $ascribe_time) {
                     return 'already';
                 }
-            }
-
-            // Get everyone's most recent saved tally.
-            $sql = sprintf(
-                "
-                SELECT holder_id, tally_value
-                FROM past_tallies
-                WHERE
-                    timestamp       = $prev_ascribe_time
-                    AND tally_name  = '%s'
-                    AND holder_type = '%s'
-                ",
-                DPDatabase::escape($this->tally_name),
-                DPDatabase::escape($this->holder_type)
-            );
-            $result = DPDatabase::query($sql);
-            while ([$holder_id, $prev_tally_value] = mysqli_fetch_row($result)) {
-                $prev_tally_for_[$holder_id] = $prev_tally_value;
             }
 
             // Get everyone's best tally-rank so far.
@@ -402,10 +395,34 @@ class TallyBoard
             }
         }
 
+        // update the last snapshot values for all holders of this Tallyboard
+        $query = sprintf(
+            "
+            UPDATE current_tallies
+            SET
+                last_snap_timestamp = %d,
+                last_snap_tally_delta = tally_value - last_snap_tally_value,
+                last_snap_tally_value = tally_value
+            WHERE
+                tally_name  = '%s'
+                AND holder_type = '%s'
+            ",
+            $ascribe_time,
+            DPDatabase::escape($this->tally_name),
+            DPDatabase::escape($this->holder_type),
+        );
+        if ($dry_run) {
+            // Normalize whitespace
+            $query = preg_replace('/\s+/', ' ', trim($query));
+            echo "$query\n";
+        } else {
+            DPDatabase::query($query);
+        }
+
         // Get everyone's current tally, in rank order.
         $sql = sprintf(
             "
-            SELECT holder_id, tally_value
+            SELECT holder_id, tally_value, last_snap_tally_delta
             FROM current_tallies
             WHERE
                 tally_name      = '%s'
@@ -418,31 +435,34 @@ class TallyBoard
         $result = DPDatabase::query($sql);
 
         $ranker = new Ranker(true);
-        while ([$holder_id, $current_tally] = mysqli_fetch_row($result)) {
+        while ([$holder_id, $current_tally, $tally_delta] = mysqli_fetch_row($result)) {
             $rank = $ranker->next($current_tally);
-            $previous_tally = array_get($prev_tally_for_, $holder_id, 0);
-            $tally_delta = $current_tally - $previous_tally;
-            $query = sprintf(
-                "
-                INSERT INTO past_tallies
-                SET
-                    timestamp   = $ascribe_time,
-                    tally_name  = '%s',
-                    holder_type = '%s',
-                    holder_id   = %d,
-                    tally_delta = $tally_delta,
-                    tally_value = $current_tally
-                ",
-                DPDatabase::escape($this->tally_name),
-                DPDatabase::escape($this->holder_type),
-                intval($holder_id)
-            );
-            if ($dry_run) {
-                // Normalize whitespace
-                $query = preg_replace('/\s+/', ' ', trim($query));
-                echo "$query\n";
-            } else {
-                DPDatabase::query($query);
+
+            if ($tally_delta <> 0) {
+                $query = sprintf(
+                    "
+                    INSERT INTO past_tallies
+                    SET
+                        timestamp   = $ascribe_time,
+                        tally_name  = '%s',
+                        holder_type = '%s',
+                        holder_id   = %d,
+                        tally_delta = %d,
+                        tally_value = %d
+                    ",
+                    DPDatabase::escape($this->tally_name),
+                    DPDatabase::escape($this->holder_type),
+                    $holder_id,
+                    $tally_delta,
+                    $current_tally
+                );
+                if ($dry_run) {
+                    // Normalize whitespace
+                    $query = preg_replace('/\s+/', ' ', trim($query));
+                    echo "$query\n";
+                } else {
+                    DPDatabase::query($query);
+                }
             }
 
             if ($rank > 0 && (!isset($best_rank_for_[$holder_id]) || $rank < $best_rank_for_[$holder_id])) {
@@ -469,6 +489,19 @@ class TallyBoard
                 }
             }
         }
+
+        // insert this snapshot time into tally_snapshot_times
+        $sql = sprintf(
+            "
+            INSERT INTO tally_snapshot_times
+            SET
+                timestamp = %d
+            ON DUPLICATE KEY UPDATE
+                timestamp = timestamp
+            ",
+            $ascribe_time
+        );
+        DPDatabase::query($sql);
     }
 
     // -------------------------------------------------------------------------
@@ -481,8 +514,8 @@ class TallyBoard
     {
         $sql = sprintf(
             "
-            SELECT MAX(timestamp) as max_timestamp
-            FROM past_tallies
+            SELECT MAX(last_snap_timestamp) as max_timestamp
+            FROM current_tallies
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
@@ -518,14 +551,15 @@ class TallyBoard
     {
         $sql = sprintf(
             "
-            SELECT timestamp, tally_delta, tally_value
-            FROM past_tallies
+            SELECT
+                last_snap_timestamp as timestamp,
+                last_snap_tally_delta as tally_delta,
+                last_snap_tally_value as tally_value
+            FROM current_tallies
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
                 AND holder_id   = %d
-            ORDER BY timestamp DESC
-            LIMIT 1
             ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
@@ -549,6 +583,7 @@ class TallyBoard
                 'tally_value' => 0,
             ];
         }
+
         return $info;
     }
 
@@ -641,6 +676,24 @@ class TallyBoard
     {
         $addl_where = $max_timestamp === null ? "" : sprintf("AND timestamp < %d", $max_timestamp);
 
+        // Initialize all of the snapshot times
+        $sql = sprintf(
+            "
+            SELECT timestamp
+            FROM tally_snapshot_times
+            WHERE timestamp >= %d $addl_where
+            ORDER BY timestamp ASC
+            ",
+            $min_timestamp
+        );
+        $result = DPDatabase::query($sql);
+
+        $delta_at_ = [];
+        while ([$timestamp] = mysqli_fetch_row($result)) {
+            $delta_at_[$timestamp] = 0;
+        }
+
+        // Fill in any actual deltas from past_tallies
         $sql = sprintf(
             "
             SELECT timestamp, tally_delta
@@ -649,19 +702,30 @@ class TallyBoard
                 tally_name      = '%s'
                 AND holder_type = '%s'
                 AND holder_id   = %d
-                AND timestamp  >= $min_timestamp
+                AND timestamp  >= %d
                 $addl_where
             ORDER BY timestamp ASC
             ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id)
+            $holder_id,
+            $min_timestamp
         );
         $result = DPDatabase::query($sql);
 
-        $delta_at_ = [];
         while ([$timestamp, $tally_delta] = mysqli_fetch_row($result)) {
             $delta_at_[$timestamp] = $tally_delta;
+        }
+
+        // remove all the zero tally_deltas at the beginning as the first
+        // non-zero entry is the first actual start, regardless when other
+        // snapshots started
+        foreach ($delta_at_ as $timestamp => $tally_delta) {
+            if ($tally_delta == 0) {
+                unset($delta_at_[$timestamp]);
+            } else {
+                break;
+            }
         }
         return $delta_at_;
     }
@@ -691,11 +755,12 @@ class TallyBoard
                 AND holder_type = '%s'
                 AND holder_id   = %d
                 AND $start_timestamp < timestamp
-                AND timestamp <= $end_timestamp
+                AND timestamp <= %d
             ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
-            intval($holder_id)
+            $holder_id,
+            $end_timestamp
         );
         $res = DPDatabase::query($sql);
         [$sum] = mysqli_fetch_row($res);

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -35,7 +35,7 @@
 //                  per snapshot with a non-zero tally_delta
 //
 // And one table to track all of the snapshot times:
-// * tally_snapshot_times - records all the snapshot times
+// * tally_snapshot_times - records all the snapshot times per tally_name/holder_type
 // -----------------------------------------------------------------------------
 
 /**
@@ -400,14 +400,12 @@ class TallyBoard
             "
             UPDATE current_tallies
             SET
-                last_snap_timestamp = %d,
                 last_snap_tally_delta = tally_value - last_snap_tally_value,
                 last_snap_tally_value = tally_value
             WHERE
                 tally_name  = '%s'
                 AND holder_type = '%s'
             ",
-            $ascribe_time,
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
         );
@@ -443,13 +441,14 @@ class TallyBoard
                     "
                     INSERT INTO past_tallies
                     SET
-                        timestamp   = $ascribe_time,
+                        timestamp   = %d,
                         tally_name  = '%s',
                         holder_type = '%s',
                         holder_id   = %d,
                         tally_delta = %d,
                         tally_value = %d
                     ",
+                    $ascribe_time,
                     DPDatabase::escape($this->tally_name),
                     DPDatabase::escape($this->holder_type),
                     $holder_id,
@@ -495,10 +494,12 @@ class TallyBoard
             "
             INSERT INTO tally_snapshot_times
             SET
+                tally_name = '%s',
+                holder_type = '%s',
                 timestamp = %d
-            ON DUPLICATE KEY UPDATE
-                timestamp = timestamp
             ",
+            DPDatabase::escape($this->tally_name),
+            DPDatabase::escape($this->holder_type),
             $ascribe_time
         );
         DPDatabase::query($sql);
@@ -514,8 +515,8 @@ class TallyBoard
     {
         $sql = sprintf(
             "
-            SELECT MAX(last_snap_timestamp) as max_timestamp
-            FROM current_tallies
+            SELECT MAX(timestamp) as max_timestamp
+            FROM tally_snapshot_times
             WHERE
                 tally_name      = '%s'
                 AND holder_type = '%s'
@@ -552,7 +553,6 @@ class TallyBoard
         $sql = sprintf(
             "
             SELECT
-                last_snap_timestamp as timestamp,
                 last_snap_tally_delta as tally_delta,
                 last_snap_tally_value as tally_value
             FROM current_tallies
@@ -575,14 +575,12 @@ class TallyBoard
             //     his delta would have been zero, and also
             //     his rank would have been zero (null rank).
 
-            $timestamp = $this->get_time_of_latest_snapshot(0);
-
             $info = [
-                'timestamp' => $timestamp,
                 'tally_delta' => 0,
                 'tally_value' => 0,
             ];
         }
+        $info["timestamp"] = $this->get_time_of_latest_snapshot(0);
 
         return $info;
     }
@@ -681,9 +679,15 @@ class TallyBoard
             "
             SELECT timestamp
             FROM tally_snapshot_times
-            WHERE timestamp >= %d $addl_where
+            WHERE
+                tally_name      = '%s'
+                AND holder_type = '%s'
+                AND timestamp  >= %d
+                $addl_where
             ORDER BY timestamp ASC
             ",
+            DPDatabase::escape($this->tally_name),
+            DPDatabase::escape($this->holder_type),
             $min_timestamp
         );
         $result = DPDatabase::query($sql);
@@ -717,16 +721,6 @@ class TallyBoard
             $delta_at_[$timestamp] = $tally_delta;
         }
 
-        // remove all the zero tally_deltas at the beginning as the first
-        // non-zero entry is the first actual start, regardless when other
-        // snapshots started
-        foreach ($delta_at_ as $timestamp => $tally_delta) {
-            if ($tally_delta == 0) {
-                unset($delta_at_[$timestamp]);
-            } else {
-                break;
-            }
-        }
         return $delta_at_;
     }
 

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -24,19 +24,18 @@
 // So the TallyBoard is prepared to answer questions about
 // holders it has never heard of before.
 
-// TallyBoards store and access data in 4 tables, 2 of which treat the
-// holder_type/holder_id/tally_name tuple as a primary key:
-// * current_tallies - stores the current tally and tallies from the last
-//                     snapshot, one per tuple
-// * best_tally_rank - stores the highest achieved tally per tuple
+// TallyBoards store and access data in 4 tables.
 //
-// One that adds timestamp to that tuple for the primary key:
-// * past_tallies - stores historical tallies of deltas, one row per tuple
-//                  per snapshot with a non-zero tally_delta
+// For each (tally_name, holder_type, holder_id) tuple,
+// * current_tallies - stores the holder's current tally and also their tally &
+//                     tally_delta from the latest snapshot.
+// * best_tally_rank - stores the highest 'rank' achieved by the holder, and
+//                     when they achieved it.
+// * past_tallies    - stores the holder's historical tally info, but only for
+//                     snapshots in which their tally changed (tally_delta != 0).
 //
-// And one table to track all of the snapshot times:
-// * tally_snapshot_times - records all the snapshot times per tally_name/holder_type
-// -----------------------------------------------------------------------------
+// For each (tally_name, holder_type) tuple,
+// * tally_snapshot_times - records the times of all past snapshots
 
 /**
  * Return an array of TallyBoard objects, representing all
@@ -417,10 +416,15 @@ class TallyBoard
             DPDatabase::query($query);
         }
 
+        // Now that we've captured everyone's current tally (into `last_snap_*`),
+        // `tally_value` is free to change, and we'll use `last_snap_*` to
+        // carry out the rest of this snapshot (updating `past_tallies` and
+        // `best_tally_rank`).
+
         // Get everyone's current tally, in rank order.
         $sql = sprintf(
             "
-            SELECT holder_id, tally_value, last_snap_tally_delta
+            SELECT holder_id, last_snap_tally_delta, last_snap_tally_value
             FROM current_tallies
             WHERE
                 tally_name      = '%s'
@@ -433,10 +437,10 @@ class TallyBoard
         $result = DPDatabase::query($sql);
 
         $ranker = new Ranker(true);
-        while ([$holder_id, $current_tally, $tally_delta] = mysqli_fetch_row($result)) {
-            $rank = $ranker->next($current_tally);
+        while ([$holder_id, $snap_tally_delta, $snap_tally_value] = mysqli_fetch_row($result)) {
+            $rank = $ranker->next($snap_tally_value);
 
-            if ($tally_delta <> 0) {
+            if ($snap_tally_delta <> 0) {
                 $query = sprintf(
                     "
                     INSERT INTO past_tallies
@@ -452,8 +456,8 @@ class TallyBoard
                     DPDatabase::escape($this->tally_name),
                     DPDatabase::escape($this->holder_type),
                     $holder_id,
-                    $tally_delta,
-                    $current_tally
+                    $snap_tally_delta,
+                    $snap_tally_value
                 );
                 if ($dry_run) {
                     // Normalize whitespace
@@ -502,7 +506,13 @@ class TallyBoard
             DPDatabase::escape($this->holder_type),
             $ascribe_time
         );
-        DPDatabase::query($sql);
+        if ($dry_run) {
+            // Normalize whitespace
+            $sql = preg_replace('/\s+/', ' ', trim($sql));
+            echo "$sql\n";
+        } else {
+            DPDatabase::query($sql);
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -708,7 +718,6 @@ class TallyBoard
                 AND holder_id   = %d
                 AND timestamp  >= %d
                 $addl_where
-            ORDER BY timestamp ASC
             ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
@@ -748,12 +757,13 @@ class TallyBoard
                 tally_name      = '%s'
                 AND holder_type = '%s'
                 AND holder_id   = %d
-                AND $start_timestamp < timestamp
+                AND %d < timestamp
                 AND timestamp <= %d
             ",
             DPDatabase::escape($this->tally_name),
             DPDatabase::escape($this->holder_type),
             $holder_id,
+            $start_timestamp,
             $end_timestamp
         );
         $res = DPDatabase::query($sql);

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -373,25 +373,25 @@ function get_site_tally_grouped(
 ): array {
     global $SECONDS_TO_YESTERDAY;
 
-    // The date formats below use two %s because they are embedded in an sprintf()
-    $goal_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y-%%m-%%d')";
-
     if ($grouped_into == "date") {
-        $date_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y-%%m-%%d')";
+        $date_format = "%Y-%m-%d";
     } elseif ($grouped_into == "year_month") {
-        $date_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y-%%m')";
+        $date_format = "%Y-%m";
     } elseif ($grouped_into == "year") {
-        $date_expr = "FROM_UNIXTIME(timestamp - $SECONDS_TO_YESTERDAY, '%%Y')";
+        $date_format = "%Y";
     } else {
         throw new InvalidArgumentException("\$grouped_into is an invalid value");
     }
 
-    $where_time = "1 ";
+    $goal_where_time = "1 ";
+    $tally_where_time = "1 ";
     if (isset($min_timestamp)) {
-        $where_time .= sprintf("AND timestamp >= %d ", $min_timestamp + $SECONDS_TO_YESTERDAY);
+        $goal_where_time .= sprintf("AND UNIX_TIMESTAMP(date) >= %d ", $min_timestamp + $SECONDS_TO_YESTERDAY);
+        $tally_where_time .= sprintf("AND timestamp >= %d ", $min_timestamp + $SECONDS_TO_YESTERDAY);
     }
     if (isset($max_timestamp)) {
-        $where_time .= sprintf("AND timestamp < %d ", $max_timestamp + $SECONDS_TO_YESTERDAY);
+        $goal_where_time .= sprintf("AND UNIX_TIMESTAMP(date) < %d ", $max_timestamp + $SECONDS_TO_YESTERDAY);
+        $tally_where_time .= sprintf("AND timestamp < %d ", $max_timestamp + $SECONDS_TO_YESTERDAY);
     }
 
     if (!$sort) {
@@ -411,18 +411,17 @@ function get_site_tally_grouped(
     }
     $sort_direction = $sort_direction == strtolower("asc") ? SORT_ASC : SORT_DESC;
 
+    // get all the goals
     $sql = sprintf(
         "
-        SELECT $date_expr as dateunit, sum(goal) as goal
-        FROM tally_snapshot_times
-            LEFT OUTER JOIN site_tally_goals
-            ON (site_tally_goals.tally_name = '%s'
-                AND $goal_expr = site_tally_goals.date
-            )
+        SELECT DATE_FORMAT(date, '%s') as dateunit, sum(goal) as goal
+        FROM site_tally_goals
         WHERE
-            $where_time
+            $goal_where_time
+            AND tally_name = '%s'
         GROUP BY dateunit
         ",
+        $date_format,
         $tally_name
     );
     $result = DPDatabase::query($sql);
@@ -435,17 +434,20 @@ function get_site_tally_grouped(
         ];
     }
 
+    // get the tally deltas
     $sql = sprintf(
         "
-        SELECT $date_expr as dateunit, sum(tally_delta) as tally_delta
+        SELECT FROM_UNIXTIME(timestamp - %d, '%s') as dateunit, sum(tally_delta) as tally_delta
         FROM past_tallies
         WHERE
-            $where_time
+            $tally_where_time
             AND past_tallies.tally_name = '%s'
             AND holder_type = 'S'
             AND holder_id = 1
         GROUP BY dateunit
         ",
+        $SECONDS_TO_YESTERDAY,
+        $date_format,
         $tally_name
     );
     $result = DPDatabase::query($sql);
@@ -464,8 +466,8 @@ function get_site_tally_grouped(
     array_multisort(array_column($dataset, $sort_column), $sort_direction, $dataset);
 
     $rows = [];
-    foreach ($dataset as $dateunit => $data) {
-        $rows[] = [$dateunit, $data["tally_delta"], $data["goal"] ?? 0];
+    foreach ($dataset as $data) {
+        $rows[] = [$data["dateunit"], $data["tally_delta"], $data["goal"] ?? 0];
     }
 
     if ($limit) {

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -386,17 +386,12 @@ function get_site_tally_grouped(
         throw new InvalidArgumentException("\$grouped_into is an invalid value");
     }
 
-    $where_time = "";
+    $where_time = "1 ";
     if (isset($min_timestamp)) {
         $where_time .= sprintf("AND timestamp >= %d ", $min_timestamp + $SECONDS_TO_YESTERDAY);
     }
     if (isset($max_timestamp)) {
         $where_time .= sprintf("AND timestamp < %d ", $max_timestamp + $SECONDS_TO_YESTERDAY);
-    }
-
-    $limit_string = "";
-    if (isset($limit)) {
-        $limit_string = sprintf("LIMIT %d", $limit);
     }
 
     if (!$sort) {
@@ -414,31 +409,67 @@ function get_site_tally_grouped(
     if (!in_array(strtolower($sort_direction), ["asc", "desc"])) {
         throw new InvalidArgumentException("Invalid \$sort direction`");
     }
-    $sort_string = "ORDER BY $sort_column $sort_direction";
+    $sort_direction = $sort_direction == strtolower("asc") ? SORT_ASC : SORT_DESC;
 
     $sql = sprintf(
         "
-        SELECT $date_expr as dateunit, sum(tally_delta) as tally_delta, sum(goal) as goal
-        FROM past_tallies
+        SELECT $date_expr as dateunit, sum(goal) as goal
+        FROM tally_snapshot_times
             LEFT OUTER JOIN site_tally_goals
-            ON (past_tallies.tally_name = site_tally_goals.tally_name
+            ON (site_tally_goals.tally_name = '%s'
                 AND $goal_expr = site_tally_goals.date
             )
         WHERE
-            past_tallies.tally_name = '%s'
-            AND holder_type = 'S'
-            AND holder_id = 1
             $where_time
         GROUP BY dateunit
-        $sort_string
-        $limit_string
         ",
         $tally_name
     );
     $result = DPDatabase::query($sql);
+    $dataset = [];
+    while ([$dateunit, $goal] = mysqli_fetch_row($result)) {
+        $dataset[$dateunit] = [
+            "dateunit" => $dateunit,
+            "tally_delta" => 0,
+            "goal" => $goal,
+        ];
+    }
+
+    $sql = sprintf(
+        "
+        SELECT $date_expr as dateunit, sum(tally_delta) as tally_delta
+        FROM past_tallies
+        WHERE
+            $where_time
+            AND past_tallies.tally_name = '%s'
+            AND holder_type = 'S'
+            AND holder_id = 1
+        GROUP BY dateunit
+        ",
+        $tally_name
+    );
+    $result = DPDatabase::query($sql);
+    while ([$dateunit, $tally_delta] = mysqli_fetch_row($result)) {
+        // this shouldn't happen, but check for it anyway
+        if (!isset($dataset[$dateunit])) {
+            $dataset[$dateunit] = [
+                "dateunit" => $dateunit,
+                "goal" => 0,
+            ];
+        }
+        $dataset[$dateunit]["tally_delta"] = $tally_delta;
+    }
+
+    // now we need to sort and enforce our limit
+    array_multisort(array_column($dataset, $sort_column), $sort_direction, $dataset);
+
     $rows = [];
-    while ($row = mysqli_fetch_row($result)) {
-        $rows[] = $row;
+    foreach ($dataset as $dateunit => $data) {
+        $rows[] = [$dateunit, $data["tally_delta"], $data["goal"] ?? 0];
+    }
+
+    if ($limit) {
+        return array_slice($rows, 0, $limit);
     }
 
     return $rows;


### PR DESCRIPTION
# Background
_Background pulled from #1190_

The `past_tallies` table stores historical round, user, and team statistics (`current_tallies` stores the current day's statistics) including the number of pages done that day (`tally_delta`). Once a day the site takes a snapshot of `current_tallies`, calculates the delta since the last snapshot, and adds a row in the `past_tallies` table for every `[tally_type, tally_name, holder_id]` tuple.

After a user has done a page in a round, they have an entry for that round in `current_tallies` and the site adds a new record in `past_tallies` for that user/round in every daily snapshot going forward. Said another way: we keep daily records of every user that has touched a round forever, even if they never proofread another page.

At pgdp.net, 24 years of this has caught up with us. The `past_tallies` table is 50GB in size and contains 598,611,362 rows. Of those 594,322,594 are records where `tally_delta`=0 -- 99%.

# This PR
This PR converts `past_tallies` to a sparse table wherein we do not store entries where `tally_delta`==0. It includes an upgrade script to delete those records.

We use `past_tallies` in a few primary ways:
1. To get the sum of pages done over a specific time span eg: last week, last month
   * A sparse table format where we do not store rows where `tally_delta` == 0 isn't a problem for this one. We just `sum(tally_delta)` over a time range anyway -- we don't need the zeros.
2. To get the number of pages done at a specific time (usually "yesterday")
   * This one we could calculate from a sparse `past_tallies` pretty easily.
3. To get the number of pages done every day over some span for a table or a chart
   * Without some sort of secondary table that records all of the snapshot times we can't accurately generate the data because we don't know what days are in-between the records where `tally_delta` <> 0. `past_tallies` itself isn't set up to query against `timestamp` and there's nothing that guarantees that every snapshot will have at least one non-zero `tally_delta`. (This might be practically true on pgdp.net but isn't guaranteed to be true for all sites.)
4. In concert with `current_tallies` to determine how many pages they did between yesterday and today to add new entries into `past_tallies
   * We can programmatically determine this from a sparse `past_tallies` but we add a whole lot of computation for every snapshot in ways that just don't make sense.

This PR introduces 1 new tables:
* `tally_snapshot_times` stores a timestamp of every snapshot. That's it. This one is useful for recreating charts and tables that might be filled with zeros.

And adds additional columns to another:
* `current_tallies` now stores the most recent snapshot as well. This allows us to take a snapshot very quickly and then populate `past_tallies`. It is also used as a very fast (index-based) lookup for "yesterday's" metrics which we do very often for rounds and users. And finally it is also a fast lookup for the most recent snapshot timestamp.

`past_tallies` is now touched in only the following places:
* `TallyBoard->take_snapshot()` -- update to only insert records where `tally_delta` != 0
* `TallyBoard->get_info_re_largest_delta()` -- unchanged, we still return info about the largest `tally_delta`. It already handles the case where the tally_holder does not exist in the table.
* `TallyBoard->get_deltas()` -- we initialize all possible snapshot times with zeros and fill in any non-zero entries.
* `TallyBoard->get_delta_sum()` -- unchanged
* `get_site_tally_grouped()` -- we initialize the snapshot times to zeros and then fill in the non-zero values from `past_tallies`.

# Testing
Testing/validating this is going to be a bit tricky because it involves changing data. I've created a separate database on TEST that is a copy of the current one. On this copy I've run the upgrade scripts and the sandbox below is using it. There is a crontab that refreshes the sparse DB after UTC midnight so they will only have at most a day of drift.

The sandbox has a nightly cronjob to take snapshots of the database but it is currently disabled. What this means is that the database will drift throughout a day and catch up at midnight UTC.

I suggest we test this in two phases:
1. Validate that the overall approach is sound, the non-snapshot-taking code works, and that the sparse DB sandbox matches the main TEST sandbox.  This is going to be confirming that the user's "yesterday" stats are correct and that the stats (graphs and tables) match across the rounds.
2. After we feel good with the code and the sparse format functionality I'll disable the sync and enable the snapshot crontab and we can validate that the nightly snapshot code is working like we want.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/revamp-past-tallies-sandbox/

# Current `past_tallies` sizes on TEST
```
# Main DB
mysql> select count(*) from past_tallies;
+----------+
| count(*) |
+----------+
|  2304294 |
+----------+
1 row in set (1.69 sec)

# Sparse DB
mysql> select count(*) from past_tallies;
+----------+
| count(*) |
+----------+
|     9027 |
+----------+
1 row in set (0.01 sec)
```