### PR TITLE
Refine site search based on user feedback

### DIFF
--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -213,9 +213,11 @@ function html_logobar()
         echo "</div>"; // icon-menu
 
         echo "<div id='search-menu' class='nodisp'>";
-        $placeholder = attr_safe(sprintf(_("Search for '%s' to see options"), "help"));
+        $placeholder = attr_safe(_("Search..."));
         echo "<form action='$code_url/tools/site_search.php'>";
-        echo "<input id='search-menu-input' type='text' placeholder='$placeholder' name='q' autocapitalize='none'>&nbsp;<i aria-hidden='true' class='far fa-window-close' onclick='hideSiteSearch()'></i>";
+        echo "<input id='search-menu-input' type='text' placeholder='$placeholder' name='q' autocapitalize='none'>";
+        echo "&nbsp;<a href='$code_url/tools/site_search.php'><i aria-hidden='true' class='fas fa-info-circle fa-lg'></i></a>";
+        echo "&nbsp;<i aria-hidden='true' class='far fa-window-close fa-lg' onclick='hideSiteSearch()'></i>";
         echo "</form>";
         echo "</div>"; // search-menu
     }

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -265,9 +265,10 @@ header, #header {
         padding-right: 1em;
         font-size: 1.2em;
         color: @navbar-background;
+        .unicolor-link(@navbar-background);
     }
     #search-menu-input {
-        width: 90%;
+        width: 80%;
         font-size: 1em;
         border-radius: 8px;
         border: solid thin @border-color-base-lowc;

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -1280,9 +1280,17 @@ header #search-menu,
   font-size: 1.2em;
   color: black;
 }
+header #search-menu a:link,
+#header #search-menu a:link,
+header #search-menu a:visited,
+#header #search-menu a:visited,
+header #search-menu a:active,
+#header #search-menu a:active {
+  color: black;
+}
 header #search-menu-input,
 #header #search-menu-input {
-  width: 90%;
+  width: 80%;
   font-size: 1em;
   border-radius: 8px;
   border: solid thin #404040;
@@ -2971,6 +2979,14 @@ header #logo-img,
 header #search-menu,
 #header #search-menu {
   color: #cdcdcd;
+}
+header #search-menu a:link,
+#header #search-menu a:link,
+header #search-menu a:visited,
+#header #search-menu a:visited,
+header #search-menu a:active,
+#header #search-menu a:active {
+  color: #bcbcbc;
 }
 header .icon-menu-item,
 #header .icon-menu-item {

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -38,6 +38,7 @@ header, #header {
     }
     #search-menu {
         color: @navbar-text;
+        .unicolor-link(@heading-color);
     }
     .icon-menu-item {
         color: @heading-color;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1280,9 +1280,17 @@ header #search-menu,
   font-size: 1.2em;
   color: #444444;
 }
+header #search-menu a:link,
+#header #search-menu a:link,
+header #search-menu a:visited,
+#header #search-menu a:visited,
+header #search-menu a:active,
+#header #search-menu a:active {
+  color: #444444;
+}
 header #search-menu-input,
 #header #search-menu-input {
-  width: 90%;
+  width: 80%;
   font-size: 1em;
   border-radius: 8px;
   border: solid thin #d3d3d3;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1280,9 +1280,17 @@ header #search-menu,
   font-size: 1.2em;
   color: #336633;
 }
+header #search-menu a:link,
+#header #search-menu a:link,
+header #search-menu a:visited,
+#header #search-menu a:visited,
+header #search-menu a:active,
+#header #search-menu a:active {
+  color: #336633;
+}
 header #search-menu-input,
 #header #search-menu-input {
-  width: 90%;
+  width: 80%;
   font-size: 1em;
   border-radius: 8px;
   border: solid thin #d3d3d3;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1280,9 +1280,17 @@ header #search-menu,
   font-size: 1.2em;
   color: #000099;
 }
+header #search-menu a:link,
+#header #search-menu a:link,
+header #search-menu a:visited,
+#header #search-menu a:visited,
+header #search-menu a:active,
+#header #search-menu a:active {
+  color: #000099;
+}
 header #search-menu-input,
 #header #search-menu-input {
-  width: 90%;
+  width: 80%;
   font-size: 1em;
   border-radius: 8px;
   border: solid thin #d3d3d3;

--- a/tasks.php
+++ b/tasks.php
@@ -37,6 +37,17 @@ if (isset($_GET['f']) && !isset($_GET['action'])) {
     unset($_REQUEST['f']);
 }
 
+// If we got here with a generic query param, if it's numeric assume its
+// a task ID, otherwise a summary search
+if (isset($_GET['q'])) {
+    if (is_numeric($_GET['q'])) {
+        $_REQUEST['task_id'] = $_GET['task_id'] = $_GET['q'];
+    } else {
+        $_REQUEST['search_text'] = $_GET['search_text'] = $_GET['q'];
+        $_REQUEST['action'] = $_GET['action'] = 'search';
+    }
+}
+
 if (isset($_GET['tid']) && !isset($_GET['task_id'])) {
     $_REQUEST['task_id'] = $_GET['task_id'] = $_GET['tid'];
     unset($_GET['tid']);

--- a/tools/site_search.php
+++ b/tools/site_search.php
@@ -3,7 +3,6 @@ $relPath = "./../pinc/";
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'Project.inc');
-include_once($relPath.'User.inc');
 
 require_login();
 
