### PR TITLE
Type pinc/wordcheck_engine.pinc

### DIFF
--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -7,8 +7,10 @@
 /**
  * Returns an associative array of those languages with a dictionary that is
  * installed on the system
+ *
+ * @return array<string, string>
  */
-function get_languages_with_dictionaries()
+function get_languages_with_dictionaries(): array
 {
     global $aspell_prefix;
 
@@ -32,7 +34,7 @@ function get_languages_with_dictionaries()
  *
  * Will return "Latin" if the langcode is not known.
  */
-function get_script_for_langcode($langcode)
+function get_script_for_langcode(string $langcode): string
 {
     // This, decidedly incomplete, mapping was created by taking the list of
     // available aspell 0.60 dictionaries and running the "Native Name" through
@@ -112,7 +114,8 @@ function get_script_for_langcode($langcode)
 // and then have a mapping of language codes to language names in the
 // desired locale.
 
-function get_iso_language_list()
+/** @return array{"lang_name": string, "lang_code": string, "preferred"?: bool}[] */
+function get_iso_language_list(): array
 {
     return [
         ["lang_name" => "Abkhazian", "lang_code" => "abk"],
@@ -616,7 +619,7 @@ function get_iso_language_list()
  * For the given three-letter code, return the corresponding language-name,
  * or null if not found.
  */
-function langname_for_langcode3($langcode3)
+function langname_for_langcode3(string $langcode3): ?string
 {
     $found_languages = [];
     foreach (get_iso_language_list() as $entry) {
@@ -641,7 +644,7 @@ function langname_for_langcode3($langcode3)
  * For the given language-name, return the corresponding three-letter code,
  * or null if not found.
  */
-function langcode3_for_langname($langname)
+function langcode3_for_langname(string $langname): ?string
 {
     foreach (get_iso_language_list() as $entry) {
         $entry_name = $entry['lang_name'];
@@ -660,7 +663,7 @@ function langcode3_for_langname($langname)
 /**
  * Given a two-letter language code, return the language name or NULL
  */
-function langname_for_langcode2($langcode2)
+function langname_for_langcode2(string $langcode2): ?string
 {
     $langcode3 = array_search($langcode2, get_iso_639_3_to_2_mapping());
     if ($langcode3) {
@@ -675,7 +678,7 @@ function langname_for_langcode2($langcode2)
  * If a two letter code isn't available, but a three-letter one is, return that.
  * If the language is not found return NULL.
  */
-function langcode2_for_langname($langname)
+function langcode2_for_langname(string $langname): ?string
 {
     $mapping = get_iso_639_3_to_2_mapping();
     $fallback_code = null;
@@ -697,7 +700,7 @@ function langcode2_for_langname($langname)
 /**
  * Given a two- or three-letter language code return the language name or NULL.
  */
-function langname_for_langcode($langcode)
+function langname_for_langcode(string $langcode): ?string
 {
     return langname_for_langcode2($langcode) ?? langname_for_langcode3($langcode);
 }
@@ -710,7 +713,8 @@ function langname_for_langcode($langcode)
 // these language tags use the 2-letter code when present, or the
 // 3-letter bibliographical codes for languages having no 2-letter code.
 
-function get_iso_639_3_to_2_mapping()
+/** @return array<string, string> */
+function get_iso_639_3_to_2_mapping(): array
 {
     return [
         // This part extracted from ISO-639-2 downloaded on 2010-08-18 from

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -251,7 +251,7 @@ function get_bad_words_for_text($text, $languages, $word_lists = [])
 
 class BadWordAccumulator
 {
-    /** @var string[] */
+    /** @var array<string, int> */
     public array $words;
     /** @var string[] */
     public array $messages;
@@ -266,7 +266,8 @@ class BadWordAccumulator
         $this->messages = [];
     }
 
-    public function add_bad_words($bad_words, $val)
+    /** @param string|string[] $bad_words */
+    public function add_bad_words($bad_words, int $val): void
     {
         if (is_string($bad_words)) {
             $this->messages[] = $bad_words;
@@ -277,7 +278,8 @@ class BadWordAccumulator
         }
     }
 
-    public function remove_good_words($good_words)
+    /** @param string|string[] $good_words */
+    public function remove_good_words($good_words): void
     {
         if (is_string($good_words)) {
             $this->messages[] = $good_words;
@@ -304,11 +306,11 @@ class BadWordAccumulator
  *
  * @param array $input_words_w_freq
  *   An array whose keys are the distinct words of the input text
- * @param array $languages
+ * @param string[] $languages
  *   Array of languages, used to load aspell dictionary
  *   for those languages if available
  *
- * @return array
+ * @return array{0:string[], 1:string[]}
  */
 function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 {
@@ -409,8 +411,10 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
  *
  * @param array $input_words_w_freq
  *   An array whose keys are the distinct words of the input text
+ *
+ * @return string[]
  */
-function get_bad_words_with_diacritical_markup($input_words_w_freq)
+function get_bad_words_with_diacritical_markup($input_words_w_freq): array
 {
     // Consider words that contain diacritical markup via []-notation.
     // For example, consider the oe ligature, which we represent as "[oe]",
@@ -457,7 +461,7 @@ function get_bad_words_with_diacritical_markup($input_words_w_freq)
  * @param array $languages
  *   Array of languages to check against
  *
- * @return array
+ * @return string[]
  */
 function get_bad_words_via_pattern($input_words_w_freq, $languages)
 {
@@ -501,22 +505,42 @@ function get_bad_words_via_pattern($input_words_w_freq, $languages)
 
 // -----------------------------------------------------------------------------
 
+/**
+ * @param string|string[] $langcode3s
+ *
+ * @return string[]
+ */
 function load_site_good_words($langcode3s)
 {
     return _load_site_words("good", $langcode3s);
 }
 
+/**
+ * @param string|string[] $langcode3s
+ *
+ * @return string[]
+ */
 function load_site_bad_words($langcode3s)
 {
     return _load_site_words("bad", $langcode3s);
 }
 
+/**
+ * @param string|string[] $langcode3s
+ *
+ * @return string[]
+ */
 function load_site_possible_bad_words($langcode3s)
 {
     return _load_site_words("possible_bad", $langcode3s);
 }
 
-function _load_site_words($type, $langcode3s)
+/**
+ * @param string|string[] $langcode3s
+ *
+ * @return string[]
+ */
+function _load_site_words(string $type, $langcode3s): array
 {
     if (!is_array($langcode3s)) {
         $langcode3s = [$langcode3s];
@@ -535,14 +559,15 @@ function _load_site_words($type, $langcode3s)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // Project-Level
 
-function load_project_good_words($projectid)
+/** @return string|string[] */
+function load_project_good_words(string $projectid)
 {
     $fileObject = get_project_word_file($projectid, "good");
 
     return load_word_list($fileObject->abs_path);
 }
 
-function save_project_good_words($projectid, $words)
+function save_project_good_words(string $projectid, array $words): string
 {
     $fileObject = get_project_word_file($projectid, "good");
 
@@ -551,14 +576,15 @@ function save_project_good_words($projectid, $words)
 
 // -----------------------------------------------------------------------------
 
-function load_project_bad_words($projectid)
+/** @return string|string[] */
+function load_project_bad_words(string $projectid)
 {
     $fileObject = get_project_word_file($projectid, "bad");
 
     return load_word_list($fileObject->abs_path);
 }
 
-function save_project_bad_words($projectid, $words)
+function save_project_bad_words(string $projectid, array $words): string
 {
     $fileObject = get_project_word_file($projectid, "bad");
 
@@ -567,7 +593,12 @@ function save_project_bad_words($projectid, $words)
 
 // -----------------------------------------------------------------------------
 
-function normalize_word_list($words)
+/**
+ * @param string[] $words
+ *
+ * @return string[]
+ */
+function normalize_word_list(array $words): array
 {
     // normalize the strings
     $words = array_map('utf8_normalize', $words);
@@ -874,8 +905,10 @@ function get_file_info_object($filename, $base_dir, $base_url)
  * Returns:
  * - on success: an array of words
  * - on error:   a string containing an error message
+ *
+ * @return string|string[]
  */
-function load_word_list($path)
+function load_word_list(string $path)
 {
     if (!is_file($path)) {
         // The file does not exist.
@@ -910,9 +943,9 @@ function load_word_list($path)
   * @param string $string
   *     The input string to split
   *
-  * @return array<string>
+  * @return string[]
   */
-function _explode_no_empty($sep, $string)
+function _explode_no_empty(string $sep, string $string): array
 {
     return empty($string) ? [] : explode($sep, $string);
 }
@@ -922,8 +955,10 @@ function _explode_no_empty($sep, $string)
  * Save a list of words (one per line) to a file.
  *
  * Return a string, either "Success" or an error message.
+ *
+ * @param string[] $words
  */
-function save_word_list($path, $words)
+function save_word_list(string $path, array $words): string
 {
     // standardize word list
     array_walk($words, 'rtrim_walk');
@@ -977,13 +1012,13 @@ function save_word_list($path, $words)
  *
  * @param string $projectid
  *   ID of project
- * @param array $aux_languages
+ * @param string[] $aux_languages
  *   Any additional languages to append to the list of project languages.
  *   This function will silently filter out any invalid values.
  *
- * @return array
+ * @return string[]
  */
-function get_project_languages($projectid, $aux_languages = [])
+function get_project_languages(string $projectid, array $aux_languages = []): array
 {
     $returnArray = [];
 
@@ -1009,8 +1044,10 @@ function get_project_languages($projectid, $aux_languages = [])
 /**
  * Returns an associative array of site word lists
  * with their corresponding URL
+ *
+ * @return array<string, string>
  */
-function get_site_good_bad_word_lists()
+function get_site_good_bad_word_lists(): array
 {
     return get_site_word_files("/^(good|bad)_words\.[a-z]{3}\.txt$/");
 }
@@ -1018,8 +1055,10 @@ function get_site_good_bad_word_lists()
 /**
  * Returns an associative array of site possible bad word lists
  * with their corresponding URL
+ *
+ * @return array<string, string>
  */
-function get_site_possible_bad_word_lists()
+function get_site_possible_bad_word_lists(): array
 {
     return get_site_word_files("/^possible_bad_words\.[a-z]{3}\.txt$/");
 }
@@ -1039,8 +1078,10 @@ function get_site_possible_bad_word_lists()
  * @param bool $urlbase
  *   If TRUE files will be turned as a URL,
  *   If FALSE absolute filesystem paths are returned
+ *
+ * @return array<string, string>
  */
-function get_site_word_files($pattern = "", $urlbase = true)
+function get_site_word_files(string $pattern = "", bool $urlbase = true): array
 {
     global $dyn_dir;
     global $dyn_url;
@@ -1169,7 +1210,7 @@ function get_distinct_words_in_text($text)
  * Note that it's *not* inefficient accessing an array with the same number
  * of items, but having consecutive integers as the keys!
  */
-function get_all_words_in_text($text, $with_offsets = false)
+function get_all_words_in_text(string $text, bool $with_offsets = false)
 {
     global $word_pattern;
     $flags = $with_offsets ? PREG_OFFSET_CAPTURE : 0;
@@ -1195,8 +1236,12 @@ function get_all_words_in_text($text, $with_offsets = false)
 
 /**
  * Given an array of words, calculate the frequency
+ *
+ * @param string[] $wordList
+ *
+ * @return array<string, int>
  */
-function generate_frequencies($wordList)
+function generate_frequencies(array $wordList): array
 {
     $wordCount = array_count_values($wordList);
     unset($wordCount['']);
@@ -1212,6 +1257,8 @@ function generate_frequencies($wordList)
  *
  * @param array $languages
  *   Array of language names
+ *
+ * @return array{0: string[], 1: string[]}
  */
 function get_langcode3s_for_languages($languages)
 {
@@ -1236,7 +1283,7 @@ function get_langcode3s_for_languages($languages)
  * the calling sort function would be non-deterministic based on PHP
  * docs (see online docs for usort()) and manual confirmation.
  */
-function deterministicStrnatcasecmp($a, $b)
+function deterministicStrnatcasecmp(string $a, string $b): int
 {
     return ($cmp = strnatcasecmp($a, $b)) != 0 ? $cmp : strnatcmp($a, $b);
 }
@@ -1244,15 +1291,19 @@ function deterministicStrnatcasecmp($a, $b)
 /**
  * rtrim version to use in array_walk
  */
-function rtrim_walk(&$item)
+function rtrim_walk(string &$item): void
 {
     $item = rtrim($item);
 }
 
 /**
  * Filter words to only those of a specific script + Inherited
+ *
+ * @param string[] $words
+ *
+ * @return string[]
  */
-function filter_words_to_script($words, $script)
+function filter_words_to_script(array $words, string $script): array
 {
     $script_words = [];
     foreach ($words as $word) {
@@ -1270,10 +1321,10 @@ function filter_words_to_script($words, $script)
  * Returns:
  * - the array: [words[], found_scripts[]]
  *
- * @param array $words
+ * @param string[] $words
  *   An array of words
  *
- * @return array
+ * @return array{0: string[], 1: string[]}
  */
 function get_words_with_uncommon_scripts($words)
 {


### PR DESCRIPTION
There were some missing return types and params.

When possible, I have narrowed down the PHPStan
annotations so they are more useful (the runtime
behavior in this case is unchanged).

TEST=Tested adding/removing words to the site-wide and the project-wide lists.

_Update by cpeel_: sandbox at https://www.pgdp.org/~cpeel/c.branch/julien_type_wordcheck_engine/