### PR TITLE
Add job log visibilitiy

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -114,10 +114,11 @@ CREATE TABLE `image_sources` (
 --
 
 CREATE TABLE `job_logs` (
-  `filename` varchar(40) NOT NULL default ''' ''',
+  `filename` varchar(40) NOT NULL default '',
   `tracetime` int(12) unsigned NOT NULL default '0',
-  `event` varchar(20) NOT NULL default ''' ''',
-  `comments` varchar(255) default NULL
+  `event` varchar(20) NOT NULL default '',
+  `comments` varchar(255) default NULL,
+  KEY `timestamp` (`tracetime`)
 );
 
 --

--- a/SETUP/upgrade/21/20240611_update_job_logs.php
+++ b/SETUP/upgrade/21/20240611_update_job_logs.php
@@ -1,0 +1,20 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+// ------------------------------------------------------------
+
+echo "Altering job_logs...\n";
+
+$sql = "
+    ALTER TABLE `job_logs`
+        MODIFY COLUMN `filename` varchar(40) NOT NULL default '',
+        MODIFY COLUMN `event` varchar(20) NOT NULL default '',
+        ADD INDEX timestamp (tracetime)
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/pinc/job_log.inc
+++ b/pinc/job_log.inc
@@ -18,3 +18,26 @@ function insert_job_log_entry($filename, $event, $comments, $tracetime = null)
     );
     DPDatabase::query($sql);
 }
+
+function get_job_log_entries($timestamp, $filename = null, $event = null)
+{
+    $filename_where = $filename ? sprintf("AND filename = '%s'", DPDatabase::escape($filename)) : "";
+    $event_where = $event ? sprintf("AND event = '%s'", DPDatabase::escape($event)) : "";
+    $sql = sprintf(
+        "
+        SELECT *
+        FROM job_logs
+        WHERE tracetime >= %d
+            $filename_where
+            $event_where
+        ORDER BY tracetime desc
+        ",
+        $timestamp
+    );
+    $result = DPDatabase::query($sql);
+    $entries = [];
+    while ($row = mysqli_fetch_assoc($result)) {
+        $entries[] = $row;
+    }
+    return $entries;
+}

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -290,12 +290,6 @@ if ($verbose) {
 echo "</pre>\n";
 
 if (!$one_project) {
-    insert_job_log_entry(
-        'automodify.php',
-        'MIDDLE',
-        sprintf("pre autorelease, %d seconds so far", time() - $start_time)
-    );
-
     autorelease();
 
     insert_job_log_entry(

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -43,6 +43,7 @@ $sections = [
         "manage_special_days.php" => _("Manage Special Days"),
         "manage_site_charsuites.php" => _("Manage Site Character Suites"),
         "manage_site_word_lists.php" => _("Manage Site Word Lists"),
+        "show_job_log.php" => _("Show Job Log"),
         "../../locale/translators/index.php" => _("Translation Center"),
     ],
 ];

--- a/tools/site_admin/show_job_log.php
+++ b/tools/site_admin/show_job_log.php
@@ -45,13 +45,13 @@ echo "<hr>";
 echo "<table class='themed theme_striped'>";
 echo "<tr>";
 echo "<th>" . _("Timestamp") . "</th>";
-echo "<th>" . _("Filename") . "</th>";
+echo "<th>" . _("Job") . "</th>";
 echo "<th>" . _("Event") . "</th>";
 echo "<th>" . _("Comments") . "</th>";
 echo "</tr>";
 foreach (get_job_log_entries($start_timestamp, $filename, $event) as $row) {
     echo "<tr>";
-    echo "<td>" . date("Y-h-d H:i:s", $row["tracetime"]) . "</td>";
+    echo "<td>" . date("Y-m-d H:i:s", $row["tracetime"]) . "</td>";
     echo "<td>" . $row["filename"] . "</td>";
     echo "<td>" . $row["event"] . "</td>";
     echo "<td>" . $row["comments"] . "</td>";

--- a/tools/site_admin/show_job_log.php
+++ b/tools/site_admin/show_job_log.php
@@ -1,0 +1,60 @@
+<?php
+$relPath = "./../../pinc/";
+include_once($relPath.'base.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath.'job_log.inc');
+
+$days_ago = get_integer_param($_GET, 'days_ago', 1, 0, 365);
+$filename = array_get($_GET, 'filename', null);
+$event = array_get($_GET, 'event', 'BEGIN');
+
+$start_timestamp = time() - (60 * 60 * 24 * $days_ago);
+
+require_login();
+
+// check to see if the user is authorized to be here
+if (!(user_is_a_sitemanager())) {
+    die(_("You are not authorized to invoke this script."));
+}
+
+$title = _("Job Log");
+output_header($title, NO_STATSBAR);
+
+echo "<h1>$title</h1>";
+
+echo "<form method='GET'>";
+echo "<table class='basic'>";
+echo "<tr>";
+echo "  <th>" . _("Days to show") . "</th>";
+echo "  <td><input name='days_ago' type='number' value='$days_ago''></td>";
+echo "</tr>";
+echo "<tr>";
+echo "  <th>" . _("Filename") . "</th>";
+echo "  <td><input name='filename' type='text' value='" . attr_safe($filename) . "'></td>";
+echo "</tr>";
+echo "<tr>";
+echo "  <th>" . _("Event") . "</th>";
+echo "  <td><input name='event' type='text' value='" . attr_safe($event) . "'></td>";
+echo "</tr>";
+echo "</table>";
+echo "<input type='submit' value='" . attr_safe(_("Show")) . "'>";
+echo "</form>";
+
+echo "<hr>";
+
+echo "<table class='themed theme_striped'>";
+echo "<tr>";
+echo "<th>" . _("Timestamp") . "</th>";
+echo "<th>" . _("Filename") . "</th>";
+echo "<th>" . _("Event") . "</th>";
+echo "<th>" . _("Comments") . "</th>";
+echo "</tr>";
+foreach (get_job_log_entries($start_timestamp, $filename, $event) as $row) {
+    echo "<tr>";
+    echo "<td>" . date("Y-h-d H:i:s", $row["tracetime"]) . "</td>";
+    echo "<td>" . $row["filename"] . "</td>";
+    echo "<td>" . $row["event"] . "</td>";
+    echo "<td>" . $row["comments"] . "</td>";
+    echo "</tr>";
+}
+echo "</table>";


### PR DESCRIPTION
Did you know we have a job log? Me neither! That's because we currently log to it in exactly two scripts and have zero way to view it. This gives SAs the ability to see the table and adds an index on the timestamp.

It removes a useless "MIDDLE" message from automodify.

https://www.pgdp.org/~cpeel/c.branch/job-log-visibilitiy/

This is related to https://github.com/DistributedProofreaders/dproofreaders/issues/1233