### PR TITLE
Fix comments for PHPStan

### DIFF
--- a/SETUP/ci/check_security.php
+++ b/SETUP/ci/check_security.php
@@ -63,6 +63,7 @@ foreach ($files as $file) {
 
 }
 
+/** @return string[] */
 function get_all_php_files(string $basedir): array
 {
     $php_files = [];

--- a/SETUP/ci/check_security.php
+++ b/SETUP/ci/check_security.php
@@ -63,7 +63,6 @@ foreach ($files as $file) {
 
 }
 
-// @param $basedir string[]
 function get_all_php_files(string $basedir): array
 {
     $php_files = [];
@@ -101,7 +100,7 @@ function file_includes_system_call(string $filename): bool
     return preg_match("/\b(?:exec|system|passthru|shell_exec|escapeshellcmd)\(/", $contents, $matches);
 }
 
-// @return never
+/** @return never */
 // TODO: Add never as a return value once we switch to PHP 8.1.
 function abort(string $message)
 {

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -386,8 +386,12 @@ $word_check_messages = [
     "rerun" => _("Check page against an additional language"),
 ];
 
-// @param $accepted_words string[]
-// @param $languages string[]
+/**
+ * output_wordcheck_interface outputs all the buttons used by WordCheck
+ *
+ * @param string[] $accepted_words
+ * @param string[] $languages
+ */
 // TODO: Switch $is_changed to a bool once we have `get_bool_param`.
 function output_wordcheck_interface(User $user, PPage $ppage, string $text_data, int $is_changed, array $accepted_words, array $languages): void
 {
@@ -556,7 +560,7 @@ function output_wordcheck_interface(User $user, PPage $ppage, string $text_data,
     echo '</div>';
 }
 
-// @param $languages string[]
+/** @param string[] $languages */
 function output_wordcheck_language_buttons(array $languages): void
 {
     foreach ($languages as $language) {
@@ -601,7 +605,7 @@ function get_page_js(int $interface_type_init_value): string
         PAGE_JS;
 }
 
-// @return array<"js_files" => string[], "js_data" => string, "body_attributes" => string, "css_data"? = string
+/** @return array{"js_files": string[], "js_data": string, "body_attributes": string, "css_data"?: string} */
 function get_wordcheck_page_header_args(User $user, PPage $ppage): array
 {
     global $code_url, $word_check_messages;

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -387,7 +387,7 @@ $word_check_messages = [
 ];
 
 /**
- * output_wordcheck_interface outputs all the buttons used by WordCheck
+ * Output all the buttons used by WordCheck.
  *
  * @param string[] $accepted_words
  * @param string[] $languages

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -94,7 +94,7 @@ function output_page_links(string $current_page_id): void
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-// @param array<string, string> $options
+/** @param array<string, string> $options */
 function echo_selection(string $name, array $options, string $value_selected): void
 {
     echo "<select name='$name'>";


### PR DESCRIPTION
I made some errors when adding comments for PHPStan.

The main one is that we must be using PHPDoc's format (/** @param type param_name */) or else those are
ignored by PHPStan.

This exposed a bad array syntax in
tools/proofers/spellcheck_text.inc that got fixed.