### PR TITLE
Adjust <kbd> style to mirror markdown code blocks

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -39,7 +39,6 @@
 @text-alert: #ff6600;        // orange family
 @text-warning: blue;         // blue family
 @text-ok: green;             // green family
-@text-mono: #cc0000;         // red family, different from error
 @text-base-highc: #232323;   // high contrast theme page-text color
 @text-base-mediumc: #666666; // medium contrast theme page-text color
 @text-base-lowc: #9a9a9a;    // low contrast theme page-text color
@@ -831,8 +830,10 @@ div.calloutheader {
 
 kbd {
     font-family: DejaVu Sans Mono, monospace;
-    color: @text-mono;
-    font-size: .95em;
+    background-color: @table-cell-base-mediumc;
+    font-size: 85%;
+    border-radius: 6px;
+    padding: 0 0.3em;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -1899,8 +1899,10 @@ div.calloutheader {
 }
 kbd {
   font-family: DejaVu Sans Mono, monospace;
-  color: #ff4d4d;
-  font-size: 0.95em;
+  background-color: #3a3a3a;
+  font-size: 85%;
+  border-radius: 6px;
+  padding: 0 0.3em;
 }
 /* ------------------------------------------------------------------------ */
 /* Round and Pool filter table */

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -105,7 +105,6 @@ select {
 @text-alert: #ff6600;
 @text-warning: #a4a4f4;
 @text-ok: green;
-@text-mono: #ff4d4d;
 @text-base-highc: #cacaca;
 @text-base-mediumc: #a6a6a6;
 @text-base-lowc: #707070;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -1899,8 +1899,10 @@ div.calloutheader {
 }
 kbd {
   font-family: DejaVu Sans Mono, monospace;
-  color: #cc0000;
-  font-size: 0.95em;
+  background-color: #dddddd;
+  font-size: 85%;
+  border-radius: 6px;
+  padding: 0 0.3em;
 }
 /* ------------------------------------------------------------------------ */
 /* Round and Pool filter table */

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -1899,8 +1899,10 @@ div.calloutheader {
 }
 kbd {
   font-family: DejaVu Sans Mono, monospace;
-  color: #cc0000;
-  font-size: 0.95em;
+  background-color: #dddddd;
+  font-size: 85%;
+  border-radius: 6px;
+  padding: 0 0.3em;
 }
 /* ------------------------------------------------------------------------ */
 /* Round and Pool filter table */

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -1899,8 +1899,10 @@ div.calloutheader {
 }
 kbd {
   font-family: DejaVu Sans Mono, monospace;
-  color: #cc0000;
-  font-size: 0.95em;
+  background-color: #dddddd;
+  font-size: 85%;
+  border-radius: 6px;
+  padding: 0 0.3em;
 }
 /* ------------------------------------------------------------------------ */
 /* Round and Pool filter table */


### PR DESCRIPTION
During the development of the initial site search, @chrismiceli rightly pointed out that our `<kbd>` styling sure look a lot like errors being big and red and all. This PR changes the styling to be more reminiscent of common Markdown monospace rendered stylings.

`<kbd>` styles are mostly used in the quizzes as well as (links to in the sandbox):
* [site search](https://www.pgdp.org/~cpeel/c.branch/update-kbd-style/tools/site_search.php?q=)
* [smoothreading page](https://www.pgdp.org/~cpeel/c.branch/update-kbd-style/tools/post_proofers/smooth_reading.php)
* [faq/translate.php](https://www.pgdp.org/~cpeel/c.branch/update-kbd-style/faq/translate.php)
* [random rules](https://www.pgdp.org/~cpeel/c.branch/update-kbd-style/tools/site_admin/displayrandrules.php?document=formatting_guidelines.php&langcode=en) (link is to SA interface)

Sandbox: https://www.pgdp.org/~cpeel/c.branch/update-kbd-style/

A thank you to @srjfoo and @windymilla for their help refining the style.