### PR TITLE
Replace $user_is_logged_in global with static User call

### DIFF
--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -15,7 +15,7 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'metarefresh.inc');
 
 // If the user is already logged in, send them to the Activity Hub
-if ($user_is_logged_in) {
+if (User::is_logged_in()) {
     metarefresh(0, "$code_url/activity_hub.php");
 }
 

--- a/accounts/logout.php
+++ b/accounts/logout.php
@@ -5,7 +5,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'metarefresh.inc');
 include_once($relPath.'forum_interface.inc');
 
-if ($user_is_logged_in) {
+if (User::is_logged_in()) {
     logout_forum_user();
 
     dpsession_end();

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -418,6 +418,14 @@ class User
     }
 
     /**
+     * Is the user logged in?
+     */
+    public static function is_logged_in(): bool
+    {
+        return User::current_username() === null ? false : true;
+    }
+
+    /**
      * Load the current user object
      */
     public static function load_current(): ?User

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -40,7 +40,7 @@ if (!headers_sent()) {
 
 // If we don't have a database connection, don't try to resume the session.
 if (DPDatabase::get_connection()) {
-    $user_is_logged_in = dpsession_resume();
+    dpsession_resume();
 }
 
 configure_gettext(get_desired_language(), $dyn_locales_dir, $system_locales_dir);
@@ -124,12 +124,11 @@ function test_exception_handler($exception)
 
 function require_login()
 {
-    global $user_is_logged_in;
     global $code_url;
     global $relPath;
 
     // return if the user is already logged in
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
         return;
     }
 

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -7,6 +7,7 @@ ini_set('session.cookie_lifetime', 86400 * 31); // 31 days ~= 1 month
 ini_set('session.cookie_secure', $use_secure_cookies);
 ini_set('session.cookie_samesite', 'Lax');
 
+global $pguser;
 $pguser = null;
 
 // -----------------------------------------------------------------------------
@@ -36,7 +37,7 @@ function dpsession_begin($userID)
  * global variable ($pguser) of that session, and return TRUE.
  * Otherwise, return FALSE.
  */
-function dpsession_resume()
+function dpsession_resume(): void
 {
     global $pguser;
 
@@ -78,8 +79,6 @@ function dpsession_resume()
             dp_setcookie('http_referer', '');
         }
     }
-
-    return $user_is_logged_in;
 }
 
 /**

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -622,10 +622,10 @@ function html_statsbar($nameofpage)
 
 function maybe_show_language_selector()
 {
-    global $code_url, $user_is_logged_in;
+    global $code_url;
 
     // if user is logged in, return instead of showing the drop-down
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
         return;
     }
 

--- a/project.php
+++ b/project.php
@@ -49,7 +49,7 @@ $title_for_theme = sprintf(_('"%s" project page'), $project->nameofwork);
 
 $title = $project->nameofwork;
 
-if ($user_is_logged_in && $mark_bookmark !== null) {
+if (User::is_logged_in() && $mark_bookmark !== null) {
     upi_set_bookmark($pguser, $project->projectid, $mark_bookmark);
 }
 
@@ -86,7 +86,7 @@ echo "<h1>" . get_bookmark_form() . html_safe($title) . "</h1>\n";
 
 maybe_output_new_proofer_project_message($project);
 
-if (!$user_is_logged_in) {
+if (!User::is_logged_in()) {
     // Guests see a reduced version of the project page.
 
     [$top_blurb, $bottom_blurb] = decide_blurbs();
@@ -98,7 +98,7 @@ if (!$user_is_logged_in) {
 
     echo "<br>\n";
     return;
-} else { // $user_is_logged_in
+} else {
     upi_set_t_latest_home_visit(
         $pguser,
         $project->projectid,
@@ -404,7 +404,6 @@ function do_blurb_box(?string $blurb): void
 function do_project_info_table(): void
 {
     global $project, $code_url;
-    global $user_is_logged_in;
     global $detail_level;
     global $pguser;
 
@@ -487,7 +486,7 @@ function do_project_info_table(): void
     }
 
     // We choose not to show guests anything involving users' names.
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
         echo_row_a(_("Project Manager"), $project->username, true);
 
         if ($project->PPer) {
@@ -533,7 +532,7 @@ function do_project_info_table(): void
     // -------------------------------------------------------------------------
 
     // We choose not to show guests the word lists.
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
         $good_bad = [
             'good' => _("Good Words"),
             'bad' => _("Bad Words"),
@@ -591,7 +590,7 @@ function do_project_info_table(): void
 
     // If the topic is only visible to logged-in users,
     // there's little point showing guests the link to it.
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
         if (($state == PROJ_DELETE) && ($topic_id == "")) {
             echo_row_a(_("Forum"), _("The project has been deleted, and no discussion exists."), true);
         } else {
@@ -616,7 +615,7 @@ function do_project_info_table(): void
     // -------------------------------------------------------------------------
 
     // For now, we say that guests can't see page details or page browser
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
 
         if ($detail_level >= 4) {
             // We'll call do_page_table later, so we don't need the "Page Detail" link.
@@ -660,7 +659,7 @@ function do_project_info_table(): void
     // Personal data with respect to this project
 
     // If you're not logged in, we certainly can't show your personal data.
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
         if ($round && $detail_level > 1) {
             recentlyproofed(0);
             recentlyproofed(1);
@@ -699,7 +698,7 @@ function do_project_info_table(): void
 
     // For now, we suppress Project Comments for guests.
     // (They might be confused by the instructions for proofreaders.)
-    if ($user_is_logged_in) {
+    if (User::is_logged_in()) {
         $comments = $project->comments;
 
         // insert e.g. templates and biographies
@@ -1788,8 +1787,7 @@ function do_smooth_reading(): void
             if (!$project->PPer_is_current_user) {
                 echo "<ul class='list-head'>";
                 // We don't allow guests to upload the results of smooth-reading.
-                global $user_is_logged_in;
-                if ($user_is_logged_in) {
+                if (User::is_logged_in()) {
                     echo "<li class='list-head'>";
                     echo "<a href='$code_url/tools/upload_text.php?project=$projectid&stage=smooth_done'>";
                     echo _("Upload a Smooth Read report") ;

--- a/quiz/generic/proof.php
+++ b/quiz/generic/proof.php
@@ -12,7 +12,7 @@ $quiz_page_id = get_quiz_page_id_param($_REQUEST, 'quiz_page_id');
 include "./quiz_page.inc"; // qp_initial_page_text qp_sample_solution
 
 // Figure out what font to use
-if ($user_is_logged_in) {
+if (User::is_logged_in()) {
     [, $font_size, $font_family] = get_user_proofreading_font();
 
     $font_settings = "font-family: $font_family; ";


### PR DESCRIPTION
Minor code cleanup to remove the global to determine if the user is logged in. Found this working though some session cleanup in prep for PHP 8.4 support.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/remove-user-logged-in-global/