### PR TITLE
Update wordcheck_event & page_events on page renames

### DIFF
--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -347,7 +347,7 @@ switch ($submit_button) {
                     "
                     UPDATE $projectid
                     SET fileid = '%s', image = '%s'
-                    WHERE fileid = '%s' AND image='%s'
+                    WHERE fileid = '%s' AND image = '%s'
                     ",
                     DPDatabase::escape($new_fileid),
                     DPDatabase::escape($new_image),


### PR DESCRIPTION
When pages are renamed (renumbered) we need to update `wordcheck_events` and `page_events` to keep the implicit foreign keys the same. [Task 2080](https://www.pgdp.net/c/tasks.php?task_id=2080) 

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-wordcheck-events-on-rename/