### PR TITLE
Try to speed up manage proofers suggestions

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -16,12 +16,9 @@ $bracketed_character_pattern = "\\[(?:oe|OE|$mark$base|$base$mark)\\]";
 
 // This is used when splitting a text into words.
 $char_pattern = "(?:\w\pM*|$bracketed_character_pattern)";
-$word_pattern = "!$char_pattern+(?:'$char_pattern+)*!uS";
+$word_pattern = "!$char_pattern+(?:'$char_pattern+)*!u";
 // (The pattern is delimited by exclamation marks rather than the usual slashes,
 // because slash is a character within the pattern.)
-// (Supposedly, the 'S' modifier makes the regex engine spend more time
-// analyzing the pattern in order to speed up the time taken for matching,
-// but the effect seems pretty close to negligible.)
 
 
 // The following two variables control text highlighting in the interface.

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -752,6 +752,30 @@ function load_wordcheck_events($projectid, $start_time = 0)
     return $eventArray;
 }
 
+/** @return string[] */
+function load_project_good_word_suggestions_flat(string $projectid, int $start_time = 0): array
+{
+    $sql = sprintf(
+        "
+        SELECT suggestions
+        FROM wordcheck_events
+        WHERE projectid = '%s' AND timestamp > %d AND suggestions <> ''
+        ",
+        DPDatabase::escape($projectid),
+        $start_time
+    );
+
+    $res = DPDatabase::query($sql);
+
+    $words = [];
+    while ([$suggestions] = mysqli_fetch_row($res)) {
+        $words = array_merge($words, explode("\n", $suggestions));
+    }
+
+    mysqli_free_result($res);
+
+    return $words;
+}
 
 function load_project_good_word_suggestions($projectid, $start_time = 0)
 {

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -151,7 +151,7 @@ foreach ($projects as $projectid => $projectdata) {
     }
 
     // get the data
-    [$suggestions_w_freq, $suggestions_w_occurrences, $messages] =
+    [$suggestions_w_freq, $suggestions_w_occurrences] =
         _get_word_list($projectid, $suggestions);
 
     // if no words are returned (probably because something was
@@ -167,8 +167,6 @@ foreach ($projects as $projectid => $projectdata) {
     echo "<p><b>" . pgettext("project state", "State") . ":</b> $projectstate</p>";
 
     echo_checkbox_selects($projectid);
-
-    echo_any_warnings_errors($messages);
 
     $count = 0;
     foreach ($suggestions_w_freq as $word => $freq) {
@@ -210,11 +208,9 @@ echo "</div></div>";
 
 function _get_word_list($projectid, $suggestions)
 {
-    $messages = [];
-
     // check that there are suggestions
     if (count($suggestions) == 0) {
-        return [[], [], $messages];
+        return [[], []];
     }
 
     // load project good words
@@ -256,7 +252,7 @@ function _get_word_list($projectid, $suggestions)
     // sort the list by frequency, then by word
     array_multisort(array_values($all_suggestions_w_freq), SORT_DESC, array_map('voku\helper\UTF8::strtolower', array_keys($all_suggestions_w_freq)), SORT_ASC, $all_suggestions_w_freq);
 
-    return [$all_suggestions_w_freq, $all_suggestions_w_occurrences, $messages];
+    return [$all_suggestions_w_freq, $all_suggestions_w_occurrences];
 }
 
 function _get_projects_for_pm($pm)

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -219,10 +219,6 @@ function _get_word_list(string $projectid, array $suggestions): array
     // load project bad words
     $project_bad_words = load_project_bad_words($projectid);
 
-    // get the latest project text of all pages up to last possible round
-    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
-    $all_words_w_freq = get_distinct_words_in_text(get_page_texts($pages_res));
-
     // array to hold all words
     $all_suggestions = [];
 
@@ -237,6 +233,17 @@ function _get_word_list(string $projectid, array $suggestions): array
 
     // now, remove any words that are already on the project's good or bad words lists
     $all_suggestions = array_diff($all_suggestions, array_merge($project_good_words, $project_bad_words));
+
+    // if all of the suggestions are already on a good or bad word list
+    // there won't be anything to intersect with the word pages so don't do
+    // that work and just return
+    if (count($all_suggestions) == 0) {
+        return [[], []];
+    }
+
+    // get the latest project text of all pages up to last possible round
+    $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
+    $all_words_w_freq = get_distinct_words_in_text(get_page_texts($pages_res));
 
     // get the number of suggestion occurrences
     $all_suggestions_w_occurrences = generate_frequencies($all_suggestions);

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -206,7 +206,7 @@ echo "</div></div>";
 //---------------------------------------------------------------------------
 // supporting page functions
 
-function _get_word_list($projectid, $suggestions)
+function _get_word_list(string $projectid, array $suggestions): array
 {
     // check that there are suggestions
     if (count($suggestions) == 0) {
@@ -255,7 +255,7 @@ function _get_word_list($projectid, $suggestions)
     return [$all_suggestions_w_freq, $all_suggestions_w_occurrences];
 }
 
-function _get_projects_for_pm($pm)
+function _get_projects_for_pm(string $pm): array
 {
     $returnArray = [];
 
@@ -277,7 +277,7 @@ function _get_projects_for_pm($pm)
     return $returnArray;
 }
 
-function _get_project_states_in_order()
+function _get_project_states_in_order(): array
 {
     $projectStates = [];
 


### PR DESCRIPTION
This attempts to speed up the "Manage proofreaders' Suggestions" page from [Task 2098](https://www.pgdp.net/c/tasks.php?action=show&task_id=2098) after some analysis in xdebug. Unfortunately there's not a lot we can do to make it faster because the bulk of the time is spent in getting all the distinct words from each project and ultimately that boils down to a `preg_match_all()`. I tried various iterations on ways to speed that part up but none of it panned out.

These changes are small code improvements that I tested and discovered which may help the page load faster on a loaded system but it's likely only to be a marginal improvement.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/faster-word-suggestions/