### PR TITLE
phpstan: Fix "Call to an undefined method" error (and re-enable)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,6 +28,5 @@ parameters:
           path: pinc/DifferenceEngineWrapper.inc
 
         - message: '#invoked with \d+ parameter(s?), \d+((-\d+)?) required#'
-        - message: '#Call to an undefined method#'
         - message: '#Variable .* might not be defined#'
         - message: '#Constant .* not found#'

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -23,7 +23,7 @@ class ProjectSearchWidget
         }
     }
 
-    public function get_html_control()
+    public function get_html_control(): string
     {
         // make all widgets 100% width
         $size_attr = "style='width: 100%;'";
@@ -71,6 +71,8 @@ class ProjectSearchWidget
                 $r .= "<br>$this->invert_label<input type='checkbox' name='{$this->id}_inv'$check>";
             }
             return $r;
+        } else {
+            throw new InvalidArgumentException("type is invalid '{$this->type}'");
         }
     }
 
@@ -181,7 +183,7 @@ class SpecialDayWidget extends ProjectSearchWidget
 
 class HoldWidget extends ProjectSearchWidget
 {
-    public function get_html_control()
+    public function get_html_control(): string
     {
         $check = isset($_GET[$this->id]) ? " checked" : "";
         return "<input type='checkbox' name='$this->id'$check>";

--- a/pinc/ProjectSearchResultsConfig.inc
+++ b/pinc/ProjectSearchResultsConfig.inc
@@ -1,12 +1,14 @@
 <?php
 include_once($relPath.'metarefresh.inc');
 
-class Selector
+abstract class Selector
 {
     public string $id;
     public string $label;
     protected Settings $userSettings;
     protected string $search_origin;
+
+    abstract public function get_html_control(): string;
 
     public function echo_select_item()
     {
@@ -32,7 +34,7 @@ class ColumnSelector extends Selector
         $this->search_origin = $search_origin;
     }
 
-    public function get_html_control()
+    public function get_html_control(): string
     {
         $check = $this->column->is_active() ? " checked" : "";
         return "<input type='checkbox' name='{$this->column->id}'$check>";
@@ -55,15 +57,16 @@ class OptionSelector extends Selector
         $this->search_origin = $search_origin;
     }
 
-    public function get_html_control()
+    public function get_html_control(): string
     {
-        echo "<select name='$this->id'>\n";
+        $r = "<select name='$this->id'>\n";
         $selected_item = $this->get_value();
         foreach ($this->options as $option_value => $option_label) {
             $selected_attr = ($option_value == $selected_item) ? 'selected' : '';
-            echo "<option value='", attr_safe($option_value), "' $selected_attr>", html_safe($option_label), "</option>\n";
+            $r .= "<option value='" . attr_safe($option_value) . "' $selected_attr>" . html_safe($option_label) . "</option>\n";
         }
-        echo "</select>\n";
+        $r .= "</select>\n";
+        return $r;
     }
 
     public function get_value()


### PR DESCRIPTION
To do this:
1. Make class Selector abstract as it already implicitly is and add the abstract method declaration it needs.

2. Fix OptionSelector::get_html_control() to return a string to make it consistent with the other get_html_control()s, The `echo`s in this method accidentally worked before now because of the use of `echo "foo", get_html_control(), "bar"` in Selector and PHP happening to evaluate the arguments to `echo` (and their side effects) in left-to-right order.

There's a sandbox to test this at https://www.pgdp.org/~bfoley/c.branch/invalid-fn/

The code in question affects all the widgets on the project search page, in particular the popup menus under 'Configure Result'; the checkboxes, and the lists such as Language, Special Day, State.