### PR TITLE
Create a text PG catalog for noncvs/in_progress_check.php

### DIFF
--- a/crontab/ImportPGCatalog.inc
+++ b/crontab/ImportPGCatalog.inc
@@ -115,6 +115,9 @@ class ImportPGCatalog extends BackgroundJob
 
     private function process_catalog()
     {
+        global $dyn_dir;
+        $title_authors = [];
+
         $etexts = [];
         $mime_types_not_in_display_mapping = [];
 
@@ -240,6 +243,24 @@ class ImportPGCatalog extends BackgroundJob
             }
             $etexts[$etext_number] = $display_formats;
             $n_rdf_files_processed += 1;
+
+
+            // Pull out title and author for text-based catalog
+            // Use xpath wildcards instead of full xpath
+            $authors = [];
+            foreach ($root->xpath('//pgterms:name') as $author_value_element) {
+                $authors[] = (string)$author_value_element;
+            }
+            $author = join("; ", $authors);
+
+            $title = "";
+            foreach ($root->xpath('//dcterms:title') as $title_value_element) {
+                $t_as_string = $title_value_element->asXML();
+                $t_as_string = str_replace('&#13;', '', $t_as_string);
+                $t_as_string = str_replace(PHP_EOL, ' / ', $t_as_string);
+                $title .= strip_tags($t_as_string);
+            }
+            $title_authors[$etext_number] = [$title, $author];
         }
 
         echo "Finished processing $n_rdf_files_processed RDF files.\n";
@@ -267,6 +288,33 @@ class ImportPGCatalog extends BackgroundJob
             ", $etext_number, DPDatabase::escape($formats_string));
             DPDatabase::query($sql);
         }
+
+        // Create the text-based catalog used by noncvs/in_progress_check.php
+        echo "Creating text catalog...\n";
+        $pg_catalog_converted = "$dyn_dir/pg/catalog.txt";
+        $text_catalog = fopen($pg_catalog_converted, 'w');
+        // Include the current time as the first line of the output file so
+        // search results can display it.
+        fwrite(
+            $text_catalog,
+            sprintf(
+                "Catalog retrieved: %s (converted on %s)\n",
+                date("F d, Y"),
+                date("F j, Y, g:i a")
+            )
+        );
+
+        ksort($title_authors); // sort numerically by $etext_number
+        foreach ($title_authors as $etext_number => [$title, $author]) {
+            // Skip entries which are placeholder PG numbers by
+            // checking that $author is not empty.
+            if ($author) {
+                $output = "$etext_number \"$title\" by $author";
+                $output = preg_replace('/\s+/', ' ', $output);
+                fwrite($text_catalog, "$output\n");
+            }
+        }
+        fclose($text_catalog);
 
         $this->stop_message = sprintf("Processed %d etexts", count($etexts));
     }


### PR DESCRIPTION
`noncvs/in_progress_check.php` uses a text-based catalog file. The script currently relies on the extracted RDF files that I removed in the new crontab file to create the file. Instead, create the file when we're parsing the catalog the first time. Because nothing in the main code uses this file, this commit is in `pgdp-production`.