### PR TITLE
[4/n] Remove array_get

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -9,7 +9,7 @@ include_once($relPath.'User.inc');
 
 // The current param value is "reg_token" but the prior value was "id"
 // so we support both here.
-$reg_token = array_get($_GET, "reg_token", array_get($_GET, "id", ""));
+$reg_token = $_GET["reg_token"] ?? ($_GET["id"] ?? "");
 
 // If the user is already logged in, redirect them to the Activity Hub.
 if (User::current_username()) {

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -8,15 +8,15 @@ include_once($relPath.'new_user_mails.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'User.inc');
 
-$real_name = array_get($_POST, 'real_name', '');
-$username = array_get($_POST, 'userNM', '');
-$userpass = array_get($_POST, 'userPW', '');
-$userpass2 = array_get($_POST, 'userPW2', '');
-$email = array_get($_POST, 'email', '');
-$email2 = array_get($_POST, 'email2', '');
+$real_name = $_POST['real_name'] ?? '';
+$username = $_POST['userNM'] ?? '';
+$userpass = $_POST['userPW'] ?? '';
+$userpass2 = $_POST['userPW2'] ?? '';
+$email = $_POST['email'] ?? '';
+$email2 = $_POST['email2'] ?? '';
 $email_updates = get_bool_param($_POST, 'email_updates', true);
-$referrer = array_get($_POST, 'referrer', '');
-$referrer_details = array_get($_POST, 'referrer_details', '');
+$referrer = $_POST['referrer'] ?? '';
+$referrer_details = $_POST['referrer_details'] ?? '';
 
 $form_data_inserters = [];
 $form_validators = [
@@ -64,7 +64,7 @@ if (count($_POST)) {
         $register->email_updates = $email_updates;
         $register->referrer = $referrer;
         $register->referrer_details = $referrer_details;
-        $register->http_referrer = array_get($_COOKIE, "http_referer", "");
+        $register->http_referrer = $_COOKIE["http_referer"] ?? "";
         $register->u_intlang = $intlang;
         $register->user_password = forum_password_hash($userpass);
 

--- a/locale/debug_ui_language.php
+++ b/locale/debug_ui_language.php
@@ -11,14 +11,14 @@ output_header($title, NO_STATSBAR);
 $user = User::load_current();
 
 $detected_language = get_desired_language();
-$url_language = array_get($_GET, 'lang', "<i>not set</i>");
+$url_language = $_GET['lang'] ?? "<i>not set</i>";
 $pref_language = $user ? $user->u_intlang : "<i>not set</i>";
 $user_logged_in = $user ? $user->username : "<i>not logged in</i>";
 if ($pref_language == "") {
     $pref_language = "<i>browser detect</i>";
 }
-$cookie_language = array_get($_COOKIE, 'language', "<i>not set</i>");
-$http_accept_language = array_get($_SERVER, 'HTTP_ACCEPT_LANGUAGE', "<i>not set </i>");
+$cookie_language = $_COOKIE['language'] ?? "<i>not set</i>";
+$http_accept_language = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? "<i>not set </i>";
 $browser_locale = get_locale_matching_browser_accept_language(@$_SERVER['HTTP_ACCEPT_LANGUAGE']);
 
 $enabled_languages = implode(", ", array_merge(get_installed_locale_translations("all"), ["en_US"]));

--- a/project.php
+++ b/project.php
@@ -1206,7 +1206,7 @@ function do_history(): void
 
         $event_type = $event['event_type'];
         echo "<td>",
-        array_get($event_type_labels, $event_type, $event_type),
+        $event_type_labels[$event_type] ?? $event_type,
         "</td>\n";
         // count columns so we can fill up space after
         $spare_cols = 3;
@@ -1276,7 +1276,7 @@ function do_history(): void
 
                     $labels = [];
                     foreach (explode(' ', $changed_fields) as $fieldname) {
-                        $labels[] = html_safe(array_get($label_for_project_field_, $fieldname, $fieldname));
+                        $labels[] = html_safe($label_for_project_field_[$fieldname] ?? $fieldname);
                     }
                     // Note that this lists the changed fields in the same order
                     // as they appear in the 'details1' field of the events table,

--- a/tasks.php
+++ b/tasks.php
@@ -467,8 +467,8 @@ function create_task_from_form_submission($formsub)
     global $requester_u_id;
     global $site_abbreviation;
 
-    $task_summary = trim(array_get($formsub, 'task_summary', ''));
-    $task_details = trim(array_get($formsub, 'task_details', ''));
+    $task_summary = trim($formsub['task_summary'] ?? '');
+    $task_details = trim($formsub['task_details'] ?? '');
 
     if (empty($task_summary) || empty($task_details)) {
         return _("You must supply a Task Summary and Task Details.");
@@ -704,8 +704,8 @@ function handle_action_on_a_specified_task()
         DPDatabase::query($sql);
         metarefresh(0, "$tasks_url?task_id=$task_id");
     } elseif ($action == 'edit') {
-        $task_summary = trim(array_get($_POST, 'task_summary', ''));
-        $task_details = trim(array_get($_POST, 'task_details', ''));
+        $task_summary = trim($_POST['task_summary'] ?? '');
+        $task_details = trim($_POST['task_details'] ?? '');
         // The user is supplying values for the properties of a pre-existing task.
         if (empty($task_summary) || empty($task_details)) {
             ShowError(_("You must supply a Task Summary and Task Details."), true);
@@ -796,7 +796,7 @@ function handle_action_on_a_specified_task()
             return;
         }
     } elseif ($action == 'add_comment') {
-        $comment = trim(array_get($_POST, 'task_comment', ''));
+        $comment = trim($_POST['task_comment'] ?? '');
         if ($comment) {
             NotificationMail($task_id, "$pguser commented:\n\n$comment");
             $sql = sprintf(
@@ -870,8 +870,8 @@ function handle_action_on_a_specified_task()
         // Redirect back to show task page to clear POST data
         metarefresh(0, "$tasks_url?action=show&task_id=$task_id");
     } elseif ($action == 'save_edit_comment') {
-        $comment_id = array_get($_POST, 'comment_id', "");
-        $comment = trim(array_get($_POST, 'task_comment', ''));
+        $comment_id = $_POST['comment_id'] ?? "";
+        $comment = trim($_POST['task_comment'] ?? '');
         [$u_id, $comment_date] = explode('_', $comment_id, 2);
         if (($u_id === $requester_u_id && $now_sse - $comment_date <= 86400) || user_is_a_sitemanager()) {
             $sql = sprintf(
@@ -1783,7 +1783,7 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
     global $tasks_close_array;
     global $tasks_status_array;
 
-    $raw_value = array_get($task_a, $property_id, null);
+    $raw_value = $task_a[$property_id] ?? null;
     switch ($property_id) {
         // The raw value is used directly:
         case 'task_id':
@@ -1792,7 +1792,7 @@ function property_format_value($property_id, $task_a, $for_list_of_tasks)
 
             // The raw value is an index into an array.
         case 'closed_reason':
-            return array_get($tasks_close_array, $raw_value, "");
+            return $tasks_close_array[$raw_value] ?? "";
         case 'task_browser':
             return $browser_array[$raw_value];
         case 'task_category':

--- a/userprefs.php
+++ b/userprefs.php
@@ -21,7 +21,7 @@ require_login();
 // $origin will be uninitialized, in which case it could be set
 // to ".../userprefs.php..." at the next calls. Avoid this by setting
 // the fallback origin to the Activity Hub.
-$origin = array_get($_REQUEST, "origin", "");
+$origin = $_REQUEST["origin"] ?? "";
 if (empty($origin)) {
     if (array_key_exists('HTTP_REFERER', $_SERVER)
         && !startswith($_SERVER['HTTP_REFERER'], "$code_url/userprefs.php")) {
@@ -68,7 +68,7 @@ if (isset($_POST["quitnc"])) {
     metarefresh(0, $origin, _("Quit"));
 }
 
-if (array_get($_POST, "insertdb", "") != "") {
+if (($_POST["insertdb"] ?? "") != "") {
     // one of the tabs was displayed and now it has been posted
     // determine which and let that tab save 'itself'.
 


### PR DESCRIPTION
The function cannot be properly typed as it
is and fixing this would take a while, removing
it is shorter and better.

The change updates accounts/*, locale/*,
project.php, tasks.php and userprefs.php.

TESTS=Created a new account, created a new task,
updated user prefs, and updated a project.

Sandbox at: https://www.pgdp.org/~cpeel/c.branch/julien_remove_array_get_4/