### PR TITLE
move validate_text into project

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1797,6 +1797,16 @@ class Project
 
         return new ProjectPage($pagename, $pagestate);
     }
+
+    public function validate_text(string $text): void
+    {
+        $pattern_string = build_character_regex_filter($this->get_valid_codepoints());
+        foreach (split_graphemes($text) as $grapheme) {
+            if (1 != preg_match("/$pattern_string/u", $grapheme)) {
+                throw new ProjectInvalidTextException(_("The text contains characters which are not allowed for this project"));
+            }
+        }
+    }
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/pinc/ProofProject.inc
+++ b/pinc/ProofProject.inc
@@ -18,7 +18,7 @@ class ProofProjectPage extends LPage
     {
         global $pguser;
 
-        $this->validate_text($page_text);
+        $this->project->validate_text($page_text);
         // see comment in LPage.inc
         [$saved, $dpl_reached] = $this->attemptSaveAsDone($page_text, $pguser);
 
@@ -46,7 +46,7 @@ class ProofProjectPage extends LPage
     public function save(string $page_text): array
     {
         global $pguser;
-        $this->validate_text($page_text);
+        $this->project->validate_text($page_text);
         $this->saveAsInProgress($page_text, $pguser);
         return $this->get_page_text_data();
     }
@@ -54,7 +54,7 @@ class ProofProjectPage extends LPage
     public function save_and_revert(string $page_text): array
     {
         global $pguser;
-        $this->validate_text($page_text);
+        $this->project->validate_text($page_text);
         $this->saveAsInProgress($page_text, $pguser);
         $this->revertToOriginal();
         return $this->get_page_text_data();
@@ -88,16 +88,6 @@ class ProofProjectPage extends LPage
             "pagestate" => $this->page_state,
             "saved" => $this->can_be_reverted_to_last_save(),
         ];
-    }
-
-    private function validate_text(string $text): void
-    {
-        $pattern_string = build_character_regex_filter($this->project->get_valid_codepoints());
-        foreach (split_graphemes($text) as $grapheme) {
-            if (1 != preg_match("/$pattern_string/u", $grapheme)) {
-                throw new ProjectInvalidTextException(_("The text contains characters which are not allowed for this project"));
-            }
-        }
     }
 }
 


### PR DESCRIPTION
The validate_text() function does not belong in the ProofProjectPage class since it does not depend on the page.
(preparing for wordcheck api)
