### PR TITLE
Add an explicit Content Security Policy (CSP)

### DIFF
--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -20,9 +20,22 @@ include_once($relPath."bootstrap.inc");
 if (!headers_sent()) {
     header("Content-Type: text/html; charset=UTF-8");
 
-    // Disallow other sites from embedding pages in frames/iframes
-    header("Content-Security-Policy: frame-ancestors 'self'", false);
-    header("X-Frame-Options: SAMEORIGIN");
+    // Set CSP for security
+    $policies = [
+        // default is to just load from self
+        "default-src 'self'",
+        // allow inline styles
+        "style-src 'self' 'unsafe-inline'",
+        // allow inline scripts until we remove them, and cdn.jsdelivr.net
+        // for MathJAX
+        "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net",
+        // allow images from anywhere (due to project comments)
+        "img-src 'self' *",
+        // Disallow other sites from embedding pages in frames/iframes;
+        // unlike other params it does not fallback to default-src
+        "frame-ancestors 'self'",
+    ];
+    header("Content-Security-Policy: " . join("; ", $policies), false);
 }
 
 // If we don't have a database connection, don't try to resume the session.

--- a/tools/authors/add.php
+++ b/tools/authors/add.php
@@ -328,9 +328,6 @@ if (year == "" || year == 0) {
 return true;
 }
 
-function setComments(bd, comments) {
-eval("document.addform."+bd+"comments.value=comments;");
-}
 // -->
 </script>
 <?php
@@ -377,14 +374,7 @@ function echo_date_fields($bd)
 <input type="number" name="<?php echo $bd; ?>year" min="1" style='width: 4em;'<?php echo(_var($bd, 'yearRadio') == '1' ? ' VALUE="'.abs(_var($bd, 'year')).'"' : ''); ?> onFocus="this.form.<?php echo $bd; ?>yearRadio[1].checked=true;">
 <input type="checkbox" name="<?php echo $bd; ?>bc" value="yes"<?php echo(_var($bd, 'bc') ? ' CHECKED' : ''); ?>><?php echo _('B. C.'); ?>
 </td></tr><tr><td><?php echo _('Comments (in<br>English, please)'); ?>:</td><td><input type="text" size="20" maxlength="20" name="<?php echo $bd; ?>comments" value="<?php echo attr_safe(_var($bd, 'comments')); ?>"> 
-<?php echo _('Handy links:').' '; ?>
-<a href="javascript:setComments('<?php echo $bd; ?>', '');" onClick="false">Empty (Unknown)</A> | 
-<a href="javascript:setComments('<?php echo $bd; ?>', '(circa)');" onClick="false">(circa)</A>
 <?php
-    // 'Still alive' only if death-field.
-    if ($bd == 'd') {
-        echo " | <a href=\"javascript:setComments('$bd', 'Still alive');\" onClick=\"false\">Still alive</A>";
-    }
     echo '</td></tr></table>';
 }
 

--- a/tools/authors/manage.php
+++ b/tools/authors/manage.php
@@ -183,12 +183,12 @@ function deleteAuthor(check, author) {
             check.checked = false;
             return;
         }
-        eval("form.new_enabled_author_"+author+".disabled=true;");
+        document.getElementsByName("new_enabled_author_" + author)[0].disabled = true;
         setMoveToAuthorDisabled(form, author, true);
         setAuthorsBiosChecksDisabled(form, author, true);
     }
     else {
-        eval("form.new_enabled_author_"+author+".disabled=false;");
+        document.getElementsByName("new_enabled_author_" + author)[0].disabled = false;
         setMoveToAuthorDisabled(form, author, false);
         setAuthorsBiosChecksDisabled(form, author, false);
     }
