### PR TITLE
Alpha-sort `v1/projects/:projectid/` API route & add WordCheck API to docs

### DIFF
--- a/api/USERS_GUIDE.md
+++ b/api/USERS_GUIDE.md
@@ -316,6 +316,13 @@ curl -s -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
     -d @page_text.json
 ```
 
+Check the page text for bad words:
+```bash
+curl -s -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \
+    -X PUT "https://www.pgdp.org/api/v1/projects/projectID44de3936807f1/wordcheck" \
+    -d @page_text.json
+```
+
 Save the page as in-progress:
 ```bash
 curl -s -H "Accept: application/json" -H "X-API-KEY: $API_KEY" \

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -31,27 +31,26 @@ $router->add_route("GET", "v1/projects/imagesources", "api_v1_projects_imagesour
 $router->add_route("GET", "v1/projects/holdstates", "api_v1_projects_holdstates");
 $router->add_route("GET", "v1/projects/:projectid", "api_v1_project");
 $router->add_route("PUT", "v1/projects/:projectid", "api_v1_project");
+$router->add_route("PUT", "v1/projects/:projectid/checkout", "api_v1_project_checkout");
 $router->add_route("GET", "v1/projects/:projectid/holdstates", "api_v1_project_holdstates");
 $router->add_route("PUT", "v1/projects/:projectid/holdstates", "api_v1_project_holdstates");
+$router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
+$router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
+$router->add_route("GET", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/wordcheck", "api_v1_project_page_wordcheck");
+$router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
+$router->add_route("GET", "v1/projects/:projectid/pickersets", "api_v1_project_pickersets");
+$router->add_route("GET", "v1/projects/:projectid/transitions", "api_v1_project_transitions");
+$router->add_route("PUT", "v1/projects/:projectid/validatetext", "api_v1_project_validatetext");
+$router->add_route("PUT", "v1/projects/:projectid/wordcheck", "api_v1_project_wordcheck");
 $router->add_route("GET", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
 $router->add_route("PUT", "v1/projects/:projectid/wordlists/:wordlist_type", "api_v1_project_wordlists");
-$router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
-$router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_pagedetails");
-$router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");
-$router->add_route("GET", "v1/projects/:projectid/transitions", "api_v1_project_transitions");
 
 $router->add_route("GET", "v1/queues", "api_v1_queues");
 $router->add_route("GET", "v1/queues/:queueid", "api_v1_queue");
 $router->add_route("GET", "v1/queues/:queueid/stats", "api_v1_queue_stats");
 $router->add_route("GET", "v1/queues/:queueid/projects", "api_v1_queue_projects");
-
-$router->add_route("PUT", "v1/projects/:projectid/checkout", "api_v1_project_checkout");
-$router->add_route("PUT", "v1/projects/:projectid/validatetext", "api_v1_project_validatetext");
-$router->add_route("PUT", "v1/projects/:projectid/wordcheck", "api_v1_project_wordcheck");
-$router->add_route("GET", "v1/projects/:projectid/pickersets", "api_v1_project_pickersets");
-$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
-$router->add_route("GET", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
-$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/wordcheck", "api_v1_project_page_wordcheck");
 
 $router->add_route("GET", "v1/stats/site", "api_v1_stats_site");
 $router->add_route("GET", "v1/stats/site/projects/stages", "api_v1_stats_site_projects_stages");


### PR DESCRIPTION
This alpha-sorts the `v1/projects/:projectid/` API routes instead of them being in two separate blocks (how they got this way I don't know and didn't bother to look up). No functional change here.

Added a section to the API user's guide on the wordcheck endpoint too.