### PR TITLE
Add horiz ellipsis to smart punctuation list

### DIFF
--- a/tools/proofers/text_data_processor.js
+++ b/tools/proofers/text_data_processor.js
@@ -4,7 +4,8 @@ window.addEventListener('DOMContentLoaded', function() {
         '“': '"',
         '’': '\'',
         '”': '"',
-        '—': '--'
+        '—': '--',
+        '…': '...'
     };
 
     document.getElementById('text_data').addEventListener('input', (event) => {


### PR DESCRIPTION
Smart punctuation list in the characteMap should include horizontal ellipsis. First noticed in the quizzes, and not discovered before, because by the time new proofers using iPads got that far, they'd switched off smart punctuation, until recently.

If anyone can think of anything that might be considered part of that set of characters that Apple considers to be "Smart punctuation", I'm happy to add it, but the only one I could think of offhand that might affect us is the en-dash (slightly shorter than the em-dash, and commonly used for ranges in numbers and dates). I checked on my iPad, and fortunately that doesn't seem to be happening.

Sandbox available [https://www.pgdp.org/~srjfoo/c.branch/fix-ellipsis/](https://www.pgdp.org/~srjfoo/c.branch/fix-ellipsis/). Should work in both PIs and [quizzes](https://www.pgdp.org/~srjfoo/c.branch/fix-ellipsis/quiz/start.php)