### PR TITLE
Type pinc/CharSuites.inc

### DIFF
--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -7,11 +7,13 @@ class CharSuiteNotEnabledException extends Exception
 
 class PickerSet
 {
-    public $name;
+    public string $name;
     private array $subsets;
+    /** @var string[] */
     private array $titles;
 
-    public function add_subset($name, $codepoints, $title = null)
+    /** @param $codepoints string[] */
+    public function add_subset(string $name, array $codepoints, ?string $title = null)
     {
         $this->subsets[$name] = $codepoints;
 
@@ -22,12 +24,13 @@ class PickerSet
         }
     }
 
-    public function get_subsets()
+    /** @return string[] */
+    public function get_subsets(): array
     {
         return $this->subsets;
     }
 
-    public function get_title($name)
+    public function get_title(string $name): string
     {
         return $this->titles[$name];
     }
@@ -38,15 +41,17 @@ class PickerSet
  */
 class CharSuite
 {
-    public $name;
-    public $title;
-    public $codepoints;
-    public $description;
-    public $adhoc;
+    public string $name;
+    public string $title;
+    /** @var string[] */
+    public ?array $codepoints;
+    public ?string $description = null;
+    public bool $adhoc;
     public $reference_urls = [];
-    private $_pickerset = null;
+    private ?PickerSet $_pickerset = null;
 
-    public function __construct($name, $title, $codepoints = null, $adhoc = false)
+    /** @param $codepoints ?string[] */
+    public function __construct(string $name, string $title, ?array $codepoints = null, bool $adhoc = false)
     {
         $this->name = $name;
         $this->title = $title;
@@ -54,7 +59,7 @@ class CharSuite
         $this->adhoc = $adhoc;
     }
 
-    public function __get($name)
+    public function __get(string $name): ?PickerSet
     {
         if ($name == 'pickerset') {
             return $this->_pickerset;
@@ -71,7 +76,7 @@ class CharSuite
         return null;
     }
 
-    public function __set($name, $value)
+    public function __set(string $name, PickerSet $value)
     {
         if ($name == 'pickerset') {
             $this->_pickerset = $value;
@@ -88,7 +93,7 @@ class CharSuite
         }
     }
 
-    public function is_enabled()
+    public function is_enabled(): bool
     {
         if ($this->adhoc) {
             return true;
@@ -106,9 +111,10 @@ class CharSuite
 
 class CharSuites
 {
-    private static $_available_charsuites = [];
+    /** @var array<string, CharSuite> */
+    private static array $_available_charsuites = [];
 
-    private static function load()
+    private static function load(): void
     {
         // load all available charsuites if not already loaded
 
@@ -124,12 +130,12 @@ class CharSuites
         }
     }
 
-    public static function add($charsuite)
+    public static function add(CharSuite $charsuite): void
     {
         self::$_available_charsuites[$charsuite->name] = $charsuite;
     }
 
-    public static function get($name)
+    public static function get(string $name): CharSuite
     {
         self::load();
 
@@ -139,14 +145,16 @@ class CharSuites
         return self::$_available_charsuites[$name];
     }
 
-    public static function get_all()
+    /** @return CharSuite[] */
+    public static function get_all(): array
     {
         self::load();
 
         return array_values(self::$_available_charsuites);
     }
 
-    public static function get_enabled()
+    /** @return CharSuite[] */
+    public static function get_enabled(): array
     {
         $sql = "
             SELECT name
@@ -164,7 +172,7 @@ class CharSuites
         return $charsuites;
     }
 
-    public static function enable($name)
+    public static function enable(string $name): void
     {
         // Validate we have a valid charsuite
         $charsuite = CharSuites::get($name);
@@ -182,7 +190,7 @@ class CharSuites
         DPDatabase::query($sql);
     }
 
-    public static function disable($name)
+    public static function disable(string $name): void
     {
         // We don't validate the charsuite is installed in case it was
         // uninstalled before being disabled.
@@ -204,11 +212,9 @@ class CharSuites
      * Check to see if `$charsuite` is a real CharSuite object or a charsuite
      * name and if the latter, return a CharSuite object of that name.
      *
-     * @param string|object $charsuite Character suite name or object
-     *
-     * @return object
+     * @param string|CharSuite $charsuite Character suite name or object
      */
-    public static function resolve($charsuite)
+    public static function resolve($charsuite): CharSuite
     {
         if ($charsuite instanceof CharSuite) {
             return $charsuite;
@@ -222,7 +228,8 @@ class CharSuites
 
 trait CharSuiteSet
 {
-    public function get_pickersets()
+    /** @return PickerSet[] */
+    public function get_pickersets(): array
     {
         $pickersets = [];
         foreach ($this->get_charsuites() as $charsuite) {
@@ -231,7 +238,8 @@ trait CharSuiteSet
         return $pickersets;
     }
 
-    public function get_valid_codepoints()
+    /** @return string[] */
+    public function get_valid_codepoints(): array
     {
         // Codepoints applicable to all projects
         $global_codepoints = [
@@ -248,7 +256,8 @@ trait CharSuiteSet
     }
 }
 
-function get_project_or_quiz($identifier)
+/** @return QuizCharSuites|Project */
+function get_project_or_quiz(string $identifier)
 {
     if ($identifier == "quiz") {
         return new QuizCharSuites();


### PR DESCRIPTION
This exposed that CharSuite::description was not initialized in the constructor and was never set for several charsuite, Basic Cyrillic among them.

TESTS=Enabled/disabled a charsuite for the SA,
made sure all charsuites could be displayed in SA, added/removed a charsuite on a project.

_Update from cpeel_: sandbox at https://www.pgdp.org/~cpeel/c.branch/julien_type_CharSuite/