### PR TITLE
change character picker text-align to right

### DIFF
--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -60,7 +60,12 @@ class CharacterSelector
                 $row .= "<button type='button' class='picker invisible'></button>";
             } else {
                 $title_string = attr_safe(utf8_character_name($character));
-                $row .= "<button type='button' class='picker' title='$title_string'>" . html_safe($character) . "</button>";
+                if(str_contains($title_string, "GREEK CAPITAL") && (str_contains($title_string, "OXIA") || str_contains($title_string, "VARIA"))) {
+                    $align_style = "style='text-indent:0.4em'";
+                } else {
+                    $align_style = "";
+                }
+                $row .= "<button type='button' class='picker' title='$title_string' $align_style>" . html_safe($character) . "</button>";
             }
             $row .= "</div>";
         }

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -60,6 +60,7 @@ class CharacterSelector
                 $row .= "<button type='button' class='picker invisible'></button>";
             } else {
                 $title_string = attr_safe(utf8_character_name($character));
+                // to ensure the accents for Greek capital letters are visible, add a text indent.
                 if (startswith($title_string, "GREEK CAPITAL") && (str_contains($title_string, "OXIA") || str_contains($title_string, "VARIA"))) {
                     $align_style = "style='text-indent:0.4em'";
                 } else {

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -60,7 +60,7 @@ class CharacterSelector
                 $row .= "<button type='button' class='picker invisible'></button>";
             } else {
                 $title_string = attr_safe(utf8_character_name($character));
-                if(str_contains($title_string, "GREEK CAPITAL") && (str_contains($title_string, "OXIA") || str_contains($title_string, "VARIA"))) {
+                if (startswith($title_string, "GREEK CAPITAL") && (str_contains($title_string, "OXIA") || str_contains($title_string, "VARIA"))) {
                     $align_style = "style='text-indent:0.4em'";
                 } else {
                     $align_style = "";

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -61,8 +61,9 @@ class CharacterSelector
             } else {
                 $title_string = attr_safe(utf8_character_name($character));
                 // to ensure the accents for Greek capital letters are visible, add a text indent.
+                // see also similar code in tools/proofers/character_selector.js
                 if (startswith($title_string, "GREEK CAPITAL") && (str_contains($title_string, "OXIA") || str_contains($title_string, "VARIA"))) {
-                    $align_style = "style='text-indent:0.4em'";
+                    $align_style = "style='text-indent:0.35em'";
                 } else {
                     $align_style = "";
                 }

--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -375,7 +375,7 @@
     .picker {
         font-size: 1em;
         margin-top: 1px;
-        padding: 0 1px 0 0;
+        padding: 0;
     }
 
     #hide-picker {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -850,7 +850,7 @@
 #toolbox .picker {
   font-size: 1em;
   margin-top: 1px;
-  padding: 0 1px 0 0;
+  padding: 0;
 }
 #toolbox #hide-picker {
   box-shadow: -1px -1px grey;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -850,7 +850,7 @@
 #toolbox .picker {
   font-size: 1em;
   margin-top: 1px;
-  padding: 0 1px 0 0;
+  padding: 0;
 }
 #toolbox #hide-picker {
   box-shadow: -1px -1px grey;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -850,7 +850,7 @@
 #toolbox .picker {
   font-size: 1em;
   margin-top: 1px;
-  padding: 0 1px 0 0;
+  padding: 0;
 }
 #toolbox #hide-picker {
   box-shadow: -1px -1px grey;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -850,7 +850,7 @@
 #toolbox .picker {
   font-size: 1em;
   margin-top: 1px;
-  padding: 0 1px 0 0;
+  padding: 0;
 }
 #toolbox #hide-picker {
   box-shadow: -1px -1px grey;

--- a/tools/proofers/character_selector.js
+++ b/tools/proofers/character_selector.js
@@ -57,8 +57,9 @@ $(function () {
 
     function setAlign(element, title) {
         // to ensure the accents for Greek capital letters are visible, add a text indent.
+        // see also similar code in pinc/CharacterSelector.inc
         if(title.startsWith("GREEK CAPITAL") && (title.includes("OXIA") || title.includes("VARIA"))) {
-            element.style.textIndent = '0.4em';
+            element.style.textIndent = '0.35em';
         } else {
             element.style.textIndent = '0';
         }

--- a/tools/proofers/character_selector.js
+++ b/tools/proofers/character_selector.js
@@ -90,19 +90,9 @@ $(function () {
 
     function addMru(char, titletext) {
         // is the character in MRU array?
-
-        // IE HACK - IE11 doesn't support .findIndex()
-        //var index = mru.findIndex(function (element) {
-        //   return element.character === char;
-        //});
-
-        var index = mru.length - 1;
-        while(index >= 0) {
-            if(mru[index].character === char) {
-                break;
-            }
-            index -= 1;
-        }
+        var index = mru.findIndex(function (element) {
+            return element.character === char;
+        });
 
         if(index >= 0) {
             // already in array, update time

--- a/tools/proofers/character_selector.js
+++ b/tools/proofers/character_selector.js
@@ -56,8 +56,9 @@ $(function () {
     const mruMax = 2 * mruColumns;
 
     function setAlign(element, title) {
+        // to ensure the accents for Greek capital letters are visible, add a text indent.
         if(title.startsWith("GREEK CAPITAL") && (title.includes("OXIA") || title.includes("VARIA"))) {
-            element.style.textIndent = '0.35em';
+            element.style.textIndent = '0.4em';
         } else {
             element.style.textIndent = '0';
         }

--- a/tools/proofers/character_selector.js
+++ b/tools/proofers/character_selector.js
@@ -55,16 +55,26 @@ $(function () {
     const mruColumns = 12;
     const mruMax = 2 * mruColumns;
 
+    function setAlign(element, title) {
+        if(title.startsWith("GREEK CAPITAL") && (title.includes("OXIA") || title.includes("VARIA"))) {
+            element.style.textIndent = '0.35em';
+        } else {
+            element.style.textIndent = '0';
+        }
+    }
+
     function drawRow(mruRow) {
         // it is not necessary to escape the character or title
         var row = $('<div />').addClass('table-row');
         mruRow.forEach(function(element) {
+            let mruButton = $('<button />', {type: "button", title: element.title});
+            mruButton.addClass('picker')
+                .text(element.character);
+            setAlign(mruButton[0], element.title);
+
             row.append($('<div />')
                 .addClass('table-cell')
-                .append($('<button />', {type: "button", title: element.title})
-                    .addClass('picker')
-                    .text(element.character)
-                )
+                .append(mruButton)
             );
         });
         return row;
@@ -148,5 +158,6 @@ $(function () {
         })
         .on("mouseover", ".picker", function () {
             largeChar.value = this.textContent;
+            setAlign(largeChar, this.title);
         });
 });


### PR DESCRIPTION
This enables diacritical marks for polytonic greek to appear correctly in the character picker.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/picker_indent
