### PR TITLE
Add style checks & JS linting to Makefile

### DIFF
--- a/SETUP/ci/Makefile
+++ b/SETUP/ci/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all less security_checks best_practice_checks static_checks lint_charsuites lint_css lint_code lint less tests shellcheck
+.PHONY: all less security_checks best_practice_checks static_checks code_style lint_charsuites lint_css lint_code lint less tests shellcheck
 
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-all: security_checks best_practice_checks lint static_checks
+all: security_checks best_practice_checks lint static_checks code_style
 
 #----------------------------------------------------------------------------
 # Security checks
@@ -19,6 +19,12 @@ best_practice_checks:
 # Static code checks
 static_checks:
 	cd $(SELF_DIR)../../ && ./vendor/bin/phpstan --memory-limit=512M
+
+#----------------------------------------------------------------------------
+# Code style checks
+code_style:
+	cd $(SELF_DIR)../../ && ./vendor/bin/php-cs-fixer check
+	cd $(SELF_DIR)../../ && npm run format-check
 
 #----------------------------------------------------------------------------
 # File linting

--- a/SETUP/ci/Makefile
+++ b/SETUP/ci/Makefile
@@ -2,7 +2,7 @@
 
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-all: security_checks best_practice_checks lint static_checks code_style
+all: lint code_style static_checks security_checks best_practice_checks
 
 #----------------------------------------------------------------------------
 # Security checks
@@ -38,7 +38,7 @@ lint_code:
 	$(SELF_DIR)lint_php_files.sh
 	$(SELF_DIR)lint_json_files.sh
 
-lint: lint_charsuites lint_css lint_code
+lint: lint_code lint_css lint_charsuites
 
 #----------------------------------------------------------------------------
 # CSS compilation

--- a/SETUP/ci/Makefile
+++ b/SETUP/ci/Makefile
@@ -37,6 +37,7 @@ lint_css:
 lint_code:
 	$(SELF_DIR)lint_php_files.sh
 	$(SELF_DIR)lint_json_files.sh
+	cd $(SELF_DIR)../../ && npm run lint
 
 lint: lint_code lint_css lint_charsuites
 

--- a/SETUP/ci/check_includes.php
+++ b/SETUP/ci/check_includes.php
@@ -59,6 +59,7 @@ $ok_includes_site_structure = [
     "api/index.php",
 ];
 
+echo "Checking files for include() best practices...\n";
 
 $basedir .= endswith($basedir, "/") ? "" : "/";
 $files = get_all_php_files($basedir);
@@ -88,34 +89,37 @@ foreach ($files as $file) {
         continue;
     }
 
-    echo "$file\n";
+    echo ".";
+    flush();
 
     // All .php files should include base.inc, but no .inc file should
     if (file_includes_base("$basedir/$file")) {
         if (endswith($file, ".inc")) {
-            abort(".inc files should not include base.inc");
+            abort($file, ".inc files should not include base.inc");
         }
     } elseif (in_array($file, $ok_not_includes_base)) {
         // it's in our exception list
     } elseif (endswith($file, ".php")) {
-        abort("file does not include base.inc");
+        abort($file, "file does not include base.inc");
     }
 
     // No file should include site_vars.php
     if (file_includes_site_vars("$basedir/$file") && !in_array($file, $ok_includes_site_vars)) {
-        abort("no file should include site_vars.php");
+        abort($file, "no file should include site_vars.php");
     }
 
     // No file should include misc.inc
     if (file_includes_misc("$basedir/$file") && !in_array($file, $ok_includes_misc)) {
-        abort("no file should include misc.inc");
+        abort($file, "no file should include misc.inc");
     }
 
     // No file should include site structure code
     if (file_includes_site_structure("$basedir/$file") && !in_array($file, $ok_includes_site_structure)) {
-        abort("no file should include site structure code (" . join(", ", $site_structure_includes) . ")");
+        abort($file, "no file should include site structure code (" . join(", ", $site_structure_includes) . ")");
     }
 }
+
+echo "\nAll files follow include() best practices.\n";
 
 function get_all_php_files($basedir)
 {
@@ -168,8 +172,9 @@ function file_includes_site_structure($filename)
     return false;
 }
 
-function abort($message)
+function abort(string $file, string $message)
 {
+    echo "\n$file\n";
     echo "    ERROR: $message\n";
     exit(1);
 }

--- a/SETUP/ci/check_require_login.php
+++ b/SETUP/ci/check_require_login.php
@@ -67,6 +67,8 @@ $ok_files = [
     ".php-cs-fixer.dist.php",
 ];
 
