### PR TITLE
Add missing types in Settings.inc

### DIFF
--- a/pinc/Settings.inc
+++ b/pinc/Settings.inc
@@ -10,12 +10,13 @@ class Settings
     // Multi-dimensional array containing all user settings. Each setting
     // may have one or more value associated with it. Format is:
     //     $settings_array[$setting] = array($value1, ...);
-    private $settings_array = [];
+    /** @var array<string, mixed[]> */
+    private array $settings_array = [];
 
     // username of subject user.
-    private $username = null;
+    private ?string $username = null;
 
-    public function __construct($name)
+    public function __construct(?string $name)
     {
         if ($name == '') {
             // Note that that's a "loose equals", so $name could be:
@@ -48,7 +49,7 @@ class Settings
         mysqli_free_result($result);
     }
 
-    public function UserName()
+    public function UserName(): string
     {
         return $this->username ? $this->username : "[none]";
     }
@@ -107,17 +108,22 @@ class Settings
 
     // -------------------------------------------------------------------------
 
-    private function _clear_setting($settingCode)
+    private function _clear_setting(string $settingCode): void
     {
-        $sql = "
+        $sql = sprintf(
+            "
             DELETE FROM usersettings 
-            WHERE username = '$this->username'
-                AND setting = '$settingCode'
-        " ;
+            WHERE username = '%s'
+                AND setting = '%s'
+            ",
+            DPDatabase::escape($this->username),
+            DPDatabase::escape($settingCode),
+        );
         DPDatabase::query($sql);
     }
 
-    private function _insert_setting_value($settingCode, $value)
+    /** @param mixed $value */
+    private function _insert_setting_value(string $settingCode, $value): void
     {
         $sql = sprintf(
             "
@@ -132,7 +138,8 @@ class Settings
         DPDatabase::query($sql);
     }
 
-    private function _delete_setting_value($settingCode, $value)
+    /** @param mixed $value */
+    private function _delete_setting_value(string $settingCode, $value): void
     {
         $sql = sprintf(
             "
@@ -331,9 +338,9 @@ class Settings
      * @param string $setting
      * @param mixed $value
      *
-     * @return array
+     * @return string[]
      */
-    public static function get_users_with_setting($setting, $value = null)
+    public static function get_users_with_setting($setting, $value = null): array
     {
         $usernames = [];
         $sql = sprintf(

--- a/pinc/Settings.inc
+++ b/pinc/Settings.inc
@@ -19,10 +19,10 @@ class Settings
     public function __construct(?string $name)
     {
         if ($name == '') {
-            // Note that that's a "loose equals", so $name could be:
-            // the empty string, the integer zero, the boolean false, or null.
-            // Of those, the likeliest is null, indicating that the
-            // current http-requestor is a "guest", not a logged-in user.
+            // Note that that's a "loose equals", so $name could either be
+            // the empty string or null. Of those, the likeliest is null,
+            // indicating that the current http-requestor is a "guest",
+            // not a logged-in user.
 
             // Return a Settings object with an empty $settings_array.
             return;


### PR DESCRIPTION
The file has a lot of PHPStan type annotations that were left as is (ie still not enforced by the PHP runtime).

For the new types, I have made them enforced.

TEST=Manipulated the settings page for different profile.

_Update by cpeel_: Sandbox at https://www.pgdp.org/~cpeel/c.branch/julien_add_missing_type_Settings/