### PR TITLE
Start user lifetime graphs at first non-zero value

### DIFF
--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -622,5 +622,16 @@ function get_pages_per_day_for_past_n_days($tally_name, $holder_type, $holder_id
         $pages_per_day[$date] = $tally_delta;
     }
 
+    // skip initial zeros on "all" days back
+    if ($min_timestamp == 0) {
+        foreach (array_keys($pages_per_day) as $key) {
+            if ($pages_per_day[$key] == 0) {
+                unset($pages_per_day[$key]);
+            } else {
+                break;
+            }
+        }
+    }
+
     return $pages_per_day;
 }


### PR DESCRIPTION
For the user (and team) "lifetime" stats graphs, it's more useful to show them starting at the first non-zero entry -- that is the day with the first page -- rather than the beginning of when stats were collected. This is a regression from what they showed before the sparse `past_tallies`.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/start-user-stats-at-first-data/