### PR TITLE
Fix code_style error in configuration.sh which flows into site_vars.php

### DIFF
--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -163,7 +163,7 @@ _JSON_POSTS=
 # suites must be installed and enabled on the system.
 # See SETUP/UNICODE.md for more information.
 
-_DEFAULT_CHAR_SUITES='[ "basic-latin" ]'
+_DEFAULT_CHAR_SUITES='["basic-latin"]'
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 


### PR DESCRIPTION
Fix spaces that php-cs-fixer complains about, when incorporated into site_vars.php.

The error appears if you use configuration.sh as the input to SETUP/configure,
which creates site_vars.php, and then you run `make -C SETUP/ci code_style`