### PR TITLE
Don't die if metadata.json creation fails

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -634,7 +634,12 @@ class Project
         }
 
         // Create or update the metadata file
-        $this->generate_metadata_json();
+        try {
+            $this->generate_metadata_json();
+        } catch (NoProjectDirectory $exception) {
+            // this is likely because the project has been deleted, either way
+            // continue instead of failing
+        }
     }
 
     public function delete()


### PR DESCRIPTION
Editing project information can happen even if the project directory doesn't exist (the project has been deleted or archived). In those cases, just don't generate the `metadata.json` file instead of failing.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-edit-deleted-project/