### PR TITLE
Allow selecting existing profile

### DIFF
--- a/userprefs.php
+++ b/userprefs.php
@@ -475,7 +475,7 @@ function echo_proofreading_tab(User $user): void
         foreach ($profiles as $profile) {
             echo "<option value='$profile->id'";
             if ($profile->id == $user->profile->id) {
-                echo " SELECTED disabled";
+                echo " SELECTED";
             }
             echo ">$profile->profilename</option>";
         }


### PR DESCRIPTION
This fixes an edgecase where a user tries to select the current profile but since the field is disabled the submit results in an error. Fixes the error @srjfoo discovered testing https://github.com/DistributedProofreaders/dproofreaders/pull/1293

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-profile-switching-error/