### PR TITLE
Resolve duplicate -- and different -- `make_link()` functions

### DIFF
--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -117,11 +117,11 @@ class Column
                     $switch_sort = ['sec_sort' => $sort_column_id];
                 } else {
                     $sec_sort_array = ['sec_sort' => $this->id, 'results_offset' => 0];
-                    $sec_sorter = "&nbsp;" . make_link($sec_sort_array, "^", "#head");
+                    $sec_sorter = "&nbsp;" . make_search_page_link($sec_sort_array, "^", "#head");
                 }
             }
             $pri_sort_array = array_merge(['sort' => "$this->id$dir_code", 'results_offset' => 0], $switch_sort);
-            $label = make_link($pri_sort_array, $label, "#head") . "$marker$sec_sorter";
+            $label = make_search_page_link($pri_sort_array, $label, "#head") . "$marker$sec_sorter";
         }
         echo "<th class='$this->css_class' title='", attr_safe($this->get_tooltip()), "'>$label</th>\n";
     }
@@ -521,7 +521,7 @@ class ProjectSearchResults
     {
         if ($results_offset > 0) {
             $prev_offset = max(0, $results_offset - $this->page_size);
-            echo make_link(['results_offset' => $prev_offset], _('Previous'), "#head") . " | ";
+            echo make_search_page_link(['results_offset' => $prev_offset], _('Previous'), "#head") . " | ";
         }
         echo sprintf(
             // TRANSLATORS: these are paging results: eg: "Projects 1 to 100 of 495"
@@ -534,7 +534,7 @@ class ProjectSearchResults
 
         if ($results_offset + $numrows < $num_found_rows) {
             $next_offset = $results_offset + $this->page_size;
-            echo " | " . make_link(['results_offset' => $next_offset], _('Next'), "#head");
+            echo " | " . make_search_page_link(['results_offset' => $next_offset], _('Next'), "#head");
         }
     }
 
@@ -717,23 +717,23 @@ function get_search_configure_link()
     return "<a href='?show=config&amp;origin=$origin'>" . _("Configure Result") . "</a>";
 }
 
-function make_url($new_array, $anchor = '')
+function make_search_page_url(array $new_array, string $anchor = ''): string
 {
     return "?" . http_build_query(array_replace($_GET, $new_array)) . "$anchor";
 }
 
-function make_link($new_array, $text, $anchor = '')
+function make_search_page_link(array $new_array, string $text, string $anchor = ''): string
 {
-    $url = make_url($new_array, $anchor);
+    $url = make_search_page_url($new_array, $anchor);
     return "<a href='" . attr_safe($url) . "'>$text</a>";
 }
 
-function get_refine_search_url()
+function get_refine_search_url(): string
 {
-    return make_url(['show' => 'search_form']);
+    return make_search_page_url(['show' => 'search_form']);
 }
 
-function get_refine_search_link($label = null)
+function get_refine_search_link($label = null): string
 {
     if (!$label) {
         $label = _("Refine Search");

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -717,11 +717,13 @@ function get_search_configure_link()
     return "<a href='?show=config&amp;origin=$origin'>" . _("Configure Result") . "</a>";
 }
 
+/** @param array<string, mixed> $new_array */
 function make_search_page_url(array $new_array, string $anchor = ''): string
 {
     return "?" . http_build_query(array_replace($_GET, $new_array)) . "$anchor";
 }
 
+/** @param array<string, mixed> $new_array */
 function make_search_page_link(array $new_array, string $text, string $anchor = ''): string
 {
     $url = make_search_page_url($new_array, $anchor);

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -221,7 +221,7 @@ class ImageSource
         if ($this->url == "") {
             echo "<span class='error'>" . _("Missing URL") . "</span>";
         } else {
-            echo make_link($this->url, $this->url);
+            echo "<a href='" . attr_safe($this->url) . "'>" . html_safe($this->url) . "</a>";
         }
         echo "</td>";
 
@@ -577,16 +577,6 @@ class ImageSource
 }
 
 // ----------------------------------------------------------------------------
-
-function make_link($url, $label)
-{
-    $start = substr($url, 0, 3);
-    if ($start == 'htt') {
-        return "<a href='$url'>$label</a>";
-    } else {
-        return "<a href='http://$url'>$label</a>";
-    }
-}
 
 function show_is_toolbar($action)
 {

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -224,10 +224,10 @@ class SpecialDay
         echo "</tr>\n";
 
         echo "<tr class='$row_class'>";
-        echo "<th class='right'>" . _("Info URL") . ":</th><td colspan='7'>" . make_link($this->info_url, $this->info_url) . "</td>";
+        echo "<th class='right'>" . _("Info URL") . ":</th><td colspan='7'><a href='". attr_safe($this->info_url) . "'>" . html_safe($this->info_url) . "</a></td>";
         echo "</tr>";
         echo "<tr class='$row_class'>";
-        echo "<th class='right'>" . _("Image URL") . ":</th><td colspan='7'>" . make_link($this->image_url, $this->image_url) . "</td>";
+        echo "<th class='right'>" . _("Image URL") . ":</th><td colspan='7'><a href='". attr_safe($this->image_url) . "'>" . html_safe($this->image_url) . "</a></td>";
         echo "</tr>\n";
 
         if ($this->date_changes) {
@@ -407,19 +407,6 @@ class SpecialDay
 }
 
 // ----------------------------------------------------------------------------
-
-function make_link(string $url, string $label): string
-{
-    if (!$url) {
-        return '';
-    }
-    $start = substr($url, 0, 3);
-    $label = html_safe($label);
-    if ($start != 'htt') {
-        $url = "http://" . $url;
-    }
-    return "<a href='". attr_safe($url). "'>$label</a>";
-}
 
 function show_sd_toolbar(string $action): void
 {


### PR DESCRIPTION
We have 3 `make_link()` functions in the codebase, one each in:
* `ProjectSearchResults.inc`
* `manage_special_days.php`
* `manage_image_sources.php`

For the last two scripts, one of them was very likely created as a copy of the other in the distant past.

Recently type definitions were added for the one in `manage_special_days.php` and for some users phpstan is getting confused with having duplicate names that accept different types. Even though these functions are never defined concurrently in a single page scope, phpstan doesn't know this and having duplicate function names (without namespaces) is a bad practice anyway.

This:
1. removes the two functions in the `manage_*.php` functions as they really aren't needed.
2. renames some functions in `ProjectSearchResults.inc` to be less generic since they are specific to search results.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/remove_dup_make_links/