### PR TITLE
Add an endpoint for get pickersets

### DIFF
--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -753,6 +753,21 @@ class ApiTest extends ProjectUtils
         $this->assertEquals("ProjectTest_php", $result[3]);
         $this->assertEquals($accepted_words, $result[4]);
     }
+
+    public function test_pickersets()
+    {
+        $project = $this->_create_project();
+        $path = "v1/projects/$project->projectid/pickersets";
+        $router = ApiRouter::get_router();
+        $_SERVER["REQUEST_METHOD"] = "GET";
+        $response = $router->route($path, []);
+        $pickerset = $response[0];
+        $this->assertEquals("basic-latin", $pickerset["name"]);
+        $this->assertEquals("!", $pickerset["subsets"][3]["name"]);
+        $this->assertEquals("Punctuation", $pickerset["subsets"][3]["title"]);
+        $this->assertEquals(["!", "EXCLAMATION MARK"], $pickerset["subsets"][3]["rows"][0][0]);
+        $this->assertEquals(["¿", "INVERTED QUESTION MARK"], $pickerset["subsets"][3]["rows"][1][1]);
+    }
 }
 
 // this mocks the function in index.php

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -1041,6 +1041,63 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/{projectid}/pickersets:
+    get:
+      tags:
+      - project
+      description: Gets pickersets for the project including utf8 character names
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      responses:
+        200:
+          description: picker data
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: basic-latin
+                    subsets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          title:
+                            type: string
+                          rows:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: string
+                        example:
+                          name: ˆ
+                          title: "Letters with acute, grave, and circumflex"
+                          rows: [
+                            [
+                              [Á, LATIN CAPITAL LETTER A WITH ACUTE], [É, LATIN CAPITAL LETTER E WITH ACUTE]
+                            ],
+                            [
+                              [á, LATIN SMALL LETTER A WITH ACUTE], [é, LATIN SMALL LETTER E WITH ACUTE]
+                            ]
+                          ]
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/{projectid}/pages/{pagename}:
     put:
       tags:

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -48,6 +48,7 @@ $router->add_route("GET", "v1/queues/:queueid/projects", "api_v1_queue_projects"
 $router->add_route("PUT", "v1/projects/:projectid/checkout", "api_v1_project_checkout");
 $router->add_route("PUT", "v1/projects/:projectid/validatetext", "api_v1_project_validatetext");
 $router->add_route("PUT", "v1/projects/:projectid/wordcheck", "api_v1_project_wordcheck");
+$router->add_route("GET", "v1/projects/:projectid/pickersets", "api_v1_project_pickersets");
 $router->add_route("PUT", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
 $router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/wordcheck", "api_v1_project_page_wordcheck");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -817,6 +817,19 @@ function api_v1_project_wordcheck($method, $data, array $query_params)
     ];
 }
 
+function api_v1_project_pickersets(string $method, array $data, array $query_params): array
+{
+    $project = $data[":projectid"];
+    $verbose_pickersets = [];
+    foreach ($project->get_pickersets() as $pickerset) {
+        $verbose_pickersets[] = [
+            "name" => $pickerset->name,
+            "subsets" => $pickerset->get_verbose_subsets(),
+        ];
+    }
+    return $verbose_pickersets;
+}
+
 function api_v1_project_page(string $method, array $data, array $query_params)
 {
     global $pguser;

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -31,6 +31,24 @@ class PickerSet
         return $this->subsets;
     }
 
+    public function get_verbose_subsets(): array
+    {
+        $verbose_subsets = [];
+        foreach ($this->subsets as $subset_name => $codepoint_rows) {
+            $verbose_rows = [];
+            foreach ($codepoint_rows as $row) {
+                $chars = convert_codepoint_ranges_to_characters($row);
+                $char_names = [];
+                foreach ($chars as $char) {
+                    $char_names[] = [$char, (null !== $char) ? utf8_character_name($char) : null];
+                }
+                $verbose_rows[] = $char_names;
+            }
+            $verbose_subsets[] = ["name" => (string)$subset_name, "title" => $this->get_title($subset_name), "rows" => $verbose_rows];
+        }
+        return $verbose_subsets;
+    }
+
     public function get_title(string $name): string
     {
         return $this->titles[$name];


### PR DESCRIPTION
We could avoid the expand_pickersets() function by creating the pickersets with character names to start with but then we would have to change some other stuff to use the data in this form.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/api_pickers
