### PR TITLE
Add endpoint for languages with dictionaries

### DIFF
--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -835,7 +835,7 @@ class ApiTest extends ProjectUtils
     }
 
     //---------------------------------------------------------------------------
-    // tests for documents
+    // tests for documents & dictionaries
 
     public function test_available_italian_documents(): void
     {
@@ -872,6 +872,15 @@ class ApiTest extends ProjectUtils
         $router = ApiRouter::get_router();
         $_SERVER["REQUEST_METHOD"] = "GET";
         $router->route($path, ['language_code' => 'de']);
+    }
+
+    public function test_dictionaries(): void
+    {
+        $path = "v1/dictionaries";
+        $router = ApiRouter::get_router();
+        $_SERVER["REQUEST_METHOD"] = "GET";
+        $response = $router->route($path, []);
+        $this->assertEquals("English", $response["en"]);
     }
 
     //---------------------------------------------------------------------------

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -1373,6 +1373,21 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
+  /dictionaries:
+    get:
+      tags:
+      - dictionaries
+      description: Gets an array of languages with dictionaries.
+      responses:
+        200:
+          description: Array of languages with dictionaries keyed by the language code
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+
   /storage/{storagekey}:
     get:
       tags:

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -24,6 +24,7 @@ $router->add_validator(":storagekey", "validate_storage_key");
 // Add routes
 $router->add_route("GET", "v1/documents", "api_v1_documents");
 $router->add_route("GET", "v1/documents/:document", "api_v1_document");
+$router->add_route("GET", "v1/dictionaries", "api_v1_dictionaries");
 
 $router->add_route("GET", "v1/projects", "api_v1_projects");
 $router->add_route("POST", "v1/projects", "api_v1_project");

--- a/api/v1_docs.inc
+++ b/api/v1_docs.inc
@@ -31,3 +31,11 @@ function api_v1_document(string $method, array $data, array $query_params): stri
     }
     return $faq_url;
 }
+
+/** @param array<string, string|string[]> $query_params */
+function api_v1_dictionaries(string $method, array $data, array $query_params): array
+{
+    $dict_list = get_languages_with_dictionaries();
+    asort($dict_list);
+    return $dict_list;
+}


### PR DESCRIPTION
The code has been put in api_docs.inc. Perhaps we should give it a more generic name like api_site_data.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/api_dics
