### PR TITLE
Relax get_(integer|float|bool)_param() definitions

### DIFF
--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -257,7 +257,7 @@ function get_enumerated_param(array $arr, string $key, $default, array $choices,
  *
  * @see get_float_param()
  */
-function get_integer_param(array $arr, string $key, ?int $default, ?int $min, ?int $max, bool $allownull = false): ?int
+function get_integer_param(array $arr, string $key, ?int $default = null, ?int $min = null, ?int $max = null, bool $allownull = false): ?int
 {
     return get_numeric_param("integer", $arr, $key, $default, $min, $max, $allownull);
 }
@@ -283,7 +283,7 @@ function get_integer_param(array $arr, string $key, ?int $default, ?int $min, ?i
  *
  * @see get_integer_param()
  */
-function get_float_param(array $arr, string $key, ?float $default, ?float $min, ?float $max, bool $allownull = false): ?float
+function get_float_param(array $arr, string $key, ?float $default = null, ?float $min = null, ?float $max = null, bool $allownull = false): ?float
 {
     return get_numeric_param("float", $arr, $key, $default, $min, $max, $allownull);
 }
@@ -309,7 +309,7 @@ function get_float_param(array $arr, string $key, ?float $default, ?float $min, 
  * @see get_integer_param()
  * @see get_float_param()
  */
-function get_numeric_param(string $type, array $arr, string $key, $default, $min, $max, bool $allownull)
+function get_numeric_param(string $type, array $arr, string $key, $default = null, $min = null, $max = null, bool $allownull = false)
 {
     // sanity checks on the args
     if ($type == 'integer') {
@@ -429,7 +429,7 @@ function get_numeric_param(string $type, array $arr, string $key, $default, $min
  *
  * @throws InvalidArgumentException
  */
-function get_bool_param(array $arr, string $key, ?bool $default, bool $allownull = false): ?bool
+function get_bool_param(array $arr, string $key, ?bool $default = null, bool $allownull = false): ?bool
 {
     if (!is_null($default) && $allownull) {
         throw new InvalidArgumentException("\$allownull = true but \$default is specified");

--- a/tools/project_manager/edit_common.inc
+++ b/tools/project_manager/edit_common.inc
@@ -23,9 +23,11 @@ function text_field($field_value, $field_name, $args = [])
     $required = array_get($args, "required", false);
     $required_attr = $required ? " required" : "";
     $field_type = array_get($args, "type", "text");
+    $min = array_get($args, "min", null);
+    $min_attr = isset($min) ? " min='$min'" : "";
 
     $enc_field_value = attr_safe($field_value);
-    echo "<input type='$field_type' style='width: 30em;' name='$field_name' value='$enc_field_value' $maxlength_attr$required_attr>";
+    echo "<input type='$field_type' style='width: 30em;' name='$field_name' value='$enc_field_value' $maxlength_attr$required_attr$min_attr>";
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -280,7 +280,7 @@ class ProjectInfoHolder
             if ($_POST["postednum"] == "") {
                 $this->project->postednum = null;
             } else {
-                $this->project->postednum = (int)$_POST["postednum"];
+                $this->project->postednum = get_integer_param($_POST, "postednum");
             }
         }
 

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -533,7 +533,7 @@ class ProjectInfoHolder
             $this->row(_("Scanner Credit (deprecated)"), 'text_field', $this->project->scannercredit, 'scannercredit');
         }
         $this->row(_("Clearance Line"), 'text_field', $this->project->clearance, 'clearance');
-        $this->row(_("PG etext number"), 'text_field', $this->project->postednum, 'postednum', '', ["type" => "number"]);
+        $this->row(_("PG etext number"), 'text_field', $this->project->postednum, 'postednum', '', ["type" => "number", "min" => 1]);
         $this->row(_("Project Comments Format"), 'proj_comments_format', $this->project->comment_format);
         $this->row(_("Project Comments"), 'proj_comments_field', $this->project->comments);
 


### PR DESCRIPTION
Sometimes we just want to do basic type validation and return a param of that type. We already accept null values for these, so make them optional. This implements what @jchaffraix suggested in https://github.com/DistributedProofreaders/dproofreaders/pull/1292 -- which is obvious in retrospect but it took me thinking about it post-merge to see it.

Note that this means that `get_{type}_param($array, $key)` must return a value of that type and not null since `$default=null` and `$allownull=false`. This makes sense to me.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/relax-type-getters/