### PR TITLE
use old german dictionary if possible

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -295,6 +295,8 @@ class BadWordAccumulator
 
 function get_dictionary_for_langcode(string $langcode): ?string
 {
+    global $aspell_prefix;
+
     $dict_file = "$aspell_prefix/lib/aspell/$langcode.multi";
     return is_file($dict_file) ? $dict_file : null;
 }

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -293,6 +293,12 @@ class BadWordAccumulator
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // World-Level
 
+function get_dictionary_for_langcode(string $langcode): ?string
+{
+    $dict_file = "$aspell_prefix/lib/aspell/$langcode.multi";
+    return is_file($dict_file) ? $dict_file : null;
+}
+
 /**
  * Returns a list of 'bad' words on a page
  *
@@ -320,9 +326,15 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
     $misspellings = [];
     foreach ($languages as $language) {
         $langcode = langcode2_for_langname($language);
+        $dict_file = null;
         if ($langcode) {
-            $dict_file = "$aspell_prefix/lib/aspell/$langcode.multi";
-            if (is_file($dict_file)) {
+            if ("de" === $langcode) {
+                $dict_file = get_dictionary_for_langcode("de_DE-1901");
+            }
+            if (!$dict_file) {
+                $dict_file = get_dictionary_for_langcode($langcode);
+            }
+            if ($dict_file) {
                 // run aspell using this language
 
                 $process = new Process([


### PR DESCRIPTION
This addresses [task 573](https://www.pgdp.net/c/tasks.php?action=show&task_id=573)
This is a hack for this special case. Looking at the list of .multi files in /usr/lib/aspell there are many variants which could be useful. It would require more extensive code changes to allow for more general selection of options.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/lang_var
It can be tested by using some old and new german spellings with wordcheck. e.g. 'daß dass'.