### PR TITLE
Documentation updates for upcoming R202409 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,13 +7,30 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
-## R??????
+## R202409
 Scripts supporting this upgrade are in `SETUP/upgrade/21`
 
-**This is the last release to support PHP 7.4. Future releases will only
-support PHP 8.0 and later.**
+### Notices & Deprecations
+
+This is the last release to support PHP 7.4. Future releases will only
+support PHP 8.1 and later.
+
+This is the last release to support the Hieroglyphs tool. WikiHiero which backs
+the tool has been unsupported for 20+ years and was written for PHP 4.3.3.
+
+### Changes
 
 * Updated minimum middleware to MySQL 8.0 (cpeel)
+* The deprecated globals mentioned in the last release notes were removed (cpeel)
+* Most `faq/*` content has been deleted (cpeel)
+* A `metadata.json` file has replaced `dc.xml` in the project directory (cpeel)
+* New API endpoints for proofreading (70ray)
+* Cronjobs now run through common interface with SA UI to show job status (cpeel)
+* Typing added to numerous functions and classes (bpfoley, jchaffraix)
+* XML feed types removed and feed backend improved (mrducky4)
+* Navigation bar updates for smaller screens (cpeel)
+* New site search page (cpeel)
+* `past_tallies` is now a sparse table (cpeel)
 
 ## R202403
 Scripts supporting this upgrade are in `SETUP/upgrade/20`

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -17,7 +17,7 @@ components.
 
 ### PHP
 PHP version 7.4 is the minimum supported version. Limited testing has been done
-on PHP 8.0 and 8.1.
+on PHP 8.1 and 8.3.
 
 The following PHP extensions are required. They are listed below with their
 Ubuntu system package names.
@@ -77,6 +77,8 @@ assuming it isn't already.
 Any web server that supports PHP should work, although all testing has
 been done using Apache 2. All known deployments, including pgdp.net,
 are using Apache 2 as well.
+
+The code will function with Apache's `mod_php` as well as `php-fpm`.
 
 See `apache2.conf.example` for an example Apache config file, including
 examples on enabling page compression and caching.

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -117,6 +117,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/18/
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
+* c/SETUP/upgrade/21/
 
 ### Upgrading from release R202102
 Run the scripts in the following directories in order
@@ -126,6 +127,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/18/
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
+* c/SETUP/upgrade/21/
 
 ### Upgrading from release R202109
 Run the scripts in the following directories in order
@@ -134,6 +136,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/18/
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
+* c/SETUP/upgrade/21/
 
 ### Upgrading from release R202202
 Run the scripts in the following directories in order
@@ -141,17 +144,25 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/18/
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
+* c/SETUP/upgrade/21/
 
 ### Upgrading from release R202209 or R202303
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
+* c/SETUP/upgrade/21/
 
 ### Upgrading from release R202309
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/20/
+* c/SETUP/upgrade/21/
+
+### Upgrading from release R202403
+Run the scripts in the following directories in order
+
+* c/SETUP/upgrade/21/
 
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.

--- a/SETUP/check_db_schema.template
+++ b/SETUP/check_db_schema.template
@@ -62,11 +62,16 @@ echo "
     _DEFAULT_CHAR_SUITES='[ \"basic-latin\" ]'
     _PHPMAILER_SMTP_CONFIG='[]'
 
-    # For update_phpbb_posts_text.php
+    # Integer values that must be filled in
     _FORUMS_PROJECT_WAITING_IDX=99
     _FORUMS_PROJECT_AVAIL_IDX=99
     _FORUMS_PROJECT_PP_IDX=99
     _FORUMS_PROJECT_POSTED_IDX=99
+    _FORUMS_BEGIN_SITE_IDX=99
+    _FORUMS_PROJECT_DELETED_IDX=99
+    _FORUMS_PROJECT_COMPLETED_IDX=99
+    _FORUMS_POST_PROCESSORS_IDX=99
+    _FORUMS_TEAMS_IDX=99
 " > $testing_dir/config.sh
 
 echo "Getting a test copy of the '$curr_tag' code..."


### PR DESCRIPTION
This updates the usual doc suspects for our upcoming R202409 release. As a reminder we try to highlight things in the changelog that we think most site admins would be interested in`*` and tell them to look in the git history for the full details. The order is roughly what I think is the most important first which is very subjective.

Feedback on what was included, the order of the things listed, and any other thoughts are appreciated!

`*` I also ensure that every developer who contributed to the release has an item in the `CHANGELOG.md` file too.