### PR TITLE
Type most *Exception::_construct

### DIFF
--- a/api/exceptions.inc
+++ b/api/exceptions.inc
@@ -7,7 +7,7 @@
  */
 class ApiException extends Exception
 {
-    public function __construct($message = "API exception", $code = 1)
+    public function __construct(string $message = "API exception", int $code = 1)
     {
         parent::__construct($message, $code);
     }
@@ -23,7 +23,7 @@ class ApiException extends Exception
 
 class BadRequest extends ApiException
 {
-    public function __construct($message = "Bad request", $code = 2)
+    public function __construct(string $message = "Bad request", int $code = 2)
     {
         parent::__construct($message, $code);
     }
@@ -31,7 +31,7 @@ class BadRequest extends ApiException
 
 class UnauthorizedError extends ApiException
 {
-    public function __construct($message = "Unauthorized", $code = 3)
+    public function __construct(string $message = "Unauthorized", int $code = 3)
     {
         parent::__construct($message, $code);
     }
@@ -44,7 +44,7 @@ class UnauthorizedError extends ApiException
 
 class NotFoundError extends ApiException
 {
-    public function __construct($message = "Object not found", $code = 4)
+    public function __construct(string $message = "Object not found", int $code = 4)
     {
         parent::__construct($message, $code);
     }
@@ -57,7 +57,7 @@ class NotFoundError extends ApiException
 
 class RateLimitExceeded extends ApiException
 {
-    public function __construct($message = "Rate limit exceeded", $code = 5)
+    public function __construct(string $message = "Rate limit exceeded", int $code = 5)
     {
         parent::__construct($message, $code);
     }
@@ -70,7 +70,7 @@ class RateLimitExceeded extends ApiException
 
 class InvalidValue extends ApiException
 {
-    public function __construct($message = "Request contained an invalid value for a parameter", $code = 6)
+    public function __construct(string $message = "Request contained an invalid value for a parameter", int $code = 6)
     {
         parent::__construct($message, $code);
     }
@@ -83,7 +83,7 @@ class InvalidValue extends ApiException
 
 class ForbiddenError extends ApiException
 {
-    public function __construct($message = "Forbidden", $code = 7)
+    public function __construct(string $message = "Forbidden", int $code = 7)
     {
         parent::__construct($message, $code);
     }
@@ -100,7 +100,7 @@ class ForbiddenError extends ApiException
 
 class UnexpectedError extends ApiException
 {
-    public function __construct($message = "Unexpected error", $code = 7)
+    public function __construct(string $message = "Unexpected error", int $code = 7)
     {
         parent::__construct($message, $code);
     }
@@ -108,7 +108,7 @@ class UnexpectedError extends ApiException
 
 class InvalidAPI extends ApiException
 {
-    public function __construct($message = "Invalid API path", $code = 8)
+    public function __construct(string $message = "Invalid API path", int $code = 8)
     {
         parent::__construct($message, $code);
     }
@@ -121,7 +121,7 @@ class InvalidAPI extends ApiException
 
 class MethodNotAllowed extends ApiException
 {
-    public function __construct($message = "API endpoint doesn't support this method", $code = 9)
+    public function __construct(string $message = "API endpoint doesn't support this method", int $code = 9)
     {
         parent::__construct($message, $code);
     }
@@ -134,7 +134,7 @@ class MethodNotAllowed extends ApiException
 
 class NotImplementedError extends ApiException
 {
-    public function __construct($message = "API not implemented", $code = 10)
+    public function __construct(string $message = "API not implemented", int $code = 10)
     {
         parent::__construct($message, $code);
     }
@@ -142,7 +142,7 @@ class NotImplementedError extends ApiException
 
 class ServerError extends ApiException
 {
-    public function __construct($message = "An unhandled error happened on the server", $code = 11)
+    public function __construct(string $message = "An unhandled error happened on the server", int $code = 11)
     {
         parent::__construct($message, $code);
     }

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -21,77 +21,77 @@ class UTF8ConversionException extends Exception
  */
 class ProjectException extends Exception
 {
-    public function __construct($message, $code = 100)
+    public function __construct(string $message, int $code = 100)
     {
         parent::__construct($message, $code);
     }
 }
 class NonexistentProjectException extends ProjectException
 {
-    public function __construct($message, $code = 101)
+    public function __construct(string $message, int $code = 101)
     {
         parent::__construct($message, $code);
     }
 }
 class InvalidProjectIDException extends ProjectException
 {
-    public function __construct($message, $code = 102)
+    public function __construct(string $message, int $code = 102)
     {
         parent::__construct($message, $code);
     }
 }
 class InvalidRoundException extends ProjectException
 {
-    public function __construct($message, $code = 103)
+    public function __construct(string $message, int $code = 103)
     {
         parent::__construct($message, $code);
     }
 }
 class NonexistentPageException extends ProjectException
 {
-    public function __construct($message, $code = 104)
+    public function __construct(string $message, int $code = 104)
     {
         parent::__construct($message, $code);
     }
 }
 class InvalidPageRoundException extends ProjectException
 {
-    public function __construct($message, $code = 105)
+    public function __construct(string $message, int $code = 105)
     {
         parent::__construct($message, $code);
     }
 }
 class InvalidPageException extends ProjectException
 {
-    public function __construct($message, $code = 106)
+    public function __construct(string $message, int $code = 106)
     {
         parent::__construct($message, $code);
     }
 }
 class NoProjectPageTable extends ProjectException
 {
-    public function __construct($message, $code = 107)
+    public function __construct(string $message, int $code = 107)
     {
         parent::__construct($message, $code);
     }
 }
 class NoProjectDirectory extends ProjectException
 {
-    public function __construct($message, $code = 108)
+    public function __construct(string $message, int $code = 108)
     {
         parent::__construct($message, $code);
     }
 }
 class ProjectPageException extends ProjectException
 {
-    public function __construct($message, $code = 109)
+    public function __construct(string $message, int $code = 109)
     {
         parent::__construct($message, $code);
     }
 }
 class ProjectNotInRoundException extends ProjectException
 {
-    public function __construct($message, $code = 110)
+    public function __construct(string $message, int $code = 110)
     {
         parent::__construct($message, $code);
     }
@@ -99,7 +99,7 @@ class ProjectNotInRoundException extends ProjectException
 
 class ProjectRequiresMaintenanceException extends ProjectException
 {
-    public function __construct($message, $code = 111)
+    public function __construct(string $message, int $code = 111)
     {
         parent::__construct($message, $code);
     }
@@ -107,7 +107,7 @@ class ProjectRequiresMaintenanceException extends ProjectException
 
 class ProjectNotAvailableException extends ProjectException
 {
-    public function __construct($message, $code = 112)
+    public function __construct(string $message, int $code = 112)
     {
         parent::__construct($message, $code);
     }
@@ -115,7 +115,7 @@ class ProjectNotAvailableException extends ProjectException
 
 class ProjectNoMorePagesException extends ProjectException
 {
-    public function __construct($message, $code = 113)
+    public function __construct(string $message, int $code = 113)
     {
         parent::__construct($message, $code);
     }
@@ -123,7 +123,7 @@ class ProjectNoMorePagesException extends ProjectException
 
 class ProjectPageStateException extends ProjectException
 {
-    public function __construct($message, $code = 115)
+    public function __construct(string $message, int $code = 115)
     {
         parent::__construct($message, $code);
     }
@@ -131,7 +131,7 @@ class ProjectPageStateException extends ProjectException
 
 class ProjectPageInconsistentStateException extends ProjectException
 {
-    public function __construct($message, $code = 119)
+    public function __construct(string $message, int $code = 119)
     {
         parent::__construct($message, $code);
     }
@@ -139,7 +139,7 @@ class ProjectPageInconsistentStateException extends ProjectException
 
 class ProjectNotInRequiredStateException extends ProjectException
 {
-    public function __construct($message, $code = 120)
+    public function __construct(string $message, int $code = 120)
     {
         parent::__construct($message, $code);
     }
@@ -147,7 +147,7 @@ class ProjectNotInRequiredStateException extends ProjectException
 
 class ProjectInvalidTextException extends ProjectException
 {
-    public function __construct($message, $code = 125)
+    public function __construct(string $message, int $code = 125)
     {
         parent::__construct($message, $code);
     }

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -17,7 +17,7 @@ class NonuniqueUserException extends Exception
  */
 class UserAccessException extends Exception
 {
-    public function __construct($message = "", $code = 300)
+    public function __construct(string $message = "", int $code = 300)
     {
         parent::__construct($message, $code);
     }
@@ -25,7 +25,7 @@ class UserAccessException extends Exception
 
 class UserNotLoggedInException extends UserAccessException
 {
-    public function __construct($message = "", $code = 301)
+    public function __construct(string $message = "", int $code = 301)
     {
         parent::__construct($message, $code);
     }
@@ -33,7 +33,7 @@ class UserNotLoggedInException extends UserAccessException
 
 class UserNotQualifiedForRoundException extends UserAccessException
 {
-    public function __construct($message = "", $code = 302)
+    public function __construct(string $message = "", int $code = 302)
     {
         parent::__construct($message, $code);
     }
@@ -41,7 +41,7 @@ class UserNotQualifiedForRoundException extends UserAccessException
 
 class BeginnersQuotaReachedException extends UserAccessException
 {
-    public function __construct($message = "", $code = 303)
+    public function __construct(string $message = "", int $code = 303)
     {
         parent::__construct($message, $code);
     }
@@ -49,7 +49,7 @@ class BeginnersQuotaReachedException extends UserAccessException
 
 class BeginnersProjectQuotaReachedException extends UserAccessException
 {
-    public function __construct($message = "", $code = 304)
+    public function __construct(string $message = "", int $code = 304)
     {
         parent::__construct($message, $code);
     }
@@ -57,7 +57,7 @@ class BeginnersProjectQuotaReachedException extends UserAccessException
 
 class NoAccessToMentorsOnlyException extends UserAccessException
 {
-    public function __construct($message = "", $code = 305)
+    public function __construct(string $message = "", int $code = 305)
     {
         parent::__construct($message, $code);
     }
@@ -65,7 +65,7 @@ class NoAccessToMentorsOnlyException extends UserAccessException
 
 class ReservedForNewProofreadersException extends UserAccessException
 {
-    public function __construct($message = "", $code = 306)
+    public function __construct(string $message = "", int $code = 306)
     {
         parent::__construct($message, $code);
     }
@@ -73,7 +73,7 @@ class ReservedForNewProofreadersException extends UserAccessException
 
 class PageNotOwnedException extends UserAccessException
 {
-    public function __construct($message = "", $code = 307)
+    public function __construct(string $message = "", int $code = 307)
     {
         parent::__construct($message, $code);
     }
@@ -81,7 +81,7 @@ class PageNotOwnedException extends UserAccessException
 
 class DailyLimitExceededException extends UserAccessException
 {
-    public function __construct($message = "", $code = 308)
+    public function __construct(string $message = "", int $code = 308)
     {
         parent::__construct($message, $code);
     }


### PR DESCRIPTION
The arguments from the derived classes are passed
to the base constructor and thus must match the
definition from PHP:

https://www.php.net/manual/en/exception.construct.php