### PR TITLE
Make ImageSource class & DB match

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -99,13 +99,13 @@ CREATE TABLE `image_sources` (
   `full_name` varchar(100) NOT NULL default '',
   `info_page_visibility` tinyint(3) unsigned NOT NULL default '0',
   `is_active` tinyint(3) NOT NULL default '-1',
-  `url` varchar(200) default NULL,
-  `credit` varchar(200) default NULL,
+  `url` varchar(255) NOT NULL default '',
+  `credit` varchar(255) NOT NULL default '',
   `ok_keep_images` tinyint(4) NOT NULL default '-1',
   `ok_show_images` tinyint(4) NOT NULL default '-1',
-  `public_comment` varchar(255) default NULL,
+  `public_comment` varchar(255) NOT NULL default '',
   `internal_comment` text,
-  UNIQUE KEY `code_name` (`code_name`),
+  PRIMARY KEY (`code_name`),
   UNIQUE KEY `display_name` (`display_name`)
 );
 

--- a/SETUP/upgrade/21/20240915_update_image_sources.php
+++ b/SETUP/upgrade/21/20240915_update_image_sources.php
@@ -1,0 +1,34 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Updating image_sources...\n";
+$update_statements = [
+    "UPDATE image_sources SET url = '' where url is NULL",
+    "UPDATE image_sources SET credit = '' where credit is NULL",
+    "UPDATE image_sources SET public_comment = '' where public_comment is NULL",
+];
+
+foreach ($update_statements as $sql) {
+    echo "\n    $sql\n";
+    mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+}
+
+$sql = "
+    ALTER TABLE image_sources
+        MODIFY COLUMN `url` varchar(255) NOT NULL default '',
+        MODIFY COLUMN `credit` varchar(255) NOT NULL default '',
+        MODIFY COLUMN `public_comment` varchar(255) NOT NULL default '',
+        DROP INDEX `code_name`,
+        ADD PRIMARY KEY (code_name);
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -152,7 +152,7 @@ class ImageSource
     public int $ok_keep_images; // TODO: bool
     public int $ok_show_images; // TODO: bool
     public string $public_comment;
-    public string $internal_comment;
+    public ?string $internal_comment;
     public int $is_active;
 
     public function __construct($code_name = null)
@@ -286,8 +286,8 @@ class ImageSource
         }
         $this->_show_edit_row('display_name', _('Display Name'), false, 30, true);
         $this->_show_edit_row('full_name', _('Full Name'), false, 100, true);
-        $this->_show_edit_row('url', _('Website'), false, 200);
-        $this->_show_edit_row('credit', _('Credits Line (no URLs)'), true, 200);
+        $this->_show_edit_row('url', _('Website'), false, 255);
+        $this->_show_edit_row('credit', _('Credits Line (no URLs)'), true, 255);
         $this->_show_edit_permissions_row();
         $this->_show_edit_row('public_comment', _('Description (public comments)'), true, 255);
         $this->_show_edit_row('internal_comment', _('Notes (internal comments)'), true);
@@ -419,8 +419,8 @@ class ImageSource
                 code_name = LEFT('%s', 10),
                 display_name = LEFT('%s', 30),
                 full_name = LEFT('%s', 100),
-                url = LEFT('%s', 200),
-                credit = LEFT('%s', 200),
+                url = LEFT('%s', 255),
+                credit = LEFT('%s', 255),
                 ok_keep_images = %d,
                 ok_show_images = %d,
                 info_page_visibility = %d,


### PR DESCRIPTION
86ab2156db set the types for the ImageSource class but some of the strings can be null in the DB. Reconcile the two. While we're here make the url and credit fields the max 255 varchar size (like the URLs are in other tables).

That commit was added right after the R202403 release so I'd like to get this one in before the upcoming one. Turns out there is a single row in PROD with a `null` value in it and it's a wonder we didn't catch this prior in the past 6 months.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-manage-image-sources-types/