### PR TITLE
Type tools/proofers/processtext.php and callees

### DIFF
--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -303,14 +303,14 @@ try {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function switch_layout()
+function switch_layout(): void
 {
     $user = User::load_current();
     $user->profile->i_layout = $user->profile->i_layout == 1 ? 0 : 1;
     $user->profile->save();
 }
 
-function leave_spellcheck_mode($ppage)
+function leave_spellcheck_mode(PPage $ppage): void
 {
     $user = User::load_current();
 
@@ -333,7 +333,7 @@ function leave_spellcheck_mode($ppage)
     }
 }
 
-function leave_proofing_interface($title)
+function leave_proofing_interface(string $title): void
 {
     global $code_url, $projectid, $proj_state;
 

--- a/tools/proofers/proof_frame.inc
+++ b/tools/proofers/proof_frame.inc
@@ -6,7 +6,7 @@
 include_once('proof_frame_std.inc');
 include_once('proof_frame_enh.inc');
 
-function echo_proof_frame($ppage)
+function echo_proof_frame(PPage $ppage): void
 {
     $user = User::load_current();
 

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -8,7 +8,7 @@ include_once('PPage.inc');
 include_once('image_block_enh.inc');
 include_once('preview.inc');
 
-function echo_proof_frame_enh($ppage)
+function echo_proof_frame_enh(PPage $ppage): void
 {
     global $code_url;
 

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -386,7 +386,10 @@ $word_check_messages = [
     "rerun" => _("Check page against an additional language"),
 ];
 
-function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $accepted_words, $languages)
+// @param $accepted_words string[]
+// @param $languages string[]
+// TODO: Switch $is_changed to a bool once we have `get_bool_param`.
+function output_wordcheck_interface(User $user, PPage $ppage, string $text_data, int $is_changed, array $accepted_words, array $languages): void
 {
     global $code_url, $word_check_messages;
 
@@ -553,7 +556,8 @@ function output_wordcheck_interface($user, $ppage, $text_data, $is_changed, $acc
     echo '</div>';
 }
 
-function output_wordcheck_language_buttons($languages)
+// @param $languages string[]
+function output_wordcheck_language_buttons(array $languages): void
 {
     foreach ($languages as $language) {
         $name = attr_safe("remove_language[$language]");
@@ -566,7 +570,7 @@ function output_wordcheck_language_buttons($languages)
     }
 }
 
-function get_page_js($interface_type_init_value)
+function get_page_js(int $interface_type_init_value): string
 {
     $show_wc_header_label = javascript_safe(_("Show WordCheck Header"));
     $hide_wc_header_label = javascript_safe(_("Hide WordCheck Header"));
@@ -597,7 +601,8 @@ function get_page_js($interface_type_init_value)
         PAGE_JS;
 }
 
-function get_wordcheck_page_header_args($user, $ppage)
+// @return array<"js_files" => string[], "js_data" => string, "body_attributes" => string, "css_data"? = string
+function get_wordcheck_page_header_args(User $user, PPage $ppage): array
 {
     global $code_url, $word_check_messages;
 

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -4,7 +4,7 @@ include_once($relPath.'slim_header.inc');
 include_once($relPath.'codepoint_validator.inc');
 include_once('preview.inc');
 
-function echo_text_frame_std($ppage)
+function echo_text_frame_std(PPage $ppage): void
 {
     global $code_url;
 


### PR DESCRIPTION
Manually tested the different buttons in the proofer's interface. Also confirmed that we could add a word to the good/bad list.

_Update by cpeel_: sandbox avail at https://www.pgdp.org/~cpeel/c.branch/julien_type_wordcheck/