### PR TITLE
Wrangle special_days management page

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -403,17 +403,17 @@ CREATE TABLE `special_days` (
   `spec_code` varchar(20) NOT NULL default '',
   `display_name` varchar(80) NOT NULL default '',
   `enable` tinyint(1) NOT NULL default '1',
-  `comment` varchar(255) default NULL,
+  `comment` varchar(255) NOT NULL default '',
   `color` varchar(8) NOT NULL default '',
-  `open_day` tinyint(2) default NULL,
-  `open_month` tinyint(2) default NULL,
-  `close_day` tinyint(2) default NULL,
-  `close_month` tinyint(2) default NULL,
-  `date_changes` varchar(100) default NULL,
-  `info_url` varchar(255) default NULL,
-  `image_url` varchar(255) default NULL,
-  `symbol` varchar(2) default '',
-  UNIQUE KEY `spec_code` (`spec_code`)
+  `open_day` tinyint NOT NULL default '0',
+  `open_month` tinyint NOT NULL default '0',
+  `close_day` tinyint NOT NULL default '0',
+  `close_month` tinyint NOT NULL default '0',
+  `date_changes` varchar(100) NOT NULL default '',
+  `info_url` varchar(255) NOT NULL default '',
+  `image_url` varchar(255) NOT NULL default '',
+  `symbol` varchar(2) NOT NULL default '',
+  PRIMARY KEY (`spec_code`)
 ) COMMENT='definitions of SPECIAL days';
 
 --

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -412,7 +412,7 @@ CREATE TABLE `special_days` (
   `date_changes` varchar(100) NOT NULL default '',
   `info_url` varchar(255) NOT NULL default '',
   `image_url` varchar(255) NOT NULL default '',
-  `symbol` varchar(2) NOT NULL default '',
+  `symbol` varchar(4) NOT NULL default '',
   PRIMARY KEY (`spec_code`)
 ) COMMENT='definitions of SPECIAL days';
 

--- a/SETUP/upgrade/21/20240712_update_special_days.php
+++ b/SETUP/upgrade/21/20240712_update_special_days.php
@@ -34,7 +34,7 @@ $sql = "
         MODIFY COLUMN `date_changes` varchar(100) NOT NULL default '',
         MODIFY COLUMN `info_url` varchar(255) NOT NULL default '',
         MODIFY COLUMN `image_url` varchar(255) NOT NULL default '',
-        MODIFY COLUMN `symbol` varchar(2) NOT NULL default '',
+        MODIFY COLUMN `symbol` varchar(4) NOT NULL default '',
         DROP INDEX `spec_code`,
         ADD PRIMARY KEY (spec_code);
 ";

--- a/SETUP/upgrade/21/20240712_update_special_days.php
+++ b/SETUP/upgrade/21/20240712_update_special_days.php
@@ -1,0 +1,46 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Updating special_days...\n";
+$update_statements = [
+    "UPDATE special_days SET comment = '' where comment is NULL",
+    "UPDATE special_days SET open_day = 0 where open_day is NULL",
+    "UPDATE special_days SET open_month = 0 where open_day is NULL",
+    "UPDATE special_days SET close_day = 0 where open_day is NULL",
+    "UPDATE special_days SET close_month = 0 where open_day is NULL",
+    "UPDATE special_days SET date_changes = '' where date_changes is NULL",
+    "UPDATE special_days SET info_url = '' where info_url is NULL",
+    "UPDATE special_days SET image_url = '' where image_url is NULL",
+    "UPDATE special_days SET symbol = '' where symbol is NULL",
+];
+
+foreach ($update_statements as $sql) {
+    echo "\n    $sql\n";
+    mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+}
+
+$sql = "
+    ALTER TABLE special_days
+        MODIFY COLUMN `comment` varchar(255) NOT NULL default '',
+        MODIFY COLUMN `open_day` tinyint NOT NULL default 0,
+        MODIFY COLUMN `open_month` tinyint NOT NULL default 0,
+        MODIFY COLUMN `close_day` tinyint NOT NULL default 0,
+        MODIFY COLUMN `close_month` tinyint NOT NULL default 0,
+        MODIFY COLUMN `date_changes` varchar(100) NOT NULL default '',
+        MODIFY COLUMN `info_url` varchar(255) NOT NULL default '',
+        MODIFY COLUMN `image_url` varchar(255) NOT NULL default '',
+        MODIFY COLUMN `symbol` varchar(2) NOT NULL default '',
+        DROP INDEX `spec_code`,
+        ADD PRIMARY KEY (spec_code);
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -134,16 +134,16 @@ class SpecialDay
     public ?string $spec_code;
     public string $display_name;
     public int $enable;
-    public ?string $comment;
+    public string $comment;
     public string $color;
