### PR TITLE
Only use filters if we show the controls

### DIFF
--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -194,11 +194,12 @@ function show_projects_for_stage(
     }
     echo "\n<p>{$stage->description}</p>";
 
+    $filtered_project_selector = $initial_project_selector;
     if ($show_filter_block) {
         process_and_display_project_filter_form($pguser, $stage->id, $stage->name, $_POST, $initial_project_selector, $filter_custom_display_fields);
+        $projects_filter = get_project_filter_sql($pguser, $stage->id);
+        $filtered_project_selector .= " $projects_filter";
     }
-    $projects_filter = get_project_filter_sql($pguser, $stage->id);
-    $filtered_project_selector = "$initial_project_selector $projects_filter";
 
     $ext_sort_param_name = "order{$stage->id}";
     $ext_sort_setting_name = "{$stage->id}_order";


### PR DESCRIPTION
In rare cases if a user has passed 20 pages and set a filter, then returns pages to the round, they won't see the filter selection but their filters will be used which will lead to confusion. Only use a project filter if the user can see the filter and change it.

@srjfoo found this on TEST which is most likely bad data, but there's no reason not to fix it.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/filter-fixin/