### PR TITLE
Wordcheck API returning bad words with levels

### DIFF
--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -81,7 +81,7 @@ class ApiTest extends ProjectUtils
         return $router->route($path, []);
     }
 
-    protected function wordcheck_report(string $projectid, string $project_state, string $page_name, string $page_state, array $accepted_words = [])
+    protected function wordcheck_report(string $projectid, string $page_name, array $accepted_words = [])
     {
         global $request_body;
 
@@ -89,7 +89,7 @@ class ApiTest extends ProjectUtils
         $request_body = ["accepted_words" => $accepted_words];
         $path = "v1/projects/$projectid/pages/$page_name/wordcheck";
         $router = ApiRouter::get_router();
-        return $router->route($path, ['state' => $project_state, 'pagestate' => $page_state]);
+        return $router->route($path, []);
     }
 
     //---------------------------------------------------------------------------
@@ -748,7 +748,7 @@ class ApiTest extends ProjectUtils
 
         // report wordcheck results
         $accepted_words = ["Snelling", "b[oe]uf"];
-        $this->wordcheck_report($project->projectid, "P1.proj_avail", "001.png", "P1.page_out", $accepted_words);
+        $this->wordcheck_report($project->projectid, "001.png", $accepted_words);
         [$result] = load_wordcheck_events($project->projectid);
         $this->assertEquals("P1", $result[1]);
         $this->assertEquals("001.png", $result[2]);

