### PR TITLE
Beef up development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,9 @@ If you need assistance with the code, inquire within the
 ## Code development
 
 To get involved with development on this code base, see
-[DP Code Development](https://www.pgdp.net/wiki/DP_Code_Development) in the
-pgdp.net wiki.
-
-See also our [coding standards](SETUP/CODE_STYLE.md) and
-[coding documentation](SETUP/CODE_DOCS.md).
+[DP Code Development](https://www.pgdp.net/wiki/DP_Code_Development:_dproofreaders)
+in the pgdp.net wiki. See also the [development](SETUP/DEVELOPMENT.md) document
+in this repo.
 
 ## License
 

--- a/SETUP/DEVELOPMENT.md
+++ b/SETUP/DEVELOPMENT.md
@@ -13,6 +13,25 @@ for information on minimum middleware versions.
 The code does not use a PHP framework or an ORM. It was developed 20 years ago
 and has grown very organically over the years. There has been effort in the
 past decade to standardize things but you'll find many different patterns remain.
+We have a defined [coding style](CODE_STYLE.md) for the codebase and a set of
+[best practices](https://www.pgdp.net/wiki/DP_Code_Best_Practices) that cover
+some of our prescribed patterns.
+
+## Contributing
+
+DP code uses git for source control and is housed at GitHub in the
+[DProofreaders/dproofreaders](https://github.com/DistributedProofreaders/dproofreaders)
+repository -- likely where you got this code to begin with.
+
+We use the "fork, branch, develop, merge" model, where developers are expected to:
+1. fork the main repository
+2. create a development branch off master
+3. develop code on the branch
+4. generate a merge/pull request when ready to merge
+
+See also [DP Code Development Using git](https://www.pgdp.net/wiki/DP_Code_Development_Using_git)
+and a similar guide specific to the [dproofreaders](https://www.pgdp.net/wiki/DP_Code_Development_Using_git:_dproofreaders)
+repo.
 
 ## Development Environment
 
@@ -39,6 +58,38 @@ nodejs dependencies (runtime and development) run the following in the repo base
 npm install
 ```
 
+## Organizing principals
+
+The code is loosely organized around the following ideas:
+* PHP pages end in `.php` extensions. As site entry points, all `.php` pages
+  need to include `pinc/base.inc` which sets up common infrastructure like
+  database connections, gettext for localization, error handlers, and more.
+* PHP code that is included in PHP pages end in `.inc` extensions.
+* Strings are localized by using gettext. These are wrapped in a `_()` function
+  that the localization tooling will extract into `.po` files that volunteer
+  translators will translate. We do not have any official change control over
+  translated strings, just update them as necessary. See the
+  [translation best practices](https://www.pgdp.net/wiki/DP_Code_Best_Practices#String_localization).
+
+### Directories
+
+* `pinc/` - Includes many of the `.inc` files -- this is short for *P*hp *INC*lude.
+  * `pinc/3rdparty/` - code that we distribute but (generally) do not modify.
+    See the [3rdparty readme](../pinc/3rdparty/README.md).
+* `scripts/` - JS files used for various features.
+* `styles/` - CSS scripts which include `.less` source files and the rendered
+  `.css` files. See [CSS / style documentation](../style/README.md).
+* `SETUP/` - Non-runtime code, such as site admin docs, development docs, tests,
+  tooling and other miscellanea. The expectations is that this directory
+  will not, and should not be, accessible via the web context on a live site.
+  * `SETUP/tests/` - Tests, mostly automated but some manual. See the
+    [tests README](tests/README.md).
+  * `SETUP/upgrade/` - Upgrade scripts. Each release gets a new subdir
+    where we collect upgrade scripts for site admins to run when they install
+    a new release. See also [UPGRADE](UPGRADE.md).
+  * `SETUP/ci/` - CI scripts that are run as part of Github Actions -- and can
+    be run manually. See `.github/workflows/ci.yml` for the GHA workflows.
+
 ## Development-related docs
 
 * [coding standards](CODE_STYLE.md)
@@ -49,31 +100,3 @@ npm install
 * [coding documentation](CODE_DOCS.md)
 * [graphs design](GRAPHS.md)
 * [Unicode support](UNICODE.md)
-
-## Organizing principals
-
-The code is loosely organized around the following ideas:
-* PHP pages end in `.php` extensions. As site entry points, all `.php` pages
-  need to include `pinc/base.inc` which sets up common infrastructure like
-  database connections, gettext for localization, error handlers, and more.
-* PHP code that is included in PHP pages end in `.inc` extensions. Many of
-  these live in the `pinc/` directory -- short for *P*hp *INC*lude.
-  * 3rd party code that we distribute but (generally) do not modify is contained
-    in `pinc/3rdparty/`. See the [3rdparty readme](../pinc/3rdparty/README.md).
-* Strings are localized by using gettext. These are wrapped in a `_()` function
-  that the localization tooling will extract into `.po` files that volunteer
-  translators will translate. We do not have any official change control over
-  translated strings, just update them as necessary. See the
-  [translation best practices](https://www.pgdp.net/wiki/DP_Code_Best_Practices#String_localization).
-* CSS scripts are in `styles/` which include `.less` source files and the
-  rendered `.css` files. See [CSS / style documentation](../style/README.md).
-* Non-runtime code, such as site admin docs, development docs, tests, tooling
-  and other miscellanea are in `SETUP/`. The expectations is that this directory
-  will not, and should not be, accessible via the web context on a live site.
-  * Upgrade scripts are in `SETUP/upgrade/`. Each release gets a new subdir
-    where we collect upgrade scripts for site admins to run when they install
-    a new release. See also [UPGRADE](UPGRADE.md).
-  * Tests, mostly automated but some manual, are in `SETUP/tests`. See the
-    [tests README](tests/README.md).
-  * CI scripts that are run as part of Github Actions -- and can be run manually --
-    are in `SETUP/ci`. See `.github/workflows/ci.yml` for the GHA workflows.

--- a/SETUP/DEVELOPMENT.md
+++ b/SETUP/DEVELOPMENT.md
@@ -51,9 +51,13 @@ and development) run the following in the repo base:
 composer install
 ```
 
-The code also uses [npm](https://www.npmjs.com/) for some _development only_
-dependencies, such as linting (eslint) and CSS creation (less). To install
-nodejs dependencies (runtime and development) run the following in the repo base:
+The code also uses [nodejs](https://nodejs.org/) for some _development only_
+dependencies, such as linting (eslint) and CSS creation (less). Packages are
+installed with npm that comes with nodejs. For Linux distros, you can find
+packages for recent nodejs versions from
+[nodesource](https://github.com/nodesource/distributions).
+
+To install nodejs dependencies run the following in the repo base:
 ```bash
 npm install
 ```

--- a/SETUP/DEVELOPMENT.md
+++ b/SETUP/DEVELOPMENT.md
@@ -1,0 +1,79 @@
+# Code Development
+
+This doc is designed for users who want to develop on the DProofreaders (DP)
+codebase.
+
+## Introduction
+
+The DP code is almost entirely server-side PHP with a smattering of JS and
+CSS. It uses a MySQL backend database and requires a web server -- pgdp.net
+uses Apache but Nginx should work as well. See the [installation docs](INSTALL.md)
+for information on minimum middleware versions.
+
+The code does not use a PHP framework or an ORM. It was developed 20 years ago
+and has grown very organically over the years. There has been effort in the
+past decade to standardize things but you'll find many different patterns remain.
+
+## Development Environment
+
+The best current development environment is using the
+[DP development VM](https://www.pgdp.net/wiki/DP_Code_Development_VM) which
+comes with a recent release of the DP code, all required middleware, and some
+sample data. There is a desire to get a true local development environment --
+via vagrant or docker -- created but that has not yet been completed.
+
+### Tooling
+
+The code uses [Composer](https://getcomposer.org/) to manage PHP dependencies.
+Some of these dependencies are runtime dependencies, others are just used for
+development (phpstan, phpunit, etc). To install PHP dependencies (runtime
+and development) run the following in the repo base:
+```bash
+composer install
+```
+
+The code also uses [npm](https://www.npmjs.com/) for some _development only_
+dependencies, such as linting (eslint) and CSS creation (less). To install
+nodejs dependencies (runtime and development) run the following in the repo base:
+```bash
+npm install
+```
+
+## Development-related docs
+
+* [coding standards](CODE_STYLE.md)
+* [coding best practices](https://www.pgdp.net/wiki/DP_Code_Best_Practices)
+* [automated tests](tests/README.md)
+* [CSS / style documentation](../style/README.md)
+* [API documentation](../api/README.md)
+* [coding documentation](CODE_DOCS.md)
+* [graphs design](GRAPHS.md)
+* [Unicode support](UNICODE.md)
+
+## Organizing principals
+
+The code is loosely organized around the following ideas:
+* PHP pages end in `.php` extensions. As site entry points, all `.php` pages
+  need to include `pinc/base.inc` which sets up common infrastructure like
+  database connections, gettext for localization, error handlers, and more.
+* PHP code that is included in PHP pages end in `.inc` extensions. Many of
+  these live in the `pinc/` directory -- short for *P*hp *INC*lude.
+  * 3rd party code that we distribute but (generally) do not modify is contained
+    in `pinc/3rdparty/`. See the [3rdparty readme](../pinc/3rdparty/README.md).
+* Strings are localized by using gettext. These are wrapped in a `_()` function
+  that the localization tooling will extract into `.po` files that volunteer
+  translators will translate. We do not have any official change control over
+  translated strings, just update them as necessary. See the
+  [translation best practices](https://www.pgdp.net/wiki/DP_Code_Best_Practices#String_localization).
+* CSS scripts are in `styles/` which include `.less` source files and the
+  rendered `.css` files. See [CSS / style documentation](../style/README.md).
+* Non-runtime code, such as site admin docs, development docs, tests, tooling
+  and other miscellanea are in `SETUP/`. The expectations is that this directory
+  will not, and should not be, accessible via the web context on a live site.
+  * Upgrade scripts are in `SETUP/upgrade/`. Each release gets a new subdir
+    where we collect upgrade scripts for site admins to run when they install
+    a new release. See also [UPGRADE](UPGRADE.md).
+  * Tests, mostly automated but some manual, are in `SETUP/tests`. See the
+    [tests README](tests/README.md).
+  * CI scripts that are run as part of Github Actions -- and can be run manually --
+    are in `SETUP/ci`. See `.github/workflows/ci.yml` for the GHA workflows.

--- a/styles/README.md
+++ b/styles/README.md
@@ -5,15 +5,9 @@ This easily allows the creation of different themes with a common set of CSS
 code.
 
 ## Installing less
-less is a node.js application, so start by making sure you have a somewhat
-recent version of [node.js](https://nodejs.org). They have
-[packages](https://nodejs.org/en/download/package-manager) for different
-operating systems, including Ubuntu.
-
-After you have a recent version of node.js installed, use npm to install less:
-```bash
-sudo npm install -g less
-```
+less is a node.js application and is part of our npm development requirements.
+See the [DEVELOPMENT](../SETUP/DEVELOPMENT.md) docs for information on installing
+it.
 
 ## File layout
 CSS is broken down into three major sections:
@@ -33,6 +27,12 @@ cd SETUP/ci
 make less
 ```
 
+or run the script directly:
+```bash
+cd SETUP
+./generate_css_from_less.sh
+```
+
 Check in both the `.css` and `.less` files. While it isn't ideal to have generated
 code checked into source control, doing so means that consumers of the DP code
 don't also have to install and use less to generate the CSS.
@@ -44,4 +44,3 @@ at:
 
 * [Design Philosophy](https://www.pgdp.net/c/styles/design_philosophy.php)
 * [Style Demo](https://www.pgdp.net/c/styles/style_demo.php)
-


### PR DESCRIPTION
It's a bit of a brain dump but here's my first pass at adding more useful development docs to the repo. A reminder that the markdown files can be viewed rendered in the [update-dev-docs branch directly](https://github.com/cpeel/dproofreaders/tree/update-dev-docs?tab=readme-ov-file).

To review this, my request is that you come at the updates with "fresh" eyes and think what other questions you might have as a new person interested in developing that this doesn't answer but should.