### PR TITLE
Type pinc/DPDatabase.inc

### DIFF
--- a/SETUP/tests/unittests/DPDatabaseTest.php
+++ b/SETUP/tests/unittests/DPDatabaseTest.php
@@ -18,12 +18,12 @@ class DPDatabaseTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    public function test_does_table_exit_existing_table(): void
+    public function test_does_table_exist_existing_table(): void
     {
         $this->assertSame(true, DPDatabase::does_table_exist("dpdb_tests"));
     }
 
-    public function test_does_table_exit_inexistent_table(): void
+    public function test_does_table_exist_inexistent_table(): void
     {
         $this->assertSame(false, DPDatabase::does_table_exist("inexistent_for_sure"));
     }

--- a/SETUP/tests/unittests/DPDatabaseTest.php
+++ b/SETUP/tests/unittests/DPDatabaseTest.php
@@ -1,0 +1,83 @@
+<?php
+
+// DPDatabase basic tests
+
+class DPDatabaseTest extends PHPUnit\Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // Sanity check: Remove the existing table so we start from a clean state.
+        $r = DPDatabase::query("DROP TABLE IF EXISTS `dpdb_tests`");
+        if ($r === false) {
+            throw new Exception("Failed to clean-up test table");
+        }
+
+        $r = DPDatabase::query("CREATE TABLE `dpdb_tests` (`id` int(20) NOT NULL, `comment` varchar(25) NOT NULL default '', PRIMARY KEY (`id`))");
+        if ($r === false) {
+            throw new Exception("Failed to create test table");
+        }
+    }
+
+    public function test_does_table_exit_existing_table(): void
+    {
+        $this->assertSame(true, DPDatabase::does_table_exist("dpdb_tests"));
+    }
+
+    public function test_does_table_exit_inexistent_table(): void
+    {
+        $this->assertSame(false, DPDatabase::does_table_exist("inexistent_for_sure"));
+    }
+
+    public function test_insert_delete_table()
+    {
+        $r = DPDatabase::query("INSERT INTO `dpdb_tests` VALUES(0, \"test\")");
+        $this->assertTrue($r);
+
+        // Fetch the row back.
+        $r = DPDatabase::query("SELECT * FROM `dpdb_tests` where id=0");
+        if (is_bool($r)) {
+            throw new Exception("Got a boolean from select on DPDatabase::query: {$r}");
+        }
+        $this->assertSame(1, $r->num_rows);
+        $this->assertSame(1, DPDatabase::affected_rows());
+        $row = $r->fetch_array();
+        $this->assertSame('0', $row['id']);
+        $this->assertSame('test', $row['comment']);
+
+        // Clean-up.
+        $r = DPDatabase::query("DELETE FROM `dpdb_tests`");
+        $this->assertTrue($r);
+    }
+
+    public function test_fail_insert_inexistent_table()
+    {
+        $this->expectException(DBQueryError::class);
+        $r = DPDatabase::query("INSERT INTO `inexistent_for_sure` VALUES(0)");
+    }
+
+    public function test_fail_insert_inexistent_table_no_exception()
+    {
+        $r = DPDatabase::query("INSERT INTO `inexistent_for_sure` VALUES(0)", /*throw_on_failure*/ false);
+        $this->assertSame(false, $r);
+    }
+
+    public function test_fail_insert_missing_values()
+    {
+        $this->expectException(DBQueryError::class);
+        $r = DPDatabase::query("INSERT INTO `dpdb_tests` VALUES()");
+    }
+
+    public function test_fail_insert_missing_values_no_exception()
+    {
+        $r = DPDatabase::query("INSERT INTO `dpdb_tests` VALUES()", /*throw_on_failure*/ false);
+        $this->assertSame(false, $r);
+    }
+
+    public function test_close_then_reopen()
+    {
+        DPDatabase::close();
+        $this->assertNull(DPDatabase::get_connection());
+        DPDatabase::connect("localhost", "dp_test_db", "dp_test_user", "dp_test_password");
+        $this->assertIsObject(DPDatabase::get_connection());
+    }
+}

--- a/SETUP/tests/unittests/DPDatabaseTest.php
+++ b/SETUP/tests/unittests/DPDatabaseTest.php
@@ -40,7 +40,7 @@ class DPDatabaseTest extends PHPUnit\Framework\TestCase
         }
         $this->assertSame(1, $r->num_rows);
         $this->assertSame(1, DPDatabase::affected_rows());
-        $row = $r->fetch_array();
+        $row = mysqli_fetch_array($r);
         $this->assertSame('0', $row['id']);
         $this->assertSame('test', $row['comment']);
 

--- a/SETUP/tests/unittests/phpunit_bootstrap.php
+++ b/SETUP/tests/unittests/phpunit_bootstrap.php
@@ -8,8 +8,7 @@ include_once($relPath.'base.inc');
 
 // Reconnect to the test DB
 DPDatabase::close();
-// Note: The connect arguments need to be kept in sync with DPDatabaseTest.php
-// as we can't define constants here to share those variables across.
+// Note: The values need to be kept in sync with other files in SETUP/tests/.
 DPDatabase::connect("localhost", "dp_test_db", "dp_test_user", "dp_test_password");
 
 include_once($relPath.'wordcheck_engine.inc');

--- a/SETUP/tests/unittests/phpunit_bootstrap.php
+++ b/SETUP/tests/unittests/phpunit_bootstrap.php
@@ -8,6 +8,8 @@ include_once($relPath.'base.inc');
 
 // Reconnect to the test DB
 DPDatabase::close();