@@ -200,8 +200,8 @@ function allAuthorsBiosAreMarkedForMovalOrRemoval(form, author) {
     var authorsBios = bios[author];
     for (var i=0;i<authorsBios.length;i++) {
         var bio = authorsBios[i];
-        if (!(  eval('form.delete_bio_'+bio+'.checked')
-              ||eval('form.move_bio_'+bio+'.checked'))) {
+        if (!document.getElementsByName("delete_bio_" + bio)[0].checked ||
+             document.getElementsByName("move_bio_" + bio)[0].checked) {
             return false;
         }
     }
@@ -214,18 +214,18 @@ function setAuthorsBiosChecksDisabled(form, author, disabled) {
         // simply disable all
         for (var i=0;i<authorsBios.length;i++) {
             var bio = authorsBios[i];
-            eval('form.delete_bio_'+bio+'.disabled=true');
-            eval('form.move_bio_'+bio+'.disabled=true');
+            document.getElementsByName("delete_bio_" + bio)[0].disabled = true;
+            document.getElementsByName("move_bio_" + bio)[0].disabled = true;
         }
     }
     else {
         // only disable the one that's checked
         for (var i=0;i<authorsBios.length;i++) {
             var bio = authorsBios[i];
-            if (eval('form.delete_bio_'+bio+'.checked'))
-                eval('form.delete_bio_'+bio+'.disabled=false');
+            if (document.getElementsByName("delete_bio_" + bio)[0].checked)
+                document.getElementsByName("delete_bio_" + bio)[0].disabled = false;
             else
-                eval('form.move_bio_'+bio+'.disabled=false');
+                document.getElementsByName("move_bio_" + bio)[0].disabled = false;
         }
     }
 }
@@ -262,12 +262,12 @@ function moveToHere(check, author) {
     if (author == 0) {
         check.checked = false;
         if (selectedMoveToHere != 0)
-            eval('form.delete_author_'+selectedMoveToHere+'.disabled=!allAuthorsBiosAreMarkedForMovalOrRemoval(form, selectedMoveToHere)')
+            document.getElementsByName("delete_author_" + selectedMoveToHere)[0].disabled = !allAuthorsBiosAreMarkedForMovalOrRemoval(form, selectedMoveToHere);
         selectedMoveToHere = 0;
         return;
     }
 
-    if (eval('form.delete_author_'+author+'.checked')) {
+    if (document.getElementsByName("delete_author_" + author)[0].checked) {
         // undo, reset
         check.checked = false;
         if (selectedMoveToHere != 0)
@@ -275,9 +275,9 @@ function moveToHere(check, author) {
     }
     else {
         if (selectedMoveToHere != 0)
-            eval('form.delete_author_'+selectedMoveToHere+'.disabled=!allAuthorsBiosAreMarkedForMovalOrRemoval(form, selectedMoveToHere)')
+            document.getElementsByName("delete_author_" + selectedMoveToHere)[0].disabled = !allAuthorsBiosAreMarkedForMovalOrRemoval(form, selectedMoveToHere);
         selectedMoveToHere = getSelectedRadioBox(form.move_to_author).value;
-        eval('form.delete_author_'+author+'.disabled=true')
+        document.getElementsByName("delete_author_" + author)[0].disabled = true;
     }
 }
 
@@ -285,8 +285,8 @@ function moveToHere(check, author) {
 function moveBio(check, author, bio) {
     var form = check.form;
 
-    var deleteChk = eval("form.delete_bio_"+bio);
-    var authorChk = eval("form.delete_author_"+author);
+    var deleteChk = document.getElementsByName("delete_bio_" + bio)[0];
+    var authorChk = document.getElementsByName("delete_author_" + author)[0];
 
     // the two values currently selected for the "delete" and "move"-checkboxes for this bio
     var move = check.checked;
@@ -303,7 +303,7 @@ function moveBio(check, author, bio) {
         }
     }
     else if (!move) {
-        if (!del && eval("form.delete_author_"+author+".checked"))
+        if (!del && document.getElementsByName("delete_author_" + author)[0].checked)
             // author is marked for removal
             // undo -- keep the bio selected for removal
             check.checked = true;
@@ -318,8 +318,8 @@ function moveBio(check, author, bio) {
 function deleteBio(check, author, bio) {
     var form = check.form;
 
-    var moveChk = eval("form.move_bio_"+bio);
-    var authorChk = eval("form.delete_author_"+author);
+    var moveChk = document.getElementsByName("move_bio_" + bio);
+    var authorChk = document.getElementsByName("delete_author_" + author);
 
     // the two values currently selected for the "delete" and "move"-checkboxes for this bio
     var del = check.checked;
@@ -336,7 +336,7 @@ function deleteBio(check, author, bio) {
         }
     }
     else if (!del) {
-        if (!move && eval("form.delete_author_"+author+".checked"))
+        if (!move && document.getElementsByName("delete_author_" + author)[0].checked)
             // author is marked for removal
             // undo -- keep the bio selected for moval
             check.checked = true;

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -267,7 +267,7 @@ try {
             $body = _("Page Saved.");
             slim_header($title);
             echo "<script><!--\n";
-            echo "setTimeout(\"top.proofframe.location.href='$url';\", 1000);\n";
+            echo "setTimeout(function() {top.proofframe.location.href='$url';}, 1000);\n";
             echo "// --></script>\n";
             echo $body;
             break;
@@ -346,6 +346,6 @@ function leave_proofing_interface(string $title): void
     $text = _("You will be returned to the <a href='%s' target='_top'>project page</a> in one second.");
     echo sprintf($text, $safe_url);
     echo "<script><!--\n";
-    echo "setTimeout(\"top.location.href='$raw_url';\", 1000);\n";
+    echo "setTimeout(function() {top.location.href='$raw_url';}, 1000);\n";
     echo "// --></script>\n";
 }

--- a/userprefs.php
+++ b/userprefs.php
@@ -125,10 +125,11 @@ $theme_extra_args["js_data"] =
     // The code checks that a checkbox really exists
     // before accessing it.
     function check_boxes(value) {
-        var f = document.forms[0];
         for (var i = 1; i < arguments.length; i++) {
-            var name = arguments[i];
-            eval('if (f.'+name+') f.'+name+'.checked=value');
+            var elements = document.getElementsByName(arguments[i]);
+            if (elements.length > 0) {
+                elements[0].checked = value;
+            }
         }
     }
 


### PR DESCRIPTION
This adds an explicit [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) beyond preventing other sites from embedding our code in frames/iframes. This isn't a very high bar since we still allow inline JS and CSS but it is a small step in the right direction since we now disallow unsafe-evals.

The new CSP should let everything else work, including:
* the use of MathJAX in Format Preview
* the use of JS to manipulate CSS (used in Format Preview)
* the use of images from anywhere in project comments

The following pages were updated to remove unsafe evals:
* https://www.pgdp.org/~cpeel/c.branch/explicit-csp/tools/authors/manage.php
* https://www.pgdp.org/~cpeel/c.branch/explicit-csp/userprefs.php
* Leaving the proofreading interface

The kicker is going to be finding what other edgecases the new policy doesn't cover. Testing is best done with the developer tools console open.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/explicit-csp/