### PR TITLE
Decrease list_etexts.php overhead

### DIFF
--- a/list_etexts.php
+++ b/list_etexts.php
@@ -5,8 +5,7 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'list_projects.inc');
 
 $x = get_enumerated_param($_GET, 'x', 'g', ['g', 's', 'b']);
-$sort = get_integer_param($_GET, 'sort', 0, 0, 5);
-$per_page = get_integer_param($_GET, 'per_page', 20, 1, 100);
+$per_page = get_integer_param($_GET, 'per_page', 50, 1, 100);
 $offset = get_integer_param($_GET, 'offset', 0, 0, null);
 
 if ($x == "g") {
@@ -14,7 +13,7 @@ if ($x == "g") {
     $title = _("Completed Gold E-Texts");
     $info = [
         _("Below is the list of Gold e-texts that have been produced on this site. Gold e-texts are books that have passed through all phases of proofreading, formatting, and post-processing. They have been submitted to Project Gutenberg and are now available for your enjoyment and download."),
-        _("These e-texts are the product of hundreds of hours of labor donated by all of our volunteers. The list is sorted with the most recently submitted e-texts at the top. You can sort them based upon your own preferences by clicking below. Enjoy!!"),
+        _("These e-texts are the product of hundreds of hours of labor donated by all of our volunteers. The list is sorted with the most recently submitted e-texts at the top. Enjoy!!"),
     ];
     $rss_content = "posted";
 } elseif ($x == "s") {
@@ -23,7 +22,7 @@ if ($x == "g") {
     $group_clause = "";
     $info = [
         _("Below is the list of Silver e-texts that have almost completed processing on our site. Silver e-texts are books that have passed through all phases of proofreading and formatting and are now in the post-processing phase. Post-processing is the final assembly stage in which one volunteer performs a series of checks for consistency and correctness before the e-book is submitted to Project Gutenberg for your enjoyment and download."),
-        _("These e-texts are the product of hundreds of hours of labor donated by our volunteers, and are in one of our post-processing states. The list is sorted by date, with the most recent to have changed state sorted to the top. You can re-sort them based on your own preferences. Enjoy!!"),
+        _("These e-texts are the product of hundreds of hours of labor donated by our volunteers, and are in one of our post-processing states. The list is sorted by date, with the most recent to have changed state sorted to the top. Enjoy!!"),
     ];
     $rss_content = "postprocessing";
 } elseif ($x == "b") {
@@ -33,7 +32,7 @@ if ($x == "g") {
     $info = [
         _("Below is the list of Bronze e-texts that are currently available for proofreading on this site. Bronze e-texts are those that our volunteers are now proofreading or formatting. After going through three proofreading and two formatting rounds, the e-text then goes to an experienced volunteer for final assembly (post-processing), after which the e-text is submitted to Project Gutenberg for your enjoyment and download."),
         _("Some of these e-texts are just beginning their journeys, others are almost done, and many variations in between. If you would like to help, log in and choose an activity from the navigation bar to see the lists of projects you are eligible to work in."),
-        _("The list is sorted by date, with the most recent to have changed state sorted to the top, and all rounds mixed together. You can re-sort them based on your own preferences."),
+        _("The list is sorted by date, with the most recent to have changed state sorted to the top, and all rounds mixed together."),
     ];
     $rss_content = "proofing";
 } else {
@@ -50,7 +49,7 @@ output_header($title, NO_STATSBAR, $extra_args);
 
 echo "<h1>$title</h1>";
 
-$listsuffix = "&amp;sort=$sort&amp;per_page=$per_page";
+$listsuffix = "&amp;per_page=$per_page";
 $menu = [];
 foreach (["g" => _("Gold"), "s" => _("Silver"), "b" => _("Bronze")] as $key => $type_option) {
     if ($x == $key) {
@@ -63,20 +62,6 @@ echo "<p>" .  implode(" | ", $menu) . "</p>";
 echo "<div class='star-$type' style='float: left; width: 1.5em;'>★</div>";
 echo surround_and_join($info, "<p>", "</p>", "");
 
-$listurl = "list_etexts.php?x=$x&amp;per_page=$per_page&amp;offset=$offset";
-echo sprintf(_("<i>Title:</i> <a href='%1\$s'>asc</a> or <a href='%2\$s'>desc</a> | "), "$listurl&amp;sort=0", "$listurl&amp;sort=1");
-echo sprintf(_("<i>Author:</i> <a href='%1\$s'>asc</a> or <a href='%2\$s'>desc</a> | "), "$listurl&amp;sort=2", "$listurl&amp;sort=3");
-echo sprintf(_("<i>Date:</i> <a href='%1\$s'>asc</a> or <a href='%2\$s'>desc</a>"), "$listurl&amp;sort=4", "$listurl&amp;sort=5");
-
 echo "<hr class='divider'>";
 
-$sortlist = [
-    "ORDER BY nameofwork asc",
-    "ORDER BY nameofwork desc",
-    "ORDER BY authorsname asc",
-    "ORDER BY authorsname desc",
-    "ORDER BY modifieddate asc",
-    "ORDER BY modifieddate desc",
-];
-
-list_projects($type, $sortlist[$sort], "list_etexts.php?x=$x&amp;sort=$sort&amp;", $per_page, $offset);
+list_projects($type, "ORDER BY modifieddate desc", "list_etexts.php?x=$x&amp;", $per_page, $offset);

--- a/list_etexts.php
+++ b/list_etexts.php
@@ -12,8 +12,6 @@ $offset = get_integer_param($_GET, 'offset', 0, 0, null);
 if ($x == "g") {
     $type = "gold";
     $title = _("Completed Gold E-Texts");
-    $state = SQL_CONDITION_GOLD;
-    $group_clause = "GROUP BY postednum";
     $info = [
         _("Below is the list of Gold e-texts that have been produced on this site. Gold e-texts are books that have passed through all phases of proofreading, formatting, and post-processing. They have been submitted to Project Gutenberg and are now available for your enjoyment and download."),
         _("These e-texts are the product of hundreds of hours of labor donated by all of our volunteers. The list is sorted with the most recently submitted e-texts at the top. You can sort them based upon your own preferences by clicking below. Enjoy!!"),
@@ -22,7 +20,6 @@ if ($x == "g") {
 } elseif ($x == "s") {
     $type = "silver";
     $title = _("In Progress Silver E-Texts");
-    $state = SQL_CONDITION_SILVER;
     $group_clause = "";
     $info = [
         _("Below is the list of Silver e-texts that have almost completed processing on our site. Silver e-texts are books that have passed through all phases of proofreading and formatting and are now in the post-processing phase. Post-processing is the final assembly stage in which one volunteer performs a series of checks for consistency and correctness before the e-book is submitted to Project Gutenberg for your enjoyment and download."),
@@ -32,7 +29,6 @@ if ($x == "g") {
 } elseif ($x == "b") {
     $type = "bronze";
     $title = _("Now Proofreading Bronze E-Texts");
-    $state = SQL_CONDITION_BRONZE;
     $group_clause = "";
     $info = [
         _("Below is the list of Bronze e-texts that are currently available for proofreading on this site. Bronze e-texts are those that our volunteers are now proofreading or formatting. After going through three proofreading and two formatting rounds, the e-text then goes to an experienced volunteer for final assembly (post-processing), after which the e-text is submitted to Project Gutenberg for your enjoyment and download."),
@@ -83,4 +79,4 @@ $sortlist = [
     "ORDER BY modifieddate desc",
 ];
 
-list_projects($state, $sortlist[$sort], $group_clause, "list_etexts.php?x=$x&amp;sort=$sort&amp;", $per_page, $offset);
+list_projects($type, $sortlist[$sort], "list_etexts.php?x=$x&amp;sort=$sort&amp;", $per_page, $offset);

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -4,8 +4,16 @@ include_once($relPath.'pg.inc');
 /**
  * Output a list of projects giving very brief information about each
  */
-function list_projects_tersely($where_condition, $order_clause, $limit_clause)
+function list_projects_tersely(string $metal, string $order_clause, string $limit_clause)
 {
+    if ($metal == "gold") {
+        $where_condition = SQL_CONDITION_GOLD;
+    } elseif ($metal == "silver") {
+        $where_condition = SQL_CONDITION_SILVER;
+    } elseif ($metal == "bronze") {
+        $where_condition = SQL_CONDITION_BRONZE;
+    }
+
     $sql = "
         SELECT nameofwork, authorsname, language, postednum
         FROM projects
@@ -37,11 +45,39 @@ function list_projects_tersely($where_condition, $order_clause, $limit_clause)
  *
  * url_base is the URL with the beginning of a query string, eg "foo.php?x=10&amp;" or "foo.php?"
  */
-function list_projects($where_condition, $order_clause, $group_clause, $url_base, $per_page = 20, $offset = 0)
+function list_projects(string $metal, string $order_clause, string $url_base, int $per_page = 20, int $offset = 0)
 {
     global $code_url;
 
-    // first get the number of projects
+    if ($metal == "gold") {
+        $join = "
+            LEFT OUTER JOIN pg_books
+            ON projects.postednum=pg_books.etext_number
+        ";
+        $join_columns = "formats,";
+        $where_condition = SQL_CONDITION_GOLD;
+        $group_clause = "GROUP BY postednum";
+    } elseif ($metal == "silver") {
+        $join = "";
+        $join_columns = "";
+        $where_condition = SQL_CONDITION_SILVER;
+        $group_clause = "";
+    } elseif ($metal == "bronze") {
+        $join = "";
+        $join_columns = "";
+        $where_condition = SQL_CONDITION_BRONZE;
+        $group_clause = "";
+    }
+
+    // first get the number of projects, we cache this value for an hour
+    // so it might be a bit out of sync with the full listing, but it means
+    // we don't have to do this query twice
+    $num_found_rows = memoize_function("get_star_texts_count", [$metal]);
+    if ($num_found_rows == 0) {
+        echo _("There are currently no projects in this category.");
+        return;
+    }
+
     $sql = "
         SELECT
             projectid,
@@ -51,24 +87,18 @@ function list_projects($where_condition, $order_clause, $group_clause, $url_base
             n_pages,
             modifieddate,
             postednum,
-            formats,
+            $join_columns
             state
         FROM projects
-            LEFT OUTER JOIN pg_books
-            ON projects.postednum=pg_books.etext_number
+            $join
         WHERE $where_condition
         $group_clause
+        $order_clause
+        LIMIT $per_page OFFSET $offset
     ";
-    $num_found_rows = mysqli_num_rows(DPDatabase::query($sql));
-    if ($num_found_rows == 0) {
-        echo _("There are currently no projects in this category.");
-        return;
-    }
 
     // now load the paged results by ordering, limiting and offsetting
     $sql .= "
-        $order_clause
-        LIMIT $per_page OFFSET $offset
     ";
     $result = DPDatabase::query($sql);
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -549,8 +549,7 @@ function html_statsbar($nameofpage)
             // Show the 7 most recently completed, tersely
             echo "<div id='completed-titles'>\n";
             echo "<h2>" . _("Recently Completed Titles") . "</h2>\n";
-            $state = SQL_CONDITION_GOLD;
-            list_projects_tersely($state, "ORDER BY modifieddate DESC", "LIMIT 7");
+            list_projects_tersely("gold", "ORDER BY modifieddate DESC", "LIMIT 7");
 
             // Show "More..." link
             echo "<p class='more-link'>";
@@ -562,9 +561,8 @@ function html_statsbar($nameofpage)
             // Show 3 (random) of the 10 most recently arrived (most recent P1)
             echo "<div id='recent-titles'>";
             echo "<h2>" . _("Recently Begun") . "</h2>\n";
-            $state = SQL_CONDITION_BRONZE;
             $limit_phrase = "LIMIT 3 OFFSET " . rand(0, 7);
-            list_projects_tersely($state, "ORDER BY modifieddate DESC", $limit_phrase);
+            list_projects_tersely("bronze", "ORDER BY modifieddate DESC", $limit_phrase);
 
             // Show "More..." link
             echo "<p class='more-link'>";


### PR DESCRIPTION
`list_etexts.php` is one of the few public pages (does not require login to access) and its worth trying to decrease the system overhead for it. This PR does the following:
1. optimizes the SQL used to generate the page by:
   * removing 1 of the 2 queries and using a 1-hour cached value for total number of projects per star metal
   * simplifying the query for the silver and bronze stars
2. removing the sorting options on the page -- this reduces the links crawlers can hit that just generate more load and removes a feature that I don't think is really all that useful to humans.

While we're here increase the default page size to 50 from 20. This is likely more useful to users without changing the impact to the query.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/decrease-list_etexts-overhead/list_etexts.php?x=g&sort=5