### PR TITLE
[1/n] Remove array_get

### DIFF
--- a/SETUP/tests/manual_web/page_compare/manual_page_compare_test.php
+++ b/SETUP/tests/manual_web/page_compare/manual_page_compare_test.php
@@ -10,8 +10,8 @@ include_once($relPath."PageUnformatter.inc"); // PageUnformatter()
 
 require_login();
 
-$L_input = array_get($_POST, "Ltex", "");
-$R_input = array_get($_POST, "Rtex", "");
+$L_input = $_POST["Ltex"] ?? "";
+$R_input = $_POST["Rtex"] ?? "";
 $unwrap = isset($_POST['Unwrap']); // can only be 'on'
 $ignore_case = isset($_POST['IgnoreCase']);
 

--- a/SETUP/tests/unittests/MiscUtilsTest.php
+++ b/SETUP/tests/unittests/MiscUtilsTest.php
@@ -7,14 +7,14 @@ class MiscUtilsTest extends PHPUnit\Framework\TestCase
     public function test_array_get_exists()
     {
         $arr = ["param" => "value"];
-        $value = array_get($arr, "param", "default");
+        $value = $arr["param"] ?? "default";
         $this->assertEquals($arr["param"], $value);
     }
 
     public function test_array_get_doesnt_exists()
     {
         $arr = [];
-        $value = array_get($arr, "param", "default");
+        $value = $arr["param"] ?? "default";
         $this->assertEquals("default", $value);
     }
 

--- a/SETUP/upgrade/20/20240205_alter_queue_defns.php
+++ b/SETUP/upgrade/20/20240205_alter_queue_defns.php
@@ -58,8 +58,8 @@ if ($n_rows > 0) {
 
         $targets_array = convert($release_criterion, $queue_ident);
 
-        $setters = 'projects_target = ' . array_get($targets_array, 'projects', 0)
-            . ', pages_target = ' . array_get($targets_array, 'pages', 0);
+        $setters = 'projects_target = ' . ($targets_array['projects'] ?? 0)
+            . ', pages_target = ' . ($targets_array['pages'] ?? 0);
         $sql = "UPDATE queue_defns SET $setters WHERE id=$id\n";
         // echo "$sql\n";
         $res = mysqli_query(DPDatabase::get_connection(), $sql) or die("At $queue_ident, " . mysqli_error(DPDatabase::get_connection()));

--- a/api/index.php
+++ b/api/index.php
@@ -35,7 +35,7 @@ function api()
     api_rate_limit($username);
 
     $query_params = $_GET;
-    $path = array_get($query_params, "url", "");
+    $path = $query_params["url"] ?? "";
     unset($query_params["url"]);
 
     $router = ApiRouter::get_router();
@@ -183,7 +183,7 @@ function api_send_pagination_header($query_params, $total_rows, $per_page, $page
     // NB We don't use $_SERVER['SCRIPT_URI'] because not all servers set
     // it. Most notably, the `php -S` CLI server we use for testing.
     // See https://www.php.net/manual/en/reserved.variables.server.php
-    $proto = !empty(array_get($_SERVER, 'HTTPS', '')) ? 'https://' : 'http://';
+    $proto = !empty($_SERVER['HTTPS'] ?? '') ? 'https://' : 'http://';
     $script_uri = $proto . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
     $link_base = $script_uri . "?";
     if (stripos($link_base, $_GET["url"]) === false) {

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -470,7 +470,7 @@ function api_v1_project_pagedetails($method, $data, $query_params)
 {
     // optional page round IDs (one or more) to filter down to
     $only_rounds = null;
-    $pageroundids = array_get($query_params, "pageroundid", null);
+    $pageroundids = $query_params["pageroundid"] ?? null;
     if ($pageroundids) {
         $only_rounds = [];
         if (!is_array($pageroundids)) {

--- a/api/v1_queues.inc
+++ b/api/v1_queues.inc
@@ -10,7 +10,7 @@ include_once("api_common.inc");
 // queues -- list queues, optionally filtered by round
 function api_v1_queues($method, $data, $query_params)
 {
-    $roundid = array_get($query_params, "roundid", null);
+    $roundid = $query_params["roundid"] ?? null;
     $round = !is_null($roundid) ? validate_round($roundid, null) : null;
 
     $show = get_enumerated_param($query_params, "show", "all", ["enabled", "populated", "all"]);
@@ -42,8 +42,8 @@ function api_v1_queues($method, $data, $query_params)
     $return_fields = array_get_as_array($query_params, "field", $valid_return_fields);
     $return_fields = array_intersect($return_fields, $valid_return_fields);
 
-    $name_selector = array_get($query_params, "name", null);
-    $group_selector = array_get($query_params, "group", null);
+    $name_selector = $query_params["name"] ?? null;
+    $group_selector = $query_params["group"] ?? null;
 
     $output = [];
     foreach (fetch_queues_data($round, $show, false, $name_selector, $group_selector) as $queue_data) {

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -12,9 +12,20 @@ use voku\helper\UTF8;
 
 /**
  * Return $arr[$key], or if it's not defined, $default.
+ *
+ * You should be using the ?? operator moving forward as this function is deprecated:
+ *    $arr[$key] ?? $default
+ *
+ * @param array $arr
+ * @param string|int $key
+ * @param mixed $default
+ * @return mixed
+ * @deprecated
  */
 function array_get($arr, $key, $default)
 {
+    // TODO(jchaffraix): Enable once we have no users in the codebase.
+    // trigger_error("array_get() is deprecated, use the null coalescing operator instead", E_USER_DEPRECATED);
     if (isset($arr[$key])) {
         return $arr[$key];
     } else {


### PR DESCRIPTION
The function cannot be properly typed as it
is and fixing this would take a while, removing
it is shorter and better.

This PR only covers SETUP/* and api/*.
It also deprecates array_get so users know that
they should migrate.

TESTS=None.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/julien_remove_array_get_1/