### PR TITLE
Explicitly give test user access to P1

### DIFF
--- a/SETUP/tests/ApiTest.php
+++ b/SETUP/tests/ApiTest.php
@@ -163,6 +163,9 @@ class ApiTest extends ProjectUtils
 
     public function test_get_page_data()
     {
+        global $pguser;
+        $pguser = $this->TEST_USERNAME;
+
         $project = $this->_create_available_project();
         $_SERVER["REQUEST_METHOD"] = "GET";
         $path = "v1/projects/$project->projectid/pages/001.png";
@@ -386,7 +389,7 @@ class ApiTest extends ProjectUtils
         $this->checkout($project->projectid, "P1.proj_avail");
 
         // let another user try to resume it
-        $pguser = $this->TEST_USERNAME_PM;
+        $pguser = $this->TEST_OLDUSERNAME;
         $this->resume($project->projectid, 'P1.proj_avail', '001.png', 'P1.page_out');
     }
 
@@ -517,7 +520,7 @@ class ApiTest extends ProjectUtils
         $this->checkout($project->projectid, "P1.proj_avail");
 
         // let another user return it to round
-        $pguser = $this->TEST_USERNAME_PM;
+        $pguser = $this->TEST_OLDUSERNAME;
         $this->return_to_round($project->projectid, "P1.proj_avail", "001.png", "P1.page_out");
     }
 

--- a/SETUP/tests/ProjectUtils.inc
+++ b/SETUP/tests/ProjectUtils.inc
@@ -30,9 +30,11 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
         $settings->set_boolean("manager", true);
 
         create_test_user($this->TEST_USERNAME);
+        grant_user_access($this->TEST_USERNAME, "P1");
 
         // create an old user (new users $days_on_site_threshold = 21)
         create_test_user($this->TEST_OLDUSERNAME, 22);
+        grant_user_access($this->TEST_OLDUSERNAME, "P1");
 
         create_test_image_source($this->TEST_IMAGESOURCE);
 

--- a/SETUP/tests/phpunit_test_helpers.inc
+++ b/SETUP/tests/phpunit_test_helpers.inc
@@ -22,6 +22,12 @@ function create_test_user($username, $age = 0)
     }
 }
 
+function grant_user_access($username, $activity)
+{
+    $user = new User($username);
+    $user->grant_access($activity, "none");
+}
+
 function delete_test_user($username)
 {
     // Delete test user's page events
@@ -43,6 +49,20 @@ function delete_test_user($username)
     $sql = sprintf(
         "DELETE FROM current_tallies WHERE holder_id = %d",
         $user->u_id
+    );
+    DPDatabase::query($sql);
+
+    // Delete any usersettings
+    $sql = sprintf(
+        "DELETE FROM usersettings WHERE username = '%s'",
+        DPDatabase::escape($username)
+    );
+    DPDatabase::query($sql);
+
+    // Delete any access_log
+    $sql = sprintf(
+        "DELETE FROM access_log WHERE subject_username = '%s'",
+        DPDatabase::escape($username)
     );
     DPDatabase::query($sql);
 


### PR DESCRIPTION
Explicitly give the test user access to P1. This resolves unit tests in the `pgdp-production` branch where P1 requires passing a quiz first. This also means we can remove the skip for `ProjectTest->test_can_be_proofed_available()` in that branch as it will now pass.