### PR TITLE
Some style cleanups

### DIFF
--- a/styles/page_interfaces.less
+++ b/styles/page_interfaces.less
@@ -2,10 +2,13 @@
 /* Page Interface Structures */
 
 /*
- * The following classes all relate to various page interfaces, such as the
- * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
- * toolbox, code point validator, display image interface, etc.
+ * The following variables and classes all relate to various page
+ * interfaces, such as the proofreading interfaces (standard and
+ * enhanced), WordCheck, the proofreading toolbox, code point
+ * validator, display image interface, etc.
  */
+
+/* variables */
 
 /* Base layer for page interface */
 @page-interface-background: #CDCDC1;
@@ -24,6 +27,16 @@
 @page-interface-link-color: #0000ff;
 @page-interface-visited-color: #990099;
 @page-interface-active-color: #ff0000;
+
+/* WordCheck*/
+@preWC: #c2c2c2;
+@noWC: #ffb321;
+@WC: #97fc9e;
+
+/* Other colors */
+@pi-text-link-disabled: #666666;
+
+/* Classes*/
 
 .page-interface {
     background-color: @page-interface-background;
@@ -153,10 +166,10 @@
         .page-interface;
     }
     #tdbottom {
-        background-color: #EEDFCC;
-	.text-link-disabled {
-	    color: #666666;  // will need to be themed
-	}
+        background-color: @control-pane-background;
+        .text-link-disabled {
+            color: @pi-text-link-disabled;
+        }
     }
     #text_data, #text_data:focus {
         padding: 2px;
@@ -247,14 +260,14 @@
 }
 
 .preWC {
-    background-color: #c2c2c2;
+    background-color: @preWC;
 }
 .noWC {
-    background-color: #ffb321;
+    background-color: @noWC;
     .bold;
 }
 .WC {
-    background-color: #97fc9e;
+    background-color: @WC;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -156,14 +156,19 @@
 /* ======================================================================== */
 /* Page Interface Structures */
 /*
- * The following classes all relate to various page interfaces, such as the
- * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
- * toolbox, code point validator, display image interface, etc.
+ * The following variables and classes all relate to various page
+ * interfaces, such as the proofreading interfaces (standard and
+ * enhanced), WordCheck, the proofreading toolbox, code point
+ * validator, display image interface, etc.
  */
+/* variables */
 /* Base layer for page interface */
 /* Text pane */
 /* Control panes */
 /* Links */
+/* WordCheck*/
+/* Other colors */
+/* Classes*/
 .page-interface {
   background-color: #CDCDC1;
   color: black;
@@ -437,7 +442,7 @@
   background-color: Bisque;
 }
 #enhanced_interface #tdbottom {
-  background-color: #EEDFCC;
+  background-color: #CDC0B0;
 }
 #enhanced_interface #tdbottom .text-link-disabled {
   color: #666666;
@@ -599,14 +604,14 @@
   color: red;
 }
 .preWC {
-  background-color: #c2c2c2;
+  background-color: #666666;
 }
 .noWC {
-  background-color: #ffb321;
+  background-color: #996300;
   font-weight: bold;
 }
 .WC {
-  background-color: #97fc9e;
+  background-color: #036309;
 }
 /* ------------------------------------------------------------------------ */
 /* Format Preview */
