### PR TITLE
Fix two PHP 8.3 deprecation warnings

### DIFF
--- a/pinc/Stopwatch.inc
+++ b/pinc/Stopwatch.inc
@@ -7,7 +7,7 @@ class Stopwatch
 // (start/stop button can also be seen as a pause/resume button)
 {
     private bool $running;
-    private int $seconds_from_completed_runs;
+    private float $seconds_from_completed_runs;
     private array $run_start_tod;
 
     // The time between a 'start' ('resume') and the subsequent 'stop' ('pause')

--- a/tools/upload_text.php
+++ b/tools/upload_text.php
@@ -22,7 +22,7 @@ $stage = get_enumerated_param($_REQUEST, 'stage', null, $valid_stages, true);
 // days not given (defaults to 0): replace file only
 $days = get_integer_param($_REQUEST, 'days', 0, 0, 56);
 $action = @$_REQUEST['action'];
-$postcomments = @$_POST['postcomments'];
+$postcomments = array_get($_POST, 'postcomments', "");
 
 $project = new Project($projectid);
 


### PR DESCRIPTION
Somewhat shockingly, these are the only two outstanding issues that were found in the PHP 8.3 testing. These address two deprecation warnings.