### PR TITLE
remove scripts from theme.inc (simpified version)

### DIFF
--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -186,16 +186,16 @@ function html_logobar()
         $icon_links[] = [
             "name" => _("Search"),
             "class" => "fas fa-search fa-2x",
-            "onclick" => "showSiteSearch(); return false;",
+            "identifier" => "id='site_search'",
         ];
         $links = [];
         foreach ($icon_links as $data) {
             $name = attr_safe($data["name"]);
             $class = $data["class"];
-            $url = $data["url"] ?? "";
-            $onclick = isset($data["onclick"]) ? "onclick='" . attr_safe($data["onclick"]) . "'" : "";
+            $url = $data["url"] ?? "#";
+            $identifier = $data["identifier"] ?? "";
             $text = "<div class='icon-menu-item'>";
-            $text .= "<a href='$url' aria-label='$name' $onclick>";
+            $text .= "<a href='$url' aria-label='$name' $identifier>";
             $text .= "<i aria-hidden='true' class='$class' title='$name'></i>";
             if ($data["name"] == _("Inbox")) {
                 $numofPMs = get_number_of_unread_messages($user->username);
@@ -203,7 +203,7 @@ function html_logobar()
                     $text .= "<span class='inbox-badge'>$numofPMs</span>";
                 }
             }
-            $text .= "<br><span class='icon-menu-item-name' $onclick>$name</span>";
+            $text .= "<br><span class='icon-menu-item-name'>$name</span>";
             $text .= "</a>";
             $text .= "</div>";
             $links[] = $text;

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -632,19 +632,13 @@ function maybe_show_language_selector()
     $options = get_locale_translation_selection_options();
     if (count($options) <= 1) {
         return;
-    } ?>
-    <script><!--
-        function submitLang(i) {
-            top.document.forms.langform.submit();
-        }
-    // --></script>
-    <?php
+    }
 
     $intlang = get_desired_language();
     echo "<form id='langform' action='$code_url/tools/setlangcookie.php' method='POST'>";
     echo "<div>\n";
     echo "<label for='langform-lang'>" . _("Set language") . ": </label>";
-    echo "<select id='langform-lang' name='lang' onChange='submitLang(this)'>\n";
+    echo "<select id='langform-lang' name='lang'>\n";
     echo "<option value=''>" . _("Browser default") . "</option>";
     foreach ($options as $locale => $label) {
         echo "<option value='$locale'".(($locale == $intlang) ? " selected" : "").">$label</option>\n";

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -218,7 +218,7 @@ function html_logobar()
         echo "<form action='$code_url/tools/site_search.php'>";
         echo "<input id='search-menu-input' type='text' placeholder='$placeholder' name='q' autocapitalize='none'>";
         echo "&nbsp;<a href='$code_url/tools/site_search.php'><i aria-hidden='true' class='fas fa-info-circle fa-lg'></i></a>";
-        echo "&nbsp;<i aria-hidden='true' class='far fa-window-close fa-lg' onclick='hideSiteSearch()'></i>";
+        echo "&nbsp;<i aria-hidden='true' class='far fa-window-close fa-lg' id='hide_site_search'></i>";
         echo "</form>";
         echo "</div>"; // search-menu
     }

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -431,10 +431,9 @@ function headerbar_menu(string $menu_title, array $links, bool $align_right = fa
         $menu_contents_style = "style='right: 0;'";
     }
 
