### PR TITLE
Include how to run static checks in dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ vendor
 .php_cs.cache
 .php-cs-fixer.cache
 .phpdoc
+.phpstan.cache
+

--- a/SETUP/DEVELOPMENT.md
+++ b/SETUP/DEVELOPMENT.md
@@ -29,6 +29,14 @@ We use the "fork, branch, develop, merge" model, where developers are expected t
 3. develop code on the branch
 4. generate a merge/pull request when ready to merge
 
+Several CI tests will run when the PR is opened, including things like linting,
+security checks, phpstan, and more. Most of these can be run locally with:
+
+```bash
+# run the base set of linting and static analysis checks
+make -C SETUP/ci
+```
+
 See also [DP Code Development Using git](https://www.pgdp.net/wiki/DP_Code_Development_Using_git)
 and a similar guide specific to the [dproofreaders](https://www.pgdp.net/wiki/DP_Code_Development_Using_git:_dproofreaders)
 repo.
@@ -53,8 +61,9 @@ composer install
 
 The code also uses [nodejs](https://nodejs.org/) for some _development only_
 dependencies, such as linting (eslint) and CSS creation (less). Packages are
-installed with npm that comes with nodejs. For Linux distros, you can find
-packages for recent nodejs versions from
+installed with npm that comes with nodejs. In addition to the
+[nodejs download site](https://nodejs.org/en/download/package-manager), Linux
+users can find packages for recent nodejs versions from
 [nodesource](https://github.com/nodesource/distributions).
 
 To install nodejs dependencies run the following in the repo base:
@@ -62,7 +71,7 @@ To install nodejs dependencies run the following in the repo base:
 npm install
 ```
 
-## Organizing principals
+## Organizing Principles
 
 The code is loosely organized around the following ideas:
 * PHP pages end in `.php` extensions. As site entry points, all `.php` pages
@@ -84,7 +93,7 @@ The code is loosely organized around the following ideas:
 * `styles/` - CSS scripts which include `.less` source files and the rendered
   `.css` files. See [CSS / style documentation](../style/README.md).
 * `SETUP/` - Non-runtime code, such as site admin docs, development docs, tests,
-  tooling and other miscellanea. The expectations is that this directory
+  tooling and other miscellanea. The expectation is that this directory
   will not, and should not be, accessible via the web context on a live site.
   * `SETUP/tests/` - Tests, mostly automated but some manual. See the
     [tests README](tests/README.md).

--- a/SETUP/ci/Makefile
+++ b/SETUP/ci/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all less security_checks best_practice_checks lint_charsuites lint_css lint_code lint tests
+.PHONY: all less security_checks best_practice_checks static_checks lint_charsuites lint_css lint_code lint less tests shellcheck
 
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-all: less security_checks best_practice_checks lint
+all: security_checks best_practice_checks lint static_checks
 
 #----------------------------------------------------------------------------
 # Security checks
@@ -14,6 +14,11 @@ security_checks:
 # Best Practice checks
 best_practice_checks:
 	$(SELF_DIR)check_includes.php
+
+#----------------------------------------------------------------------------
+# Static code checks
+static_checks:
+	cd $(SELF_DIR)../../ && ./vendor/bin/phpstan --memory-limit=512M
 
 #----------------------------------------------------------------------------
 # File linting
@@ -38,7 +43,7 @@ less:
 #----------------------------------------------------------------------------
 # Unit tests
 tests:
-	cd $(SELF_DIR)/tests/unittests && phpunit
+	cd $(SELF_DIR)/../tests/unittests && ../../../vendor/bin/phpunit
 
 #----------------------------------------------------------------------------
 # Shellcheck: Shell script linter

--- a/SETUP/ci/check_includes.php
+++ b/SETUP/ci/check_includes.php
@@ -73,6 +73,11 @@ foreach ($files as $file) {
         continue;
     }
 
+    // If it's in the phpstan cache directory, skip it
+    if (startswith($file, ".phpstan.cache/")) {
+        continue;
+    }
+
     // If it's in the node_modules directory, skip it
     if (startswith($file, "node_modules/")) {
         continue;

--- a/SETUP/ci/check_require_login.php
+++ b/SETUP/ci/check_require_login.php
@@ -81,6 +81,11 @@ foreach ($files as $file) {
         continue;
     }
 
+    // If it's in the phpstan cache directory, skip it
+    if (startswith($file, ".phpstan.cache/")) {
+        continue;
+    }
+
     // If it's in the node_modules directory, skip it
     if (startswith($file, "node_modules/")) {
         continue;

--- a/SETUP/ci/check_security.sh
+++ b/SETUP/ci/check_security.sh
@@ -14,7 +14,7 @@ fi
 
 echo "Checking PHP files for known security issues..."
 
-for file in $(find $BASE_DIR -name "*.php" -o -name "*.inc" | grep -v vendor); do
+for file in $(find $BASE_DIR -name "*.php" -o -name "*.inc" | grep -v vendor | grep -v .phpstan.cache); do
     # skip files in SETUP
     [[ "$file" =~ SETUP ]] && continue
 

--- a/SETUP/ci/lint_php_files.sh
+++ b/SETUP/ci/lint_php_files.sh
@@ -34,7 +34,7 @@ function lint_file()
 echo "Checking all .php and .inc files under $BASE_DIR for linting errors..."
 N=$(nproc)
 # shellcheck disable=SC2044
-for file in $(find $BASE_DIR -name "*.php" -o -name "*.inc" | grep -v /vendor/); do
+for file in $(find $BASE_DIR -name "*.php" -o -name "*.inc" | grep -v /vendor/ | grep -v /.phpstan.cache/); do
    lint_file "$file" &
    # Run at most N at a time.
    [[ $(jobs -r -p | wc -l) -ge $N ]] && wait -n

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
     bootstrapFiles:
         - SETUP/phpstan_bootstrap.inc
         - pinc/bootstrap.inc
+    tmpDir: .phpstan.cache
 
     # https://phpstan.org/user-guide/rule-levels
     # We want to gradually ratchet up the level here.


### PR DESCRIPTION
Add phpstan to our ci Makefile and give instructions on how to run the static checks as part of our dev docs. I needed to update the phpstan temp directory such that it worked on TEST which is a shared dev environment.

FYI @mrducky4 & @jchaffraix 