### PR TITLE
Include username in bad page notifications

### DIFF
--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -448,7 +448,7 @@ class LPage
 
         // Advise PM that the page has been marked bad.
         configure_gettext_for_user($this->project->username);
-        $body_blurb_messages[] = sprintf(_('Page %1$s of this project has been marked bad due to %2$s.'), $this->imagefile, $PAGE_BADNESS_REASONS[$reason]);
+        $body_blurb_messages[] = sprintf(_('Page %1$s of this project has been marked bad by %3$s due to %2$s.'), $this->imagefile, $PAGE_BADNESS_REASONS[$reason], $user);
         $body_blurb_messages[] = sprintf(
             // TRANSLATORS: %s is a url
             _("Please visit %s to make any needed changes and make the page available for proofreading again."),


### PR DESCRIPTION
Turns out this is a 1-line change, so lets do it. [Task 1786](https://www.pgdp.net/c/tasks.php?task_id=1786)

Sandbox: https://www.pgdp.org/~cpeel/c.branch/username-in-bad-page/