### PR TITLE
Replace die()s with exceptions and fix an assert

### DIFF
--- a/SETUP/smoketests/pageload_smoketest.py
+++ b/SETUP/smoketests/pageload_smoketest.py
@@ -83,7 +83,7 @@ MISC_TESTS = [
 
 QUIZ_TESTS = [
     {'path': 'quiz/start.php'},
-    {'path': 'quiz/generic/hints.php?quiz_page_id=p_greek_4&error=G_n_u&number=1'},
+    {'path': 'quiz/generic/hints.php?quiz_page_id=p_basicx_2&error=arid&number=1'},
     {'path': 'quiz/generic/main.php?quiz_page_id=p_greek_1'},
     {'path': 'quiz/generic/orig.php?quiz_page_id=p_greek_2'},
     {'path': 'quiz/generic/proof.php?quiz_page_id=p_greek_3'},

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -321,7 +321,7 @@ class Activity
                     break;
 
                 default:
-                    die("bad after_satisfying_minima value: '$this->after_satisfying_minima'");
+                    throw new UnexpectedValueException("bad after_satisfying_minima value: '$this->after_satisfying_minima'");
             }
         } else {
             // They don't satisfy the requirements
@@ -480,7 +480,7 @@ function show_user_access_object($uao, $will_autogrant = false)
             break;
 
         default:
-            die("bad request_status '$uao->request_status'");
+            throw new UnexpectedValueException("bad request_status '$uao->request_status'");
     }
 
     if (!empty($request_status_string)) {
@@ -509,7 +509,7 @@ function show_user_access_chart($username)
     global $ACCESS_CRITERIA, $code_url;
 
     if (is_null($username)) {
-        die('show_user_access_chart: $username is null');
+        throw new UnexpectedValueException('show_user_access_chart: $username is null');
     }
 
     [$allow_grant, $allow_revoke] = user_can_modify_access_of($username);
@@ -635,7 +635,7 @@ function show_user_access_chart($username)
 
 
             default:
-                die("bad request_status '$uao->request_status'");
+                throw new UnexpectedValueException("bad request_status '$uao->request_status'");
         }
         echo "</td>";
 

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -245,7 +245,7 @@ class Project
             $this->_create_source = "empty";
         } else {
             $arg_type = gettype($arg);
-            die("Project::Project(): 'arg' has unexpected type $arg_type");
+            throw new InvalidArgumentException("Project::Project(): 'arg' has unexpected type $arg_type");
         }
     }
 

--- a/pinc/ProjectState.inc
+++ b/pinc/ProjectState.inc
@@ -388,7 +388,7 @@ function get_project_status_descriptor(string $which): object
             break;
 
         default:
-            die(html_safe("bad value for 'which': '$which'"));
+            throw new UnexpectedValueException(html_safe("bad value for 'which': '$which'"));
     }
 
     return $obj;

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -143,7 +143,7 @@ class ProjectTransition
             }
         }
 