+echo "Checking PHP files for proper login requirements...\n";
+
 $basedir .= endswith($basedir, "/") ? "" : "/";
 $files = get_all_php_files($basedir);
 foreach ($files as $file) {
@@ -90,7 +92,8 @@ foreach ($files as $file) {
         continue;
     }
 
-    echo "$file\n";
+    echo ".";
+    flush();
 
     // If it requires authentication, skip it
     if (file_requires_auth("../../$file")) {
@@ -102,9 +105,12 @@ foreach ($files as $file) {
         continue;
     }
 
-    echo "ERROR: file does not require authentication and is not on the known-good list\n";
+    echo "\n$file\n";
+    echo "    ERROR: file does not require authentication and is not on the known-good list\n";
     exit(1);
 }
+
+echo "\nNo login requirement issues found.\n";
 
 function get_all_php_files($basedir)
 {

--- a/SETUP/ci/check_security.php
+++ b/SETUP/ci/check_security.php
@@ -38,6 +38,8 @@ $skip_file_prefixes = [
     "node_modules/",
 ];
 
+echo "Checking PHP files for security issues...\n";
+
 $basedir .= endswith($basedir, "/") ? "" : "/";
 $files = get_all_php_files($basedir);
 foreach ($files as $file) {
@@ -47,19 +49,22 @@ foreach ($files as $file) {
         }
     }
 
-    echo "$file\n";
+    echo ".";
+    flush();
 
     // No file should include mysqli_error()
     if (file_includes_mysqli_error("$basedir/$file") && !in_array($file, $ok_mysqli_error_calls)) {
-        abort("file includes mysqli_error()");
+        abort($file, "file includes mysqli_error()");
     }
 
     // No file should include a system call (use Symfony Process instead)
     if (file_includes_system_call("$basedir/$file") && !in_array($file, $ok_system_calls)) {
-        abort("file includes system(), exec(), passthru(), shell_exec(), or escapeshellcmd()");
+        abort($file, "file includes system(), exec(), passthru(), shell_exec(), or escapeshellcmd()");
     }
 
 }
+
+echo "\nNo security issues found.\n";
 
 /** @return string[] */
 function get_all_php_files(string $basedir): array
@@ -101,8 +106,9 @@ function file_includes_system_call(string $filename): bool
 
 /** @return never */
 // TODO: Add never as a return value once we switch to PHP 8.1.
-function abort(string $message)
+function abort(string $file, string $message)
 {
+    echo "\n$file\n";
     echo "    ERROR: $message\n";
     exit(1);
 }

--- a/SETUP/ci/lint_json_files.sh
+++ b/SETUP/ci/lint_json_files.sh
@@ -17,8 +17,9 @@ echo "Checking all .json files under $BASE_DIR excluding node_modules/ and vendo
 function lint_json()
 {
     local file=$1
-    echo "$file"
+    echo -n .
     if ! OUT=$(php -r "exit(json_decode(file_get_contents('$file')) === NULL);" 2>&1) || [ "$OUT" = 1 ]; then
+        echo
         echo "ERROR: JSON lint failure in $file"
         exit 1
     fi
@@ -34,3 +35,6 @@ done
 
 # Wait for all jobs to finish
 wait
+
+echo
+echo "No JSON linting errors found."

--- a/SETUP/ci/lint_php_files.sh
+++ b/SETUP/ci/lint_php_files.sh
@@ -15,9 +15,10 @@ fi
 function lint_file()
 {
     local file=$1
-    echo "$file"
-    OUTPUT=$(php -l "$file")
+    echo -n .
+    OUTPUT=$(php -l "$file" 2> /dev/null || true)
     if ! echo "$OUTPUT" | grep -q 'No syntax errors detected'; then
+        echo 
         echo "ERROR: PHP lint failure in $file"
         echo "$OUTPUT"
         exit 1
@@ -25,6 +26,7 @@ function lint_file()
 
     OUTPUT=$(file "$file")
     if ! echo "$OUTPUT" | grep -Eq 'ASCII|UTF-8'; then
+        echo
         echo "ERROR: Unexpected encoding in $file"
         echo "$OUTPUT"
         exit 1
@@ -42,3 +44,6 @@ done
 
 # Wait for all jobs to finish
 wait
+
+echo
+echo "No PHP linting errors found."


### PR DESCRIPTION
This adds PHP and JS style checks and JS linting to the Makefile for devs to easily run them locally. I've updated the check scripts to be less verbose while still reporting progress as they go. The CI does not use the Makefile directly but it does use the `SETUP/ci/*` scripts.