### PR TITLE
Check for corrupt images at project load

### DIFF
--- a/pinc/ImageUtils.inc
+++ b/pinc/ImageUtils.inc
@@ -5,13 +5,25 @@ use Symfony\Component\Process\Process;
 class ImageUtils
 {
     public const IMAGE_OK = 1;
-    public const IMAGE_CORRUPT = 2;
-    public const IMAGE_SKIPPED = 3;
+    public const IMAGE_WARNING = 2;
+    public const IMAGE_CORRUPT = 3;
+    public const IMAGE_SKIPPED = 4;
 
     /** @var array<string, bool> */
     protected array $external_tools = [
         "pngcheck" => false,
         "jpeginfo" => false,
+    ];
+
+    // These strings are returned from the validation tools but don't
+    // prevent the image from being loaded/used. Let's treat these substrings
+    // as warnings, not errors.
+    /** @var string[] */
+    public array $warning_strings = [
+        "illegal (unless recently approved) unknown, public chunk eXIf",
+        "invalid gAMA value (0.0000)",
+        "invalid tIME year (1969)",
+        "tEXt text contains NULL character(s)",
     ];
 
     public function __construct()
@@ -71,7 +83,18 @@ class ImageUtils
         $process->run();
         if (!$process->isSuccessful()) {
             $output = explode("\n", $process->getOutput());
-            return [ImageUtils::IMAGE_CORRUPT, $output[0]];
+
+            // remove the filename from the string, it doesn't add value
+            $output = str_replace($filename, "", $output[0]);
+
+            // if its one of our known warning strings, downgrade the severity
+            foreach ($this->warning_strings as $string) {
+                if (stripos($string, $output) !== false) {
+                    return [ImageUtils::IMAGE_WARNING, $output];
+                }
+            }
+
+            return [ImageUtils::IMAGE_CORRUPT, $output];
         }
 
         return [ImageUtils::IMAGE_OK, ""];

--- a/pinc/ImageUtils.inc
+++ b/pinc/ImageUtils.inc
@@ -85,11 +85,11 @@ class ImageUtils
             $output = explode("\n", $process->getOutput());
 
             // remove the filename from the string, it doesn't add value
-            $output = str_replace($filename, "", $output[0]);
+            $output = trim(str_replace($filename, "", $output[0]));
 
             // if its one of our known warning strings, downgrade the severity
             foreach ($this->warning_strings as $string) {
-                if (stripos($string, $output) !== false) {
+                if (stripos($output, $string) !== false) {
                     return [ImageUtils::IMAGE_WARNING, $output];
                 }
             }

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -226,7 +226,7 @@ function _test_project_for_corrupt_pngs($projectid)
             if ($image_status == ImageUtils::IMAGE_CORRUPT) {
                 $details .= "<tr>";
                 $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
-                $details .= "<td>" . str_replace($file_info->abs_path, "", $image_message) . "</td>";
+                $details .= "<td>" . html_safe($image_message) . "</td>";
                 $details .= "</tr>";
 
                 $error_pngs++;
@@ -343,7 +343,7 @@ function _test_project_for_illo_images($projectid)
                 if ($image_status == ImageUtils::IMAGE_CORRUPT) {
                     $details .= "<tr>";
                     $details .= "<td><a href='{$file_info->abs_url}'>" . html_safe($image) . "</a></td>";
-                    $details .= "<td>" . str_replace($file_info->abs_path, "", $image_message) . "</td>";
+                    $details .= "<td>" . html_safe($image_message) . "</td>";
                     $details .= "</tr>";
 
                     $errors++;


### PR DESCRIPTION
Check for corrupt images at project load -- both page images and illustrations. We've found that there are some warnings reported by the image check tools that don't prevent the image from loading. We special-case these as warnings, not errors, in add projects.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/validate-images-add-files/