### PR TITLE
Fix string|float-to-int convertion errors

### DIFF
--- a/activity_hub.php
+++ b/activity_hub.php
@@ -62,7 +62,7 @@ foreach (Rounds::get_all() as $round) {
 
 // Get the project transitions for the number of projects completed today
 // set the timestamp representing the start of today
-$t_start_of_today = mktime(0, 0, 0, date('m'), date('d'), date('y'));
+$t_start_of_today = mktime(0, 0, 0, (int)date('m'), (int)date('d'), (int)date('y'));
 
 // For transition events (event_type = 'transition'), details2 gives
 // the project's new state.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,10 +24,8 @@ parameters:
           path: pinc/3rdparty/mediawiki/DairikiDiff.php
         - message: '#Comparison operation .* results in an error#'
           path: pinc/3rdparty/mediawiki/DiffEngine.php
-        - message: '#^Parameter \#2 \$num of function array_fill expects int, float given\.$#'
+        - message: '#^Parameter \#2 \$.* of function array_fill expects int, float given\.$#'
           path: pinc/3rdparty/mediawiki/DiffEngine.php
-          # This only applies to PHP7, remove this rule when we use PHP8.
-          reportUnmatched: false
         - message: '#Instantiated class DiffFormatter is abstract#'
           path: pinc/DifferenceEngineWrapper.inc
 
@@ -44,44 +42,9 @@ parameters:
         # Temporary baseline while switching PHPStan to level 5.
         # TODO(jchaffraix): Fix and remove all those entries.
         # For PHP7:
-        - message: "#^Parameter \\#4 \\$mon of function mktime expects int, string given\\.$#"
-          count: 1
-          path: activity_hub.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#5 \\$day of function mktime expects int, string given\\.$#"
-          count: 1
-          path: activity_hub.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#6 \\$year of function mktime expects int, string given\\.$#"
-          count: 1
-          path: activity_hub.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#1 \\$month of function checkdate expects int, string given\\.$#"
-          count: 1
-          path: pinc/Project.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$day of function checkdate expects int, string given\\.$#"
-          count: 1
-          path: pinc/Project.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#3 \\$length of function array_slice expects int\\|null, float given\\.$#"
-          count: 1
-          path: pinc/Project.inc
-          reportUnmatched: false
-
         - message: "#^Parameter \\#4 \\$filter_custom_display_fields of function show_projects_for_stage expects array, null given\\.$#"
           count: 1
           path: pinc/showavailablebooks.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#1 \\$id of class Pool constructor expects int, string given\\.$#"
-          count: 2
-          path: pinc/stages.inc
           reportUnmatched: false
 
         - message: "#^Parameter \\#9 \\$pi_tools of class Round constructor expects array\\<string, array\\<string\\>\\>, array\\<string, string\\> given\\.$#"
@@ -89,79 +52,9 @@ parameters:
           path: pinc/stages.inc
           reportUnmatched: false
 
-        - message: "#^Parameter \\#4 \\$mon of function mktime expects int, string given\\.$#"
-          count: 2
-          path: pinc/theme.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#5 \\$day of function mktime expects int, string given\\.$#"
-          count: 1
-          path: pinc/theme.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#6 \\$year of function mktime expects int, string given\\.$#"
-          count: 4
-          path: pinc/theme.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int, string given\\.$#"
-          count: 1
-          path: sitemap.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#3 \\$n of function ngettext expects int, float given\\.$#"
-          count: 1
-          path: stats/includes/member.inc
-          reportUnmatched: false
-
         - message: "#^Parameter \\#1 \\$number of function number_format expects float, string given\\.$#"
           count: 1
           path: stats/includes/team.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int, string given\\.$#"
-          count: 1
-          path: stats/includes/team.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int, string given\\.$#"
-          count: 1
-          path: stats/members/mbr_list.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#3 \\$min_timestamp of function get_site_tally_grouped expects int\\|null, string given\\.$#"
-          count: 1
-          path: stats/misc_stats1.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#4 \\$max_timestamp of function get_site_tally_grouped expects int\\|null, string given\\.$#"
-          count: 1
-          path: stats/misc_stats1.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#4 \\$mon of function mktime expects int, string given\\.$#"
-          count: 1
-          path: stats/pp_stage_goal.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#6 \\$year of function mktime expects int, string given\\.$#"
-          count: 1
-          path: stats/pp_stage_goal.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int, string given\\.$#"
-          count: 2
-          path: stats/teams/teams_xml.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int, string given\\.$#"
-          count: 1
-          path: tasks.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int, string given\\.$#"
-          count: 1
-          path: tools/post_proofers/ppv_report.php
           reportUnmatched: false
 
         - message: "#^Parameter \\#2 \\$pieces of function implode expects array, string given\\.$#"
@@ -169,32 +62,7 @@ parameters:
           path: tools/project_manager/add_files.php
           reportUnmatched: false
 
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int, string given\\.$#"
-          count: 1
-          path: tools/site_admin/edit_mail_address_for_non_activated_user.php
-          reportUnmatched: false
-
         # For PHP8:
-        - message: "#^Parameter \\#4 \\$month of function mktime expects int\\|null, string given\\.$#"
-          count: 1
-          path: activity_hub.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#5 \\$day of function mktime expects int\\|null, string given\\.$#"
-          count: 1
-          path: activity_hub.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
-          count: 1
-          path: activity_hub.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$count of function array_fill expects int, float given\\.$#"
-          count: 1
-          path: pinc/3rdparty/mediawiki/DiffEngine.php
-          reportUnmatched: false
-
         - message: "#^Parameter \\#1 \\$array of function array_multisort is passed by reference, so it expects variables only\\.$#"
           count: 1
           path: pinc/page_tally.inc
@@ -205,69 +73,9 @@ parameters:
           path: pinc/special_colors.inc
           reportUnmatched: false
 
-        - message: "#^Parameter \\#4 \\$month of function mktime expects int\\|null, string given\\.$#"
-          count: 2
-          path: pinc/theme.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#5 \\$day of function mktime expects int\\|null, string given\\.$#"
-          count: 1
-          path: pinc/theme.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
-          count: 4
-          path: pinc/theme.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
-          count: 1
-          path: sitemap.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#3 \\$count of function ngettext expects int, float given\\.$#"
-          count: 1
-          path: stats/includes/member.inc
-          reportUnmatched: false
-
         - message: "#^Parameter \\#1 \\$num of function number_format expects float, string given\\.$#"
           count: 1
           path: stats/includes/team.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
-          count: 1
-          path: stats/includes/team.inc
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
-          count: 1
-          path: stats/members/mbr_list.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#4 \\$month of function mktime expects int\\|null, string given\\.$#"
-          count: 1
-          path: stats/pp_stage_goal.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
-          count: 1
-          path: stats/pp_stage_goal.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
-          count: 2
-          path: stats/teams/teams_xml.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
-          count: 1
-          path: tasks.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
-          count: 1
-          path: tools/post_proofers/ppv_report.php
           reportUnmatched: false
 
         - message: "#^Parameter \\#2 \\$array of function implode expects array\\|null, string given\\.$#"
@@ -303,9 +111,4 @@ parameters:
         - message: "#^Parameter \\#1 \\$array of function array_multisort is passed by reference, so it expects variables only\\.$#"
           count: 1
           path: tools/project_manager/show_project_stealth_scannos.php
-          reportUnmatched: false
-
-        - message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
-          count: 1
-          path: tools/site_admin/edit_mail_address_for_non_activated_user.php
           reportUnmatched: false

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -137,12 +137,13 @@ class Activity
      *   where $change is one of `[ "grant", "revoke", "request", "deny_request_for" ]`
      */
     public function __construct(
-        $id,
-        $name,
-        $access_minima,
-        $after_satisfying_minima,
-        $evaluation_criteria,
-        $access_change_callback
+        string $id,
+        string $name,
+        /** @var array<string,int> */
+        array $access_minima,
+        string $after_satisfying_minima,
+        string $evaluation_criteria,
+        ?string $access_change_callback
     ) {
         $this->id = $id;
         $this->name = $name;

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -35,17 +35,18 @@ class Pool extends Stage
      *   An array of strings to echo on the pool's home page.
      */
     public function __construct(
-        $id,
-        $name,
-        $access_minima,
-        $after_satisfying_minima,
-        $evaluation_criteria,
-        $access_change_callback,
-        $description,
-        $document,
-        $foo_Header,
-        $foo_field_name,
-        $blather
+        string $id,
+        string $name,
+        /** @var array<string,int> */
+        array $access_minima,
+        string $after_satisfying_minima,
+        string $evaluation_criteria,
+        ?string $access_change_callback,
+        string $description,
+        ?string $document,
+        string $foo_Header,
+        string $foo_field_name,
+        array $blather
     ) {
         parent::__construct(
             $id,

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -427,7 +427,7 @@ class Project
                  startswith($this->special_code, 'Otherday')
             ) {
                 if (preg_match("/\w+ (\d{2})(\d{2})/", $this->special_code, $matches)) {
-                    if (!checkdate($matches[1], $matches[2], 2000)) {
+                    if (!checkdate((int)$matches[1], (int)$matches[2], 2000)) {
                         $errors[] = _("Invalid date supplied for Birthday or Otherday Special.");
                     }
                 } else {
@@ -1006,7 +1006,7 @@ class Project
         $proj_suite = new CharSuite($this->projectid, _("Custom"), $codepoints, true);
 
         $pickerset = new PickerSet();
-        $row1 = array_slice($codepoints, 0, round(count($codepoints) / 2));
+        $row1 = array_slice($codepoints, 0, (int)round(count($codepoints) / 2));
         $row2 = array_slice($codepoints, count($row1));
         $pickerset->add_subset("Proj", [$row1, $row2]);
         $proj_suite->pickerset = $pickerset;

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -37,15 +37,16 @@ class Stage extends Activity
      *   The "home" location (relative to `$code_url/`) of the stage.
      */
     public function __construct(
-        $id,
-        $name,
-        $access_minima,
-        $after_satisfying_minima,
-        $evaluation_criteria,
-        $access_change_callback,
-        $description,
-        $document,
-        $relative_url
+        string $id,
+        string $name,
+        /** @var array<string,int> */
+        array $access_minima,
+        string $after_satisfying_minima,
+        string $evaluation_criteria,
+        ?string $access_change_callback,
+        string $description,
+        ?string $document,
+        string $relative_url
     ) {
         parent::__construct(
             $id,

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -259,7 +259,7 @@ $ELR_round = get_Round_for_round_number(1);
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 new Pool(
-    'PP',
+    'PP', // @phpstan-ignore-line PHPStan 1.10 reports a string-to-int conv here, seems like a bug
     _('Post-Processing'),
     ['F1' => 400],
     'REQ-AUTO',
@@ -307,7 +307,7 @@ new Stage(
 // -----------------------------------------------------------------------------
 
 new Pool(
-    'PPV',
+    'PPV', // @phpstan-ignore-line PHPStan 1.10 reports a string-to-int conv here, seems like a bug
     _('Post-Processing Verification'),
     [],
     'NOREQ', // "Peer approval. Also gives F2 access."

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -972,8 +972,8 @@ function show_completed_projects($terse = false)
         echo "<table>\n";
         $num_months = 12;
     }
-    $thismonth = date("n");
-    $thisyear = date("Y");
+    $thismonth = (int)date("n");
+    $thisyear = (int)date("Y");
     for ($months_ago = 0; $months_ago <= $num_months; $months_ago++) {
         // midnight that begins the 1st day of this month and the next:
         $begindate = mktime(0, 0, 0, $thismonth - $months_ago, 1, $thisyear);
@@ -1118,13 +1118,13 @@ function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_col
 
     // Calculate the progress bar color scaling based on the time of day.
     if ($prorate_goal_for_color == 'bar' || $prorate_goal_for_color === true) {
-        $t_start_of_today = mktime(0, 0, 0, date('m'), date('d'), date('y'));
+        $t_start_of_today = mktime(0, 0, 0, (int)date('m'), (int)date('d'), (int)date('y'));
         $fraction_of_time_passed = (time() - $t_start_of_today) / (60 * 60 * 24);
         // Note: Calculation assumes a 24-hour day which is true except
         // possibly for the first and last days of daylight saving time
         // depending on how PHP calculates DST in the mktime() call.
     } elseif ($prorate_goal_for_color == 'month') {
-        $t_start_of_month = mktime(0, 0, 0, date('m'), 1, date('y'));
+        $t_start_of_month = mktime(0, 0, 0, (int)date('m'), 1, (int)date('y'));
         $fraction_of_time_passed = (time() - $t_start_of_month) / (60 * 60 * 24 * date("t"));
     } else {
         $fraction_of_time_passed = 1;

--- a/sitemap.php
+++ b/sitemap.php
@@ -62,12 +62,13 @@ while ($row = mysqli_fetch_assoc($result)) {
     }
 
     // skip entries with no modifieddate
-    if ($row["modifieddate"] == 0) {
+    $modified_date = (int)$row["modifieddate"];
+    if ($modified_date == 0) {
         continue;
     }
 
     $url = "$code_url/project.php?id=" . $row["projectid"];
-    $lastmod = date("Y-m-d", $row["modifieddate"]);
+    $lastmod = date("Y-m-d", $modified_date);
 
     echo <<<URL
             <url>

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -77,7 +77,7 @@ function days_to_now($timestamp)
         $now = time();
     }
 
-    $days = floor(($now - $timestamp) / 86400);
+    $days = (int)floor(($now - $timestamp) / 86400);
     if ($days == 0) {
         return _("Today");
     } elseif ($days == 1) {

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -390,7 +390,7 @@ function showTeamMbrs($curTeam, $tally_name)
             $t->row(
                 "<a href='$member_url'>$username</a>",
                 number_format($curMbr['current_tally']),
-                date("m/d/Y", $curMbr['date_created'])
+                date("m/d/Y", (int)$curMbr['date_created'])
             );
         }
     }

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -110,7 +110,7 @@ if (!empty($mRows)) {
         if (can_reveal_details_about($row['username'], $row['u_privacy'])) {
             echo "<td style='text-align: center;'><b>".$row['u_id']."</b></td>";
             echo "<td>".$row['username']."</td>";
-            echo "<td style='text-align: center;'>".date("m/d/Y", $row['date_created'])."</td>";
+            echo "<td style='text-align: center;'>".date("m/d/Y", (int)$row['date_created'])."</td>";
             $contact_url = attr_safe(get_url_to_compose_message_to_user($row['username']));
             echo "<td style='text-align: center'><b><a href='mdetail.php?id=".$row['u_id']."'>"._("Statistics")."</a>&nbsp;|&nbsp;<a href='$contact_url'>" . pgettext("private message", "PM") . "</a></b></td>\n";
         } else {

--- a/stats/misc_stats1.php
+++ b/stats/misc_stats1.php
@@ -25,9 +25,9 @@ $title = sprintf(_("Miscellaneous Statistics for Round %s"), $tally_name);
 $js_data = "";
 if (isset($start) && isset($end)) {
     $start_date = new DateTime("$start-01");
-    $start_timestamp = $start_date->format("U");
+    $start_timestamp = (int)$start_date->format("U");
     $end_date = new DateTime("last day of $end-01");
-    $end_timestamp = $end_date->format("U");
+    $end_timestamp = (int)$end_date->format("U");
     $data = get_site_tally_grouped($tally_name, 'year_month', $start_timestamp, $end_timestamp);
     $datax = array_column($data, 0);
     $datay = array_column($data, 1);

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -34,7 +34,7 @@ function _get_pages_posted_data($start_timestamp)
 }
 
 // Get the total pages for projects that have posted in current month
-$start_timestamp = mktime(0, 0, 0, date('m'), 1, date('Y'));
+$start_timestamp = mktime(0, 0, 0, (int)date('m'), 1, (int)date('Y'));
 // cache pages posted data for 1 day
 $pp_pages_total = query_graph_cache("_get_pages_posted_data", [$start_timestamp], 60 * 60 * 24);
 

--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -40,7 +40,7 @@ $totalTeams = $row["totalTeams"];
 
 $data = "<teaminfo id='$team_id'>
         <teamname>".xmlencode($curTeam['teamname'])."</teamname>
-        <datecreated>".date("m/d/Y", $curTeam['created'])."</datecreated>
+        <datecreated>".date("m/d/Y", (int)$curTeam['created'])."</datecreated>
         <createdby>".xmlencode($curTeam['createdby'])."</createdby>
         <leader>".xmlencode(get_username_for_uid($curTeam['owner']))."</leader>
         <description>".xmlencode($curTeam['team_info'])."</description>
@@ -95,7 +95,7 @@ while ($curMbr = mysqli_fetch_assoc($mbrQuery)) {
     if ($curMbr['u_privacy'] == PRIVACY_PRIVATE) {
         $data .= "<member id=\"".$curMbr['u_id']."\">
             <username>".xmlencode($curMbr['username'])."</username>
-            <datejoined>".date("m/d/Y", $curMbr['date_created'])."</datejoined>
+            <datejoined>".date("m/d/Y", (int)$curMbr['date_created'])."</datejoined>
         </member>
         ";
     }

--- a/tasks.php
+++ b/tasks.php
@@ -1496,7 +1496,7 @@ function TaskComments($tid, $action)
         $comment_username_link = private_message_link_for_uid($row['u_id']);
 
         echo "<div class='task-comment-title'>";
-        echo "<b>$comment_username_link</b> - <b>" . date("l d M Y @ g:ia", $row['comment_date']) . "</b>";
+        echo "<b>$comment_username_link</b> - <b>" . date("l d M Y @ g:ia", (int)$row['comment_date']) . "</b>";
         echo "&nbsp;<a class='perma' href='$tasks_url?action=show&task_id=$tid#$comment_id'><i class='fas fa-link'></i></a>";
         if ($can_edit_comment && $action != 'edit_comment') {
             echo " - <a href='$tasks_url?action=edit_comment&task_id=$tid&comment_id=$comment_id#$comment_id'>" . _("edit") . "</a>";

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -151,7 +151,7 @@ if ($row) {
     $row = mysqli_fetch_assoc($result);
     mysqli_free_result($result);
     if ($row) {
-        $pp_date = date("d-M-Y", $row["timestamp"]);
+        $pp_date = date("d-M-Y", (int)$row["timestamp"]);
     }
 }
 

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -65,7 +65,7 @@ if ($action == 'default') {
             echo "<td><a href='?action=get_user&username=".urlencode($row['username'])."'>{$row['username']}</a></td>\n";
             echo "<td>" . html_safe($row['real_name']) . "</td>\n";
             echo "<td>" . html_safe($row['email']) . "</td>\n";
-            echo "<td>" . date("Y-m-d H:i", $row['date_created']) . "</td>\n";
+            echo "<td>" . date("Y-m-d H:i", (int)$row['date_created']) . "</td>\n";
             echo "</tr>\n";
         }
         echo "</table>\n";


### PR DESCRIPTION
There were 3 major errors:
- int fields from the DB that are returned as string by mysqli.
- date('s|d|y|U') that returns an int as a string.
- PHP float truncating functions that returns a float.

_Update by cpeel_: Sandbox avail at https://www.pgdp.org/~cpeel/c.branch/julien_fix_int_to_str_conv/