### PR TITLE
Ensure unittests are run against a test-only DB

### DIFF
--- a/.github/actions/setup-mysql-db/action.yml
+++ b/.github/actions/setup-mysql-db/action.yml
@@ -7,9 +7,9 @@ runs:
     - name: Configure mysql
       shell: bash
       run: |
-        mysql -uroot -proot -e "CREATE DATABASE dp_db CHARACTER SET utf8mb4;"
-        mysql -uroot -proot -e "CREATE USER dp_user@localhost IDENTIFIED BY 'dp_password';"
-        mysql -uroot -proot -e "GRANT ALL ON dp_db.* TO dp_user@localhost;"
+        mysql -uroot -proot -e "CREATE DATABASE dp_test_db CHARACTER SET utf8mb4;"
+        mysql -uroot -proot -e "CREATE USER dp_test_user@localhost IDENTIFIED BY 'dp_test_password';"
+        mysql -uroot -proot -e "GRANT ALL ON dp_test_db.* TO dp_test_user@localhost;"
     - name: Configure site setup
       shell: bash
       run: SETUP/configure SETUP/tests/ci_configuration.sh .

--- a/SETUP/smoketests/test_tables.sql
+++ b/SETUP/smoketests/test_tables.sql
@@ -1,4 +1,4 @@
-USE dp_db;
+USE dp_test_db;
 SET FOREIGN_KEY_CHECKS=0;
 
 /* $p = new Project(); $p->foo = bar; $p->save() does not allow new projects

--- a/SETUP/tests/ci_configuration.sh
+++ b/SETUP/tests/ci_configuration.sh
@@ -8,10 +8,10 @@
 # shellcheck shell=bash disable=SC2034
 
 _DB_SERVER=localhost
-_DB_USER=dp_user
-_DB_PASSWORD=dp_password
-_DB_NAME=dp_db
-_ARCHIVE_DB_NAME=dp_archive
+_DB_USER=dp_test_user
+_DB_PASSWORD=dp_test_password
+_DB_NAME=dp_test_db
+_ARCHIVE_DB_NAME=dp_test_archive
 
 _CODE_DIR=$PWD
 _CODE_URL='http://127.0.0.1:12345'

--- a/SETUP/tests/phpunit_bootstrap.php
+++ b/SETUP/tests/phpunit_bootstrap.php
@@ -5,6 +5,11 @@ $completed_projects_forum_idx, $deleted_projects_forum_idx;
 
 $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
+
+// Reconnect to the test DB
+DPDatabase::close();
+DPDatabase::connect("localhost", "dp_test_db", "dp_test_user", "dp_test_password");
+
 include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'TableDocumentation.inc');
 include_once($relPath.'../api/v1.inc');

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -16,9 +16,11 @@ final class DPDatabase
     private static $_default_db_collation = null;
     public static $skip_encoding_check = false;
 
-    public static function connect()
+    public static function connect($db_server = null, $db_name = null, $db_user = null, $db_password = null)
     {
-        include('udb_user.php');
+        if (!isset($db_server)) {
+            include('udb_user.php');
+        }
         self::$_db_name = $db_name;
 
         // Throw exceptions for DB call failures (PHP 8.1 default values)


### PR DESCRIPTION
When running unit tests, run them against a test DB instead of the real DB. This doesn't impact the CI at all, but does help when running unit tests on the TEST server. While the tests try to clean up after themselves, it's impossible to do so cleanly, for instance the crazy high round page counts.

One downside to this approach on TEST is that its possible the databases will drift. It's easy enough to drop and recreate the database however if the unit tests fail because of said drift.