### PR TITLE
Fix syntax errors in PHPDocs

### DIFF
--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -8,12 +8,12 @@ class CharSuiteNotEnabledException extends Exception
 class PickerSet
 {
     public string $name;
-    /** @var array<string, (string|null)[]> */
+    /** @var (?string[])[] */
     private array $subsets;
     /** @var string[] */
     private array $titles;
 
-    /** @param $codepoints (string|null)[] */
+    /** @param (?string[])[] $codepoints */
     public function add_subset(string $name, array $codepoints, ?string $title = null)
     {
         $this->subsets[$name] = $codepoints;
@@ -25,7 +25,7 @@ class PickerSet
         }
     }
 
-    /** @return array<string, string[]> */
+    /** @return (?string[])[] */
     public function get_subsets(): array
     {
         return $this->subsets;
@@ -69,7 +69,7 @@ class CharSuite
     public $reference_urls = [];
     private ?PickerSet $_pickerset = null;
 
-    /** @param $codepoints ?string[] */
+    /** @param ?string[] $codepoints */
     public function __construct(string $name, string $title, ?array $codepoints = null, bool $adhoc = false)
     {
         $this->name = $name;

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -714,7 +714,7 @@ function sanitize_html(string $html, string $parent_tag = 'div'): string
 
 /* Parse markdown text string using Parsedown library and output HTML
  *
- * @param $message Markdown text
+ * @param string $message Markdown text
  * @return string HTML content
  */
 function render_markdown_as_html(string $message): string

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -364,7 +364,7 @@ function show_projects_for_pool($pool, $checkedout_or_available)
  *   Stage object (Round, Pool, or Stage)
  * @param string $optional_join_clause
  *   If needed. Default to "", but useful/necessary for SR & PP
- * @param $optional_select_clause
+ * @param string $optional_select_clause
  *   If needed. Default to "", but useful/necessary for PP
  */
 function show_project_listing(

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -28,7 +28,7 @@ function utf8_combined_chr(string $codepoint): string
 /**
  * Given a character, return the Unicode script it belongs to
  *
- * @param $char int|string
+ * @param int|string $char
  */
 function utf8_char_script($char): string
 {
@@ -282,7 +282,7 @@ function build_character_regex_filter($codepoints, $lang = 'php')
  * (U+####-U+####), or combined characters (U+####>U+####) and
  * return an array of unicode characters.
  *
- * @param $codepoints string|(string|null)[]
+ * @param string|(string|null)[] $codepoints
  * @return (string|null)[]
  */
 function convert_codepoint_ranges_to_characters($codepoints): array

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -741,7 +741,7 @@ function copy_pages(
     }
 }
 
-/** @param $array string[] */
+/** @param string[] $arr */
 function str_max(array & $arr): string
 {
     $max_so_far = null;


### PR DESCRIPTION
/** @param $var type */ is not a valid PHPDoc
and thus is not recognized by PHPStan.

Fixing those uncovered some mistyped values in
CharSuites.inc. Kudos to Ray for finding those
in the first place on PR #1430!

There should be no prod impact as those are
just PHPStan annotations.

Sandbox: https://www.pgdp.org/~jchaffraix/c.branch/julien_fix_phpdoc_param_syntax_errors