### PR TITLE
Remove Ubuntu 20.04 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: 'ubuntu-20.04', php: '7.4' }
+          - { os: 'ubuntu-22.04', php: '7.4' }
           - { os: 'ubuntu-22.04', php: '8.1' }
           - { os: 'ubuntu-24.04', php: '8.3' }
     runs-on: ${{ matrix.cfg.os }}
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: 'ubuntu-20.04', php: '7.4' }
+          - { os: 'ubuntu-22.04', php: '7.4' }
           - { os: 'ubuntu-22.04', php: '8.1' }
           - { os: 'ubuntu-24.04', php: '8.3' }
     runs-on: ${{ matrix.cfg.os }}
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: 'ubuntu-20.04', php: '7.4' }
+          - { os: 'ubuntu-22.04', php: '7.4' }
           - { os: 'ubuntu-22.04', php: '8.1' }
           - { os: 'ubuntu-24.04', php: '8.3' }
     runs-on: ${{ matrix.cfg.os }}


### PR DESCRIPTION
GitHub is deprecating 20.04 at its EOL but is doing brownouts before we're fully cut over on TEST and PROD to Ubuntu 24.04. This is a stop-gap until then to continue coverage on PHP 7.4.

Recent email from GitHub:
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> * March 4 14:00 UTC – 22:00 UTC
> * March 11 13:00 UTC – 21:00 UTC
> * March 18 13:00 UTC – 21:00 UTC
> * March 25 13:00 UTC – 21:00 UTC