--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -74,7 +74,7 @@ class ApiTest extends ProjectUtils
     {
         global $request_body;
 
-        $request_body = ["text" => $text, "languages" => $languages, "acceptedwords" => $accepted_words];
+        $request_body = ["text" => $text, "languages" => $languages, "accepted_words" => $accepted_words];
         $_SERVER["REQUEST_METHOD"] = "PUT";
         $path = "v1/projects/$projectid/wordcheck";
         $router = ApiRouter::get_router();

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -960,7 +960,14 @@ paths:
       parameters:
       - $ref: '#/components/parameters/projectid'
       requestBody:
-        $ref: '#/components/requestBodies/page_text'
+        description: Text to save or analyse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
       responses:
         200:
           description: analysis data
@@ -968,6 +975,61 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/text_analysis'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/wordcheck:
+    put:
+      tags:
+      - project
+      description: Checks the given text for bad words, returns an array of bad words with their type and an array of messages
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      requestBody:
+        description: text, accepted words and languages
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                acceptedwords:
+                  type: array
+                  items:
+                    type: string
+                languages:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        200:
+          description: wordcheck data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bad_words:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties:
+                        type: integer
+                        description: Keys are bad words, values are levels
+                  messages:
+                    type: array
+                    items:
+                      type: string
         '400':
           $ref: '#/components/responses/InvalidValue'
         '401':
@@ -1002,11 +1064,25 @@ paths:
             revert - Checks the page for invalid characters and if valid, saves it as in progress. Response:- page_text_state object.
             <br><br>
             abandon - Returns the page to the round, response:- none.
+            <br><br>
+            report - Submits a wordcheck report with any accepted words
         required: true
         schema:
           type: string
       requestBody:
-        $ref: '#/components/requestBodies/page_text'
+        description: text, +accepted words in report case
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+                acceptedwords:
+                  type: array
+                  items:
+                    type: string
       responses:
         200:
           description: Page data
@@ -1174,17 +1250,6 @@ components:
       required: true
       schema:
         type: string
-
-  requestBodies:
-    page_text:
-      description: Text to save or analyse
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              text:
-                type: string
 
   schemas:
     project:

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -1064,13 +1064,11 @@ paths:
             revert - Checks the page for invalid characters and if valid, saves it as in progress. Response:- page_text_state object.
             <br><br>
             abandon - Returns the page to the round, response:- none.
-            <br><br>
-            report - Submits a wordcheck report with any accepted words
         required: true
         schema:
           type: string
       requestBody:
-        description: text, +accepted words in report case
+        description: text
         required: true
         content:
           application/json:
@@ -1079,10 +1077,6 @@ paths:
               properties:
                 text:
                   type: string
-                accepted_words:
-                  type: array
-                  items:
-                    type: string
       responses:
         200:
           description: Page data
@@ -1120,6 +1114,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/page_text_state'
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
+  /projects/{projectid}/pages/{pagename}/wordcheck:
+    put:
+      tags:
+      - project
+      description: Report wordcheck reults
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/state_query'
+      - $ref: '#/components/parameters/pagename'
+      - $ref: '#/components/parameters/pagestate_query'
+      requestBody:
+        description: accepted words if any
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                accepted_words:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        200:
+          description: OK
         '400':
           $ref: '#/components/responses/InvalidValue'
         '401':

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -1003,7 +1003,7 @@ paths:
               properties:
                 text:
                   type: string
-                acceptedwords:
+                accepted_words:
                   type: array
                   items:
                     type: string
@@ -1079,7 +1079,7 @@ paths:
               properties:
                 text:
                   type: string
-                acceptedwords:
+                accepted_words:
                   type: array
                   items:
                     type: string

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -960,14 +960,7 @@ paths:
       parameters:
       - $ref: '#/components/parameters/projectid'
       requestBody:
-        description: Text to save or analyse
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                text:
-                  type: string
+        $ref: '#/components/requestBodies/page_text'
       responses:
         200:
           description: analysis data
@@ -1068,15 +1061,7 @@ paths:
         schema:
           type: string
       requestBody:
-        description: text
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                text:
-                  type: string
+        $ref: '#/components/requestBodies/page_text'
       responses:
         200:
           description: Page data
@@ -1280,6 +1265,17 @@ components:
       required: true
       schema:
         type: string
+
+  requestBodies:
+    page_text:
+      description: Text to save or analyse
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              text:
+                type: string
 
   schemas:
     project:

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -1134,9 +1134,7 @@ paths:
       description: Report wordcheck reults
       parameters:
       - $ref: '#/components/parameters/projectid'
-      - $ref: '#/components/parameters/state_query'
       - $ref: '#/components/parameters/pagename'
-      - $ref: '#/components/parameters/pagestate_query'
       requestBody:
         description: accepted words if any
         required: true

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -48,6 +48,7 @@ $router->add_route("GET", "v1/queues/:queueid/projects", "api_v1_queue_projects"
 
 $router->add_route("PUT", "v1/projects/:projectid/checkout", "api_v1_project_checkout");
 $router->add_route("PUT", "v1/projects/:projectid/validatetext", "api_v1_project_validatetext");
+$router->add_route("PUT", "v1/projects/:projectid/wordcheck", "api_v1_project_wordcheck");
 $router->add_route("PUT", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
 

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -45,12 +45,12 @@ $router->add_route("GET", "v1/queues/:queueid", "api_v1_queue");
 $router->add_route("GET", "v1/queues/:queueid/stats", "api_v1_queue_stats");
 $router->add_route("GET", "v1/queues/:queueid/projects", "api_v1_queue_projects");
 
-
 $router->add_route("PUT", "v1/projects/:projectid/checkout", "api_v1_project_checkout");
 $router->add_route("PUT", "v1/projects/:projectid/validatetext", "api_v1_project_validatetext");
 $router->add_route("PUT", "v1/projects/:projectid/wordcheck", "api_v1_project_wordcheck");
 $router->add_route("PUT", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/wordcheck", "api_v1_project_page_wordcheck");
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
 $router->add_route("GET", "v1/stats/site/projects/stages", "api_v1_stats_site_projects_stages");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -801,24 +801,19 @@ function api_v1_project_validatetext($method, $data, array $query_params)
 
 function api_v1_project_wordcheck($method, $data, array $query_params)
 {
-    try {
-        $project = $data[":projectid"];
-        $accepted_words = receive_data_from_request_body("acceptedwords") ?? [];
-        $languages = receive_data_from_request_body("languages") ?? [];
-        if (!$languages) {
-            $languages = $project->languages;
-        }
-
-        $text = receive_project_text_from_request_body();
-        [$bad_words, $languages, $messages] = get_bad_word_levels_for_project_text($text, $project->projectid, $languages, $accepted_words);
-        return [
-            "bad_words" => $bad_words,
-            "messages" => $messages,
-        ];
-
-    } catch (ProjectException $exception) {
-        throw new NotFoundError($exception->getMessage(), $exception->getCode());
+    $project = $data[":projectid"];
+    $accepted_words = receive_data_from_request_body("acceptedwords") ?? [];
+    $languages = receive_data_from_request_body("languages") ?? [];
+    if (!$languages) {
+        $languages = $project->languages;
     }
+
+    $text = receive_project_text_from_request_body();
+    [$bad_words, $languages, $messages] = get_bad_word_levels_for_project_text($text, $project->projectid, $languages, $accepted_words);
+    return [
+        "bad_words" => $bad_words,
+        "messages" => $messages,
+    ];
 }
 
 function api_v1_project_page(string $method, array $data, array $query_params)

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -802,7 +802,7 @@ function api_v1_project_validatetext($method, $data, array $query_params)
 function api_v1_project_wordcheck($method, $data, array $query_params)
 {
     $project = $data[":projectid"];
-    $accepted_words = receive_data_from_request_body("acceptedwords") ?? [];
+    $accepted_words = receive_data_from_request_body("accepted_words") ?? [];
     $languages = receive_data_from_request_body("languages") ?? [];
     if (!$languages) {
         $languages = $project->languages;
@@ -866,7 +866,7 @@ function api_v1_project_page(string $method, array $data, array $query_params)
             case 'abandon':
                 return $proof_project_page->returnToRound($pguser);
             case 'report':
-                $proof_project_page->wc_report(receive_data_from_request_body("acceptedwords") ?? []);
+                $proof_project_page->wc_report(receive_data_from_request_body("accepted_words") ?? []);
                 break;
             default:
                 throw new BadRequest("$page_action is not a valid page action.");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -799,6 +799,28 @@ function api_v1_project_validatetext($method, $data, array $query_params)
     return $text_checker->analyse(receive_project_text_from_request_body('text'), $data[":projectid"]);
 }
 
+function api_v1_project_wordcheck($method, $data, array $query_params)
+{
+    try {
+        $project = $data[":projectid"];
+        $accepted_words = receive_data_from_request_body("acceptedwords") ?? [];
+        $languages = receive_data_from_request_body("languages") ?? [];
+        if (!$languages) {
+            $languages = $project->languages;
+        }
+
+        $text = receive_project_text_from_request_body();
+        [$bad_words, $languages, $messages] = get_bad_word_levels_for_project_text($text, $project->projectid, $languages, $accepted_words);
+        return [
+            "bad_words" => $bad_words,
+            "messages" => $messages,
+        ];
+
+    } catch (ProjectException $exception) {
+        throw new NotFoundError($exception->getMessage(), $exception->getCode());
+    }
+}
+
 function api_v1_project_page(string $method, array $data, array $query_params)
 {
     global $pguser;
@@ -848,6 +870,9 @@ function api_v1_project_page(string $method, array $data, array $query_params)
                 return $proof_project_page->save_and_revert(receive_project_text_from_request_body('text'));
             case 'abandon':
                 return $proof_project_page->returnToRound($pguser);
+            case 'report':
+                $proof_project_page->wc_report(receive_data_from_request_body("acceptedwords") ?? []);
+                break;
             default:
                 throw new BadRequest("$page_action is not a valid page action.");
         }
@@ -877,12 +902,17 @@ function validate_project_state($project, $state)
     }
 }
 
-function receive_project_text_from_request_body($field): string
+function receive_project_text_from_request_body(): string
 {
-    $request_data = api_get_request_body();
-    $page_text = $request_data[$field] ?? null;
+    $page_text = receive_data_from_request_body("text");
     if (null === $page_text) {
         throw new InvalidValue("There is no text");
     }
     return $page_text;
+}
+
+function receive_data_from_request_body($field)
+{
+    $request_data = api_get_request_body();
+    return $request_data[$field] ?? null;
 }

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -834,23 +834,9 @@ function api_v1_project_page(string $method, array $data, array $query_params)
         $proof_project = new ProofProject($project);
 
         $page_state = $query_params['pagestate'] ?? null;
-        if (null === $page_state) {
-            throw new InvalidValue("No page state found in request.");
-        }
-        if (!in_array($page_state, Rounds::get_page_states())) {
-            throw new InvalidValue(sprintf("%s is not a valid page state", $page_state));
-        }
-        if ($page_state != $project_page->page_state) {
-            $err = sprintf(
-                _('Page "%1$s" is not in state "%2$s"; it is now in state "%3$s".'),
-                $project_page->page_name,
-                $page_state,
-                $project_page->page_state
-            );
-            throw new ProjectPageInconsistentStateException($err);
-        }
-
+        validate_page_state($project_page, $page_state);
         $proof_project_page = new ProofProjectPage($proof_project, $project_page);
+
         $page_action = $query_params['pageaction'] ?? null;
         switch ($page_action) {
             case null:
@@ -865,12 +851,30 @@ function api_v1_project_page(string $method, array $data, array $query_params)
                 return $proof_project_page->save_and_revert(receive_project_text_from_request_body('text'));
             case 'abandon':
                 return $proof_project_page->returnToRound($pguser);
-            case 'report':
-                $proof_project_page->wc_report(receive_data_from_request_body("accepted_words") ?? []);
-                break;
             default:
                 throw new BadRequest("$page_action is not a valid page action.");
         }
+    } catch (ProjectException $exception) {
+        throw new NotFoundError($exception->getMessage(), $exception->getCode());
+    } catch (UserAccessException $exception) {
+        throw new ForbiddenError($exception->getMessage(), $exception->getCode());
+    }
+}
+
+function api_v1_project_page_wordcheck(string $method, array $data, array $query_params): void
+{
+    try {
+        $project = $data[":projectid"];
+        $state = $query_params["state"] ?? null;
+        validate_project_state($project, $state);
+        $proof_project = new ProofProject($project);
+
+        $project_page = $data[":pagename"];
+        $page_state = $query_params['pagestate'] ?? null;
+        validate_page_state($project_page, $page_state);
+        $proof_project_page = new ProofProjectPage($proof_project, $project_page);
+
+        $proof_project_page->wc_report(receive_data_from_request_body("accepted_words") ?? []);
     } catch (ProjectException $exception) {
         throw new NotFoundError($exception->getMessage(), $exception->getCode());
     } catch (UserAccessException $exception) {
@@ -894,6 +898,25 @@ function validate_project_state($project, $state)
             project_states_text($project->state)
         );
         throw new ProjectNotInRequiredStateException($err);
+    }
+}
+
+function validate_page_state($project_page, $page_state)
+{
+    if (null === $page_state) {
+        throw new InvalidValue("No page state found in request.");
+    }
+    if (!in_array($page_state, Rounds::get_page_states())) {
+        throw new InvalidValue(sprintf("%s is not a valid page state", $page_state));
+    }
+    if ($page_state != $project_page->page_state) {
+        $err = sprintf(
+            _('Page "%1$s" is not in state "%2$s"; it is now in state "%3$s".'),
+            $project_page->page_name,
+            $page_state,
+            $project_page->page_state
+        );
+        throw new ProjectPageInconsistentStateException($err);
     }
 }
 

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -865,13 +865,9 @@ function api_v1_project_page_wordcheck(string $method, array $data, array $query
 {
     try {
         $project = $data[":projectid"];
-        $state = $query_params["state"] ?? null;
-        validate_project_state($project, $state);
         $proof_project = new ProofProject($project);
 
         $project_page = $data[":pagename"];
-        $page_state = $query_params['pagestate'] ?? null;
-        validate_page_state($project_page, $page_state);
         $proof_project_page = new ProofProjectPage($proof_project, $project_page);
 
         $proof_project_page->wc_report(receive_data_from_request_body("accepted_words") ?? []);

--- a/pinc/ProofProject.inc
+++ b/pinc/ProofProject.inc
@@ -89,6 +89,27 @@ class ProofProjectPage extends LPage
             "saved" => $this->can_be_reverted_to_last_save(),
         ];
     }
+
+    public function wc_report(array $accepted_words): void
+    {
+        global $pguser;
+
+        _Page_require(
+            $this->projectid,
+            $this->imagefile,
+            [$this->round->page_out_state, $this->round->page_temp_state],
+            $this->round->user_column_name,
+            $pguser,
+            'report'
+        );
+        save_wordcheck_event(
+            $this->projectid,
+            $this->round->id,
+            $this->imagefile,
+            $pguser,
+            $accepted_words
+        );
+    }
 }
 
 class ProofProject


### PR DESCRIPTION
Sandbox at: https://www.pgdp.org/~rp31/c.branch/api_wc3

There are two endpoints:
- PUT v1/projects/:projectid/wordcheck This does not require the user to own the page. Needs accepted words and languages. Returns an array of bad words with their levels. 
-  PUT v1/projects/:projectid/pages/:pagename/wordcheck. [edited] This requires the user to own the page and executes save_wordcheck_event(). The logic of when to call this is left to the client. It can be as follows: When the user does any kind of save, if he has previously entered wordcheck mode and a wordcheck report has not previously been submitted then submit a report before the save even if the user has not suggested any words to be accepted. On any subsequent saves submit a report only if the user has suggested some words since the previous report and include only these words. In this way the same word will not be reported more than once for each page.