-        die("transition has bad 'restriction' value: '$simple_who_restriction'");
+        throw new UnexpectedValueException("transition has bad 'restriction' value: '$simple_who_restriction'");
     }
 
     /**

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -200,7 +200,9 @@ class ProjectTransition
         global $testing;
 
         // make sure this transition is valid
-        assert($this->is_valid_for($project, $who));
+        if (!$this->is_valid_for($project, $who)) {
+            throw new Exception("User '$who' is not authorized for this transition.");
+        }
 
         $projectid = $project->projectid;
 

--- a/pinc/ThemedTable.inc
+++ b/pinc/ThemedTable.inc
@@ -36,7 +36,7 @@ class ThemedTable
                     $subtitle = $option_value;
                     break;
                 default:
-                    die("ThemedTable created with invalid option: '$option_name'");
+                    throw new UnexpectedValueException("ThemedTable created with invalid option: '$option_name'");
             }
         }
 

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -21,7 +21,7 @@ function archive_project($project, $dry_run)
     global $archive_projects_dir, $archive_db_name;
 
     if (!is_dir($archive_projects_dir)) {
-        die("Error: archive directory $archive_projects_dir does not exist.\n");
+        throw new RuntimeException("Error: archive directory $archive_projects_dir does not exist.\n");
     }
 
     $projectid = $project->projectid;
@@ -65,7 +65,9 @@ function archive_project($project, $dry_run)
         } else {
             // Remove uncompressed versions of whole-project texts, leaving zips.
             exec("rm $project_dir/projectID*.txt");
-            rename($project_dir, $new_dir) or die("Unable to move $project_dir to $new_dir");
+            if (!rename($project_dir, $new_dir)) {
+                throw new RuntimeException("Unable to move $project_dir to $new_dir");
+            }
         }
     } else {
         echo "    Warning: $project_dir does not exist.\n";

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -750,7 +750,7 @@ function _install_bad_sequence($bytes, $code_point, $why_bad)
 
     if (!preg_match($_anchored_bad_bytes_regex, $bytes)) {
         $hex = string_to_hex($bytes);
-        die("$hex ($code_point $why_bad) is not covered by \$_bad_bytes_pattern\n");
+        throw new UnexpectedValueException("$hex ($code_point $why_bad) is not covered by \$_bad_bytes_pattern\n");
     }
 
     $_bad_byte_sequences[$bytes] = [$code_point, $why_bad];

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -25,7 +25,7 @@ function echo_button($button_id, $which_interface)
     } elseif ($which_interface == 'a') {
         $label = 'alt';
     } else {
-        die("echo_button: bad which_interface arg: '$which_interface'");
+        throw new UnexpectedValueException("echo_button: bad which_interface arg: '$which_interface'");
     }
 
     switch ($button_id) {

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -81,7 +81,7 @@ function user_logging_on($past, $preceding)
             break;
 
         default:
-            die("bad value for 'past'");
+            throw new UnexpectedValueException("bad value for 'past'");
     }
 
     switch ($preceding) {
@@ -106,7 +106,7 @@ function user_logging_on($past, $preceding)
             break;
 
         default:
-            die("bad value for 'preceding'");
+            throw new UnexpectedValueException("bad value for 'preceding'");
     }
 
     ///////////////////////////////////////////////////
@@ -614,7 +614,7 @@ function pages_daily(string $tally_name, string $c_or_i, string $timeframe)
             break;
 
         default:
-            die("bad 'timeframe' value: '$timeframe'");
+            throw new UnexpectedValueException("bad 'timeframe' value: '$timeframe'");
     }
 
     switch ($c_or_i) {
@@ -627,7 +627,7 @@ function pages_daily(string $tally_name, string $c_or_i, string $timeframe)
             break;
 
         default:
-            die("bad 'cori' value: '$c_or_i'");
+            throw new UnexpectedValueException("bad 'cori' value: '$c_or_i'");
     }
 
     $days_to_average = 21;
@@ -714,7 +714,7 @@ function _get_project_state_selector($which, $desired_states = null)
         return $sql;
     }
 
-    die("bad value for 'which': '$which'");
+    throw new UnexpectedValueException("bad value for 'which': '$which'");
 }
 
 function get_round_backlog_stats($interested_phases)

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -227,7 +227,7 @@ function set_locale_translation_enabled($locale, $enable)
     $enabled_file = "$translation_base/enabled";
 
     if (!is_dir($translation_base)) {
-        die(sprintf(_("Locale translation %s not installed"), $locale));
+        throw new RuntimeException(sprintf(_("Locale translation %s not installed"), $locale));
     }
 
     if ($enable && !is_file($enabled_file)) {

--- a/pinc/privacy.inc
+++ b/pinc/privacy.inc
@@ -20,6 +20,6 @@ function can_reveal_details_about($username, $user_privacy_setting)
 
         default:
             // Shouldn't happen.
-            die("can_reveal_details_about(): bad privacy setting: '$user_privacy_setting'");
+            throw new UnexpectedValueException("can_reveal_details_about(): bad privacy setting: '$user_privacy_setting'");
     }
 }

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -27,7 +27,7 @@ function detect_too_large()
 {
     if ($_SERVER['REQUEST_METHOD'] == 'POST' && empty($_POST) &&
         empty($_FILES) && array_get($_SERVER, 'CONTENT_LENGTH', 0) > 0) {
-        die(sprintf(_("Uploaded file is too large. Maximum file size is %s."), humanize_bytes(get_max_upload_size())));
+        throw new LengthException(sprintf(_("Uploaded file is too large. Maximum file size is %s."), humanize_bytes(get_max_upload_size())));
     }
 }
 

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -97,7 +97,7 @@ function get_label_for_event($event)
     $subscribable_project_events = get_subscribable_project_events();
     $label = @$subscribable_project_events[$event];
     if (is_null($label)) {
-        die("Unknown event: '$event'");
+        throw new UnexpectedValueException("Unknown event: '$event'");
     }
     return $label;
 }

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -1195,7 +1195,7 @@ function get_all_words_in_text($text, $with_offsets = false)
     $flags = $with_offsets ? PREG_OFFSET_CAPTURE : 0;
     $n_matches = preg_match_all($word_pattern, $text, $matches, $flags);
     if ($n_matches === false) {
-        die("get_all_words_in_text: An error occurred.");
+        throw new UnexpectedValueException("get_all_words_in_text: An error occurred.");
     }
 
     if ($with_offsets) {

--- a/quiz/generic/quiz_page.inc
+++ b/quiz/generic/quiz_page.inc
@@ -239,7 +239,7 @@ function qp_text_contains_anticipated_error($text, $test)
             break;
 
         default:
-            die("test-type '{$test['type']}' not recognized");
+            throw new UnexpectedValueException("test-type '{$test['type']}' not recognized");
 
     }
 
@@ -583,16 +583,16 @@ function qp_echo_hint_html($message_id, $hint_number)
     global $messages;
 
     if (!isset($messages[$message_id])) {
-        die("supplied message-id ($message_id) is not valid");
+        throw new UnexpectedValueException("supplied message-id ($message_id) is not valid");
     }
 
     if (!isset($messages[$message_id]["hints"])) {
-        die("The specified message ($message_id) does not have any hints.");
+        throw new UnexpectedValueException("The specified message ($message_id) does not have any hints.");
     }
 
     $max_hint_number = count($messages[$message_id]["hints"]) - 1;
     if ($hint_number > $max_hint_number) {
-        die("supplied hint-number ($hint_number) is greater than the maximum $max_hint_number");
+        throw new UnexpectedValueException("supplied hint-number ($hint_number) is greater than the maximum $max_hint_number");
     }
 
     $hint = $messages[$message_id]["hints"][$hint_number];

--- a/tools/project_manager/post_files.inc
+++ b/tools/project_manager/post_files.inc
@@ -216,7 +216,7 @@ function page_info_query($projectid, $limit_round_id, $which_text)
     } else {
         $limit_round = get_Round_for_round_id($limit_round_id);
         if (is_null($limit_round)) {
-            die("'$limit_round_id' is not a valid round-id\n");
+            throw new UnexpectedValueException("'$limit_round_id' is not a valid round-id\n");
         }
 
         if ($which_text == 'EQ') {
@@ -258,7 +258,7 @@ function page_info_query($projectid, $limit_round_id, $which_text)
             $text_column_expr .= " ELSE master_text";
             $text_column_expr .= " END";
         } else {
-            die("bad value for which_text: '$which_text'");
+            throw new UnexpectedValueException("bad value for which_text: '$which_text'");
         }
 
         $user_fields = "";

--- a/tools/proofers/proof_frame.inc
+++ b/tools/proofers/proof_frame.inc
@@ -23,6 +23,6 @@ function echo_proof_frame($ppage)
             break;
 
         default:
-            die("unknown i_type: '$interface_type'");
+            throw new UnexpectedValueException("unknown i_type: '$interface_type'");
     }
 }


### PR DESCRIPTION
`die()`s in functions are a Very Bad Idea because there's no way for callers to capture and do something about the error. They also can cause silent failures by exiting the page without anyone else knowing. This replaces `die()`s in our include files with exceptions. This does not replace `die()`s in non-include files. This shouldn't need a lot of (any?) testing as `die()`s are effectively the same as thrown exceptions from a "stop the world" perspective.

Also replace an `assert()` that should always be checked. Asserts are only for dev & test and in "production" mode the code within them is not generated or evaluated at all. See https://www.php.net/manual/en/function.assert.php

Sandbox: https://www.pgdp.org/~cpeel/c.branch/die-die-and-asserts/