### PR TITLE
Correctly load UTF-8 system locales

### DIFF
--- a/SETUP/ci/check_security.php
+++ b/SETUP/ci/check_security.php
@@ -13,7 +13,6 @@ $basedir = $argv[1] ?? "../../";
 //       others are added from the current set until they get updated.
 $ok_system_calls = [
     "pinc/forum_interface_phpbb3.inc",
-    "pinc/languages.inc",
     "pinc/phpbb3.inc",
     "pinc/POFile.inc",
     "pinc/Project.inc",

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -7,6 +7,8 @@
 include_once($relPath.'lang_data.inc');
 include_once($relPath.'iso_lang_list.inc');
 
+use Symfony\Component\Process\Process;
+
 function lang_code($language_code)
 {
     global $locales;
@@ -120,14 +122,20 @@ function lang_direction($langcode = false)
  */
 function get_installed_system_locales()
 {
-    static $system_locales = [];
-    if ($system_locales) {
-        return $system_locales;
+    static $utf8_locales = [];
+    if ($utf8_locales) {
+        return $utf8_locales;
     }
 
-    exec("locale -a", $system_locales);
+    $process = new Process(["locale", "-a"]);
+    $process->run();
+    if (!$process->isSuccessful()) {
+        throw new RuntimeException("Failed loading system locales.");
+    }
 
-    // exclude all non-UTF-8 locales
+    $system_locales = explode("\n", $process->getOutput());
+
+    // only include UTF-8 locales, but strip the .utf8 off the end
     $utf8_locales = [];
     foreach ($system_locales as $locale) {
         if (endswith($locale, '.utf8')) {


### PR DESCRIPTION
The list of system locales is only used in the translation center for managing translations. The list being returned from `get_installed_system_locales()` incorrectly included the `.utf8` extension. Sharon found this during the PHP 8.3 testing.

This fixes that bug and also changes the `exec()` to a `Process`. Because this bug prevents creating new translations I'd like to get this merged before the upcoming release -- even if we don't get it rolled out to PROD until next month.

https://www.pgdp.org/~cpeel/c.branch/fix-translation-center/ 