-    $menu_id = 'menu' . md5($menu_title);
     $output = [
-        "<div id='$menu_id' class='menu' $menu_style>",
-        "<div class='menu-selector' onclick='toggleMenu(\"$menu_id\")'>",
+        "<div class='menu' $menu_style>",
+        "<div class='menu-selector'>",
         "<i class='menu-icon fas fa-caret-right'></i>",
         " " . html_safe($menu_title),
         "</div>",

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -192,6 +192,7 @@ function html_logobar()
         foreach ($icon_links as $data) {
             $name = attr_safe($data["name"]);
             $class = $data["class"];
+            // '#' prevents page refresh when selecting 'search'
             $url = $data["url"] ?? "#";
             $identifier = $data["identifier"] ?? "";
             $text = "<div class='icon-menu-item'>";

--- a/scripts/navbar_menu.js
+++ b/scripts/navbar_menu.js
@@ -1,4 +1,4 @@
-/* exported toggleMenu hideSiteSearch */
+/* exported toggleMenu */
 
 // Toggle a menu contents to visible and rotate the menu icon
 function toggleMenu(menuId) {
@@ -55,6 +55,7 @@ window.addEventListener('DOMContentLoaded', function() {
         });
 
         document.getElementById('site_search').addEventListener('click', showSiteSearch);
+        document.getElementById('hide_site_search').addEventListener('click', hideSiteSearch);
 
         document.addEventListener('keydown', (event) => {
             if (event.key === '/' && document.activeElement.tagName == "BODY") {

--- a/scripts/navbar_menu.js
+++ b/scripts/navbar_menu.js
@@ -1,8 +1,5 @@
-/* exported toggleMenu */
-
 // Toggle a menu contents to visible and rotate the menu icon
-function toggleMenu(menuId) {
-    let menu = document.getElementById(menuId);
+function toggleMenu(menu) {
     for (const element of menu.getElementsByClassName('menu-contents')) {
         element.classList.toggle("invisible");
         element.classList.toggle("transparent");
@@ -46,6 +43,13 @@ function hideSiteSearch() {
 }
 
 window.addEventListener('DOMContentLoaded', function() {
+    const menuSelectors = document.getElementsByClassName('menu-selector');
+    for (const menuSelector of menuSelectors) {
+        menuSelector.addEventListener('click', function () {
+            toggleMenu(this.parentElement);
+        });
+    }
+
     // if the page has the search menu, add some listeners for it
     if (document.getElementById('search-menu')) {
         document.getElementById('search-menu').addEventListener('keydown', (event) => {

--- a/scripts/navbar_menu.js
+++ b/scripts/navbar_menu.js
@@ -68,4 +68,12 @@ window.addEventListener('DOMContentLoaded', function() {
             }
         });
     }
+
+    // if the page has a language selector, listen for a change
+    let langSelector = document.getElementById('langform-lang');
+    if (langSelector) {
+        langSelector.addEventListener("change", function() {
+            document.getElementById('langform').submit();
+        });
+    }
 });

--- a/scripts/navbar_menu.js
+++ b/scripts/navbar_menu.js
@@ -1,4 +1,4 @@
-/* exported toggleMenu showSiteSearch hideSiteSearch */
+/* exported toggleMenu hideSiteSearch */
 
 // Toggle a menu contents to visible and rotate the menu icon
 function toggleMenu(menuId) {
@@ -53,6 +53,8 @@ window.addEventListener('DOMContentLoaded', function() {
                 hideSiteSearch();
             }
         });
+
+        document.getElementById('site_search').addEventListener('click', showSiteSearch);
 
         document.addEventListener('keydown', (event) => {
             if (event.key === '/' && document.activeElement.tagName == "BODY") {


### PR DESCRIPTION
Sandbox at: https://www.pgdp.org/~rp31/c.branch/alt_theme_script

There are some considerations regarding the icon links: It was necessary to use the url "#" for the search to prevent the page from refreshing and immediately removing the search box. This apparently does not happen if "onclick" is present. This is mentioned in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#onclick_events. Using an anchor in this way it is possible to right-click and attempt to open the search in a new tab which does not work (same for present version).
As discussed on the mozilla page, ideally a button should be used for this purpose. I tried this earlier but it presents a different appearance which could probably be fixed by styling. I also tried (in the earlier PR) using a 'div'. This does not change the appearance but behaves slightly differently: it is not tabbable (unless it is given a tab_order) and if selected (by tabbing) does not actuate on pressing 'enter' (possibly also fixable by adding an event listener).
It then seemed best for this PR just to remove embedded scripts and leave the rest unchanged.
It would also be possible in future to re-arrange the icon link code to use classes which could make it clearer and make it easier to revise how search option works.