### PR TITLE
[5/n] Remove array_get

### DIFF
--- a/tools/proofers/ctrl_frame.php
+++ b/tools/proofers/ctrl_frame.php
@@ -9,7 +9,7 @@ $round = get_round_param($_GET, 'round_id');
 // if this is used in a quiz there will not be a real projectid, 'quiz' will be
 // used for the MRU local storage prefix and the character selector will
 // provide the quiz pickers
-$projectid = array_get($_GET, 'projectid', 'quiz');
+$projectid = $_GET['projectid'] ?? 'quiz';
 if ($projectid != "quiz") {
     validate_projectID($projectid);
 }

--- a/tools/proofers/mktable.php
+++ b/tools/proofers/mktable.php
@@ -15,14 +15,14 @@ define("ARRAY_PAD_BOTH", 0);
 
 mb_internal_encoding($charset);
 
-$row = array_get($_POST, 'row', 1);
-$col = array_get($_POST, 'col', 1);
-$bord = array_get($_POST, 'border', 1);
-$trim = (array_get($_POST, 'trim', 'off') == 'on');
-$clear = array_get($_POST, 'clear', 0);
-$vert_align = array_map('intval', array_get($_POST, 'vert_align', []));
-$horiz_align = array_map('intval', array_get($_POST, 'horiz_align', []));
-$table_contents = array_get($_POST, 'table_contents', []);
+$row = $_POST['row'] ?? 1;
+$col = $_POST['col'] ?? 1;
+$bord = $_POST['border'] ?? 1;
+$trim = (($_POST['trim'] ?? 'off') == 'on');
+$clear = $_POST['clear'] ?? 0;
+$vert_align = array_map('intval', $_POST['vert_align'] ?? []);
+$horiz_align = array_map('intval', $_POST['horiz_align'] ?? []);
+$table_contents = $_POST['table_contents'] ?? [];
 
 if ($clear) {
     $table_contents = [];

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -13,7 +13,7 @@ require_login();
 
 $username = $pguser;
 if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
-    $username = array_get($_GET, 'username', $pguser);
+    $username = $_GET['username'] ?? $pguser;
     if (!User::is_valid_user($username)) {
         die("Invalid username.");
     }

--- a/tools/proofers/my_suggestions.php
+++ b/tools/proofers/my_suggestions.php
@@ -15,7 +15,7 @@ $flush_cache = get_integer_param($_GET, "flush_cache", 0, 0, 1);
 
 $username = User::current_username();
 if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
-    $username = array_get($_GET, 'username', $username);
+    $username = $_GET['username'] ?? $username;
     if (!User::is_valid_user($username)) {
         die("Invalid username.");
     }

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -23,7 +23,7 @@ $_POST:
 $projectid = get_projectID_param($_POST, 'projectid');
 $proj_state = get_enumerated_param($_POST, 'proj_state', null, ProjectStates::get_states());
 $imagefile = get_page_image_param($_POST, 'imagefile');
-$text_data = array_get($_POST, 'text_data', '');
+$text_data = $_POST['text_data'] ?? '';
 
 define('B_TEMPSAVE', 1);
 define('B_SAVE_AND_DO_ANOTHER', 2);

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -16,7 +16,7 @@ define("MESSAGE_ERROR", 2);
 $rounds = Rounds::get_all();
 
 // load any data passed into the page
-$username = array_get($_GET, "username", $pguser);
+$username = $_GET["username"] ?? $pguser;
 $work_round = get_round_param($_GET, "work_round_id", null, true);
 $review_round = get_round_param($_GET, "review_round_id", null, true);
 $sampleLimit = get_integer_param($_GET, "sample_limit", 0, 0, null);

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -399,7 +399,7 @@ function output_wordcheck_interface(User $user, PPage $ppage, string $text_data,
 
     $revert_text = $_POST['revert_text'] ?? $text_data;
 
-    $is_header_visible = array_get($_SESSION, "is_header_visible", 1);
+    $is_header_visible = $_SESSION["is_header_visible"] ?? 1;
 
     // print basic image html
     if ($user->profile->i_type == 1) {


### PR DESCRIPTION
The function cannot be properly typed as it
is and fixing this would take a while, removing
it is shorter and better.

The change updates tools/proofers/*.

TESTS=Did a few P1 checks, including WordCheck.

Sandbox at: https://www.pgdp.org/~cpeel/c.branch/julien_remove_array_get_5/