+// Note: The connect arguments need to be kept in sync with DPDatabaseTest.php
+// as we can't define constants here to share those variables across.
 DPDatabase::connect("localhost", "dp_test_db", "dp_test_user", "dp_test_password");
 
 include_once($relPath.'wordcheck_engine.inc');

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -10,14 +10,14 @@ class DBQueryError extends Exception
 
 final class DPDatabase
 {
-    private static $_connection = false;
+    private static ?mysqli $_connection = null;
     private static ?string $_db_name = null;
     private static ?string $_default_db_charset = null;
     private static ?string $_default_db_collation = null;
     public static bool $skip_encoding_check = false;
     public static ?string $tracing_log = null;
 
-    public static function connect($db_server = null, $db_name = null, $db_user = null, $db_password = null)
+    public static function connect(?string $db_server = null, ?string $db_name = null, ?string $db_user = null, ?string $db_password = null): void
     {
         if (!isset($db_server)) {
             include('udb_user.php');
@@ -36,7 +36,7 @@ final class DPDatabase
         }
 
         try {
-            mysqli_select_db(self::$_connection, $db_name);
+            self::$_connection->select_db($db_name);
         } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to locate database.");
         }
@@ -48,7 +48,7 @@ final class DPDatabase
         // to not impact other database users (forum, wiki, etc).
         $sql = "SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));";
         try {
-            mysqli_query(self::$_connection, $sql);
+            self::$_connection->query($sql);
         } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to set sql_mode");
         }
@@ -66,16 +66,17 @@ final class DPDatabase
         mysqli_set_charset(self::$_connection, "utf8mb4");
     }
 
-    public static function close()
+    public static function close(): void
     {
         if (!self::$_connection) {
             return;
         }
 
-        mysqli_close(self::$_connection);
+        self::$_connection->close();
+        self::$_connection = null;
     }
 
-    public static function get_connection()
+    public static function get_connection(): ?mysqli
     {
         return self::$_connection;
     }
@@ -90,10 +91,23 @@ final class DPDatabase
         return addcslashes($value, "%_");
     }
 
+    /**
+     * Execute a query against the MySQL server
+     *
+     * In the background, this calls mysqli_query and thus
+     * will return:
+     *  - on success, either a mysqli_result or true depending on
+     *    the SQL statement (see the documentation for mysqli_query).
+     *  - on failure, it depends on the value of `$throw_on_failure`:
+     *      - If it is true, it will throw an exception.
+     *      - If it is false, it will return false.
+     *
+     * @return mysqli_result|bool
+     */
     public static function query(string $sql, bool $throw_on_failure = true, bool $log_on_failure = true)
     {
         try {
-            $result = mysqli_query(self::$_connection, $sql);
+            $result = self::$_connection->query($sql);
             DPDatabase::log_trace($sql);
         } catch (mysqli_sql_exception $e) {
             if ($log_on_failure) {
@@ -105,13 +119,14 @@ final class DPDatabase
             if ($throw_on_failure) {
                 throw new DBQueryError($error);
             }
+            return false;
         }
         return $result;
     }
 
-    public static function affected_rows()
+    public static function affected_rows(): int
     {
-        return mysqli_affected_rows(self::$_connection);
+        return self::$_connection->affected_rows;
     }
 
     public static function log_error(int $backtrace_level = 0): string
@@ -125,7 +140,7 @@ final class DPDatabase
         return _("An error occurred during a database query and has been logged.");
     }
 
-    private static function get_db_defaults()
+    private static function get_db_defaults(): void
     {
         $sql = sprintf(
             "
@@ -137,10 +152,10 @@ final class DPDatabase
         );
         $result = self::query($sql);
 
-        $row = mysqli_fetch_assoc($result);
+        $row = $result->fetch_assoc();
         self::$_default_db_charset = $row['DEFAULT_CHARACTER_SET_NAME'];
         self::$_default_db_collation = $row['DEFAULT_COLLATION_NAME'];
-        mysqli_free_result($result);
+        $result->free();
     }
 
     public static function get_default_db_charset(): string
@@ -171,9 +186,9 @@ final class DPDatabase
             self::escape($table_name)
         );
         $result = self::query($sql);
-        $row = mysqli_fetch_assoc($result);
+        $row = $result->fetch_assoc();
         $table_encoding = $row['TABLE_COLLATION'];
-        mysqli_free_result($result);
+        $result->free();
 
         return stripos($table_encoding, 'utf8mb4') === 0;
     }
@@ -190,10 +205,10 @@ final class DPDatabase
             self::escape($table_name)
         );
         $result = self::query($sql);
-        return mysqli_fetch_assoc($result) !== null;
+        return $result->fetch_assoc() !== null;
     }
 
-    private static function log_trace(string $sql)
+    private static function log_trace(string $sql): void
     {
         if (!DPDatabase::$tracing_log) {
             return;


### PR DESCRIPTION
The function is core to all the code so this
PR adds some integration tests to make sure
that the basic operations still work.

The tests uncovered a few issues that were fixed,
like `close` wouldn't clear the connection or
`query` could return an unset variable.

The code in DPDatabase.pinc was switched to the
object-oriented API for easier typing but the
caller are mostly using the imperative API. The
mysqli documentation confirmed that this should
be fine, albeit ugly.