### PR TITLE
Lift automodify into a BackgroundJob

### DIFF
--- a/SETUP/ci/check_require_login.php
+++ b/SETUP/ci/check_require_login.php
@@ -59,7 +59,6 @@ $ok_files = [
     // Tools
     "tools/setlangcookie.php",  // allows unauth users to set their language
     "tools/post_proofers/smooth_reading.php",
-    "tools/project_manager/automodify.php",  // requires localhost or login
     "tools/proofers/ctrl_frame.php",  // required for unauth quiz access
     // Dev tools
     ".php-cs-fixer.dist.php",

--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -1,6 +1,5 @@
 # multiple times per hour:
-10,25,40,55 1-23 * * * now=`date +\%Y-\%m-\%d_\%H:\%M:\%S`; URL=<<CODE_URL>>/tools/project_manager/automodify.php; <<URL_DUMP_PROGRAM>> $URL > <<DYN_DIR>>/stats/automodify_logs/$now.txt
-   25,40       0 * * * now=`date +\%Y-\%m-\%d_\%H:\%M:\%S`; URL=<<CODE_URL>>/tools/project_manager/automodify.php; <<URL_DUMP_PROGRAM>> $URL > <<DYN_DIR>>/stats/automodify_logs/$now.txt
+10,25,40,55 * * * * JOB=AutoModify; <<PHP_CLI_EXECUTABLE>> <<CODE_DIR>>/crontab/run_background_job.php $JOB
 
 # hourly:
 03 * * * * JOB=RecordUserCounts; <<PHP_CLI_EXECUTABLE>> <<CODE_DIR>>/crontab/run_background_job.php $JOB

--- a/crontab/AutoModify.inc
+++ b/crontab/AutoModify.inc
@@ -1,0 +1,36 @@
+<?php
+include_once($relPath."automodify.inc");
+include_once($relPath."autorelease.inc");
+
+// Run periodic project validation and transitions
+class AutoModify extends BackgroundJob
+{
+    private $filehandle = null;
+    private ?string $logfile = null;
+
+    public function work(): void
+    {
+        global $dyn_dir;
+
+        // Capture the automodify output to a log file
+        $logs_dir = "$dyn_dir/stats/automodify_logs";
+        if (! is_dir($logs_dir)) {
+            mkdir($logs_dir, 0777, true);
+        }
+        $this->logfile = sprintf("$logs_dir/%s.txt", date("Y-m-d_H:i:s"));
+        $this->filehandle = fopen($this->logfile, "wt");
+        ob_start([$this, 'flush'], 1024);
+
+        automodify();
+        autorelease();
+
+        ob_end_flush();
+        fclose($this->filehandle);
+    }
+
+    private function flush(string $buffer, int $phase): string
+    {
+        fwrite($this->filehandle, $buffer);
+        return $buffer;
+    }
+}

--- a/pinc/automodify.inc
+++ b/pinc/automodify.inc
@@ -1,0 +1,234 @@
+<?php
+include_once($relPath.'project_trans.inc');
+include_once($relPath.'DPage.inc');
+include_once($relPath.'Project.inc'); // project_get_auto_PPer
+
+function ensure_project_blurb(Project $project): void
+{
+    static $project_blurb_echoed = [];
+
+    if (!isset($project_blurb_echoed[$project->projectid])) {
+        echo "\n";
+        echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n";
+        echo "projectid  = {$project->projectid}\n";
+        echo "nameofwork = \"" . html_safe($project->nameofwork) . "\"\n";
+        echo "state      = {$project->state}\n";
+        echo "\n";
+        $project_blurb_echoed[$project->projectid] = true;
+    }
+}
+
+function automodify(?string $projectid = null): void
+{
+    $trace = false;
+
+    if ($projectid) {
+        $verbose = $GLOBALS['testing'];
+        $condition = sprintf("projectid = '%s'", DPDatabase::escape($projectid));
+    } else {
+        $verbose = 1;
+
+        $condition = "0";
+        foreach (Rounds::get_all() as $round) {
+            $condition .= sprintf(
+                "
+                OR state = '%s'
+                OR state = '%s'
+                OR state = '%s'
+                ",
+                DPDatabase::escape($round->project_available_state),
+                DPDatabase::escape($round->project_complete_state),
+                DPDatabase::escape($round->project_bad_state)
+            );
+        }
+    }
+    $sql = "
+        SELECT projectid
+        FROM projects
+        WHERE $condition
+        ORDER BY projectid
+    ";
+    $allprojects = DPDatabase::query($sql);
+    // The "ORDER BY" ensures consistency of order.
+
+    while ([$projectid] = mysqli_fetch_row($allprojects)) {
+        $project = new Project($projectid);
+        $state = $project->state;
+        $nameofwork = $project->nameofwork;
+
+        if ($trace) { /** @phpstan-ignore-line */
+            ensure_project_blurb($project);
+        }
+
+        // Decide which round the project is in
+        $round = get_Round_for_project_state($state);
+        if (is_null($round)) {
+            echo "    automodify.php: unexpected state $state for project $projectid\n";
+            continue;
+        }
+
+        // Bad Page Error Check
+        if (($state == $round->project_available_state) || ($state == $round->project_bad_state)) {
+            if ($project->is_bad_from_pages($round)) {
+                // This project's pages indicate that it's bad.
+                // If it isn't marked as such, make it so.
+                if ($trace) { /** @phpstan-ignore-line */
+                    echo "project looks bad.\n";
+                }
+                $appropriate_state = $round->project_bad_state;
+            } else {
+                // Pages don't indicate that the project is bad.
+                // (Although it could be bad for some other reason. Hmmm.)
+                if ($trace) { /** @phpstan-ignore-line */
+                    echo "project looks okay.\n";
+                }
+                $appropriate_state = $round->project_available_state;
+            }
+
+            if ($state != $appropriate_state) {
+                if ($verbose) {
+                    ensure_project_blurb($project);
+                    echo "    Re badness, changing state to $appropriate_state\n";
+                }
+                if ($trace) { /** @phpstan-ignore-line */
+                    echo "changing its state to $appropriate_state\n";
+                }
+                $error_msg = project_transition($projectid, $appropriate_state, PT_AUTO);
+                if ($error_msg) {
+                    echo "$error_msg\n";
+                }
+                $state = $appropriate_state;
+            }
+        }
+
+        if (
+            ($projectid) ||
+            (($state == $round->project_available_state) &&
+               ($project->get_num_pages_in_state($round->page_avail_state) == 0))
+        ) {
+
+            // Reclaim MIA pages
+
+            if ($verbose) {
+                ensure_project_blurb($project);
+                echo "    Reclaiming any MIA pages\n";
+            }
+
+            $n_hours_to_wait = 4;
+            $max_reclaimable_time = time() - $n_hours_to_wait * 60 * 60;
+
+            $sql = sprintf(
+                "
+                SELECT image
+                FROM $projectid
+                WHERE state IN ('%s','%s')
+                    AND $round->time_column_name <= %d
+                ORDER BY image ASC
+                ",
+                $round->page_out_state,
+                $round->page_temp_state,
+                $max_reclaimable_time
+            );
+            try {
+                $res = DPDatabase::query($sql);
+            } catch (DBQueryError $error) {
+                echo $error->getMessage() . "\n";
+                echo "Skipping further processing of this project.\n";
+                continue;
+            }
+
+            $n_reclaimable_pages = mysqli_num_rows($res);
+            if ($verbose) {
+                echo "        reclaiming $n_reclaimable_pages pages\n";
+            }
+
+            while ([$image] = mysqli_fetch_row($res)) {
+                Page_reclaim($projectid, $image, $round, '[automodify.php]');
+            }
+
+
+            // Decide whether the project is finished its current round.
+            if ($state == $round->project_available_state) {
+                $num_done_pages = $project->get_num_pages_in_state($round->page_save_state);
+                $num_total_pages = $project->get_num_pages();
+
+                if ($num_done_pages != $num_total_pages) {
+                    if ($verbose) {
+                        echo "    Only $num_done_pages of $num_total_pages pages are in '$round->page_save_state'.\n";
+                    }
+                    continue;
+                }
+
+                if ($verbose) {
+                    echo "    All $num_total_pages pages are in '$round->page_save_state'.\n";
+                }
+
+                if (project_has_a_hold_in_state($projectid, $state)) {
+                    if ($verbose) {
+                        echo "    Normally, this project would now advance to {$round->project_complete_state},\n";
+                        echo "    but it has a hold in $state, so it stays where it is.\n";
+                    }
+                    if ($project->is_hold_notification_required($state)) {
+                        // Note that notifications are only sent for Available
+                        // states, as this if() block is only reached for those.
+                        if ($verbose) {
+                            echo "    Sending notification about held project.\n";
+                        }
+                        $project->send_hold_state_notification($state);
+                    }
+                    continue;
+                }
+
+                $state = $round->project_complete_state;
+                if ($verbose) {
+                    echo "    Advancing \"" . html_safe($nameofwork) . "\" to $state\n";
+                }
+
+                $error_msg = project_transition($projectid, $state, PT_AUTO);
+                if ($error_msg) {
+                    echo "$error_msg\n";
+                    continue;
+                }
+            }
+        }
+
+        if ($state == $round->project_complete_state) {
+            // The project is ready to exit this round.
+
+            if ($round->round_number < Rounds::get_last()->round_number) {
+                // It goes to the next round.
+                $next_round = get_Round_for_round_number(1 + $round->round_number);
+                $new_state = $next_round->project_waiting_state;
+            } elseif ($round->round_number == Rounds::get_last()->round_number) {
+                // It goes into post-processing.
+                if (is_null(project_get_auto_PPer($projectid))) {
+                    $new_state = PROJ_POST_FIRST_AVAILABLE;
+                } else {
+                    $new_state = PROJ_POST_FIRST_CHECKED_OUT;
+                }
+            } else {
+                throw new ValueError("round_number is {$round->round_number}???");
+            }
+
+            if ($verbose) {
+                ensure_project_blurb($project);
+                echo "    Promoting \"" . html_safe($nameofwork) . "\" to $new_state\n";
+            }
+
+            $error_msg = project_transition($projectid, $new_state, PT_AUTO);
+            if ($error_msg) {
+                echo "$error_msg\n";
+            }
+        }
+    }
+
+    if ($trace) { /** @phpstan-ignore-line */
+        echo "\n";
+    }
+
+    if ($verbose) {
+        echo "\n";
+        echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n";
+        echo "\n";
+    }
+}

--- a/pinc/automodify.inc
+++ b/pinc/automodify.inc
@@ -25,8 +25,10 @@ function automodify(?string $projectid = null): void
     if ($projectid) {
         $verbose = $GLOBALS['testing'];
         $condition = sprintf("projectid = '%s'", DPDatabase::escape($projectid));
+        $single_project = true;
     } else {
         $verbose = 1;
+        $single_project = false;
 
         $condition = "0";
         foreach (Rounds::get_all() as $round) {
@@ -102,7 +104,7 @@ function automodify(?string $projectid = null): void
         }
 
         if (
-            ($projectid) ||
+            $single_project ||
             (($state == $round->project_available_state) &&
                ($project->get_num_pages_in_state($round->page_avail_state) == 0))
         ) {

--- a/pinc/autorelease.inc
+++ b/pinc/autorelease.inc
@@ -4,18 +4,11 @@ include_once($relPath.'release_queue.inc');
 
 function autorelease()
 {
-    // autorelease is called via cron and output is never shown to end-users
-    // so it's safe to enable full error reporting here
-    error_reporting(E_ALL);
-
-    echo "<pre>\n";
     echo "Starting autorelease\n";
 
     foreach (Rounds::get_all() as $round) {
         autorelease_for_round($round);
     }
-
-    echo "</pre>\n";
 }
 
 function attempt_to_release($round, $project, $queue_name)

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -1,6 +1,9 @@
 <?php
-// The script is called by crontab (for all projects) and can be called by
-// project transitions (for individual projects).
+// The can be called by:
+// * project transitions (for individual projects)
+// * PMs for their own projects
+// * SA and PFs for all projects
+//
 // It is actually 4 scripts in one file:
 //   - Cleanup Pages: Bad project detection / action & reclaims MIA pages
 //   - Promote Level: If a project finished a round, it sends it to next round
@@ -9,308 +12,37 @@
 //     it will release projects waiting to be released (autorelease())
 $relPath = "./../../pinc/";
 include_once($relPath.'base.inc');
-include_once($relPath.'project_trans.inc');
-include_once($relPath.'DPage.inc');
-include_once($relPath.'Project.inc'); // project_get_auto_PPer
+include_once($relPath.'Project.inc');
 include_once($relPath.'job_log.inc');
-include_once('autorelease.inc');
+include_once($relPath.'automodify.inc');
+include_once($relPath.'autorelease.inc');
 
 $one_project = get_projectID_param($_GET, 'project', true);
 $refresh_url = $_GET['return_uri'] ?? 'projectmgr.php';
 
 $start_time = time();
 
+require_login();
 
-// The following users are authorized to run this script:
-// 1) localhost (eg: run from crontab) - can operate on all projects
-// 2) SA and PFs - can operates on all projects
-// 3) PMs - can operate only on their own projects
-if (!requester_is_localhost()) {
-    require_login();
-
-    if (!user_is_a_sitemanager() && !user_is_proj_facilitator()) {
-        if ($one_project) {
-            $project = new Project($one_project);
-            if (!$project->can_be_managed_by_user($pguser)) {
-                die('You are not authorized to invoke this script.');
-            }
-        } else {
+if (!user_is_a_sitemanager() && !user_is_proj_facilitator()) {
+    if ($one_project) {
+        $project = new Project($one_project);
+        if (!$project->can_be_managed_by_user($pguser)) {
             die('You are not authorized to invoke this script.');
         }
+    } else {
+        die('You are not authorized to invoke this script.');
     }
 }
-
-$trace = false;
-
-// -----------------------------------------------------------------------------
-
-function ensure_project_blurb($project)
-{
-    static $project_blurb_echoed = [];
-
-    if (!isset($project_blurb_echoed[$project->projectid])) {
-        echo "\n";
-        echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n";
-        echo "projectid  = {$project->projectid}\n";
-        echo "nameofwork = \"" . html_safe($project->nameofwork) . "\"\n";
-        echo "state      = {$project->state}\n";
-        echo "\n";
-        $project_blurb_echoed[$project->projectid] = true;
-    }
-}
-
-// -----------------------------------------------------------------------------
 
 echo "<pre>\n";
-
-if ($one_project) {
-    $verbose = $GLOBALS['testing'];
-    $condition = sprintf("projectid = '%s'", DPDatabase::escape($one_project));
-
-    insert_job_log_entry(
-        'automodify.php',
-        'BEGIN',
-        sprintf("running for single proj %s", $one_project)
-    );
-} else {
-    $verbose = 1;
-
-    $condition = "0";
-    foreach (Rounds::get_all() as $round) {
-        $condition .= sprintf(
-            "
-            OR state = '%s'
-            OR state = '%s'
-            OR state = '%s'
-            ",
-            DPDatabase::escape($round->project_available_state),
-            DPDatabase::escape($round->project_complete_state),
-            DPDatabase::escape($round->project_bad_state)
-        );
-    }
-
-    insert_job_log_entry(
-        'automodify.php',
-        'BEGIN',
-        'running for all eligible projects'
-    );
-}
-$sql = "
-    SELECT projectid
-    FROM projects
-    WHERE $condition
-    ORDER BY projectid
-";
-$allprojects = DPDatabase::query($sql);
-// The "ORDER BY" ensures consistency of order.
-
-while ([$projectid] = mysqli_fetch_row($allprojects)) {
-    $project = new Project($projectid);
-    $state = $project->state;
-    $nameofwork = $project->nameofwork;
-
-    if ($trace) { /** @phpstan-ignore-line */
-        ensure_project_blurb($project);
-    }
-
-    // Decide which round the project is in
-    $round = get_Round_for_project_state($state);
-    if (is_null($round)) {
-        echo "    automodify.php: unexpected state $state for project $projectid\n";
-        continue;
-    }
-
-    //Bad Page Error Check
-    {
-        if (($state == $round->project_available_state) || ($state == $round->project_bad_state)) {
-            if ($project->is_bad_from_pages($round)) {
-                // This project's pages indicate that it's bad.
-                // If it isn't marked as such, make it so.
-                if ($trace) { /** @phpstan-ignore-line */
-                    echo "project looks bad.\n";
-                }
-                $appropriate_state = $round->project_bad_state;
-            } else {
-                // Pages don't indicate that the project is bad.
-                // (Although it could be bad for some other reason. Hmmm.)
-                if ($trace) { /** @phpstan-ignore-line */
-                    echo "project looks okay.\n";
-                }
-                $appropriate_state = $round->project_available_state;
-            }
-
-            if ($state != $appropriate_state) {
-                if ($verbose) {
-                    ensure_project_blurb($project);
-                    echo "    Re badness, changing state to $appropriate_state\n";
-                }
-                if ($trace) { /** @phpstan-ignore-line */
-                    echo "changing its state to $appropriate_state\n";
-                }
-                $error_msg = project_transition($projectid, $appropriate_state, PT_AUTO);
-                if ($error_msg) {
-                    echo "$error_msg\n";
-                }
-                $state = $appropriate_state;
-            }
-        }
-    }
-
-    if (
-        ($one_project) ||
-        (($state == $round->project_available_state) &&
-           ($project->get_num_pages_in_state($round->page_avail_state) == 0))
-    ) {
-
-        // Reclaim MIA pages
-
-        if ($verbose) {
-            ensure_project_blurb($project);
-            echo "    Reclaiming any MIA pages\n";
-        }
-
-        $n_hours_to_wait = 4;
-        $max_reclaimable_time = time() - $n_hours_to_wait * 60 * 60;
-
-        $sql = sprintf(
-            "
-            SELECT image
-            FROM $projectid
-            WHERE state IN ('%s','%s')
-                AND $round->time_column_name <= %d
-            ORDER BY image ASC
-            ",
-            $round->page_out_state,
-            $round->page_temp_state,
-            $max_reclaimable_time
-        );
-        try {
-            $res = DPDatabase::query($sql);
-        } catch (DBQueryError $error) {
-            echo $error->getMessage() . "\n";
-            echo "Skipping further processing of this project.\n";
-            continue;
-        }
-
-        $n_reclaimable_pages = mysqli_num_rows($res);
-        if ($verbose) {
-            echo "        reclaiming $n_reclaimable_pages pages\n";
-        }
-
-        while ([$image] = mysqli_fetch_row($res)) {
-            Page_reclaim($projectid, $image, $round, '[automodify.php]');
-        }
-
-
-        // Decide whether the project is finished its current round.
-        if ($state == $round->project_available_state) {
-            $num_done_pages = $project->get_num_pages_in_state($round->page_save_state);
-            $num_total_pages = $project->get_num_pages();
-
-            if ($num_done_pages != $num_total_pages) {
-                if ($verbose) {
-                    echo "    Only $num_done_pages of $num_total_pages pages are in '$round->page_save_state'.\n";
-                }
-                continue;
-            }
-
-            if ($verbose) {
-                echo "    All $num_total_pages pages are in '$round->page_save_state'.\n";
-            }
-
-            if (project_has_a_hold_in_state($projectid, $state)) {
-                if ($verbose) {
-                    echo "    Normally, this project would now advance to {$round->project_complete_state},\n";
-                    echo "    but it has a hold in $state, so it stays where it is.\n";
-                }
-                if ($project->is_hold_notification_required($state)) {
-                    // Note that notifications are only sent for Available
-                    // states, as this if() block is only reached for those.
-                    if ($verbose) {
-                        echo "    Sending notification about held project.\n";
-                    }
-                    $project->send_hold_state_notification($state);
-                }
-                continue;
-            }
-
-            $state = $round->project_complete_state;
-            if ($verbose) {
-                echo "    Advancing \"" . html_safe($nameofwork) . "\" to $state\n";
-            }
-
-            $error_msg = project_transition($projectid, $state, PT_AUTO);
-            if ($error_msg) {
-                echo "$error_msg\n";
-                continue;
-            }
-        }
-    }
-
-    if ($state == $round->project_complete_state) {
-        // The project is ready to exit this round.
-
-        if ($round->round_number < Rounds::get_last()->round_number) {
-            // It goes to the next round.
-            $next_round = get_Round_for_round_number(1 + $round->round_number);
-            $new_state = $next_round->project_waiting_state;
-        } elseif ($round->round_number == Rounds::get_last()->round_number) {
-            // It goes into post-processing.
-            if (is_null(project_get_auto_PPer($projectid))) {
-                $new_state = PROJ_POST_FIRST_AVAILABLE;
-            } else {
-                $new_state = PROJ_POST_FIRST_CHECKED_OUT;
-            }
-        } else {
-            throw new ValueError("round_number is {$round->round_number}???");
-        }
-
-        if ($verbose) {
-            ensure_project_blurb($project);
-            echo "    Promoting \"" . html_safe($nameofwork) . "\" to $new_state\n";
-        }
-
-        $error_msg = project_transition($projectid, $new_state, PT_AUTO);
-        if ($error_msg) {
-            echo "$error_msg\n";
-        }
-    }
-}
-
-if ($trace) { /** @phpstan-ignore-line */
-    echo "\n";
-}
-
-if ($verbose) {
-    echo "\n";
-    echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n";
-    echo "\n";
-}
-
+automodify($one_project);
 echo "</pre>\n";
 
 if (!$one_project) {
+    echo "<pre>\n";
     autorelease();
-
-    insert_job_log_entry(
-        'automodify.php',
-        'END',
-        sprintf(
-            "post autorelease, started at %d, took %d seconds",
-            $start_time,
-            time() - $start_time
-        )
-    );
+    echo "</pre>\n";
 } else {
-    insert_job_log_entry(
-        'automodify.php',
-        'END',
-        sprintf(
-            "end single, started at %d, took %d seconds",
-            $start_time,
-            time() - $start_time
-        )
-    );
-
     echo "<META HTTP-EQUIV=\"refresh\" CONTENT=\"0 ;URL=$refresh_url\">";
 }

--- a/tools/project_manager/automodify.php
+++ b/tools/project_manager/automodify.php
@@ -1,5 +1,5 @@
 <?php
-// The can be called by:
+// This script can be called by:
 // * project transitions (for individual projects)
 // * PMs for their own projects
 // * SA and PFs for all projects
@@ -19,8 +19,6 @@ include_once($relPath.'autorelease.inc');
 
 $one_project = get_projectID_param($_GET, 'project', true);
 $refresh_url = $_GET['return_uri'] ?? 'projectmgr.php';
-
-$start_time = time();
 
 require_login();
 


### PR DESCRIPTION
This lifts automodify into a normal BackgroundJob. In doing so it moves logic that was in `automodify.php` into `pinc/automodify.inc` so it can be called from within the new BackgroundJob. Unlike the prior version, the new job will save the text output directly to a log file so we no longer need the redirect in the crontab.

The `automodify.php` file is still there and can still be run by PMs for a single project (needed for some project transitions) and by SAs.

The crontab on TEST has been updated to use the job in the sandbox below for testing.

https://www.pgdp.org/~cpeel/c.branch/automodify-as-background-job/