### PR TITLE
Update SQL for Available tab for no-access users

### DIFF
--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -597,10 +597,14 @@ function get_round_query_result($round_view, $round_sort, $round_column_specs, $
             }
         }
 
-        $avail_state_clause = sprintf(
-            "AND projects.state in (%s)",
-            surround_and_join($avail_states, "'", "'", ',')
-        );
+        if ($avail_states) {
+            $avail_state_clause = sprintf(
+                "AND projects.state in (%s)",
+                surround_and_join($avail_states, "'", "'", ',')
+            );
+        } else {
+            $avail_state_clause = "AND 0";
+        }
         $t_latest_page_event = 0;
         unset($round_column_specs['postednum']);
     } elseif ($round_view == "recent") {


### PR DESCRIPTION
If a user doesn't have access to proofread in any round, such as if they are a new user on PROD and have not passed the P1 quiz, we need to still construct a valid SQL.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/my-proj-avail-new-users/