### PR TITLE
Better handle banned account logins

### DIFF
--- a/accounts/login.php
+++ b/accounts/login.php
@@ -51,6 +51,8 @@ if (!$success) {
         login_failure('unknown_failure', $destination);
     } elseif ($reason == 'too_many_attempts') {
         login_failure('too_many_attempts', $destination);
+    } elseif ($reason == 'banned') {
+        login_failure('banned', $destination);
     } else {
         login_failure('auth_failure', $destination);
     }

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -32,7 +32,8 @@ $login_failures = [
     'form_timeout' => _("Form submission timeout, go back and try again."),
 ];
 
-$error = @$login_failures[@$_GET['error_code']];
+$error_code = @$_GET['error_code'];
+$error = @$login_failures[$error_code];
 if (!$error) {
     $error = _("An undefined error occurred while attempting to log you in.");
 }
@@ -42,6 +43,11 @@ output_header($title);
 
 echo "<br>\n";
 echo "<b>$error</b>\n";
+
+if ($error_code == "banned") {
+    // if the user is banned, stop here and not include hints on how to log in
+    exit();
+}
 
 echo "<p>" . _("Please attempt again to log in above. If problems persist, review the following possible fixes:") . "</p>";
 echo "<ol>";

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -25,6 +25,7 @@ $login_failures = [
     'no_username' => _("You did not supply a username."),
     'no_password' => _("You did not supply a password."),
     'auth_failure' => _("Unable to authenticate. The username/password may be incorrect or your account may be locked."),
+    'banned' => sprintf(_("Your account has been banned. If you feel this is in error, please contact a <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr"),
     'unknown_failure' => sprintf(_("An unexpected failure occurred, please contact a <a href='%s'>site manager</a>."), "mailto:$site_manager_email_addr"),
     'too_many_attempts' => sprintf(_("You exceeded the maximum number of failed logins. Go <a href='%s'>log into the forums</a> and answer the CAPTCHA. Once you have successfully logged in there, return here and try again."), get_url_for_forum_user_login()),
     'reg_mismatch' => sprintf(_("You are registered with the forum software, but not with %s."), $site_abbreviation),

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -145,6 +145,15 @@ function create_forum_user($username, $password, $email, $password_is_digested =
     return true;
 }
 
+function phpbb_user_error_handler($errno, $errstr, $errfile, $errline)
+{
+    if (in_array($errno, [E_USER_ERROR, E_USER_NOTICE])) {
+        throw new ValueError($errstr);
+    }
+
+    return false;
+}
+
 /**
  * Log in the user to the forums.
  *
@@ -210,11 +219,26 @@ function login_forum_user($username, $password)
     set_var($password, $password, 'string', true);
 
     $persist_login = true;
-    $results = $auth->login($username, $password, $persist_login);
 
-    $success = $results["status"] == LOGIN_SUCCESS;
-    $reason = '';
-    switch ($results["status"]) {
+    // phpBB may use trigger_error() on login if the user is banned which
+    // doesn't return, so we need to capture that and handle it here
+    $old_error_handler = set_error_handler("phpbb_user_error_handler");
+
+    try {
+        $results = $auth->login($username, $password, $persist_login);
+        $status = $results["status"];
+    } catch (ValueError $exception) {
+        if (str_contains($exception->getMessage(), "banned")) {
+            $status = "BANNED";
+        } else {
+            $status = "UNKNOWN";
+        }
+    }
+
+    set_error_handler($old_error_handler);
+
+    $success = $status == LOGIN_SUCCESS;
+    switch ($status) {
         case LOGIN_SUCCESS:
             $reason = '';
             break;
@@ -226,6 +250,9 @@ function login_forum_user($username, $password)
             break;
         case LOGIN_ERROR_ATTEMPTS:
             $reason = 'too_many_attempts';
+            break;
+        case "BANNED":
+            $reason = 'banned';
             break;
         default:
             $reason = 'unknown';

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -228,7 +228,15 @@ function login_forum_user($username, $password)
         $results = $auth->login($username, $password, $persist_login);
         $status = $results["status"];
     } catch (ValueError $exception) {
-        if (str_contains($exception->getMessage(), "banned")) {
+        // Unfortunately, the error message might be in a language that isn't
+        // English, so we need to check for a few possible combinations.
+        // Thankfully the " ban" prefix covers many languages.
+        if (
+            str_contains($exception->getMessage(), " ban") ||      // en, fr, it, pt
+            str_contains($exception->getMessage(), "gesperrt") ||  // de
+            str_contains($exception->getMessage(), "exclusión") || // es
+            str_contains($exception->getMessage(), "verbannen")    // nl
+        ) {
             $status = "BANNED";
         } else {
             $status = "UNKNOWN";


### PR DESCRIPTION
We use phpBB for authentication by calling its `$auth->login()` function. Except that if the account is banned in the forums, that function never returns because `trigger_error()` is called which kills the page. We can install our own error handler to catch that and throw an exception which we _can_ handle more gracefully.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/handle-banned-accounts/

Testing notes: User authentication should continue to work as-is, and users with banned accounts who try to log in will now get a more reasonable error messages instead of an styled phpBB error page.