### PR TITLE
Add User annotation for arguments in userprefs.php

### DIFF
--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -107,6 +107,8 @@ class DailyLimitExceededException extends UserAccessException
  * @property string $u_intlang;
  * @property bool $u_privacy;
  * @property string $api_key;
+ * @property UserProfile $profile;
+ * @property int $navbar_activity_menu;
  */
 class User
 {
@@ -418,7 +420,7 @@ class User
     /**
      * Load the current user object
      */
-    public static function load_current()
+    public static function load_current(): ?User
     {
         static $current_user = null;
 

--- a/pinc/UserProfile.inc
+++ b/pinc/UserProfile.inc
@@ -8,14 +8,14 @@ class NonexistentUserProfileException extends Exception
  * @property int $id;
  * @property int $u_ref;
  * @property string $profilename;
- * @property bool $i_res;
- * @property bool $i_type;
- * @property bool $i_layout;
+ * @property int $i_res;
+ * @property int $i_type;
+ * @property int $i_layout;
  * @property bool $i_toolbar;
  * @property bool $i_statusbar;
  * @property bool $i_newwin;
  * @property int $v_fnts;
- * @property bool $v_fntf;
+ * @property int $v_fntf;
  * @property string $v_fntf_other;
  * @property int $v_tframe;
  * @property int $v_tlines;

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -347,7 +347,7 @@ try {
 function switch_layout()
 {
     $user = User::load_current();
-    $user->profile->i_layout = $user->profile->i_layout == 1 ? 0 : 1;
+    $user->profile->i_layout = $user->profile->i_layout == true ? false : true;
     $user->profile->save();
 }
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -347,7 +347,7 @@ try {
 function switch_layout()
 {
     $user = User::load_current();
-    $user->profile->i_layout = $user->profile->i_layout == true ? false : true;
+    $user->profile->i_layout = $user->profile->i_layout == 1 ? 0 : 1;
     $user->profile->save();
 }
 

--- a/userprefs.php
+++ b/userprefs.php
@@ -232,7 +232,7 @@ echo "\n\n<script><!--\nwindow.onload = function() { $window_onload_event };\n--
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 
-function echo_general_tab($user)
+function echo_general_tab(User $user): void
 {
     global $userSettings;
 
@@ -417,7 +417,7 @@ function echo_general_tab($user)
     echo_bottom_button_row();
 }
 
-function save_general_tab($user)
+function save_general_tab(User $user): void
 {
     global $userSettings;
 
@@ -458,7 +458,7 @@ function save_general_tab($user)
     $userSettings->set_value('project_detail', $_POST["project_detail"]);
 }
 
-function echo_proofreading_tab($user)
+function echo_proofreading_tab(User $user): void
 {
     global $i_resolutions;
 
@@ -757,7 +757,7 @@ function echo_proofreading_tab($user)
     echo "</td></tr>\n";
 }
 
-function save_proofreading_tab($user)
+function save_proofreading_tab(User $user): void
 {
     $create_new_profile = false;
     if (isset($_POST["mkProfile"]) || isset($_POST["mkProfileAndQuit"])) {
@@ -789,7 +789,7 @@ function save_proofreading_tab($user)
     }
 }
 
-function echo_pm_tab($user)
+function echo_pm_tab(User $user): void
 {
     global $userSettings;
 
@@ -841,7 +841,7 @@ function echo_pm_tab($user)
     echo_bottom_button_row();
 }
 
-function save_pm_tab($user)
+function save_pm_tab(User $user): void
 {
     global $userSettings;
 


### PR DESCRIPTION
In order to have proper PHPStan coverage, first
annotated the return value from User::load_current()
then added User type annotation to userprefs.php.

This uncovered 2 missing properties on Users (`profile`
and `navbar_activity_menu`) and some fields on `UserProfile`
that were typed as `bool` but should have been `int`.

Manually tested updating a user's prefs and changing
the layout during proofing.