### PR TITLE
Upgrade PHPStan to 1.12.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.57",
         "phpunit/phpunit": "^9.6",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.12"
     },
     "replace": {
         "symfony/polyfill-ctype": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76f44b3c43ac9fdbe0b1b0dce3337abb",
+    "content-hash": "9abcdb9b00f7065450c75119d9fef2ee",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -1419,16 +1419,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.66",
+            "version": "1.12.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd"
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/94779c987e4ebd620025d9e5fdd23323903950bd",
-                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
                 "shasum": ""
             },
             "require": {
@@ -1471,13 +1471,9 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T16:17:31+00:00"
+            "time": "2024-11-28T22:13:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,7 +35,6 @@ parameters:
         - message: '#Constant .* not found#'
 
         # Low value and frequent L5 errors that are ignored by default.
-        - message: "#^Parameter \\#1 \\$.* of function array_multisort is passed by reference, so it expects variables only\\.$#"
         - message: '#^Parameter \#\d+ .* of (static )?(function|method) .* expects string(\|null)?, int.* given\.$#'
 
         # TODO(jchaffraix): Temporarily disabling those as they are dynamically created (see comment in Pool's constructor).


### PR DESCRIPTION
PHPStan was upgraded to 2.0 in November, but we're not ready to upgrade as it detects a lot of new errors.
That said our first step is to upgrade to the latest 1.x.x release, per:
https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md

There is one upside to this upgrade, which is to be able to disable errors using their identifier (added in 1.11).

Also it seems like a low-value error was removed from L5, so removed it from our configuration file.