### PR TITLE
Remove mention of PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: 'ubuntu-22.04', php: '7.4' }
           - { os: 'ubuntu-22.04', php: '8.1' }
           - { os: 'ubuntu-24.04', php: '8.3' }
     runs-on: ${{ matrix.cfg.os }}
@@ -39,7 +38,6 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: 'ubuntu-22.04', php: '7.4' }
           - { os: 'ubuntu-22.04', php: '8.1' }
           - { os: 'ubuntu-24.04', php: '8.3' }
     runs-on: ${{ matrix.cfg.os }}
@@ -106,7 +104,6 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: 'ubuntu-22.04', php: '7.4' }
           - { os: 'ubuntu-22.04', php: '8.1' }
           - { os: 'ubuntu-24.04', php: '8.3' }
     runs-on: ${{ matrix.cfg.os }}

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -16,8 +16,8 @@ The following lists supported versions for the four primary middleware
 components.
 
 ### PHP
-PHP version 7.4 is the minimum supported version. Limited testing has been done
-on PHP 8.1 and 8.3.
+PHP version 8.1 is the minimum supported version although limited testing has been done
+on PHP versions < 8.3.
 
 The following PHP extensions are required. They are listed below with their
 Ubuntu system package names.
@@ -50,11 +50,11 @@ change `core.disable_super_globals` to `false`, and flush the phpbb cache.
 
 ## Distro support
 These middleware components match the following major distribution releases:
-* Ubuntu 18.04, Bionic (with PHP 7.4 upgrade)
-* Ubuntu 20.04, Focal
-* Ubuntu 22.04, Jammy (with possible PHP 7.4 downgrade)
-* RHEL / CentOS 7.x family (with PHP 7.4 and MariaDB 10.2 or later upgrade)
-* RHEL / CentOS 8.x family
+* Ubuntu 20.04, Focal (with PHP 8.1 upgrade)
+* Ubuntu 22.04, Jammy
+* Ubuntu 24.04, Noble
+* RHEL / CentOS 8.x family (with PHP 8.1 upgrade)
+* RHEL / CentOS 9.x family
 
 ## Browser support
 The following are the lowest known supported browser versions for the code:

--- a/SETUP/tests/unittests/ParamValidatorTest.php
+++ b/SETUP/tests/unittests/ParamValidatorTest.php
@@ -372,19 +372,9 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(false, $result);
     }
 
-    public function testBoolDefaultNotBool(): void
-    {
-        // PHP will not throw a TypeError if a non-boolean is passed
-        // into a function with a bool type. It instead coerces it into a bool.
-        // This is expected and there is nothing we can do about it...
-        // As it is unlikely to change, keeping this test around for documentation.
-        $this->markTestSkipped('PHP will not enforce a bool type');
-
-        $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("must be of");
-        $default = "string";
-        get_bool_param($this->GET, 'none', $default);
-    }
+    // We don't test passing a non-boolean `$default` to `get_bool_param` as PHP will
+    // automatically coerce it to bool. Also there is no way to disable this behavior.
+    // If there is in the future, we should look at enabling it though.
 
     public function testBoolNotABool(): void
     {

--- a/SETUP/tests/unittests/ParamValidatorTest.php
+++ b/SETUP/tests/unittests/ParamValidatorTest.php
@@ -374,9 +374,10 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
 
     public function testBoolDefaultNotBool(): void
     {
-        // Shockingly, PHP 7.4 (at least) will not throw a TypeError if a
-        // non-boolean is passed into a function with a bool type. It instead
-        // coerces it into a bool. Maybe later versions will?
+        // PHP will not throw a TypeError if a non-boolean is passed
+        // into a function with a bool type. It instead coerces it into a bool.
+        // This is expected and there is nothing we can do about it...
+        // As it is unlikely to change, keeping this test around for documentation.
         $this->markTestSkipped('PHP will not enforce a bool type');
 
         $this->expectException(TypeError::class);

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -832,15 +832,6 @@ function endswith(string $subject, string $suffix): bool
     return (substr($subject, -strlen($suffix)) == $suffix);
 }
 
-// TODO: After upgrade to PHP 8, remove this
-if (!function_exists('str_contains')) {
-    // str_contains() now exists in PHP8
-    function str_contains($haystack, $needle)
-    {
-        return (strpos($haystack, $needle) !== false);
-    }
-}
-
 /** @param string[] $strings */
 function surround_and_join(array $strings, string $L, string $R, string $joiner): string
 {

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1707,11 +1707,3 @@ function validate_csrf_token(): void
 class NotImplementedException extends BadMethodCallException
 {
 }
-
-// TODO: After upgrade to PHP 8, remove this
-// ValueError exists in PHP 8 but not earlier
-if (!class_exists('\ValueError')) {
-    class ValueError extends \Error
-    {
-    }
-}


### PR DESCRIPTION
Per the 202409 changelog, the next release will not support PHP 7.4.

This PR removes any mention of PHP 7.4. Very importantly, it removes the PHP 7.4 CI so we can rely on the updated type system in PHP 8.1 (e.g. `mixed`). Right now, adding those types makes PHP 7.4 CI unhappy.