### PR TITLE
Encode valid characters

### DIFF
--- a/SETUP/tests/jsTests/characterValidation.js
+++ b/SETUP/tests/jsTests/characterValidation.js
@@ -1,44 +1,44 @@
 /* global QUnit testText */
-/* exported validCharacterPattern */
+/* exported validCharRegex */
 
-var validCharacterPattern;
+var validCharRegex;
 
 QUnit.module("Character validation test", function () {
-    let basicLatin = "^(?:[\n\r -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$";
+    let basicLatin = /^(?:[\n\r -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$/u;
 
     QUnit.test("In basic latin basic latin character is valid", function (assert) {
-        validCharacterPattern = basicLatin;
+        validCharRegex = basicLatin;
         assert.strictEqual(testText("abc"), true);
     });
 
     QUnit.test("In basic latin tabulate character is invalid", function (assert) {
-        validCharacterPattern = basicLatin;
+        validCharRegex = basicLatin;
         assert.strictEqual(testText("\tabc"), false);
     });
 
     QUnit.test("In basic latin Greek Α is invalid", function (assert) {
-        validCharacterPattern = basicLatin;
+        validCharRegex = basicLatin;
         assert.strictEqual(testText("Αabc"), false);
     });
 
     QUnit.test("In basic latin Astral char. is invalid", function (assert) {
-        validCharacterPattern = basicLatin;
+        validCharRegex = basicLatin;
         assert.strictEqual(testText("ab\u{1F702}c"), false);
     });
 
     QUnit.test("In basic latin A with combining diaeresis is valid when normalised, b is not", function (assert) {
-        validCharacterPattern = basicLatin;
+        validCharRegex = basicLatin;
         assert.strictEqual(testText("a\u0308bc"), true);
         assert.strictEqual(testText("ab\u0308c"), false);
     });
 
     QUnit.test("In basic Greek, Greek Α is valid", function (assert) {
-        validCharacterPattern = "^(?:[\n\rΑ-ΡΣ-Ωα-ω -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$";
+        validCharRegex = /^(?:[\n\rΑ-ΡΣ-Ωα-ω -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$/u;
         assert.strictEqual(testText("Αabc"), true);
     });
 
     QUnit.test("characters with combining marks", function (assert) {
-        validCharacterPattern = "^(?:S̤|T̤|Z̤|s̤|t̤|z̤|[\n\r Ā-āĒ-ēĪ-īŌ-ōŚ-śŠ-šŪ-ūʾ-ʿḌ-ḍḤ-ḥḪ-ḫḲ-ḳḷḹṀ-ṇṚ-ṝṢ-ṣṬ-ṭẒ-ẖ])$";
+        validCharRegex = /^(?:S̤|T̤|Z̤|s̤|t̤|z̤|[\n\r Ā-āĒ-ēĪ-īŌ-ōŚ-śŠ-šŪ-ūʾ-ʿḌ-ḍḤ-ḥḪ-ḫḲ-ḳḷḹṀ-ṇṚ-ṝṢ-ṣṬ-ṭẒ-ẖ])$/u;
         assert.strictEqual(testText("S\u0324"), true); // S with macron below
         assert.strictEqual(testText("U\u0324"), false); // U with macron below
         assert.strictEqual(testText("\u1e72"), false); // U with macron below normalised
@@ -47,7 +47,7 @@ QUnit.module("Character validation test", function () {
     });
 
     QUnit.test("Astral plane", function (assert) {
-        validCharacterPattern = "^(?:[\n\r 𓀀-𓀂])$";
+        validCharRegex = /^(?:[\n\r 𓀀-𓀂])$/u;
         assert.strictEqual(testText("𓀀"), true);
         assert.strictEqual(testText("\u{13000}"), true);
         assert.strictEqual(testText("𓀂"), true);

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -32,7 +32,7 @@ $header_args = [
         "$code_url/tools/proofers/text_data_processor.js",
     ],
     "js_data" => "
-        var validCharacterPattern = '$valid_character_pattern';
+        var validCharRegex = /$valid_character_pattern/u;
     ",
     'body_attributes' => "onload='top.initializeStuff(1)'",
 ];

--- a/scripts/character_test.js
+++ b/scripts/character_test.js
@@ -1,4 +1,4 @@
-/*global validCharacterPattern XRegExp */
+/*global validCharRegex XRegExp */
 /* exported testText */
 
 // regex unicode property escape is supported in Chrome 64, Safari 11.1
@@ -9,9 +9,6 @@ const charMatch = XRegExp("\\PM\\pM*", "Ag");
 
 // return false if text contains any bad characters
 function testText(text) {
-    // this regular expression matches individual good characters
-    // unicode support in Chrome 50, Edge 12, Firefox 46, Safari 10, Opera 37
-    let validCharRegex = new RegExp(validCharacterPattern, "u");
     text = text.normalize("NFC");
     let result;
     charMatch.lastIndex = 0;

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -1,4 +1,4 @@
-/*global validCharacterPattern charMatch */
+/*global validCharRegex charMatch */
 /* exported validateText */
 
 // charMatch (constructed in character_test.js) matches any unicode character
@@ -22,7 +22,6 @@ var validateText;
 
 window.addEventListener("DOMContentLoaded", function () {
     var textArea = document.getElementById("text_data");
-    let validCharRegex = new RegExp(validCharacterPattern, "u");
 
     // check each character, if bad mark or remove it
     function processText(text, clean) {

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -88,7 +88,7 @@ if (!$resolution) {
             "$code_url/tools/project_manager/handle_bad_page.js",
         ],
         "js_data" => "
-            var validCharacterPattern = '$valid_character_pattern';
+            var validCharRegex = /$valid_character_pattern/u;
         ",
     ];
 

--- a/tools/proofers/process_diacritcal_markup.js
+++ b/tools/proofers/process_diacritcal_markup.js
@@ -1,8 +1,7 @@
-/*global validCharacterPattern */
+/*global validCharRegex */
 
 window.addEventListener("DOMContentLoaded", function () {
     var textArea = document.getElementById("text_data");
-    let validCharRegex = new RegExp(validCharacterPattern, "u");
 
     var above = {
         "=": "\u0304", // macron

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -46,7 +46,7 @@ function echo_proof_frame_enh(PPage $ppage): void
         function ldAll() {
             top.initializeStuff(1);
         }
-        var validCharacterPattern = '$valid_character_pattern';
+        var validCharRegex = /$valid_character_pattern/u;
         var standardInterface = false;
         var switchConfirm = '$switch_confirm';
         var revertConfirm = '$revert_confirm';

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -632,7 +632,7 @@ function get_wordcheck_page_header_args(User $user, PPage $ppage): array
         "js_data" => get_page_js($user->profile->i_type == 1 ? 2 : 3) .
             get_control_bar_texts() . "
             var imageData = $image_data;
-            var validCharacterPattern = '$valid_character_pattern';
+            var validCharRegex = /$valid_character_pattern/u;
             var wordCheckMessages = " . json_encode($word_check_messages) . ";
         ",
 

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -29,7 +29,7 @@ function echo_text_frame_std(PPage $ppage): void
         function ldAll() {
             top.initializeStuff(0);
         }
-        var validCharacterPattern = '$valid_character_pattern';
+        var validCharRegex = /$valid_character_pattern/u;
         var standardInterface = true;
         var switchConfirm = '$switch_confirm';
         var revertConfirm = '$revert_confirm';


### PR DESCRIPTION
so escaped characters don't get changed back to plain characters. This should fix the issue with the test project projectID462699ad8f1c6 which has custom characters which are regex special characters found by @srjfoo. 

Sandbox at: https://www.pgdp.org/~rp31/c.branch/regex_escape
