### PR TITLE
Add checks for corrupt illustrations in PQC

### DIFF
--- a/SETUP/ci/check_security.php
+++ b/SETUP/ci/check_security.php
@@ -15,7 +15,6 @@ $ok_system_calls = [
     "pinc/forum_interface_phpbb3.inc",
     "pinc/POFile.inc",
     "pinc/Project.inc",
-    "pinc/project_quick_check.inc",
     "pinc/upload_file.inc",
     "tools/project_manager/add_files.php",
     "tools/project_manager/show_project_stealth_scannos.php",

--- a/pinc/ImageUtils.inc
+++ b/pinc/ImageUtils.inc
@@ -1,0 +1,76 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+class ImageUtils
+{
+    public const IMAGE_OK = 1;
+    public const IMAGE_CORRUPT = 2;
+    public const IMAGE_SKIPPED = 3;
+
+    protected array $external_tools = [
+        "pngcheck" => false,
+        "jpeginfo" => false,
+    ];
+
+    public function __construct()
+    {
+        $this->check_external_tools();
+    }
+
+    protected function check_external_tools(): void
+    {
+        foreach (array_keys($this->external_tools) as $tool) {
+            $process = new Process([$tool, "-h"]);
+            $process->run();
+            if ($process->isSuccessful()) {
+                $this->external_tools[$tool] = true;
+            }
+        }
+    }
+
+    /**
+     * Checks if this class can validate image files given an extension.
+     */
+    public function can_validate(string $extension): bool
+    {
+        $extension = strtolower($extension);
+        if ($extension == "png" && $this->external_tools["pngcheck"]) {
+            return true;
+        } elseif (($extension == "jpeg" || $extension == "jpg") && $this->external_tools["jpeginfo"]) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Validates integrity of the specified image using external tools.
+     *
+     * @returns array<int, string>
+     */
+    public function validate_integrity(string $filename): array
+    {
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+        if (!$this->can_validate($extension)) {
+            return [ImageUtils::IMAGE_SKIPPED, ""];
+        }
+
+        if ($extension == "png") {
+            $checker = ["pngcheck"];
+        } elseif ($extension == "jpeg" || $extension == "jpg") {
+            $checker = ["jpeginfo", "--check"];
+        }
+
+        $checker[] = $filename;
+        $process = new Process($checker);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            $output = explode("\n", $process->getOutput());
+            return [ImageUtils::IMAGE_CORRUPT, $output[0]];
+        }
+
+        return [ImageUtils::IMAGE_OK, ""];
+    }
+}

--- a/pinc/ImageUtils.inc
+++ b/pinc/ImageUtils.inc
@@ -62,6 +62,8 @@ class ImageUtils
             $checker = ["pngcheck"];
         } elseif ($extension == "jpeg" || $extension == "jpg") {
             $checker = ["jpeginfo", "--check"];
+        } else {
+            throw new LogicException("Unsupported extension found, update can_validate()");
         }
 
         $checker[] = $filename;

--- a/pinc/ImageUtils.inc
+++ b/pinc/ImageUtils.inc
@@ -8,6 +8,7 @@ class ImageUtils
     public const IMAGE_CORRUPT = 2;
     public const IMAGE_SKIPPED = 3;
 
