### PR TITLE
Fix misc stats graph by making end date inclusive

### DIFF
--- a/stats/misc_stats1.php
+++ b/stats/misc_stats1.php
@@ -26,7 +26,7 @@ $js_data = "";
 if (isset($start) && isset($end)) {
     $start_date = new DateTime("$start-01");
     $start_timestamp = $start_date->format("U");
-    $end_date = new DateTime("$end-01");
+    $end_date = new DateTime("last day of $end-01");
     $end_timestamp = $end_date->format("U");
     $data = get_site_tally_grouped($tally_name, 'year_month', $start_timestamp, $end_timestamp);
     $datax = array_column($data, 0);


### PR DESCRIPTION
On the (horribly named) `misc_stats1.php` page, the adhoc graph at top was pulling up to and including the midnight of the next month which has non-zero goals but zero stats. The easy fix for this is to make the end date given by the user inclusive so we just get up to the last day of the given month. This doesn't prevent the graph from showing a zero value for future months, but it fixes the most common case.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-misc-stats-graph/stats/misc_stats1.php?tally_name=P1