### PR TITLE
Add get_bool_param() validation function

### DIFF
--- a/SETUP/tests/unittests/ParamValidatorTest.php
+++ b/SETUP/tests/unittests/ParamValidatorTest.php
@@ -330,7 +330,8 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(false, $result);
     }
 
-    public function testBoolDefaultToNull() {
+    public function testBoolDefaultToNull()
+    {
         $default = null;
         $allow_null = true;
         $result = get_bool_param($this->GET, 'none', $default, $allow_null);

--- a/SETUP/tests/unittests/ParamValidatorTest.php
+++ b/SETUP/tests/unittests/ParamValidatorTest.php
@@ -323,18 +323,18 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
     //------------------------------------------------------------------------
     // get_bool_param() tests
 
-    public function testBool()
-    {
-        $default = null;
-        $result = get_bool_param($this->GET, 'true_str', $default);
-        $this->assertEquals(true, $result);
-    }
-
     public function testBoolDefault()
     {
         $default = false;
         $result = get_bool_param($this->GET, 'none', $default);
         $this->assertEquals(false, $result);
+    }
+
+    public function testBoolDefaultToNull() {
+        $default = null;
+        $allow_null = true;
+        $result = get_bool_param($this->GET, 'none', $default, $allow_null);
+        $this->assertEquals(null, $result);
     }
 
     public function testBoolTrueVariants()

--- a/SETUP/tests/unittests/ParamValidatorTest.php
+++ b/SETUP/tests/unittests/ParamValidatorTest.php
@@ -8,7 +8,18 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         "f10" => "10.0",
         "s10" => "ten",
         "date" => "2024-02-10",
+        "zero" => 0,
         "one" => 1,
+        "zero_str" => "0",
+        "one_str" => "1",
+        "true" => true,
+        "false" => false,
+        "true_str" => "true",
+        "TRUE_str" => "TRUE",
+        "True_str" => "True",
+        "false_str" => "false",
+        "FALSE_str" => "FALSE",
+        "False_str" => "False",
     ];
     private $ENUM_CHOICES = ["a", "b"];
     private $ENUM_INT_CHOICES = [1, 3, 5, 9];
@@ -307,6 +318,78 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         $min = 0;
         $max = 9;
         get_float_param($this->GET, 'f10', $default, $min, $max);
+    }
+
+    //------------------------------------------------------------------------
+    // get_bool_param() tests
+
+    public function testBool()
+    {
+        $default = null;
+        $result = get_bool_param($this->GET, 'true_str', $default);
+        $this->assertEquals(true, $result);
+    }
+
+    public function testBoolDefault()
+    {
+        $default = false;
+        $result = get_bool_param($this->GET, 'none', $default);
+        $this->assertEquals(false, $result);
+    }
+
+    public function testBoolTrueVariants()
+    {
+        $default = null;
+        $result = get_bool_param($this->GET, 'true', $default);
+        $this->assertEquals(true, $result);
+        $result = get_bool_param($this->GET, 'true_str', $default);
+        $this->assertEquals(true, $result);
+        $result = get_bool_param($this->GET, 'TRUE_str', $default);
+        $this->assertEquals(true, $result);
+        $result = get_bool_param($this->GET, 'True_str', $default);
+        $this->assertEquals(true, $result);
+        $result = get_bool_param($this->GET, 'one', $default);
+        $this->assertEquals(true, $result);
+        $result = get_bool_param($this->GET, 'one_str', $default);
+        $this->assertEquals(true, $result);
+    }
+
+    public function testBoolFalseVariants()
+    {
+        $default = null;
+        $result = get_bool_param($this->GET, 'false', $default);
+        $this->assertEquals(false, $result);
+        $result = get_bool_param($this->GET, 'false_str', $default);
+        $this->assertEquals(false, $result);
+        $result = get_bool_param($this->GET, 'FALSE_str', $default);
+        $this->assertEquals(false, $result);
+        $result = get_bool_param($this->GET, 'False_str', $default);
+        $this->assertEquals(false, $result);
+        $result = get_bool_param($this->GET, 'zero', $default);
+        $this->assertEquals(false, $result);
+        $result = get_bool_param($this->GET, 'zero_str', $default);
+        $this->assertEquals(false, $result);
+    }
+
+    public function testBoolDefaultNotBool()
+    {
+        // Shockingly, PHP 7.4 (at least) will not throw a TypeError if a
+        // non-boolean is passed into a function with a bool type. It instead
+        // coerces it into a bool. Maybe later versions will?
+        $this->markTestSkipped('PHP will not enforce a bool type');
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage("must be of");
+        $default = "string";
+        get_bool_param($this->GET, 'none', $default);
+    }
+
+    public function testBoolNotABool()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("is not a");
+        $default = true;
+        get_bool_param($this->GET, 'i10', $default);
     }
 
     //------------------------------------------------------------------------

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -420,6 +420,65 @@ function get_numeric_param(string $type, array $arr, string $key, $default, $min
 }
 
 /**
+ * Get and validate a boolean value from an array
+ *
+ * Accepts various reasonably "truthy" values, like 0, 1, "0", "1", "true",
+ * "false" and various capitalizations thereof.
+ *
+ * @param array<string, mixed> $arr
+ * @param string $key
+ * @param bool|null $default
+ * @param bool $allownull
+ *
+ * @return bool|null
+ *
+ * @throws InvalidArgumentException
+ */
+function get_bool_param(array $arr, string $key, ?bool $default, bool $allownull = false): ?bool
+{
+    if (!is_null($default) && $allownull) {
+        throw new InvalidArgumentException("\$allownull = true but \$default is specified");
+    }
+
+    if (isset($arr[$key])) {
+        $s = $arr[$key];
+
+        if (is_string($s)) {
+            // Trim whitespace from both ends of the string and make it lowercase
+            $s = strtolower(trim($s));
+            if ($s === "true" || $s === "1") {
+                return true;
+            } elseif ($s === "false" || $s === "0") {
+                return false;
+            }
+
+            // fall through to handle other strings as an exception
+        } elseif (is_int($s) && $s === 0 || $s === 1) {
+            return $s === 1;
+        } elseif (is_bool($s)) {
+            return $s;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            _("Parameter '%1\$s' ('%2\$s') is not a valid bool"),
+            $key,
+            $s
+        ));
+    } else {
+        // not set, use default
+        if (is_null($default) && !$allownull) {
+            // There is no default. The parameter is required.
+            throw new InvalidArgumentException(sprintf(
+                _("Parameter '%1\$s' is required"),
+                $key
+            ));
+        } else {
+            return $default;
+        }
+    }
+}
+
+/**
  * Get and validate a value from an array using a regex
  *
  * If `$arr[$key]` is defined and matches `$regex`, return it.

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -426,11 +426,6 @@ function get_numeric_param(string $type, array $arr, string $key, $default, $min
  * "false" and various capitalizations thereof.
  *
  * @param array<string, mixed> $arr
- * @param string $key
- * @param bool|null $default
- * @param bool $allownull
- *
- * @return bool|null
  *
  * @throws InvalidArgumentException
  */


### PR DESCRIPTION
Add a validation function to return a bool from various sensible "truthy" and "falsey" values. This isn't used anywhere but I think it will come in handy based on recent type declaration PRs. It even comes with unit tests!