### PR TITLE
Remove $charset global

### DIFF
--- a/locale/debug_ui_language.php
+++ b/locale/debug_ui_language.php
@@ -59,8 +59,8 @@ if (user_is_a_sitemanager()) {
     $set_locale = setlocale(LC_ALL, $locale);
     $bind1 = bindtextdomain($gettext_domain, $dyn_locales_dir);
     $bind2 = bindtextdomain("iso_639", $system_locales_dir);
-    $bind3 = bind_textdomain_codeset($gettext_domain, $charset);
-    $bind4 = bind_textdomain_codeset("iso_639", $charset);
+    $bind3 = bind_textdomain_codeset($gettext_domain, 'UTF-8');
+    $bind4 = bind_textdomain_codeset("iso_639", 'UTF-8');
     $textdomain = textdomain($gettext_domain);
 
     echo <<<ADMIN
@@ -77,7 +77,7 @@ if (user_is_a_sitemanager()) {
 
         <p>gettext variables:</p>
         <ul>
-            <li>charset: <b>$charset</b></li>
+            <li>charset: <b>UTF-8</b></li>
             <li>dyn_locales_dir: <b>$dyn_locales_dir</b></li>
             <li>system_locales_dir: <b>$system_locales_dir</b></li>
             <li>locale: <b>$locale</b></li>
@@ -88,8 +88,8 @@ if (user_is_a_sitemanager()) {
             <li>setlocale(LC_ALL, $locale) returned <b>$set_locale</b></li>
             <li>bindtextdomain($gettext_domain, $dyn_locales_dir) returned <b>$bind1</b></li>
             <li>bindtextdomain("iso_639", $system_locales_dir) returned <b>$bind2</b></li>
-            <li>bind_textdomain_codeset($gettext_domain, $charset) returned <b>$bind3</b></li>
-            <li>bind_textdomain_codeset("iso_639", $charset) returned <b>$bind4</b></li>
+            <li>bind_textdomain_codeset($gettext_domain, "UTF-8") returned <b>$bind3</b></li>
+            <li>bind_textdomain_codeset("iso_639", "UTF-8") returned <b>$bind4</b></li>
             <li>textdomain($gettext_domain) returned <b>$textdomain</b></li>
         </ul>
 

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -334,7 +334,7 @@ function main_form()
 
 function manage_form($locale)
 {
-    global $dyn_locales_dir, $translate_url, $charset;
+    global $dyn_locales_dir, $translate_url;
 
     $system_locales = get_installed_system_locales();
     $translation_enabled = is_locale_translation_enabled($locale);
@@ -424,8 +424,7 @@ function manage_form($locale)
         echo "<form action='$translate_url?func=delete' method='POST'>";
         echo "<input type='hidden' name='locale' value='$locale'>";
         $confirm = javascript_safe(
-            _("Are you sure you want to delete this locale and its translation file?"),
-            $charset
+            _("Are you sure you want to delete this locale and its translation file?")
         );
         echo "<input type='submit' onClick='return confirm(\"$confirm\");' value='"
             . attr_safe(_("Delete this locale")) . "'> ";

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -18,7 +18,7 @@
 include_once($relPath."bootstrap.inc");
 
 if (!headers_sent()) {
-    header("Content-Type: text/html; charset=$charset");
+    header("Content-Type: text/html; charset=UTF-8");
 
     // Disallow other sites from embedding pages in frames/iframes
     header("Content-Security-Policy: frame-ancestors 'self'", false);
@@ -30,7 +30,7 @@ if (DPDatabase::get_connection()) {
     $user_is_logged_in = dpsession_resume();
 }
 
-configure_gettext($charset, get_desired_language(), $dyn_locales_dir, $system_locales_dir);
+configure_gettext(get_desired_language(), $dyn_locales_dir, $system_locales_dir);
 
 // Load the site structure. We do this here and not in bootstrap.inc because
 // it uses _() on some strings but we need to configure_gettext() first

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -18,7 +18,6 @@ define('PREVIEW', 'S');
 
 function echo_button($button_id, $which_interface)
 {
-    global $charset;
     $CRLF = '\r\n';
     if ($which_interface == 's') {
         $label = 'value';
@@ -54,7 +53,7 @@ function echo_button($button_id, $which_interface)
                 $label => attr_safe(_("Stop Proofreading")),
                 'title' => attr_safe(_("Stop Proofreading")),
                 'onclick' => "return(confirm('"
-                    . javascript_safe(_("Are you sure you want to stop proofreading?"), $charset)
+                    . javascript_safe(_("Are you sure you want to stop proofreading?"))
                     . "'));",
                 'src' => "gfx/bt1.png",
             ];
@@ -77,8 +76,8 @@ function echo_button($button_id, $which_interface)
                 $label => attr_safe(_("Return Page to Round")),
                 'title' => attr_safe(_("Return Page to Round")),
                 'onclick' => "return(confirm('"
-                     . javascript_safe(_("This will discard all changes you have made on this page."), $charset)
-                     . $CRLF . javascript_safe(_("Are you sure you want to return this page to the current round?"), $charset)
+                     . javascript_safe(_("This will discard all changes you have made on this page."))
+                     . $CRLF . javascript_safe(_("Are you sure you want to return this page to the current round?"))
                      . "'));",
                 'src' => "gfx/bt15.png",
             ];
@@ -90,7 +89,7 @@ function echo_button($button_id, $which_interface)
                 $label => attr_safe(_("Revert to Last Save")),
                 'title' => attr_safe(_("Revert to Last Save")),
                 'onclick' => "return(confirm('"
-                    . javascript_safe(_("Are you sure you want to revert to your last save?"), $charset)
+                    . javascript_safe(_("Are you sure you want to revert to your last save?"))
                     . "'));",
                 'src' => "gfx/bt7.png",
             ];

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -53,11 +53,9 @@ function get_desired_language()
     return get_valid_locale_for_translation($locale);
 }
 
-function configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_dir)
+function configure_gettext($locale, $dyn_locales_dir, $system_locales_dir)
 {
-    if ($charset == "UTF-8") {
-        $locale .= ".$charset";
-    }
+    $locale .= ".UTF-8";
 
     // if the LANGUAGE environment variable is set, gettext will use that and
     // ignore whatever is here, so unset it
@@ -71,8 +69,8 @@ function configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_
         bindtextdomain($gettext_domain, $dyn_locales_dir);
         bindtextdomain("iso_639", $system_locales_dir);
         if (function_exists("bind_textdomain_codeset")) {
-            bind_textdomain_codeset($gettext_domain, $charset);
-            bind_textdomain_codeset("iso_639", $charset);
+            bind_textdomain_codeset($gettext_domain, 'UTF-8');
+            bind_textdomain_codeset("iso_639", 'UTF-8');
         }
         textdomain($gettext_domain);
     }
@@ -102,10 +100,10 @@ function get_user_language($user = null)
  */
 function configure_gettext_for_user($user = null)
 {
-    global $charset, $dyn_locales_dir, $system_locales_dir;
+    global $dyn_locales_dir, $system_locales_dir;
 
     $locale = get_user_language($user);
-    configure_gettext($charset, $locale, $dyn_locales_dir, $system_locales_dir);
+    configure_gettext($locale, $dyn_locales_dir, $system_locales_dir);
 }
 
 // If the gettext extension is compiled into PHP, then the function named '_'

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -15,7 +15,6 @@ define('SHOW_STATSBAR', true);
 function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true)
 {
     global $code_url, $site_abbreviation;
-    global $charset;
 
     static $was_output = false;
     if ($was_output) {
@@ -34,17 +33,9 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
 
     $intlang = get_desired_language();
 
-    // HTML 5 dictates that ISO-8859-1 documents should declare their charset
-    // as windows-1252 (which is what web browsers actually treat ISO-8859-1 as).
-    if (strcasecmp($charset, 'ISO-8859-1') == 0) {
-        $output_charset = 'windows-1252';
-    } else {
-        $output_charset = $charset;
-    }
-
     echo "<!DOCTYPE html>\n"; // HTML 5
     echo "<html ".lang_html_header($intlang).">\n<head>\n";
-    echo "<meta charset='$output_charset'>\n";
+    echo "<meta charset='UTF-8'>\n";
     echo "<meta name='viewport' content='width=device-width, initial-scale=1.0'>\n";
 
     // iOS and Android icons

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -120,8 +120,6 @@ function lang_direction($langcode = false)
  */
 function get_installed_system_locales()
 {
-    global $charset;
-
     static $system_locales = [];
     if ($system_locales) {
         return $system_locales;
@@ -129,18 +127,15 @@ function get_installed_system_locales()
 
     exec("locale -a", $system_locales);
 
-    // if $charset is UTF-8, exclude all non-UTF-8 locales
-    if ($charset == 'UTF-8') {
-        $utf8_locales = [];
-        foreach ($system_locales as $locale) {
-            if (endswith($locale, '.utf8')) {
-                $utf8_locales[] = substr($locale, 0, strpos($locale, '.utf8'));
-            }
+    // exclude all non-UTF-8 locales
+    $utf8_locales = [];
+    foreach ($system_locales as $locale) {
+        if (endswith($locale, '.utf8')) {
+            $utf8_locales[] = substr($locale, 0, strpos($locale, '.utf8'));
         }
-        $system_locales = $utf8_locales;
     }
 
-    return $system_locales;
+    return $utf8_locales;
 }
 
 /**

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -494,28 +494,18 @@ function get_param_matching_regex(array $arr, string $key, ?string $default, str
  * Return a copy of a string correctly encoded for inclusion in an HTML
  * document.
  *
- * This is essentially a wrapper around htmlspecialchars() but it
- * is aware of the global character set. Using this wrapper means we don't
- * have to rely on the global $charset variable being accessible everywhere
- * we need to call htmlspecialchars().
+ * This is essentially a wrapper around htmlspecialchars() but it ensures
+ * that it always uses UTF-8.
  *
  * By default this escapes all quotes with ENT_QUOTES. This can be changed
  * with the $flags argument which is passed directly into htmlspecailchars().
- *
- * If the $charset global isn't defined, use whatever the PHP default_charset
- * is. Note that using default_charset is the default behavior for
- * htmlspecialchars in PHP >= 5.6, whereas 5.4 and 5.5 use UTF-8.
  */
 function html_safe($string, $flags = ENT_QUOTES)
 {
-    $charset = @$GLOBALS['charset'];
-    if (!@$charset) {
-        $charset = ini_get("default_charset");
-    }
     if ($string === null) {
         return "";
     }
-    return htmlspecialchars($string, $flags, $charset);
+    return htmlspecialchars($string, $flags, 'UTF-8');
 }
 
 // -----------------------------------------------------------------------------
@@ -548,14 +538,13 @@ function html_safe($string, $flags = ENT_QUOTES)
  */
 function attr_safe($string)
 {
-    global $charset;
     if ($string === null) {
         return "";
     }
     return htmlspecialchars(
         $string,
         ENT_QUOTES,
-        $charset,
+        'UTF-8',
         false // $double_encode
     );
 }
@@ -571,10 +560,10 @@ function attr_safe($string)
  *
  * Example usage:
  * ```
- * echo '<script>alert("' . javascript_safe($string, $charset) . '"); </script>';
- * echo "<script>alert('" . javascript_safe($string, $charset) . "'); </script>";
- * echo '<a ... onClick=\'confirm("' . javascript_safe($string, $charset) . '")\'>';
- * echo "<a ... onClick=\"confirm('" . javascript_safe($string, $charset) . '")\">";
+ * echo '<script>alert("' . javascript_safe($string) . '"); </script>';
+ * echo "<script>alert('" . javascript_safe($string) . "'); </script>";
+ * echo '<a ... onClick=\'confirm("' . javascript_safe($string) . '")\'>';
+ * echo "<a ... onClick=\"confirm('" . javascript_safe($string) . '")\">";
  * ```
  *
  * Here are the detailed conversions applied:
@@ -598,9 +587,8 @@ function attr_safe($string)
  */
 function javascript_safe($str, $encoding = null)
 {
-    global $charset;
     if (!$encoding) {
-        $encoding = $charset;
+        $encoding = 'UTF-8';
     }
 
     if (!strcasecmp($encoding, 'UTF-8')) {
@@ -701,11 +689,10 @@ function normalize_whitespace($str)
  */
 function xmlencode($string)
 {
-    global $charset;
     if ($string === null) {
         return "";
     }
-    return htmlspecialchars($string, ENT_COMPAT, $charset);
+    return htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
 }
 
 // -----------------------------------------------------------------------------

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -25,7 +25,7 @@ $this_is_top_level_cli_invocation = (
 if ($this_is_top_level_cli_invocation) {
     // We assume it was invoked from the pinc/ directory.
     $relPath = './';
-    include_once($relPath.'site_vars.php'); // $forums_phpbb_dir, $charset
+    include_once($relPath.'site_vars.php'); // $forums_phpbb_dir
 }
 
 // PHPBB includes (from the standard installation)
@@ -182,7 +182,7 @@ function _insert_post(
     $poster_is_real,
     $watch_topic = null
 ) {
-    global $charset, $forums_phpbb_table_prefix;
+    global $forums_phpbb_table_prefix;
 
     // see: https://phpbbmodders.net/articles/3.0/create_post/
     global $db, $user, $auth;
@@ -241,8 +241,8 @@ function _insert_post(
     $forum_name = $row["forum_name"];
 
     // Build other data variables
-    $post_subject = utf8_recode($post_subject, $charset);
-    $post_text = utf8_recode($post_text, $charset);
+    $post_subject = utf8_recode($post_subject, 'UTF-8');
+    $post_text = utf8_recode($post_text, 'UTF-8');
 
     // see: https://wiki.phpbb.com/Function.submit_post
     $subject = utf8_normalize_nfc($post_subject);

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -126,5 +126,4 @@ $use_secure_cookies = <<USE_SECURE_COOKIES>>;
 $auto_post_to_project_topic = <<AUTO_POST_TO_PROJECT_TOPIC>>;
 $ordinary_users_can_see_queue_settings = <<ORDINARY_USERS_CAN_SEE_QUEUE_SETTINGS>>;
 $external_catalog_locator = '<<EXTERNAL_CATALOG_LOCATOR>>';
-$charset = 'UTF-8';
 $default_project_char_suites = <<DEFAULT_CHAR_SUITES>>;

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -312,7 +312,7 @@ class BadWordAccumulator
 function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 {
     global $aspell_temp_dir;
-    global $aspell_executable, $aspell_prefix, $charset;
+    global $aspell_executable, $aspell_prefix;
 
     $messages = [];
 
@@ -343,7 +343,7 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
                     "list",
                     "--prefix=" . escapeshellarg($aspell_prefix),
                     "-d " . escapeshellarg($dict_file),
-                    "--encoding " . escapeshellarg($charset),
+                    "--encoding=UTF-8",
                 ]);
                 //echo "<!-- aspell command: $aspell_command -->\n"; // Very useful for debugging
                 // build our list of possible misspellings

--- a/project.php
+++ b/project.php
@@ -1938,7 +1938,7 @@ function do_ppv_report()
 
 function do_change_state()
 {
-    global $project, $pguser, $code_url, $charset;
+    global $project, $pguser, $code_url;
 
     $valid_transitions = get_valid_transitions($project, $pguser);
     if (count($valid_transitions) == 0) {
@@ -1998,7 +1998,7 @@ function do_change_state()
             $onClick_condition = "return true;";
         } else {
             $onClick_condition = "return confirm(\""
-                . javascript_safe($question, $charset) . "\");";
+                . javascript_safe($question) . "\");";
         }
         $onclick_attr = "onClick='$onClick_condition'";
         echo "<input type='submit' value='", attr_safe($transition->action_name), "' $onclick_attr $optional_btn_attr>";

--- a/stats/members/mbr_xml.php
+++ b/stats/members/mbr_xml.php
@@ -15,13 +15,13 @@ $user = new User($username);
 $forum_profile = get_forum_user_details($username);
 
 //Try our best to make sure no browser caches the page
-header("Content-Type: text/xml; charset=$charset");
+header("Content-Type: text/xml; charset=UTF-8");
 header("Expires: Sat, 1 Jan 2000 05:00:00 GMT");
 header("Last-Modified: " . gmdate("D, d M Y H:i:s") . "GMT");
 header("Cache-Control: no-cache, must-revalidate");
 header("Pragma: no-cache");
 
-echo "<?xml version=\"1.0\" encoding=\"$charset\" ?>\n";
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
 echo "<memberstats xmlns:xsi=\"http://www.w3.org/2000/10/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"memberstats.xsd\">\n";
 
 $now = time();

--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -21,7 +21,7 @@ if (empty($_GET["id"])) {
 $req_team_id = get_integer_param($_GET, 'id', null, 0, null);
 
 //Try our best to make sure no browser caches the page
-header("Content-Type: text/xml; charset=$charset");
+header("Content-Type: text/xml; charset=UTF-8");
 header("Expires: Sat, 1 Jan 2000 05:00:00 GMT");
 header("Last-Modified: " . gmdate("D, d M Y H:i:s") . "GMT");
 header("Cache-Control: no-cache, must-revalidate");
@@ -103,7 +103,7 @@ while ($curMbr = mysqli_fetch_assoc($mbrQuery)) {
 $data .= "</teammembers>";
 
 
-$xmlpage = "<"."?"."xml version=\"1.0\" encoding=\"$charset\" ?".">
+$xmlpage = "<"."?"."xml version=\"1.0\" encoding=\"UTF-8\" ?".">
 <teamstats xmlns:xsi=\"http://www.w3.org/2000/10/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"teamstats.xsd\">
 $data
 </teamstats>";

--- a/tools/authors/authorxml.php
+++ b/tools/authors/authorxml.php
@@ -26,8 +26,8 @@ if ($author_id) {
     $wrap_in_big_tag = true;
 }
 
-header("Content-Type: text/xml; charset=$charset");
-echo "<?xml version=\"1.0\" encoding=\"$charset\" ?>\n";
+header("Content-Type: text/xml; charset=UTF-8");
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
 
 $sql = "SELECT * FROM authors $clause";
 $result = DPDatabase::query($sql);

--- a/tools/authors/bioxml.php
+++ b/tools/authors/bioxml.php
@@ -33,8 +33,8 @@ if (isset($bio_id)) {
     $wrap_in_big_tag = true;
 }
 
-header("Content-Type: text/xml; charset=$charset");
-echo "<?xml version=\"1.0\" encoding=\"$charset\" ?>\n";
+header("Content-Type: text/xml; charset=UTF-8");
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
 
 $sql = "SELECT * FROM biographies $clause";
 $result = DPDatabase::query($sql);

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -10,7 +10,7 @@ include_once($relPath.'project_quick_check.inc'); // needed for gate_on_pqc() ca
 
 require_login();
 
-header("Content-Type: text/html; charset=$charset");
+header("Content-Type: text/html; charset=UTF-8");
 
 // Get Passed parameters to code
 $projectid = get_projectID_param($_POST, 'projectid');

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -568,10 +568,8 @@ function output_wordcheck_language_buttons($languages)
 
 function get_page_js($interface_type_init_value)
 {
-    global $charset;
-
-    $show_wc_header_label = javascript_safe(_("Show WordCheck Header"), $charset);
-    $hide_wc_header_label = javascript_safe(_("Hide WordCheck Header"), $charset);
+    $show_wc_header_label = javascript_safe(_("Show WordCheck Header"));
+    $hide_wc_header_label = javascript_safe(_("Hide WordCheck Header"));
 
     return <<<PAGE_JS
                 function ldAll() {

--- a/tools/site_admin/manage_site_word_lists.php
+++ b/tools/site_admin/manage_site_word_lists.php
@@ -192,7 +192,7 @@ function _handle_action($action, $list_type, $language, $word_string)
             // the above set mirrors the clean-up code in save_word_list
             // TODO: other good checks might be ensuring that the words are
             // recognized by WordCheck, that they don't have spaces within
-            // them, that they are all in $charset, etc
+            // them, etc
 
             // calculate the differences
             $unchanged = count(array_intersect($old_words, $new_words));


### PR DESCRIPTION
The site has been UTF-8-only since 2020, this just removes the `$charset` global variable. Should be zero functional change.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/prune-charset/