+    /** @var array<string, bool> */
     protected array $external_tools = [
         "pngcheck" => false,
         "jpeginfo" => false,

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -198,9 +198,8 @@ function _test_project_for_corrupt_pngs($projectid)
 
     $project = new Project($projectid);
 
-    // see if pngcheck is installed
-    exec('pngcheck', $output, $return_code);
-    if ($return_code != 2) {
+    $checker = new ImageUtils();
+    if (!$checker->can_validate("png")) {
         $status = _("Skipped");
         $summary = _("pngcheck program not available on this system.");
         $details = "";
@@ -223,19 +222,14 @@ function _test_project_for_corrupt_pngs($projectid)
                 continue;
             }
 
-            $path_info = pathinfo($file_info->abs_path);
+            [$image_status, $image_message] = $checker->validate_integrity($file_info->abs_path);
+            if ($image_status == ImageUtils::IMAGE_CORRUPT) {
+                $details .= "<tr>";
+                $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
+                $details .= "<td>" . str_replace($file_info->abs_path, "", $image_message) . "</td>";
+                $details .= "</tr>";
 
-            if (strtolower($path_info["extension"]) == "png") {
-                $output = "";
-                exec('pngcheck -q ' . escapeshellarg($file_info->abs_path), $output, $return_code);
-                if ($return_code != 0) {
-                    $details .= "<tr>";
-                    $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
-                    $details .= "<td>" . str_replace($file_info->abs_path, "", $output[0]) . "</td>";
-                    $details .= "</tr>";
-
-                    $error_pngs++;
-                }
+                $error_pngs++;
             }
         }
 
@@ -271,7 +265,7 @@ function _test_project_for_small_images($projectid)
         $images = $project->get_page_names_from_db();
 
         foreach ($images as $image) {
-            // the the file's info
+            // get the file's info
             $file_info = get_file_info_object($image, $project->dir, $project->url);
 
             // if the file doesn't exist, skip it -- we're not testing for that
@@ -326,17 +320,62 @@ function _test_project_for_illo_images($projectid)
 
         $num_nonpage_image_files = count($nonpage_image_names);
         if ($num_nonpage_image_files > 0) {
-            $status = _("Success");
-            $summary = sprintf(_("%d illustration files found"), $num_nonpage_image_files);
+            $checker = new ImageUtils();
+
+            $details = "<table class='basic striped'>";
+            $details .= "<tr>";
+            $details .= "<th>" . _("Image") . "</th>";
+            $details .= "<th>" . _("Status") . "</th>";
+            $details .= "</tr>";
+
+            $errors = 0;
+            $skipped = 0;
+            foreach ($nonpage_image_names as $image) {
+                // get the file's info
+                $file_info = get_file_info_object($image, $project->dir, $project->url);
+
+                // if the file doesn't exist, skip it -- we're not testing for that
+                if (!$file_info->exists) {
+                    continue;
+                }
+
+                [$image_status, $image_message] = $checker->validate_integrity($file_info->abs_path);
+                if ($image_status == ImageUtils::IMAGE_CORRUPT) {
+                    $details .= "<tr>";
+                    $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
+                    $details .= "<td>" . str_replace($file_info->abs_path, "", $image_message) . "</td>";
+                    $details .= "</tr>";
+
+                    $errors++;
+                } elseif ($image_status == ImageUtils::IMAGE_SKIPPED) {
+                    $skipped++;
+                }
+            }
+
+            $details .= "</table>";
+
+            if ($skipped == $num_nonpage_image_files) {
+                $status = _("Skipped");
+                $summary = sprintf(_("%d illustration files found but no checker installed to check them"), $num_nonpage_image_files);
+                $details = "";
+            } elseif ($errors == 0) {
+                if ($skipped == 0) {
+                    $status = _("Success");
+                    $summary = sprintf(_("%d valid illustration files found"), $num_nonpage_image_files);
+                } else {
+                    $status = _("Warning");
+                    $summary = sprintf(_("%d valid illustration files found; unable to validate %d"), $num_nonpage_image_files - $skipped, $skipped);
+                }
+                $details = "";
+            } else {
+                $status = _("Error");
+                $summary = _("Some pages illustrations have corrupt images.");
+            }
         } else {
             $status = _("Warning");
             $summary = _("No illustration files found");
+            $details = "";
         }
-
-        $details = "
-            <p><a href='$code_url/tools/proofers/images_index.php?project=$projectid'>" . _("Image Index") . "</a></p>
-            <p>$summary</p>
-        ";
     } else {
         $status = _("Skipped");
         $summary = _("Page table does not exist.");


### PR DESCRIPTION
Project Quick Check (PQC) already checked for corrupt page images (pngs) but not for corrupt illustrations (usually but not always jpegs). This adds illustration file checking by centralizing image checking functionality into a new `ImageUtils` class. This class can later be expanded to include using `pngcrush`/`optipng` on images on project load too, hence the more generic name for the class.

Sandbox at https://www.pgdp.org/~cpeel/c.branch/add-jpegs-pqc/

Two projects with "problem" images on TEST:
* Bad JPG illus: `projectID5e6821d744beb`
* Bad page PNG: `projectID4c49f39aa829c`