### PR TITLE
Replace dc.xml with metadata.json and drop marc_records

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -119,17 +119,6 @@ CREATE TABLE `job_logs` (
 );
 
 --
--- Table structure for table `marc_records`
---
-
-CREATE TABLE `marc_records` (
-  `projectid` varchar(22) NOT NULL default '',
-  `original_array` text NOT NULL,
-  `updated_array` text NOT NULL,
-  PRIMARY KEY (`projectid`)
-);
-
---
 -- Table structure for table `news_items`
 --
 

--- a/SETUP/upgrade/21/20240101_drop_marc_records.php
+++ b/SETUP/upgrade/21/20240101_drop_marc_records.php
@@ -1,0 +1,18 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Dropping table marc_records...\n";
+$sql = "
+    DROP TABLE marc_records
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -493,9 +493,6 @@ class Project
                     $this->checkedoutby
                 );
             }
-
-            // Update the MARC record
-            $this->update_marc_record();
         } else {
             // Creating a new project
             $this->projectid = uniqid("projectID"); // The project ID
@@ -536,6 +533,9 @@ class Project
             // values created or assigned from the database
             $this->_load_from_db($this->projectid);
         }
+
+        // Create or update the metadata file
+        $this->generate_metadata_json();
     }
 
     public function delete()
@@ -1554,160 +1554,29 @@ class Project
     // -------------------------------------------------------------------------
 
     /**
-     * Given a MARCRecord, write a dc XML document for this project
+     * Write out project's metadata to a JSON file
      */
