### PR TITLE
Remove unneeded calls to DPDatabase::escape()

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -132,7 +132,7 @@ $profile->save();
 // add ref to profile
 $refString = sprintf(
     "UPDATE users SET u_profile=%d WHERE u_id=%d",
-    DPDatabase::escape($profile->id),
+    $profile->id,
     $u_id
 );
 DPDatabase::query($refString);

--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -132,7 +132,7 @@ if ($_POST) {
     $count = count($enable_author_values);
     for ($i = 0; $i < $count; $i++) {
         $sql = sprintf(
-            "UPDATE authors SET enabled = '%d' WHERE author_id = %d",
+            "UPDATE authors SET enabled = %d WHERE author_id = %d",
             $enable_author_values[$i],
             $enable_author_ids[$i]
         );

--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -132,8 +132,8 @@ if ($_POST) {
     $count = count($enable_author_values);
     for ($i = 0; $i < $count; $i++) {
         $sql = sprintf(
-            "UPDATE authors SET enabled = '%s' WHERE author_id = %d",
-            DPDatabase::escape($enable_author_values[$i]),
+            "UPDATE authors SET enabled = '%d' WHERE author_id = %d",
+            $enable_author_values[$i],
             $enable_author_ids[$i]
         );
         DPDatabase::query($sql);

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -433,9 +433,9 @@ class ImageSource
             DPDatabase::escape($this->full_name),
             DPDatabase::escape($this->url),
             DPDatabase::escape($this->credit),
-            DPDatabase::escape($this->ok_keep_images),
-            DPDatabase::escape($this->ok_show_images),
-            DPDatabase::escape($this->info_page_visibility),
+            $this->ok_keep_images,
+            $this->ok_show_images,
+            $this->info_page_visibility,
             DPDatabase::escape($this->public_comment),
             DPDatabase::escape($this->internal_comment),
             $this->is_active


### PR DESCRIPTION
Those are covered by a general exception for int-to-string conversions in `phpstan.neon` so
were found by temporarily disabling it. That's also why there is no progression from PHPStan's perspective.