### PR TITLE
Move misc.inc include above exception handlers

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -236,6 +236,12 @@ function handle_cors_headers()
     }
 }
 
+//----------------------------------------------------------------------------
+
+// Exception handlers should not rely on functions outside of the base PHP
+// set or defined in this file as the handlers may be used before the functions
+// are defined.
+
 function production_exception_handler($exception)
 {
     if ($exception instanceof ApiException) {

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -79,6 +79,10 @@ if ($maintenance && !@$maintenance_override) {
 
 //----------------------------------------------------------------------------
 
+// Exception handlers should not rely on functions outside of the base PHP
+// set or defined in this file as the handlers may be used before the functions
+// are defined.
+
 function production_exception_handler($exception)
 {
     global $maintenance;
@@ -100,7 +104,7 @@ function production_exception_handler($exception)
     }
 
     echo "<p class='error'>\n";
-    echo html_safe($exception->getMessage());
+    echo htmlspecialchars($exception->getMessage(), ENT_QUOTES, 'UTF-8');
     echo "\n</p>";
 }
 
@@ -110,7 +114,7 @@ function test_exception_handler($exception)
     // production_exception_handler() here because we don't want the special
     // handling on DB connection error.
     echo "<p class='error'>\n";
-    echo html_safe($exception->getMessage());
+    echo htmlspecialchars($exception->getMessage(), ENT_QUOTES, 'UTF-8');
     echo "\n</p>";
 
     // Output the stacktrace in a preformatted block

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -30,10 +30,6 @@ spl_autoload_register('dp_class_autoloader');
 // Load composer autoloader
 require_once($relPath.'../vendor/autoload.php');
 
-// Include misc.inc which contains useful functions that almost 90% of
-// the pages use in some way, including our exception handlers.
-include_once($relPath.'misc.inc');
-
 // Exception handlers are defined differently for HTML and the API
 set_exception_handler($testing ? 'test_exception_handler' : 'production_exception_handler');
 
@@ -62,6 +58,10 @@ if (!defined('SKIP_DB_CONNECT')) {
 // Load the session libraries, but allow base.inc and api/index.php to do
 // the start/resume.
 include_once($relPath.'dpsession.inc');
+
+// Include misc.inc which contains useful functions that almost 90% of
+// the pages use in some way.
+include_once($relPath.'misc.inc');
 
 //----------------------------------------------------------------------------
 

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -30,6 +30,10 @@ spl_autoload_register('dp_class_autoloader');
 // Load composer autoloader
 require_once($relPath.'../vendor/autoload.php');
 
+// Include misc.inc which contains useful functions that almost 90% of
+// the pages use in some way, including our exception handlers.
+include_once($relPath.'misc.inc');
+
 // Exception handlers are defined differently for HTML and the API
 set_exception_handler($testing ? 'test_exception_handler' : 'production_exception_handler');
 
@@ -58,10 +62,6 @@ if (!defined('SKIP_DB_CONNECT')) {
 // Load the session libraries, but allow base.inc and api/index.php to do
 // the start/resume.
 include_once($relPath.'dpsession.inc');
-
-// Include misc.inc which contains useful functions that almost 90% of
-// the pages use in some way.
-include_once($relPath.'misc.inc');
 
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
Our exception handlers use `html_safe()` so we need to include `misc.inc` before connecting to the database in case it raises an exception. Discovered this on the clone test system.