### PR TITLE
Return projects without genres in search

### DIFF
--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -574,7 +574,7 @@ class ProjectSearchResults
         $sql = "
             SELECT COUNT(*)
             FROM projects
-            NATURAL JOIN genre_translations
+            NATURAL LEFT JOIN genre_translations
             LEFT JOIN project_holds
             USING (projectid, state)
             WHERE $where_condition
@@ -587,7 +587,7 @@ class ProjectSearchResults
             SELECT projects.*, genre_translations.trans_genre,
             project_holds.projectid IS NOT NULL AS hold
             FROM projects
-            NATURAL JOIN genre_translations
+            NATURAL LEFT JOIN genre_translations
             LEFT JOIN project_holds
             USING (projectid, state)
             WHERE $where_condition


### PR DESCRIPTION
All projects should have a valid genre. However, if for some reason they don't we still want them to show up in the project search.

On TEST, the following two projects do not have a genre and don't currently show up in a project search:
* projectID47ffb9bbb5139
* projectID61e639e687114

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-project-search-no-genre/