### PR TITLE
Allow mentors to checkout / return pages in bulk

### DIFF
--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -137,7 +137,7 @@ foreach ($projects_available as $proj_obj) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function output_project_label($nameofwork, $authorsname, $date = null)
+function output_project_label(string $nameofwork, string $authorsname, ?int $date = null)
 {
     // TRANSLATORS: format is <title> by <author>.
     echo sprintf(_("%1\$s by %2\$s"), $nameofwork, $authorsname);
@@ -151,7 +151,7 @@ function output_project_label($nameofwork, $authorsname, $date = null)
  * For each mentorable project (in this round), show a summary (one line per mentee)
  * and then a listing (one line per page).
  */
-function output_project_details($mentoring_round, $mentored_round, $projectid, $nameofwork, $authorsname)
+function output_project_details(Round $mentoring_round, Round $mentored_round, string $projectid, string $nameofwork, string $authorsname)
 {
     global $code_url;
 


### PR DESCRIPTION
This allows mentors to checkout and return pages for a single proofreader in bulk. This implements the longstanding [Task 1221](https://www.pgdp.net/c/tasks.php?action=show&task_id=1221) and the UX was reviewed by two mentors (and perhaps others who did not return feedback).

This PR removes the requirement of the `LPage` caller to include the page's state and makes it optional instead. If a page state isn't passed in the constructor will look it up.

https://www.pgdp.org/~cpeel/c.branch/mentor-multi-checkout/