### PR TITLE
Reduce the overhead of Activity->user_access() calls

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -207,7 +207,15 @@ class Activity
             return $uao;
         }
 
-        $user_scores = get_user_scores($username, $this->access_minima);
+        // A user's score isn't going to change in a page load but many page
+        // loads will request an activity's user_access object multiple times
+        // so cache the scores to reduces DB hits.
+        static $_user_score_cache = [];
+        $cache_index = "$this->id:$username";
+        if (!array_key_exists($cache_index, $_user_score_cache)) {
+            $_user_score_cache[$cache_index] = get_user_scores($username, $this->access_minima);
+        }
+        $user_scores = $_user_score_cache[$cache_index];
 
         // -----------------------------------
         // recorded_access is the value recorded in the db for whether the user

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -11,11 +11,11 @@ class DBQueryError extends Exception
 final class DPDatabase
 {
     private static $_connection = false;
-    private static $_db_name = null;
-    private static $_default_db_charset = null;
-    private static $_default_db_collation = null;
-    public static $skip_encoding_check = false;
-    public static $tracing_log = null;
+    private static ?string $_db_name = null;
+    private static ?string $_default_db_charset = null;
+    private static ?string $_default_db_collation = null;
+    public static bool $skip_encoding_check = false;
+    public static ?string $tracing_log = null;
 
     public static function connect()
     {
@@ -78,17 +78,17 @@ final class DPDatabase
         return self::$_connection;
     }
 
-    public static function escape($value)
+    public static function escape(?string $value): string
     {
         return mysqli_real_escape_string(self::$_connection, $value);
     }
 
-    public static function escape_like_wildcards($value)
+    public static function escape_like_wildcards(?string $value): string
     {
         return addcslashes($value, "%_");
     }
 
-    public static function query($sql, $throw_on_failure = true, $log_on_failure = true)
+    public static function query(string $sql, bool $throw_on_failure = true, bool $log_on_failure = true)
     {
         try {
             $result = mysqli_query(self::$_connection, $sql);
@@ -112,7 +112,7 @@ final class DPDatabase
         return mysqli_affected_rows(self::$_connection);
     }
 
-    public static function log_error($backtrace_level = 0)
+    public static function log_error(int $backtrace_level = 0): string
     {
         // Log the SQL error to the PHP error log and return a generic error
         // for display to the user
@@ -141,7 +141,7 @@ final class DPDatabase
         mysqli_free_result($result);
     }
 
-    public static function get_default_db_charset()
+    public static function get_default_db_charset(): string
     {
         if (!self::$_default_db_charset) {
             self::get_db_defaults();
@@ -149,7 +149,7 @@ final class DPDatabase
         return self::$_default_db_charset;
     }
 
-    public static function get_default_db_collation()
+    public static function get_default_db_collation(): string
     {
         if (!self::$_default_db_collation) {
             self::get_db_defaults();
@@ -157,7 +157,7 @@ final class DPDatabase
         return self::$_default_db_collation;
     }
 
-    public static function is_table_utf8($table_name)
+    public static function is_table_utf8(string $table_name): bool
     {
         $sql = sprintf(
             "
@@ -176,7 +176,7 @@ final class DPDatabase
         return stripos($table_encoding, 'utf8mb4') === 0;
     }
 
-    public static function does_table_exist($table_name)
+    public static function does_table_exist(string $table_name): bool
     {
         $sql = sprintf(
             "
@@ -191,7 +191,7 @@ final class DPDatabase
         return mysqli_fetch_assoc($result) !== null;
     }
 
-    private static function log_trace($sql)
+    private static function log_trace(string $sql)
     {
         if (!DPDatabase::$tracing_log) {
             return;

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -15,6 +15,7 @@ final class DPDatabase
     private static $_default_db_charset = null;
     private static $_default_db_collation = null;
     public static $skip_encoding_check = false;
+    public static $tracing_log = null;
 
     public static function connect()
     {
@@ -91,6 +92,7 @@ final class DPDatabase
     {
         try {
             $result = mysqli_query(self::$_connection, $sql);
+            DPDatabase::log_trace($sql);
         } catch (mysqli_sql_exception $e) {
             if ($log_on_failure) {
                 // include this function's caller in the backtrace
@@ -187,6 +189,30 @@ final class DPDatabase
         );
         $result = self::query($sql);
         return mysqli_fetch_assoc($result) !== null;
+    }
+
+    private static function log_trace($sql)
+    {
+        if (!DPDatabase::$tracing_log) {
+            return;
+        }
+
+        try {
+            $backtrace = debug_backtrace();
+            $caller = $backtrace[1]['file'] . ":" . $backtrace[1]['line'];
+
+            $message = sprintf(
+                "%s %s %s\n",
+                date("c"),
+                $caller,
+                preg_replace("/\s+/", " ", $sql)
+            );
+            $fp = fopen(DPDatabase::$tracing_log, 'a');
+            fwrite($fp, $message);
+            fclose($fp);
+        } catch (Exception $e) {
+            // never fail on tracing
+        }
     }
 
     // Prevent this class from being instantiated

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -364,7 +364,6 @@ function encourage_highest_round($username, $round_id = null)
         // except the quizzes (eg number of days and pages done), nudge them along.
         $ready_ignoring_quizzes = true;
         $quiz_requirements = [];
-        $uao = $round->user_access($username);
         foreach ($uao->minima_table as $criterion_code => $tuple) {
             // skip checking any quiz criteria for pass
             if (startswith($criterion_code, 'quiz/')) {


### PR DESCRIPTION
To investigate something else I added a DB tracing feature to optionally output SQL queries and their callers to a log file (commit 1). During that investigation I discovered that we're doing the same query against `quiz_passes` table and `current_tallies` multiple times in a page load. I traced that back to the `Activity->user_access()` call.

This PR removes a redundant call in `gradual.inc` (this is the second time we load that object in the function -- see line 335) and adds a small cache within `Activity->user_access()` for the user score. The cache removes 20 DB queries on each of the round pages and Activity Hub. The queries are fast but add unnecessary load to the DB for data we literally just asked for microseconds before.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/reduce-db-query-hits/