### PR TITLE
Install and use Symfony Process for system calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "voku/portable-utf8": "^6.0",
         "phpmailer/phpmailer": "^6.8",
         "vertilia/text": "^1.5",
-        "nikic/php-parser": "^5.0"
+        "nikic/php-parser": "^5.0",
+        "symfony/process": "^5.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.57",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40bbfe731275e0c43417ac49608b70b6",
+    "content-hash": "76f44b3c43ac9fdbe0b1b0dce3337abb",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -309,6 +309,148 @@
                 }
             ],
             "time": "2023-11-25T22:23:28+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.4.40",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/deedcb3bb4669cae2148bc920eafd2b16dc7c046",
+                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.4.40"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:33:22+00:00"
         },
         {
             "name": "vertilia/text",
@@ -3927,86 +4069,6 @@
             "time": "2023-02-14T08:03:56+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-01-29T20:11:03+00:00"
-        },
-        {
             "name": "symfony/polyfill-php81",
             "version": "v1.29.0",
             "source": {
@@ -4081,68 +4143,6 @@
                 }
             ],
             "time": "2024-01-29T20:11:03+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v5.4.36",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4fdf34004f149cc20b2f51d7d119aa500caad975",
-                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.36"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-02-12T15:49:53+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4435,5 +4435,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/crontab/ImportPGCatalog.inc
+++ b/crontab/ImportPGCatalog.inc
@@ -14,6 +14,7 @@ use Symfony\Component\Process\Process;
 class ImportPGCatalog extends BackgroundJob
 {
     private string $local_catalog_dir;
+    private int $time_limit_seconds = 300;
 
     private array $display_mapping = [
         'application/epub+zip' => 'EPUB',
@@ -56,7 +57,7 @@ class ImportPGCatalog extends BackgroundJob
 
     public function work()
     {
-        set_time_limit(300);
+        set_time_limit($this->time_limit_seconds);
 
         // determine temporary directory for download and extraction
         $this->local_catalog_dir = sys_get_temp_dir() . "/pg-catalog-files";
@@ -101,7 +102,7 @@ class ImportPGCatalog extends BackgroundJob
             $this->local_catalog_dir,
             "--overwrite",
         ]);
-        $process->setTimeout(600);
+        $process->setTimeout($this->time_limit_seconds);
         $process->run();
 
         // Each file in the tar archive describes one ebook in the PG collection,

--- a/crontab/ImportPGCatalog.inc
+++ b/crontab/ImportPGCatalog.inc
@@ -1,6 +1,8 @@
 <?php
 include_once($relPath.'pg.inc');
 
+use Symfony\Component\Process\Process;
+
 // Timing requirements: This script can run anytime, but probably daily.
 
 /*
@@ -87,16 +89,21 @@ class ImportPGCatalog extends BackgroundJob
         }
 
         echo "Extracting files from $local_compressed_file to {$this->local_catalog_dir}...\n";
-        $cmd = join(" ", [
+        $process = new Process([
             "tar",
             "--extract",
             "--bzip2",
-            "--file=" . escapeshellarg($local_compressed_file),
-            "--strip-components=3",
-            "--directory=" . escapeshellarg($this->local_catalog_dir),
+            "--file",
+            $local_compressed_file,
+            "--strip-components",
+            3,
+            "--directory",
+            $this->local_catalog_dir,
             "--overwrite",
         ]);
-        system($cmd, $ret);
+        $process->setTimeout(600);
+        $process->run();
+
         // Each file in the tar archive describes one ebook in the PG collection,
         // and has a path of the form:
         //     cache/epub/NNN/pgNNN.rdf
@@ -105,7 +112,7 @@ class ImportPGCatalog extends BackgroundJob
         //     cache/epub/NNN
         // part, and --directory=$local_catalog_dir so that we end up with
         //     $local_catalog_dir/pgNNN.rdf
-        if ($ret) {
+        if (!$process->isSuccessful()) {
             throw new RuntimeException("Unable to extract files from $local_compressed_file to {$this->local_catalog_dir}");
         }
 

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -3,6 +3,7 @@ include_once($relPath.'Project.inc');
 include_once($relPath.'iso_lang_list.inc'); // langcode3_for_langname, langcode2_for_langname
 include_once($relPath.'unicode.inc');
 
+use Symfony\Component\Process\Process;
 use voku\helper\UTF8;
 
 // Handle dp-specific notation for non-Latin-1 characters
@@ -311,21 +312,11 @@ class BadWordAccumulator
  */
 function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 {
-    global $aspell_temp_dir;
     global $aspell_executable, $aspell_prefix;
 
-    $messages = [];
-
-    $tmp_file_path = tempnam($aspell_temp_dir, "pagetext-");
-
     $tmp_file_text = join("\n", array_keys($input_words_w_freq));
-    $wasWritten = file_put_contents($tmp_file_path, $tmp_file_text);
-    unset($tmp_file_text);
-    if ($wasWritten === false) {
-        $messages[] = sprintf(_("Error: unable to write text to temp file: %s"), $tmp_file_path);
-        return [[], $messages];
-    }
 
+    $messages = [];
     $misspellings = [];
     foreach ($languages as $language) {
         $langcode = langcode2_for_langname($language);
@@ -334,23 +325,26 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
             if (is_file($dict_file)) {
                 // run aspell using this language
 
-                // create the aspell command
-                $aspell_command = join(" ", [
-                    "cat",
-                    escapeshellarg($tmp_file_path),
-                    "|",
+                $process = new Process([
                     $aspell_executable,
                     "list",
-                    "--prefix=" . escapeshellarg($aspell_prefix),
-                    "-d " . escapeshellarg($dict_file),
-                    "--encoding=UTF-8",
+                    "--prefix",
+                    $aspell_prefix,
+                    "-d",
+                    $dict_file,
+                    "--encoding",
+                    "UTF-8",
                 ]);
-                //echo "<!-- aspell command: $aspell_command -->\n"; // Very useful for debugging
+                $process->setInput($tmp_file_text);
+                $process->run();
+
+                if (!$process->isSuccessful()) {
+                    $messages[] = sprintf(_("Warning: error running aspell for language '%s'"), $language);
+                    continue;
+                }
+
                 // build our list of possible misspellings
-                $misspellings[$langcode] = explode(
-                    "\n",
-                    str_replace("\r", "", shell_exec($aspell_command))
-                );
+                $misspellings[$langcode] = explode("\n", $process->getOutput());
 
                 // Reduce the set to only words that use characters in our
                 // expected script. This is necessary for some aspell
@@ -366,11 +360,6 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
         } else {
             $messages[] = sprintf(_("Warning: unknown language '%s'"), $language);
         }
-    }
-
-    // now remove the temporary file
-    if (is_file($tmp_file_path)) {
-        unlink($tmp_file_path);
     }
 
     if (count($misspellings) == 0) {


### PR DESCRIPTION
Symfony's Process class handles shell escaping and other niceties like stdin/stdout redirection. This instance fixes the issue where we can't tell if the aspell process completed successfully and didn't find anything misspelled or if it errored out.

This was identified in the newly spun up `clone.pgdp.net` instance because `shell_exec()` returned NULL and we passed that into `explode()` and that's now deprecated in PHP 8.1. Moving to `Process()` is an overall Good Thing and we should do it across the codebase. I'll create an issue.

I've done ImportPGCatalog as an example which doesn't use stdin.

Sandbox available at https://www.pgdp.org/~cpeel/c.branch/use-symfony-process/