@@ -15,12 +14,10 @@ if ($query == "help") {
 }
 
 if ($query !== "") {
-    // try a jump search first, as we want to prefer the built-in jump
-    // search strings over usernames that might conflict
+    // try a jump search first
     jump_search($query);
 
-    // try a smart search -- usernames can't contain ':' so these will
-    // never conflict
+    // try a smart search
     smart_search($query);
 
     try {
@@ -51,7 +48,6 @@ echo "<p>" . _("Site search attempts to figure out what you're looking for and g
 
 echo "<ul>";
 echo "<li>" . _("Enter a projectID to go to the project's page.") . "</li>";
-echo "<li>" . _("Enter a username to go to the user's statistics page.") . "</li>";
 echo "<li>" . sprintf(
     _("Enter an activity (%s) to go to the activity's page."),
     surround_and_join(array_keys(get_activity_jumps()), "<kbd>", "</kbd>", ", ")
@@ -303,14 +299,6 @@ function smart_search(string $query)
         new Project($query);
         metarefresh(0, "$code_url/project.php?id=$query");
     } catch (NonexistentProjectException $e) {
-        // pass
-    }
-
-    // is it a valid username?
-    try {
-        $user = new User($query);
-        metarefresh(0, "$code_url/stats/members/mdetail.php?id=$user->u_id");
-    } catch (NonexistentUserException $e) {
         // pass
     }
 

--- a/tools/site_search.php
+++ b/tools/site_search.php
@@ -125,9 +125,8 @@ function get_prefix_searches(bool $flatten_aliases = false): array
             "desc" => _("Search for this team name or part of a team name"),
         ],
         "task" => [
-            "url" => "$code_url/tasks.php?task_id=%s",
-            "desc" => _("Jump to this task ID"),
-            "validator" => "_validate_integer",
+            "url" => "$code_url/tasks.php?q=%s",
+            "desc" => _("Task search by task ID or part of a task summary"),
         ],
     ];
 
@@ -324,17 +323,5 @@ function prefix_search(string $query)
 
     $query = $matches[2];
 
-    // if there's a validator for the prefix, validate it
-    if (@$data["validator"]) {
-        $data["validator"]($query);
-    }
-
     metarefresh(0, sprintf($data["url"], urlencode($query)), "", "", true);
-}
-
-function _validate_integer(string $value)
-{
-    if (!preg_match("/^\d+$/", $value)) {
-        throw new Exception("Not a valid integer");
-    }
 }

--- a/tools/site_search.php
+++ b/tools/site_search.php
@@ -117,12 +117,12 @@ function get_prefix_searches(bool $flatten_aliases = false): array
         ],
         "user" => [
             "url" => "$code_url/stats/members/mbr_list.php?uname=%s",
-            "desc" => _("Search for this username or part of a username"),
+            "desc" => _("User search by all or part of a username"),
             "alias" => "u",
         ],
         "team" => [
             "url" => "$code_url/stats/teams/tlist.php?tname=%s",
-            "desc" => _("Search for this team name or part of a team name"),
+            "desc" => _("Team search by all or part of a team name"),
         ],
         "task" => [
             "url" => "$code_url/tasks.php?q=%s",
@@ -133,7 +133,7 @@ function get_prefix_searches(bool $flatten_aliases = false): array
     if (get_url_for_forum()) {
         $prefix_searches["forum"] = [
             "url" => get_url_for_search("%s", false),
-            "desc" => _("Search for this in forum posts"),
+            "desc" => _("Forum search for this in a post"),
             "alias" => "f",
         ];
     }
@@ -141,7 +141,7 @@ function get_prefix_searches(bool $flatten_aliases = false): array
     if (!empty($wiki_url)) {
         $prefix_searches["wiki"] = [
             "url" => "$wiki_url/Special:Search/Index.php?profile=all&search=%s",
-            "desc" => _("Search for this in the wiki"),
+            "desc" => _("Wiki search for this in an article"),
             "alias" => "w",
         ];
     }

--- a/tools/site_search.php
+++ b/tools/site_search.php
@@ -23,8 +23,6 @@ if ($query !== "") {
     try {
         // try a prefix search
         prefix_search($query);
-
-        $message = sprintf(_("Not sure what to do with '%s', maybe try one of the prefixes below."), $query);
     } catch (Exception $exception) {
         $message = sprintf(_("The input for your prefix search was invalid: %s"), $exception->getMessage());
     }
@@ -43,6 +41,22 @@ echo "<form>";
 echo "<input type='text' name='q' value='" . attr_safe($query) . "'> ";
 echo "<input type='submit' value='" . attr_safe(_("Search")) . "'>";
 echo "</form>";
+
+if ($query && $query != "help") {
+    echo "<p class='warning'>" . sprintf(_("Not sure what to do with '%s', perhaps try one of these."), html_safe($query)) . "</p>";
+    echo "<ul>";
+    foreach (get_prefix_searches(false) as $prefix => $details) {
+        echo sprintf(
+            "<li><a href='%s'>%s</a> (<kbd>%s:%s</kbd>)</li>",
+            attr_safe(sprintf("?q=%s:%s", $prefix, urlencode($query))),
+            $details["desc"],
+            $prefix,
+            html_safe($query)
+        );
+    }
+    echo "</ul>";
+    echo "<hr>";
+}
 
 echo "<p>" . _("Site search attempts to figure out what you're looking for and get you to it quickly.") . "</p>";
 


### PR DESCRIPTION
Refine the new site search experience after input from users. In brief, this:
* Removes the "jump to username" feature if the string is a username, now this needs to be prefixed with `u:`.
* Adds an icon to the search menu to get to the site search help page
* If no prefix was used the search page now lists suggestions to help the user (thanks @windymilla for this suggestion)
* Enables searching for a task by summary in addition to string (thanks @srjfoo for the suggestion)

Sandbox: https://www.pgdp.org/~cpeel/c.branch/refine-site-search/

Forum discussion: https://www.pgdp.net/phpBB3/viewtopic.php?t=81458