### PR TITLE
Remove passthru from images_index.php

### DIFF
--- a/SETUP/ci/check_security.php
+++ b/SETUP/ci/check_security.php
@@ -20,7 +20,6 @@ $ok_system_calls = [
     "pinc/upload_file.inc",
     "tools/project_manager/add_files.php",
     "tools/project_manager/show_project_stealth_scannos.php",
-    "tools/proofers/images_index.php",
 ];
 
 // List of files that can contain mysqli_error() calls


### PR DESCRIPTION
Remove `passthru()` from `images_index.php`. And TIL how to use callbacks with the `Process->run()` function.

More iterative work on #1274.

Sandbox at https://www.pgdp.org/~cpeel/c.branch/remove-zip-from-illus/