### PR TITLE
Partial fix for issue #1274, converting exec() to Process()

### DIFF
--- a/SETUP/ci/check_security.php
+++ b/SETUP/ci/check_security.php
@@ -12,8 +12,6 @@ $basedir = $argv[1] ?? "../../";
 //       opting for Symfony Process() instead -- but this ensures that no
 //       others are added from the current set until they get updated.
 $ok_system_calls = [
-    "crontab/CleanUploadsTrash.inc",
-    "locale/translators/index.php",
     "pinc/archiving.inc",
     "pinc/forum_interface_phpbb3.inc",
     "pinc/languages.inc",

--- a/crontab/CleanUploadsTrash.inc
+++ b/crontab/CleanUploadsTrash.inc
@@ -19,38 +19,34 @@ class CleanUploadsTrash extends BackgroundJob
         // remove files from TRASH subdirectory older than 30 days
         $process = new Process([
             "/usr/bin/find",
-            "$trash_dir",
+            $trash_dir,
             "-type", "f",
             "-mtime", "+30",
             "-delete",
         ]);
         $process->run();
-        $output = $process->getOutput();
-        $exitcode = $process->getExitCode();
         if (!$process->isSuccessful()) {
             echo "An error occurred while cleaning up files.\n";
-            echo "Return value: {$exitcode}\n";
+            echo "Return value: {$process->getExitCode()}\n";
             echo "Command output:\n";
-            echo $output;
+            echo $process->getOutput();
             throw new RuntimeException("An error occurred while removing files");
         }
 
         // remove empty directories
         $process = new Process([
             "/usr/bin/find",
-            "$trash_dir",
+            $trash_dir,
             "-type", "d",
             "-empty",
             "-delete",
         ]);
         $process->run();
-        $output = $process->getOutput();
-        $exitcode = $process->getExitCode();
         if (!$process->isSuccessful()) {
             echo "An error occurred while cleaning up files.\n";
-            echo "Return value: {$exitcode}\n";
+            echo "Return value: {$process->getExitCode()}\n";
             echo "Command output:\n";
-            echo $output;
+            echo $process->getOutput();
             throw new RuntimeException("An error occurred while removing empty directories");
         }
     }

--- a/crontab/CleanUploadsTrash.inc
+++ b/crontab/CleanUploadsTrash.inc
@@ -1,4 +1,5 @@
 <?php
+use Symfony\Component\Process\Process;
 
 // Clean the Uploads/TRASH subdirectory.
 class CleanUploadsTrash extends BackgroundJob
@@ -16,42 +17,40 @@ class CleanUploadsTrash extends BackgroundJob
         }
 
         // remove files from TRASH subdirectory older than 30 days
-        $cmd = join(" ", [
+        $process = new Process([
             "/usr/bin/find",
-            escapeshellarg($trash_dir),
-            "-type f",
-            "-mtime +30",
+            "$trash_dir",
+            "-type", "f",
+            "-mtime", "+30",
             "-delete",
         ]);
-        $output = $return = null;
-        exec($cmd, $output, $return);
-        if ($return != 0) {
+        $process->run();
+        $output = $process->getOutput();
+        $exitcode = $process->getExitCode();
+        if (!$process->isSuccessful()) {
             echo "An error occurred while cleaning up files.\n";
-            echo "Return value: $return\n";
+            echo "Return value: {$exitcode}\n";
             echo "Command output:\n";
-            foreach ($output as $line) {
-                echo "    $line\n";
-            }
+            echo $output;
             throw new RuntimeException("An error occurred while removing files");
         }
 
         // remove empty directories
-        $output = $return = null;
-        $cmd = join(" ", [
+        $process = new Process([
             "/usr/bin/find",
-            escapeshellarg($trash_dir),
-            "-type d",
+            "$trash_dir",
+            "-type", "d",
             "-empty",
             "-delete",
         ]);
-        exec($cmd, $output, $return);
-        if ($return != 0) {
+        $process->run();
+        $output = $process->getOutput();
+        $exitcode = $process->getExitCode();
+        if (!$process->isSuccessful()) {
             echo "An error occurred while cleaning up files.\n";
-            echo "Return value: $return\n";
+            echo "Return value: {$exitcode}\n";
             echo "Command output:\n";
-            foreach ($output as $line) {
-                echo "    $line\n";
-            }
+            echo $output;
             throw new RuntimeException("An error occurred while removing empty directories");
         }
     }

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -7,6 +7,8 @@ include_once($relPath.'metarefresh.inc');
 include_once($relPath.'POFile.inc');
 include_once($relPath.'faq.inc');
 
+use Symfony\Component\Process\Process;
+
 require_login();
 
 $translate_url = "$code_url/locale/translators/index.php";
@@ -143,7 +145,12 @@ elseif ($func == "newtranslation2") {
 elseif ($func == "delete") {
     $locale = validate_locale($_REQUEST['locale']);
     assert(is_dir("$dyn_locales_dir/$locale"));
-    exec("rm -r " . escapeshellarg("$dyn_locales_dir/$locale"));
+    $process = new Process([
+        "rm",
+        "-r",
+        "$dyn_locales_dir/$locale",
+    ]);
+    $process->run();
 
     echo "<p>" . sprintf(_("Locale %s deleted."), $locale) . "</p>";
 

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -151,6 +151,9 @@ elseif ($func == "delete") {
         "$dyn_locales_dir/$locale",
     ]);
     $process->run();
+    if (!$process->isSuccessful()) {
+        throw new RuntimeException(sprintf(_("Unable to delete locale %s"), $locale));
+    }
 
     echo "<p>" . sprintf(_("Locale %s deleted."), $locale) . "</p>";
 


### PR DESCRIPTION
I tested in the development VM.
I tested the translators change from the Translation Center page, as an admin, deleted the locale is_IS and verified the files and directories were actually deleted.
I tested the clean uploads trash job with `run_background_job.php CleanUploadsTrash` and verified it deletes TRASH/... files older than 30 days and deletes empty folders.

_Update by cpeel_: Sandbox avail at https://www.pgdp.org/~cpeel/c.branch/process_class/