### PR TITLE
Add primary key to temp table

### DIFF
--- a/tools/project_manager/autorelease.inc
+++ b/tools/project_manager/autorelease.inc
@@ -533,8 +533,9 @@ function AP_setup($round)
     $sql = "
         CREATE TEMPORARY TABLE active_page_counts
         (
-            projectid  varchar(22),
-            pages      INT(4)
+            projectid  varchar(22) NOT NULL,
+            pages      int,
+            PRIMARY KEY(projectid)
         )";
     DPDatabase::query($sql);
 


### PR DESCRIPTION
During automodify we create a temporary table for each round, populate it, query against it joining on `projectid`, and then delete it. This creates the table with an index so the join doesn't have to do a table scan for every evaluation.

Can confirm this works by comparing the automodify log output in the sandbox to that on TEST as there should be no functional change.
* Sandbox: https://www.pgdp.org/~cpeel/c.branch/index-temp-table/tools/project_manager/automodify.php
* TEST: https://www.pgdp.org/c/tools/project_manager/automodify.php