### PR TITLE
Better setlangcookie param validation

### DIFF
--- a/SETUP/tests/smoketests/pageload_smoketest.py
+++ b/SETUP/tests/smoketests/pageload_smoketest.py
@@ -252,7 +252,7 @@ TOOLS_TESTS = [
     {
         'method': 'POST',
         'path': 'tools/setlangcookie.php',
-        'data': {'lang': 'en-US'},
+        'data': {'lang': 'en_US'},
         'expect_status': 302,
     },
 ]

--- a/accounts/login.php
+++ b/accounts/login.php
@@ -109,7 +109,7 @@ if (!empty($destination) && !endswith($destination, "login_failure.php") &&
 } else {
     $url = "$code_url/activity_hub.php";
 }
-metarefresh(0, $url, "", "");
+metarefresh(0, $url);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -129,5 +129,5 @@ function login_failure($error_code, $destination)
 {
     global $code_url;
 
-    metarefresh(0, "$code_url/accounts/login_failure.php?error_code=$error_code&destination=" . urlencode($destination), "", "");
+    metarefresh(0, "$code_url/accounts/login_failure.php?error_code=$error_code&destination=" . urlencode($destination));
 }

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -130,7 +130,7 @@ elseif ($func == "newtranslation2") {
     try {
         $po_file->create_from_template("$dyn_locales_dir/messages.pot", $locale);
 
-        metarefresh(0, "$translate_url?func=manage&amp;locale=$locale", "", "");
+        metarefresh(0, "$translate_url?func=manage&amp;locale=$locale");
     } catch (Exception $exception) {
         echo "<p>" . _("An error occurred during translation initialization.") ."</p>";
         echo "<pre>" . $exception->getMessage() . "</pre>";

--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -10,7 +10,8 @@
  * client (determined if headers have been sent or if the output buffer
  * has contents in it).
  */
-function metarefresh($seconds, $url, $title = "", $body = "", $allow_external = false)
+/** @return never */
+function metarefresh(int $seconds, string $url, string $title = "", string $body = "", bool $allow_external = false)
 {
     global $testing, $code_url;
 

--- a/stats/teams/new_team.php
+++ b/stats/teams/new_team.php
@@ -117,7 +117,6 @@ if (isset($_POST['mkPreview'])) {
     $title = _("Quit Without Saving");
     $desc = _("Quitting without saving...");
     metarefresh(0, "$code_url/activity_hub.php", $title, $desc);
-    exit;
 } else {
     $name = _("Create a New Team");
     output_header($name, SHOW_STATSBAR, $theme_extra_args);

--- a/stats/teams/tedit.php
+++ b/stats/teams/tedit.php
@@ -32,7 +32,6 @@ if (($user->u_id != $curTeam['owner']) && (!user_is_a_sitemanager())) {
     $title = _("Authorization Failed");
     $desc = _("You are not authorized to edit this team....");
     metarefresh(4, "tdetail.php?tid=$tid", $title, $desc);
-    exit;
 }
 
 if (isset($_GET['tid'])) {
@@ -45,7 +44,6 @@ if (isset($_GET['tid'])) {
     $title = _("Quit Without Saving");
     $desc = _("Quitting without saving...");
     metarefresh(0, "tdetail.php?tid=$tid", $title, $desc);
-    exit;
 } elseif (isset($_POST['edPreview'])) {
     $preview = _("Preview");
     output_header($preview . " " . $teamname, SHOW_STATSBAR, $theme_extra_args);

--- a/tasks.php
+++ b/tasks.php
@@ -606,21 +606,19 @@ if (!isset($_REQUEST['task_id'])) {
                 //   the page to clear the POST data and make sure that
                 //   reloading does not lead to duplicated tasks.
                 metarefresh(0, $tasks_url);
-                break;
             }
 
-            // no break
+            // no break, metarefresh exits
         case 'notify_new':
             $userSettings = & Settings::get_Settings($pguser);
             $userSettings->add_value('taskctr_notice', 'notify_new');
             metarefresh(0, $tasks_url);
-            break;
 
+            // no break, metarefresh exits
         case 'unnotify_new':
             $userSettings = & Settings::get_Settings($pguser);
             $userSettings->remove_value('taskctr_notice', 'notify_new');
             metarefresh(0, $tasks_url);
-            break;
     }
 } else {
     handle_action_on_a_specified_task();

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -17,7 +17,7 @@ $projectid = get_projectID_param($_POST, 'projectid');
 $curr_state = get_enumerated_param($_POST, 'curr_state', null, ProjectStates::get_states());
 $next_state = get_enumerated_param($_POST, 'next_state', null, array_merge(ProjectStates::get_states(), ['automodify']));
 $confirmed = get_enumerated_param($_POST, 'confirmed', null, ['yes'], true);
-$return_uri = @$_POST['return_uri'];
+$return_uri = @$_POST['return_uri'] ?? '';
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -100,10 +100,8 @@ if (!empty($transition->detour)) {
         // or output content and exit
     } else {
         $title = _("Transferring...");
-        $body = "";
         $refresh_url = prepare_url($transition->detour);
-        metarefresh(2, $refresh_url, $title, $body);
-        exit;
+        metarefresh(2, $refresh_url, $title);
     }
 }
 

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -26,12 +26,10 @@ if (isset($_POST['saveAndProject']) || isset($_POST['saveAndPM']) || isset($_POS
         [$good_word_conflict, $bad_word_conflict, $errors] = $pwlh->save_to_files();
         if (!$errors) {
             if (isset($_POST['saveAndProject'])) {
-                metarefresh(0, "$code_url/project.php?id=$pwlh->projectid", _("Save and Go To Project"), "");
-                exit;
+                metarefresh(0, "$code_url/project.php?id=$pwlh->projectid", _("Save and Go To Project"));
             } elseif (isset($_POST['saveAndPM'])) {
                 // TRANSLATORS: PM = project manager
-                metarefresh(0, "$code_url/tools/project_manager/projectmgr.php", _("Save and Go To PM Page"), "");
-                exit;
+                metarefresh(0, "$code_url/tools/project_manager/projectmgr.php", _("Save and Go To PM Page"));
             }
         } elseif (isset($_POST['save'])) {
             // No errors, but fall through.
@@ -48,8 +46,7 @@ if (isset($_POST['saveAndProject']) || isset($_POST['saveAndPM']) || isset($_POS
     }
 
     // do the redirect
-    metarefresh(0, $return, _("Quit Without Saving"), "");
-    exit;
+    metarefresh(0, $return, _("Quit Without Saving"));
 } elseif (isset($_POST['reload'])) {
     // fall through
 }

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -34,9 +34,9 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
         }
         if (isset($_POST['saveAndQuit'])) {
             // TRANSLATORS: PM = project manager
-            metarefresh(0, "projectmgr.php", _("Save and Go To PM Page"), "");
+            metarefresh(0, "projectmgr.php", _("Save and Go To PM Page"));
         } elseif (isset($_POST['saveAndProject'])) {
-            metarefresh(0, "$code_url/project.php?id={$pih->project->projectid}", _("Save and Go To Project"), "");
+            metarefresh(0, "$code_url/project.php?id={$pih->project->projectid}", _("Save and Go To Project"));
         }
     }
 
@@ -72,7 +72,7 @@ if (isset($_POST['saveAndQuit']) || isset($_POST['saveAndProject']) || isset($_P
     }
 
     // do the redirect
-    metarefresh(0, $return, _("Quit Without Saving"), "");
+    metarefresh(0, $return, _("Quit Without Saving"));
 } else {
     $requested_action = get_enumerated_param($_REQUEST, 'action', null, ['createnew', 'clone', 'create_from_marc_record', 'edit']);
 

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -445,7 +445,6 @@ function enforce_edit_authorization($projectid)
         $message .= " ";
         $message .= sprintf(_("Redirecting you to the project page in %d seconds."), 5);
         metarefresh(5, "$code_url/project.php?id=$projectid", _("Redirect to Project"), $message);
-        exit;
     }
 }
 

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -164,8 +164,8 @@ try {
             $ppage->attempt_to_save_as_done($text_data);
             $url = $ppage->url_for_do_another_page();
             metarefresh(1, $url, _("Save as 'Done' & Proofread Next Page"), _("Page Saved."));
-            break;
 
+            // no break, metarefresh exits
         case B_SAVE_AND_QUIT:
             $ppage->attempt_to_save_as_done($text_data);
             leave_proofing_interface(_("Save as 'Done'"));

--- a/tools/setlangcookie.php
+++ b/tools/setlangcookie.php
@@ -3,9 +3,12 @@ $relPath = "../pinc/";
 include_once($relPath."base.inc");
 include_once($relPath."metarefresh.inc");
 
+$lang_options = array_keys(get_locale_translation_selection_options());
+$lang_options[] = '';
+
 // These should always be set if the user got here correctly.
 // They won't be set if someone accesses this URL directly.
-$language = array_get($_POST, 'lang', '');
+$language = get_enumerated_param($_POST, 'lang', '', $lang_options);
 $location = array_get($_POST, 'returnto', "$code_url/default.php");
 
 if ($language) {

--- a/userprefs.php
+++ b/userprefs.php
@@ -65,7 +65,7 @@ if (isset($_POST["swProfile"])) {
 
 //just a way to get them back to someplace on quit button
 if (isset($_POST["quitnc"])) {
-    metarefresh(0, $origin, _("Quit"), "");
+    metarefresh(0, $origin, _("Quit"));
 }
 
 if (array_get($_POST, "insertdb", "") != "") {
@@ -84,7 +84,7 @@ if (array_get($_POST, "insertdb", "") != "") {
 
     if (isset($_POST["saveAndQuit"]) || isset($_POST["mkProfileAndQuit"])) {
         // Quit immediately after saving
-        metarefresh(0, $origin, _("Quit"), "");
+        metarefresh(0, $origin, _("Quit"));
     } elseif (isset($_POST["deletenc"])) {
         // Delete the profile which was displayed on the previous screen.
         // This is slightly cumbersome because the user has to switch to a profile


### PR DESCRIPTION
Last night's php_errors report showed some notices after someone was poking around in `tools/setlangcookie.php`. This addresses a few of them by tightening up param validation and enforcing param types in `metarefresh()`. I vetted the param types of every `metarefresh()` call in the code with this change and cleaned up a few optional parameters on some of the calls while I was there.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/better_param_vetting/