### PR TITLE
Prune job logs -- keep 13 months worth

### DIFF
--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -20,3 +20,4 @@
 # monthly:
 50 0 1 * * URL=<<CODE_URL>>/crontab/notify_old_pp.php; <<URL_DUMP_PROGRAM>> $URL
 50 0 15 * * URL=<<CODE_URL>>/crontab/notify_old_pp.php; <<URL_DUMP_PROGRAM>> $URL
+50 0 28 * * JOB=PruneJobLogs; <<PHP_CLI_EXECUTABLE>> <<CODE_DIR>>/crontab/run_background_job.php $JOB

--- a/crontab/PruneJobLogs.inc
+++ b/crontab/PruneJobLogs.inc
@@ -1,0 +1,11 @@
+<?php
+include_once($relPath."job_log.inc");
+
+// Prune job_log entries
+class PruneJobLogs extends BackgroundJob
+{
+    public function work()
+    {
+        prune_job_log_entries(365 + 30); // ~13 months
+    }
+}

--- a/pinc/job_log.inc
+++ b/pinc/job_log.inc
@@ -38,3 +38,17 @@ function get_job_log_entries($timestamp, $filename = null, $event = null)
     }
     return $entries;
 }
+
+function prune_job_log_entries(int $days_to_keep)
+{
+    $cutoff = new DateTimeImmutable(sprintf("%d days ago", $days_to_keep));
+    $sql = sprintf(
+        "
+        DELETE
+        FROM job_logs
+        WHERE tracetime < %d
+        ",
+        $cutoff->format("U")
+    );
+    DPDatabase::query($sql);
+}


### PR DESCRIPTION
The `job_logs` table stores when jobs run and is primarily `automodify.php` right now. It currently grows unbounded and we have 20 years of data. There's no real use in keeping it for that long though. At best being able to see how long something took to run a year ago seems generous. We could probably even get away with just a month of data.

This PR takes a generous view and just saves the past 13 months of data. 13 months is better than 20 years.

Aside: it was awesome how easy it was to create a new background job with the new class, so much boilerplate gone!