### PR TITLE
Update minimum MySQL version and future PHP version

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -10,6 +10,11 @@ first before upgrading to R202102 or later releases.**
 ## R??????
 Scripts supporting this upgrade are in `SETUP/upgrade/21`
 
+**This is the last release to support PHP 7.4. Future releases will only
+support PHP 8.0 and later.**
+
+* Updated minimum middleware to MySQL 8.0 (cpeel)
+
 ## R202403
 Scripts supporting this upgrade are in `SETUP/upgrade/20`
 

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -34,9 +34,9 @@ You need a recent version of Composer installed to manage the relevant PHP
 package dependencies.
 
 ### MySQL
-MySQL version 5.7 is the minimum supported version. MySQL 8.x will also work.
+MySQL version 8.0 is the minimum supported version.
 
-MariaDB version 10.2 and later should also work but has not been tested.
+MariaDB version 10.4 and later should also work but has not been tested.
 
 ### phpBB
 [phpBB](https://www.phpbb.com) 3.3 is the minimum supported version.


### PR DESCRIPTION
Bump the minimum version of MySQL we support to 8.0 (we let folks know about this upcoming change in the [last changelog](https://github.com/DistributedProofreaders/dproofreaders/blob/master/SETUP/CHANGELOG.md#notices--deprecations)).

And give a notice that the next release will be the last to run on PHP 7.4. When we upgrade TEST and PROD we'll be running 8.3 but I don't expect we'll be intentionally using anything that requires 8.3 while I know we'll be using things that require 8.0.