### PR TITLE
Handle MARC records with multiple languages

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -339,7 +339,7 @@ class Project
 
         $this->nameofwork = $marc_record->title;
         $this->authorsname = $marc_record->author;
-        $this->language = $marc_record->language;
+        $this->languages = array_slice(explode(", ", $marc_record->language), 0, 2);
         $this->genre = $marc_record->literary_form;
     }
 


### PR DESCRIPTION
If the MARC record has multiple languages, take the first two as the primary and secondary. [Task 2095](https://www.pgdp.net/c/tasks.php?task_id=2095)

Sandbox: https://www.pgdp.org/~cpeel/c.branch/marc-records-two-languages/