### PR TITLE
Run AutoModify under web context

### DIFF
--- a/crontab/AutoModify.inc
+++ b/crontab/AutoModify.inc
@@ -5,6 +5,8 @@ include_once($relPath."autorelease.inc");
 // Run periodic project validation and transitions
 class AutoModify extends BackgroundJob
 {
+    public bool $requires_web_context = true;
+
     private $filehandle = null;
     private ?string $logfile = null;
 


### PR DESCRIPTION
Some modify actions are transitions that require filesystem access, like moving something into PP -- PP artifacts are generated.

This is hotfixed on TEST and PROD.