### PR TITLE
Fix profile link in header

### DIFF
--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -409,7 +409,7 @@ function html_navbar()
         echo "  &#183; ";
 
         $account_links = [
-            ['text' => _("Profile"), 'url' => "stats/members/mdetail.php"],
+            ['text' => _("Profile"), 'url' => "stats/members/mdetail.php?id=" . $user->u_id],
             ['text' => _("Preferences"), 'url' => "userprefs.php"],
             ['text' => _("Log Out"), 'url' => "accounts/logout.php"],
         ];


### PR DESCRIPTION
If the user is logged in and on a profile that that isn't their own the Profile link in the header should still point to the user's profile. [Task 2099](https://www.pgdp.net/c/tasks.php?action=show&task_id=2099)

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-profile-link/