-    public function create_dc_xml_oai($marc_record)
+    public function generate_metadata_json()
     {
-        global $charset, $site_name, $code_url;
-
-        $dirname = $this->dir;
-        $filename = "$dirname/dc.xml";
-
-        if (!is_dir($dirname)) {
-            // If the project directory doesn't exist, the project was likely
-            // deleted or posted/archived.
-            return;
+        if (!$this->dir_exists) {
+            throw new NoProjectDirectory(_("Project directory does not exist."));
         }
 
-        if (!file_exists($filename)) {
-            touch($filename);
-        }
-
-        // Encode fields for XML heredoc
-        $title = xmlencode($this->nameofwork);
-        $creator = xmlencode($this->authorsname);
-        $subject = xmlencode($marc_record->subject);
-        $description = xmlencode($marc_record->description);
-        $publisher = xmlencode($site_name);
-        $contributor = xmlencode($this->credits_line);
-        $type = xmlencode($this->genre);
-        $language = xmlencode($this->language);
-
-        $xmlpage = <<<XML
-            <?xml version="1.0" encoding="$charset" ?>
-                <dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://purl.org/dc/elements/1.1/ http://www.openarchives.org/OAI/dc.xsd">
-                  <title>$title</title>
-                  <creator>$creator</creator>
-                  <subject>$subject</subject>
-                  <description>$description</description>
-                  <publisher>$publisher</publisher>
-                  <contributor>$contributor</contributor>
-                  <date>$marc_record->date</date>
-                  <type>$type</type>
-                  <format>XML</format>
-                  <identifier>$code_url/project.php?id=$this->projectid</identifier>
-                  <source>LCCN: $marc_record->lccn</source>
-                  <language>$language</language>
-                </dc>
-            XML;
-
-        $fp = fopen($filename, "w");
-        if ($fp) {
-            fwrite($fp, $xmlpage);
-            fclose($fp);
-        }
-    }
-
-    // MARC records for a project are saved in marc_records, one per projectid.
-    // The original_* columns hold the values returned from the YAZ search
-    // upon project creation. The updated_* columns hold updated YAZ records
-    // based on edits to the project record.
-
-    /**
-     * Populate the original_* columns for this project's MARC record
-     */
-    public function init_marc_record($marc_record)
-    {
-        $original_marc_array = $marc_record->get_yaz_array();
-
-        $sql = sprintf(
-            "
-            INSERT INTO marc_records
-            SET
-                projectid      = '%s',
-                original_array = '%s'
-            ",
-            DPDatabase::escape($this->projectid),
-            base64_encode(serialize($original_marc_array))
-        );
-    }
-
-    /**
-     * Update the updated_* columns for this project's MARC record
-     */
-    public function save_marc_record($marc_record)
-    {
-        $updated_marc_array = $marc_record->get_yaz_array();
-        $sql = sprintf(
-            "
-            UPDATE marc_records
-            SET
-                updated_array = '%s'
-            WHERE projectid = '%s'
-            ",
-            base64_encode(serialize($updated_marc_array)),
-            DPDatabase::escape($this->projectid)
-        );
-        DPDatabase::query($sql);
-
-        // Update project's Dublin Core file
-        $this->create_dc_xml_oai($marc_record);
-    }
-
-    /**
-     * Load the updated MARC record for this project
-     */
-    public function load_marc_record()
-    {
-        $updated_record = new MARCRecord();
-        $sql = sprintf(
-            "
-            SELECT updated_array
-            FROM marc_records
-            WHERE projectid = '%s'
-            ",
-            DPDatabase::escape($this->projectid)
-        );
-        $result = DPDatabase::query($sql);
-
-        $row = mysqli_fetch_assoc($result);
-        mysqli_free_result($result);
-
-        if (!$row) {
-            return $updated_record;
-        }
-
-        $updated_record->load_yaz_array(unserialize(base64_decode($row["updated_array"])));
-
-        return $updated_record;
-    }
-
-    /**
-     * Update the project's MARC record from the current Project values
-     */
-    public function update_marc_record()
-    {
-        $marc_record = $this->load_marc_record();
-
-        // Mapping of Project field names to MARC field names
-        $marc_field_map = [
-            "nameofwork" => "title",
-            "authorsname" => "author",
-            "genre" => "literary_form",
+        $metadata = [
+            "projectid" => $this->projectid,
+            "nameofwork" => $this->nameofwork,
+            "authorsname" => $this->authorsname,
+            "language" => $this->language,
+            "genre" => $this->genre,
+            "postednum" => $this->postednum,
+            "image_source" => $this->image_source,
         ];
 
-        foreach ($marc_field_map as $project_field => $marc_field) {
-            if ($this->$project_field) {
-                $marc_record->$marc_field = $this->$project_field;
-            }
-        }
-
-        // Only pull out the primary language
-        if ($this->languages) {
-            $marc_record->language = langcode3_for_langname($this->languages[0]);
-        }
-
-        $this->save_marc_record($marc_record);
+        file_put_contents("{$this->dir}/metadata.json", json_encode(
+            $metadata,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE |
+            JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK
+        ));
     }
 
     /**

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -51,6 +51,12 @@ function archive_project($project, $dry_run)
         }
     }
 
+    if ($dry_run) {
+        echo "    Write project metadata.\n";
+    } else {
+        $project->generate_metadata_json();
+    }
+
     $project_dir = $project->dir;
     $new_dir = "$archive_projects_dir/$projectid";
     if (file_exists($project_dir)) {
@@ -66,8 +72,6 @@ function archive_project($project, $dry_run)
     }
 
     archive_ancillary_data_for_project_etc($project, '        ', $dry_run);
-
-    generate_project_metadata_json($project, "$new_dir/metadata.json", $dry_run);
 
     if ($dry_run) {
         echo "    Mark project as archived.\n";
@@ -87,33 +91,6 @@ function archive_project($project, $dry_run)
 }
 
 // -----------------------------------------------------------------------------
-
-/**
- * Write out project's metadata to a JSON file within the archive
- */
-function generate_project_metadata_json($project, $filename, $dry_run)
-{
-    $metadata = [
-        "projectid" => $project->projectid,
-        "nameofwork" => $project->nameofwork,
-        "authorsname" => $project->authorsname,
-        "language" => $project->language,
-        "genre" => $project->genre,
-        "postednum" => $project->postednum,
-        "image_source" => $project->image_source,
-    ];
-
-    if ($dry_run) {
-        echo "    Write project metadata to $filename.\n";
-    } else {
-        file_put_contents($filename, json_encode(
-            $metadata,
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE |
-            JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK
-        ))
-            or die("Error writing project metadata to $filename.");
-    }
-}
 
 /**
  * Archive the ancillary info relating to $project

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -357,15 +357,6 @@ class ProjectInfoHolder
             // We're creating a new project
             $this->project->save();
 
-            // Save original MARC record, if provided
-            $yaz_array = unserialize(base64_decode($this->original_marc_array_encd));
-            if ($yaz_array !== false) {
-                $marc_record = new MARCRecord();
-                $marc_record->load_yaz_array($yaz_array);
-                $this->project->init_marc_record($marc_record);
-                $this->project->update_marc_record();
-            }
-
             // Create the project's 'good word list' and 'bad word list'.
             if (isset($this->clone_projectid)) {
                 // We're creating a project via cloning.


### PR DESCRIPTION
The reason why Dublin Core (`dc.xml`) files were originally created is unclear. Users (PMs, PPs, and squirrels) currently use them when managing project directory contents to make sure they are in the right place. Replace them with the `metadata.json` files we already generate during archiving.

This allows us to stop storing and managing MARC records in the database. We could have opted to just have the `dc.xml` file be updated from the project table rather than the MARC record (we only pull 2 fields from it), but we are already generating the `metadata.json` file during archiving and there doesn't seem to be a good reason to keep both.

This code does not proactively create `metadata.json` files for existing projects until they are edited (or archived), nor does it remove any existing `dc.xml` files.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/remove-marc-records/

Testing hints:
* The `metadata.json` file should be created and updated when editing projects.
* Creating a project from the external search (eg MARC record) should still work fine, we just don't save the MARC record itself.