### PR TITLE
Adjust background job web proxy error detection

### DIFF
--- a/crontab/CleanUploadsTrash.inc
+++ b/crontab/CleanUploadsTrash.inc
@@ -11,7 +11,8 @@ class CleanUploadsTrash extends BackgroundJob
 
         $trash_dir = realpath("$uploads_dir/$uploads_subdir_trash");
         if (! is_dir($trash_dir)) {
-            throw new RuntimeException("Invalid or non-existent uploads trash subdirectory.");
+            $this->stop_message = "No trash directory found, nothing to do.";
+            return;
         }
 
         // remove files from TRASH subdirectory older than 30 days

--- a/pinc/BackgroundJob.inc
+++ b/pinc/BackgroundJob.inc
@@ -58,7 +58,10 @@ abstract class BackgroundJob
 
         if ($this->stdout_on_success || $hit_error && $this->stdout_on_error) {
             echo "Background job: " . get_class($this) . "\n";
-            echo "Status: $status\n";
+            echo "Succeeded: " . (!$hit_error ? "true" : "false") . "\n";
+            if ($status) {
+                echo "Message: $status\n";
+            }
             if ($this->output) {
                 echo "Output:\n";
                 echo $this->output;

--- a/tools/site_admin/show_job_log.php
+++ b/tools/site_admin/show_job_log.php
@@ -5,7 +5,7 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'job_log.inc');
 
 $days_ago = get_integer_param($_GET, 'days_ago', 1, 0, 365);
-$filename = array_get($_GET, 'filename', null);
+$job = array_get($_GET, 'job', null);
 $event = array_get($_GET, 'event', '');
 
 $start_timestamp = time() - (60 * 60 * 24 * $days_ago);
@@ -29,8 +29,8 @@ echo "  <th>" . _("Days to show") . "</th>";
 echo "  <td><input name='days_ago' type='number' value='$days_ago''></td>";
 echo "</tr>";
 echo "<tr>";
-echo "  <th>" . _("Filename") . "</th>";
-echo "  <td><input name='filename' type='text' value='" . attr_safe($filename) . "'></td>";
+echo "  <th>" . _("Job") . "</th>";
+echo "  <td><input name='job' type='text' value='" . attr_safe($job) . "'></td>";
 echo "</tr>";
 echo "<tr>";
 echo "  <th>" . _("Event") . "</th>";
@@ -50,7 +50,7 @@ echo "<th>" . _("Status") . "</th>";
 echo "<th>" . _("Event") . "</th>";
 echo "<th>" . _("Comments") . "</th>";
 echo "</tr>";
-foreach (get_job_log_entries($start_timestamp, $filename, $event) as $row) {
+foreach (get_job_log_entries($start_timestamp, $job, $event) as $row) {
     if ($row["succeeded"] === null) {
         $status = "";
     } elseif ($row["succeeded"]) {


### PR DESCRIPTION
Last night's run of CleanUploadsTrash reported success in `job_logs` but the CLI (and cron) thought it failed. I don't know exactly why but in looking at it I've added some things to help us diagnose it in the future.

Until an HTTP stream returns some byte of data, the connection hasn't succeeded. And until the stream connects we can't get any useful metadata about it, such as if it timed out. This changes the web proxy code to flush out the HTTP headers as quickly as possible while the job runs, allowing us to better detect timeouts and handle other error conditions.

As part of this, adjust the clean up job to more gracefully handle the case where the TRASH folder doesn't exist, as the cleanup job will delete it if the folder has no contents (and Remote File Manager will create it again as-needed).

Happy path:
```
$ php run_background_job.php CleanUploadsTrash true
Background job: CleanUploadsTrash
Succeeded: true
Message: No trash directory found, nothing to do.
```

Artificially-induced timeout path:
```
$ php run_background_job.php CleanUploadsTrash true
PHP Fatal error:  Uncaught RuntimeException: CleanUploadsTrash job timed out proxied through web server in /home/cpeel/u-cpeel-dp/crontab/run_background_job.php:91
Stack trace:
#0 {main}
  thrown in /home/cpeel/u-cpeel-dp/crontab/run_background_job.php on line 91
```

I made some minor field changes in the UI to make the job selection form match the table headers: https://www.pgdp.org/~cpeel/c.branch/fine-tune-job-web-proxy/tools/site_admin/show_job_log.php