@@ -3080,7 +3085,8 @@ textarea {
  * (medium contrast with @page-text) is the darker colored odd
  * cell color. In theme-charcoal, @table-cell-base-mediumc is
  * actually lighter than @page-background, so the two have to
- * be flipped */
+ * be flipped.
+ */
 table.striped tr:nth-child(odd) td {
   background-color: #262626;
 }
@@ -3089,7 +3095,8 @@ table.striped tr:nth-child(even) td {
 }
 /*--------------------------------------------------------*/
 /* Diff styling */
-/* Override default MediaWiki styling */
+/* Override default MediaWiki styling
+ */
 .diff-context {
   color: #e2e2e2;
   background-color: #3a3a3a;
@@ -3103,3 +3110,11 @@ table.striped tr:nth-child(even) td {
   color: black;
   opacity: 70%;
 }
+/*--------------------------------------------------------*/
+/* The defaults for the following are in page_interfaces.less
+ * Eventually, once it's time to sort out the dark themed
+ * PI, that stuff will go in here, too, and I'll change this
+ * comment block, but for now, the main thing is to provide
+ * a dark theme background for WC management for PMs.
+ */
+/* WordCheck */

--- a/styles/themes/charcoal.less
+++ b/styles/themes/charcoal.less
@@ -224,7 +224,8 @@ textarea {
  * (medium contrast with @page-text) is the darker colored odd
  * cell color. In theme-charcoal, @table-cell-base-mediumc is
  * actually lighter than @page-background, so the two have to
- * be flipped */
+ * be flipped.
+ */
 
 table.striped {
     tr:nth-child(odd) {
@@ -241,7 +242,8 @@ table.striped {
 
 /*--------------------------------------------------------*/
 /* Diff styling */
-/* Override default MediaWiki styling */
+/* Override default MediaWiki styling
+ */
 
 .diff-context {
     color: @page-text;
@@ -255,3 +257,16 @@ table.striped {
         opacity: 70%;
     }
 }
+
+/*--------------------------------------------------------*/
+/* The defaults for the following are in page_interfaces.less
+ * Eventually, once it's time to sort out the dark themed
+ * PI, that stuff will go in here, too, and I'll change this
+ * comment block, but for now, the main thing is to provide
+ * a dark theme background for WC management for PMs.
+ */
+ 
+/* WordCheck */
+@preWC: #666666;
+@noWC: #996300;
+@WC: #036309;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -156,14 +156,19 @@
 /* ======================================================================== */
 /* Page Interface Structures */
 /*
- * The following classes all relate to various page interfaces, such as the
- * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
- * toolbox, code point validator, display image interface, etc.
+ * The following variables and classes all relate to various page
+ * interfaces, such as the proofreading interfaces (standard and
+ * enhanced), WordCheck, the proofreading toolbox, code point
+ * validator, display image interface, etc.
  */
+/* variables */
 /* Base layer for page interface */
 /* Text pane */
 /* Control panes */
 /* Links */
+/* WordCheck*/
+/* Other colors */
+/* Classes*/
 .page-interface {
   background-color: #CDCDC1;
   color: black;
@@ -437,7 +442,7 @@
   background-color: Bisque;
 }
 #enhanced_interface #tdbottom {
-  background-color: #EEDFCC;
+  background-color: #CDC0B0;
 }
 #enhanced_interface #tdbottom .text-link-disabled {
   color: #666666;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -156,14 +156,19 @@
 /* ======================================================================== */
 /* Page Interface Structures */
 /*
- * The following classes all relate to various page interfaces, such as the
- * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
- * toolbox, code point validator, display image interface, etc.
+ * The following variables and classes all relate to various page
+ * interfaces, such as the proofreading interfaces (standard and
+ * enhanced), WordCheck, the proofreading toolbox, code point
+ * validator, display image interface, etc.
  */
+/* variables */
 /* Base layer for page interface */
 /* Text pane */
 /* Control panes */
 /* Links */
+/* WordCheck*/
+/* Other colors */
+/* Classes*/
 .page-interface {
   background-color: #CDCDC1;
   color: black;
@@ -437,7 +442,7 @@
   background-color: Bisque;
 }
 #enhanced_interface #tdbottom {
-  background-color: #EEDFCC;
+  background-color: #CDC0B0;
 }
 #enhanced_interface #tdbottom .text-link-disabled {
   color: #666666;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -156,14 +156,19 @@
 /* ======================================================================== */
 /* Page Interface Structures */
 /*
- * The following classes all relate to various page interfaces, such as the
- * proofreading interfaces (standard and enhanced), WordCheck, the proofreading
- * toolbox, code point validator, display image interface, etc.
+ * The following variables and classes all relate to various page
+ * interfaces, such as the proofreading interfaces (standard and
+ * enhanced), WordCheck, the proofreading toolbox, code point
+ * validator, display image interface, etc.
  */
+/* variables */
 /* Base layer for page interface */
 /* Text pane */
 /* Control panes */
 /* Links */
+/* WordCheck*/
+/* Other colors */
+/* Classes*/
 .page-interface {
   background-color: #CDCDC1;
   color: black;
@@ -437,7 +442,7 @@
   background-color: Bisque;
 }
 #enhanced_interface #tdbottom {
-  background-color: #EEDFCC;
+  background-color: #CDC0B0;
 }
 #enhanced_interface #tdbottom .text-link-disabled {
   color: #666666;


### PR DESCRIPTION
Found when investigating what it would take to do a dark themed version of the proofreading interfaces for the Charcoal theme:

* Update PM WC management colors for charcoal
* Make tdbottom background color same as tdtop for Enhanced interface.

Sandbox: [misc-style-fixes](https://www.pgdp.org/~srjfoo/c.branch/misc-style-fixes/)