### PR TITLE
Reduce memory usage of ImportPGCatalog job

### DIFF
--- a/crontab/ImportPGCatalog.inc
+++ b/crontab/ImportPGCatalog.inc
@@ -115,7 +115,6 @@ class ImportPGCatalog extends BackgroundJob
 
     private function process_catalog()
     {
-        $etexts = [];
         $mime_types_not_in_display_mapping = [];
 
         echo "Scanning files in {$this->local_catalog_dir}...\n";
@@ -231,14 +230,21 @@ class ImportPGCatalog extends BackgroundJob
                         $display_format .= " ($sub_type)";
                     }
                 }
+                // the $display_format may show up more than once and we only
+                // want one copy, so we use it as a hash key to weed out dups
                 $display_formats[$display_format] = 1;
             }
+            unset($nodes);
 
-            if (isset($etexts[$etext_number])) {
-                echo "Error: Found duplicate etext_number $etext_number, skipping duplicate record\n";
-                continue;
-            }
-            $etexts[$etext_number] = $display_formats;
+            ksort($display_formats); // sort alphabetically by format string
+            $formats_string = implode('; ', array_keys($display_formats));
+
+            $sql = sprintf("
+                REPLACE INTO pg_books
+                SET etext_number = %d, formats='%s'
+            ", $etext_number, DPDatabase::escape($formats_string));
+            DPDatabase::query($sql);
+
             $n_rdf_files_processed += 1;
         }
 
@@ -254,20 +260,6 @@ class ImportPGCatalog extends BackgroundJob
             }
         }
 
-        echo "Putting the data into the table...\n";
-
-        ksort($etexts); // sort numerically by $etext_number
-        foreach ($etexts as $etext_number => $formats) {
-            ksort($formats); // sort alphabetically by format string
-            $formats_string = implode('; ', array_keys($formats));
-
-            $sql = sprintf("
-                REPLACE INTO pg_books
-                SET etext_number = %d, formats='%s'
-            ", $etext_number, DPDatabase::escape($formats_string));
-            DPDatabase::query($sql);
-        }
-
-        $this->stop_message = sprintf("Processed %d etexts", count($etexts));
+        $this->stop_message = sprintf("Processed %d etexts", $n_rdf_files_processed);
     }
 }


### PR DESCRIPTION
This job hit a memory limit on PROD last night, so make it more memory efficient by just adding books as we process them instead of building an in-memory list and adding them all at the end.

```
$ php run_background_job.php ImportPGCatalog true
Background job: ImportPGCatalog
Succeeded: true
Message: Processed 73877 etexts
Output:
Downloading https://www.gutenberg.org/cache/epub/feeds/rdf-files.tar.bz2 to /tmp/pg-catalog-files/rdf-files.tar.bz2...
Extracting files from /tmp/pg-catalog-files/rdf-files.tar.bz2 to /tmp/pg-catalog-files...
Scanning files in /tmp/pg-catalog-files...
Finished processing 73877 RDF files.
Warning: The following MIME types do not have entries in $display_mapping:
     11 application/x-musescore
```