### PR TITLE
Alert SAs on background job failures

### DIFF
--- a/pinc/job_log.inc
+++ b/pinc/job_log.inc
@@ -52,3 +52,19 @@ function prune_job_log_entries(int $days_to_keep)
     );
     DPDatabase::query($sql);
 }
+
+function count_job_log_failures(int $days_ago): int
+{
+    $cutoff = new DateTimeImmutable(sprintf("%d days ago", $days_ago));
+    $sql = sprintf(
+        "
+        SELECT count(*)
+        FROM job_logs
+        WHERE tracetime > %d AND succeeded = 0
+        ",
+        $cutoff->format("U")
+    );
+    $result = DPDatabase::query($sql);
+    [$count] = mysqli_fetch_row($result);
+    return $count;
+}

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -10,6 +10,7 @@ include_once($relPath.'forum_interface.inc');
 include_once($relPath.'languages.inc');
 include_once($relPath.'post_processing.inc'); // count_pp_projects_past_threshold()
 include_once($relPath.'faq.inc');
+include_once($relPath.'job_log.inc');
 
 /**
  * Emit the opening markup and theme tags, and register a callback
@@ -226,20 +227,33 @@ function html_logobar()
 
     html_navbar();
 
-    if ($testing || $maintenance || $alert_message) {
-        $id = 'alertbar';
-        $messages = [];
-        if ($testing) {
-            $messages[] = _("This is a test site!");
-            $id = 'testbar';
+    // determine and output any important site-wide messages
+    $messages = [];
+    $id = 'alertbar';
+    if ($testing) {
+        $messages[] = _("This is a test site!");
+        $id = 'testbar';
+    }
+    if ($maintenance) {
+        $messages[] = "<span class='error'>" . _("Site is in maintenance mode.") . "</span>";
+        $id = 'testbar';
+    }
+    if ($alert_message) {
+        $messages[] = $alert_message;
+    }
+    if (user_is_a_sitemanager()) {
+        $failed_jobs = count_job_log_failures(1);
+        if ($failed_jobs) {
+            $id = 'alertbar';
+            $messages[] = sprintf(
+                _("%d <a href='%s'>background jobs</a> failed in the past day."),
+                $failed_jobs,
+                "$code_url/tools/site_admin/show_job_log.php"
+            );
         }
-        if ($maintenance) {
-            $messages[] = "<span class='error'>" . _("Site is in maintenance mode.") . "</span>";
-            $id = 'testbar';
-        }
-        if ($alert_message) {
-            $messages[] = $alert_message;
-        }
+    }
+
+    if ($messages) {
         echo "<div id='$id-outer'>";
         echo "<div id='$id'>";
         echo "<p><span>" . implode(" | ", $messages) . "</span></p>";


### PR DESCRIPTION
Background job failures are pretty rare, but when they happen we want people to know about them. When background jobs fail, cron sends an email with the failure code. But we should also let SAs know in case the emails go awry. This adds a notice to the alert bar _only for SAs_ if there was a job failure in the last 24 hours. The query is fully covered by an index so it is both fast and efficient.

The downside is that there is no way to dismiss the bar, we just have to wait for it to age out.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/jobs-0-alert-sa-on-job-fail/

I've inserted a demo failed job so the alert will show for the next 24 hours.