-    public ?int $open_day;
-    public ?int $open_month;
-    public ?int $close_day;
-    public ?int $close_month;
-    public ?string $date_changes;
-    public ?string $info_url;
-    public ?string $image_url;
-    public ?string $symbol;
+    public int $open_day;
+    public int $open_month;
+    public int $close_day;
+    public int $close_month;
+    public string $date_changes;
+    public string $info_url;
+    public string $image_url;
+    public string $symbol;
 
     public function __construct(?string $spec_code = null)
     {
@@ -257,14 +257,14 @@ class SpecialDay
 
         if ($this->new_source) {
             echo "<table class='edit_special_day'>";
-            $this->_show_edit_row('spec_code', _('Special Day ID'), 'text', 20);
+            $this->_show_edit_row('spec_code', _('Special Day ID'), 'text', 20, null, null, true);
         } else {
             echo "<input type='hidden' name='editing' value='true'>" .
                 "<input type='hidden' name='spec_code' value='" . attr_safe($this->spec_code) ."'>
                 <table class='edit_special_day'>";
             $this->_show_summary_row(_('Special Day ID'), $this->spec_code);
         }
-        $this->_show_edit_row('display_name', _('Display Name'), 'text', 80);
+        $this->_show_edit_row('display_name', _('Display Name'), 'text', 80, null, null, true);
         $this->_show_edit_row('symbol', _('Symbol'), 'text', 4);
         echo "  <tr><th class='label'>Enable</th><td><input type='checkbox' name='enable'";
         if ($this->enable) {
@@ -273,10 +273,10 @@ class SpecialDay
         echo "></td></tr>\n";
         $this->_show_edit_row('comment', _('Comment'), 'textarea');
         $this->_show_edit_row('color', _('Color'), 'text', 8);
-        $this->_show_edit_row('open_month', _('Open Month'), 'number', null, 1, 12);
-        $this->_show_edit_row('open_day', _('Open Day'), 'number', null, 1, 31);
-        $this->_show_edit_row('close_month', _('Close Month'), 'number', null, 1, 12);
-        $this->_show_edit_row('close_day', _('Close Day'), 'number', null, 1, 31);
+        $this->_show_edit_row('open_month', _('Open Month'), 'number', null, 1, 12, true);
+        $this->_show_edit_row('open_day', _('Open Day'), 'number', null, 1, 31, true);
+        $this->_show_edit_row('close_month', _('Close Month'), 'number', null, 1, 12, true);
+        $this->_show_edit_row('close_day', _('Close Day'), 'number', null, 1, 31, true);
         $this->_show_edit_row('date_changes', _('Date Changes'));
         $this->_show_edit_row('info_url', _('Info URL'));
         $this->_show_edit_row('image_url', _('Image URL'));
@@ -286,23 +286,25 @@ class SpecialDay
             </td></tr></table>\n</form>\n";
     }
 
-    private function _show_edit_row(string $field, string $label, string $type = 'text', ?int $maxlength = null, ?int $min = null, ?int $max = null): void
+    private function _show_edit_row(string $field, string $label, string $type = 'text', ?int $maxlength = null, ?int $min = null, ?int $max = null, bool $required = false): void
     {
         $value = $this->new_source
             ? (empty($_POST[$field]) ? '' : $_POST[$field])
             : $this->$field;
 
+        $required = $required ? " required" : "";
+
         $value = html_safe($value);
 
         if ($type == "textarea") {
-            $editing = "<textarea style='width: 40em; height: 5em' name='$field'>$value</textarea>";
+            $editing = "<textarea style='width: 40em; height: 5em' name='$field' $required>$value</textarea>";
         } elseif ($type == "text") {
             $maxlength_attr = is_null($maxlength) ? '' : "maxlength='$maxlength'";
-            $editing = "<input type='text' style='width: 40em' name='$field' value='$value' $maxlength_attr>";
+            $editing = "<input type='text' style='width: 40em' name='$field' value='$value' $maxlength_attr $required>";
         } elseif ($type == "number") {
             $min_attr = is_null($min) ? '' : "min='$min'";
             $max_attr = is_null($max) ? '' : "max='$max'";
-            $editing = "<input type='number' style='width: 4em' name='$field' size='60' value='$value' $min_attr $max_attr>";
+            $editing = "<input type='number' style='width: 4em' name='$field' size='60' value='$value' $min_attr $max_attr $required>";
         }
         $addl_data = '';
         if ($field == "symbol") {
@@ -406,7 +408,7 @@ class SpecialDay
 
 // ----------------------------------------------------------------------------
 
-function make_link(?string $url, ?string $label): string
+function make_link(string $url, string $label): string
 {
     if (!$url) {
         return '';


### PR DESCRIPTION
Several fields are actually required and we should make them so on the input form. Also update the database schema to remove nulls and adjust the class to match -- it doesn't make any sense why the DB schema was like it was.

Sandbox at https://www.pgdp.org/~cpeel/c.branch/wrangle-special-days/