### PR TITLE
Don't assume we're running under `mod_php`

### DIFF
--- a/crontab/run_background_job.php
+++ b/crontab/run_background_job.php
@@ -10,8 +10,9 @@
 // possible. This lets us detect timeouts and gather other stream-based metadata.
 // To that end we disable deflate plugin for fast-flushing, we want to do this
 // before we send headers so do it before the include.
-if (php_sapi_name() != "cli") {
+if (php_sapi_name() != "cli" && function_exists("apache_setenv")) {
     apache_setenv('no-gzip', '1');
+    apache_setenv('no-brotli', '1');
 }
 
 $relPath = dirname(__FILE__) . "/../pinc/";

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -298,10 +298,13 @@ function do_upload()
     global $pguser, $despecialed_username;
     global $commons_dir;
 
-    // Disable gzip compression so we can flush the buffer after each step
+    // Disable compression so we can flush the buffer after each step
     // in the process to give the user some progress details. Note that this
     // doesn't necessarily work for all browsers.
-    apache_setenv('no-gzip', '1');
+    if (function_exists("apache_setenv")) {
+        apache_setenv('no-gzip', '1');
+        apache_setenv('no-brotli', '1');
+    }
 
     $page_title = "Upload status";
     slim_header($page_title);

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -205,10 +205,13 @@ if (!isset($action)) {
     // make reasonably sure script does not timeout on large file uploads
     set_time_limit(14400);
 
-    // Disable gzip compression so we can flush the buffer after each step
+    // Disable compression so we can flush the buffer after each step
     // in the process to give the user some progress details. Note that this
     // doesn't necessarily work for all browsers.
-    apache_setenv('no-gzip', '1');
+    if (function_exists("apache_setenv")) {
+        apache_setenv('no-gzip', '1');
+        apache_setenv('no-brotli', '1');
+    }
 
     slim_header($title);
     echo "<h1>$title</h1>";


### PR DESCRIPTION
`apache_setenv()` is only available if we're running PHP under `mod_php`. It isn't available if we're using php-fpm. Simply test if the function exists before using it. While we're here, disable brotli compression too.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/conditionalize-apache_setenv/