### PR TITLE
Prepare for upcoming R202503 release

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,7 +7,7 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
-## R??????
+## R202503
 Scripts supporting this upgrade are in `SETUP/upgrade/22`
 
 ### Notices & Deprecations
@@ -25,6 +25,22 @@ instead.
 ### Changes
 
 * WikiHiero support has been removed (cpeel)
+* New APIs (70ray, cpeel) -- see [`dp-openapi.yaml`](../api/dp-openapi.yaml)
+  for complete spec
+  * `v1/documents`
+  * `v1/documents/:document`
+  * `v1/dictionaries`
+  * `v1/projects/:projectid/pages/:pagename/reportbad`
+  * `v1/projects/:projectid/pages/:pagename/wordcheck`
+  * `v1/projects/:projectid/pickersets`
+  * `v1/projects/:projectid/wordcheck`
+  * `v1/storage/:storagekey` -- see also the [API Admin Guide](API.md)
+* Check for corrupt images in Project Quick Check and during project load (cpeel)
+* Replaced all raw shell calls with Symfony's Process class (mrducky4, cpeel)
+* Work to remove inline JavaScript to `.js` files (70ray)
+* Extensive typing added to functions and classes (jchaffraix)
+* JavaScript style formatter updates (chrismiceli)
+* Composer dependencies updated and Symfony polyfills up to 8.4 added (cpeel)
 
 ## R202409
 Scripts supporting this upgrade are in `SETUP/upgrade/21`

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -22,6 +22,7 @@ on PHP 8.1 and 8.3.
 The following PHP extensions are required. They are listed below with their
 Ubuntu system package names.
 * Internationalization - php-intl
+* json - php-json (PHP <8.0)
 * mbstring - php-mbstring
 * memcached - php-memcached (for API rate limiting and stats caching)
 * MySQL - php-mysql

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -118,6 +118,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
+* c/SETUP/upgrade/22/
 
 ### Upgrading from release R202102
 Run the scripts in the following directories in order
@@ -128,6 +129,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
+* c/SETUP/upgrade/22/
 
 ### Upgrading from release R202109
 Run the scripts in the following directories in order
@@ -137,6 +139,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
+* c/SETUP/upgrade/22/
 
 ### Upgrading from release R202202
 Run the scripts in the following directories in order
@@ -145,6 +148,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
+* c/SETUP/upgrade/22/
 
 ### Upgrading from release R202209 or R202303
 Run the scripts in the following directories in order
@@ -152,17 +156,25 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/19/
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
+* c/SETUP/upgrade/22/
 
 ### Upgrading from release R202309
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
+* c/SETUP/upgrade/22/
 
 ### Upgrading from release R202403
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/21/
+* c/SETUP/upgrade/22/
+
+### Upgrading from release R202409
+Run the scripts in the following directories in order
+
+* c/SETUP/upgrade/22/
 
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.

--- a/SETUP/check_db_schema.template
+++ b/SETUP/check_db_schema.template
@@ -11,9 +11,9 @@ set -euo pipefail
 # or did we sneak a db-schema change into the current installation,
 # and are perhaps now depending on it?)
 
-prev_tag=R202309
+prev_tag=R202409
 curr_tag=master
-upgrade_number=20
+upgrade_number=22
 
 setup_dir=$(realpath $(dirname $0))
 testing_dir=/tmp/dp_schema_check
@@ -61,6 +61,7 @@ echo "
     _FORUM_TYPE='phpbb3'
     _DEFAULT_CHAR_SUITES='[ \"basic-latin\" ]'
     _PHPMAILER_SMTP_CONFIG='[]'
+    _API_STORAGE_KEYS='[]'
 
     # Integer values that must be filled in
     _FORUMS_PROJECT_WAITING_IDX=99


### PR DESCRIPTION
We're coming up on another of our 2x/year DP code releases next month. This PR updates the changelog and upgrade document. A reminder that we try to only list "major" changes in the changelog in roughly the order that a site admin might want to know about them -- this is not intended to be a value judgement about the features themselves.

Please let me know if I missed something we should include or if we should adjust the order of the entries.

This PR won't be merged until I cut the release.