### PR TITLE
Stop logging WordCheck corrections

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -707,7 +707,6 @@ CREATE TABLE `wordcheck_events` (
   `round_id` char(2) NOT NULL,
   `username` varchar(25) NOT NULL,
   `suggestions` text,
-  `corrections` text,
   PRIMARY KEY (`check_id`),
   KEY `pc_compound` (`projectid`,`timestamp`,`image`)
 );

--- a/SETUP/upgrade/21/20240620_update_wordcheck_events.php
+++ b/SETUP/upgrade/21/20240620_update_wordcheck_events.php
@@ -1,0 +1,18 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+// ------------------------------------------------------------
+
+echo "Altering wordcheck_events...\n";
+
+$sql = "
+    ALTER TABLE `wordcheck_events`
+        DROP COLUMN `corrections`
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -644,8 +644,8 @@ function copy_project_wordcheck_events($from_projectid, $to_projectid)
     $sql = sprintf(
         "
         INSERT INTO wordcheck_events
-            (projectid, timestamp, image, round_id, username, suggestions, corrections)
-        SELECT '%s', timestamp, image, round_id, username, suggestions, corrections
+            (projectid, timestamp, image, round_id, username, suggestions)
+        SELECT '%s', timestamp, image, round_id, username, suggestions
         FROM wordcheck_events
         WHERE projectid = '%s'
         ",
@@ -658,14 +658,8 @@ function copy_project_wordcheck_events($from_projectid, $to_projectid)
 
 // -----------------------------------------------------------------------------
 
-function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions, $corrections)
+function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions)
 {
-    // save the corrections in wdiff format
-    $correction_list = [];
-    foreach ($corrections as [$orig, $new]) {
-        $correction_list[] = "[-$orig-] {+$new+}";
-    }
-
     $setters = join(", ", [
         set_col_str("projectid", $projectid),
         set_col_num("timestamp", time()),
@@ -673,7 +667,6 @@ function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions,
         set_col_str("round_id", $round),
         set_col_str("username", $proofer),
         set_col_str("suggestions", join("\n", $suggestions)),
-        set_col_str("corrections", join("\n", $correction_list)),
     ]);
     $sql = "
         INSERT INTO wordcheck_events
@@ -731,12 +724,10 @@ function load_wordcheck_events($projectid, $start_time = 0)
         $page = $resultSet["image"];
         $proofer = $resultSet["username"];
         $words = $resultSet["suggestions"];
-        $corrections = $resultSet["corrections"];
 
         $words = _explode_no_empty("\n", $words);
-        $corrections = _explode_no_empty("\n", $corrections);
 
-        $eventArray[] = [$time, $round, $page, $proofer, $words, $corrections];
+        $eventArray[] = [$time, $round, $page, $proofer, $words];
     }
 
     mysqli_free_result($res);
@@ -756,7 +747,7 @@ function load_project_good_word_suggestions($projectid, $start_time = 0)
     }
 
     foreach ($eventArray as $event) {
-        [$time, $round, $page, $proofer, $words, $corrections] = $event;
+        [$time, $round, $page, $proofer, $words] = $event;
 
         if (count($words)) {
             if (!is_array(@$wordsArray[$round][$page])) {


### PR DESCRIPTION
Every time someone submits a correction in WordCheck, in the record of the event itself we write the corrected text to the `corrections` column in the `wordcheck_events` table. They look like this:
```
[-Laman-] {+Lamán+}
[-Komarov-] {+Komaróv+}
[-pubHcist-] {+publicist+}
[-Vyazemsky-] {+Vyázemsky+}
```
But we never use it. Ever. Nor have we ever used it. At some point (circa 2007) we thought that data might come in handy for some analysis later but here we are ~17 years later and nada.

This PR:
1. stops collecting the data
2. includes an upgrade script to drop the column

Before we drop the column from PROD I intend to do write a dump of this SQL query to a file in some structured format:
```sql
select projectid, image, round_id, corrections from wordcheck_events where corrections <> "";
```
That data might be useful to some researcher somewhere who is interested in common scannos -- the projectid could give them information on the language and if they really cared they could reference it back to the scan and page text. I'll do the same for the `wordcheck_events` in the archive table too (dump the data and then drop the column).

Sandbox to confirm I didn't break WordCheck itself from the corrections excising: https://www.pgdp.org/~cpeel/c.branch/stop-wc-correction-logging/