### PR TITLE
Map sessions to users and allow admins to manage them

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -378,6 +378,7 @@ CREATE TABLE `sessions` (
   `sid` varchar(32) NOT NULL default '',
   `expiration` int(11) NOT NULL default '0',
   `value` text NOT NULL,
+  `username` varchar(25) NOT NULL default '',
   PRIMARY KEY (`sid`),
   KEY `expiration` (`expiration`)
 );

--- a/SETUP/upgrade/23/20250401_alter_sessions.php
+++ b/SETUP/upgrade/23/20250401_alter_sessions.php
@@ -1,0 +1,18 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+// ------------------------------------------------------------
+
+echo "Adding username column to sessions table...\n";
+
+$sql = "
+    ALTER TABLE sessions
+        ADD COLUMN username varchar(25) NOT NULL DEFAULT ''
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -88,6 +88,41 @@ function dpsession_end()
     session_destroy();
 }
 
+// -----------------------------------------------------------------------------
+// User-centric session management functions
+
+/** @return array<array{0: string, 1: int}> */
+function load_user_sessions(string $username): array
+{
+    $sql = sprintf(
+        "
+        SELECT sid, expiration
+        FROM sessions
+        WHERE username = '%s'
+        ORDER BY expiration
+        ",
+        DPDatabase::escape($username)
+    );
+    $result = DPDatabase::query($sql);
+    $results = [];
+    while ([$sid, $expiration] = mysqli_fetch_row($result)) {
+        $results[] = [$sid, $expiration];
+    }
+    return $results;
+}
+
+function delete_user_sessions(string $username): void
+{
+    $sql = sprintf(
+        "
+        DELETE FROM sessions
+        WHERE username = '%s'
+        ",
+        DPDatabase::escape($username)
+    );
+    DPDatabase::query($sql);
+}
+
 
 // -----------------------------------------------------------------------------
 // Internal session helper functions

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -161,18 +161,21 @@ class DPSessionHandler implements SessionHandlerInterface
         $query = sprintf(
             "
             INSERT INTO sessions
-                (sid, expiration, value)
+                (sid, expiration, value, username)
             VALUES
-                ('%s', %d, '%s')
+                ('%s', %d, '%s', '%s')
             ON DUPLICATE KEY UPDATE
                 expiration = %d,
-                value = '%s'
+                value = '%s',
+                username = '%s'
             ",
             substr(DPDatabase::escape($sid), 0, 32), // truncate to column size
             $expiration,
             DPDatabase::escape($value),
+            DPDatabase::escape($_SESSION["pguser"] ?? ""),
             $expiration,
-            DPDatabase::escape($value)
+            DPDatabase::escape($value),
+            DPDatabase::escape($_SESSION["pguser"] ?? "")
         );
         $result = DPDatabase::query($query);
         return $result === false ? false : true;

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -6,6 +6,7 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'new_user_mails.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'email_address.inc');
+include_once('sa_common.inc');
 
 require_login();
 
@@ -20,10 +21,10 @@ echo "<h1>$title</h1>";
 
 $username = $_GET['username'] ?? '';
 $email = $_GET['email'] ?? '';
-$action = get_enumerated_param($_GET, 'action', 'default', ['list_all', 'get_user', 'set_email', 'default']);
+$action = get_enumerated_param($_GET, 'action', 'default', ['list_all', 'set_email', 'default']);
 $order_by = get_enumerated_param($_GET, 'order_by', 'date_created DESC', ['username', 'real_name', 'email', 'date_created DESC']);
 
-if ($action == 'default') {
+if ($action == 'default' && !$username) {
     echo "<p>";
     echo _("This form should be used when a mail has been received from a user who has not received
     his or her welcome email due to entering a bad email address when registering.");
@@ -32,14 +33,8 @@ if ($action == 'default') {
     printf(_("To change the address, please enter the name of the user below or
     <a href='%s'>list all user accounts awaiting activation</a>."), "?action=list_all");
     echo "</p>";
-    echo "<br>";
 
-    echo "<form method='get'>";
-    echo "<input type='hidden' name='action' value='get_user'>";
-    echo _("Username") . ": <input type='text' name='username' autocapitalize='none' required>";
-    echo  " <input type='submit' value='" . attr_safe(_("Continue")) . "'>";
-    echo "</form>";
-    echo "<br>";
+    show_username_form($username);
 } elseif ($action == 'list_all') {
     $result = DPDatabase::query("
         SELECT *
@@ -62,7 +57,7 @@ if ($action == 'default') {
         }
         while ($row = mysqli_fetch_assoc($result)) {
             echo "<tr>\n";
-            echo "<td><a href='?action=get_user&username=".urlencode($row['username'])."'>{$row['username']}</a></td>\n";
+            echo "<td><a href='?username=".urlencode($row['username'])."'>{$row['username']}</a></td>\n";
             echo "<td>" . html_safe($row['real_name']) . "</td>\n";
             echo "<td>" . html_safe($row['email']) . "</td>\n";
             echo "<td>" . date("Y-m-d H:i", (int)$row['date_created']) . "</td>\n";
@@ -70,7 +65,7 @@ if ($action == 'default') {
         }
         echo "</table>\n";
     }
-} elseif ($action == 'get_user') {
+} elseif ($action == 'default' && $username) {
     if (check_username($username) != '') {
         die("Invalid parameter username.");
     }

--- a/tools/site_admin/index.php
+++ b/tools/site_admin/index.php
@@ -23,6 +23,7 @@ $sections = [
         "../pending_access_requests.php" => _("Pending Access Requests"),
         "show_access_log.php" => _("Show Access Log"),
         "edit_mail_address_for_non_activated_user.php" => _("Resend Account Activation Email"),
+        "manage_user_sessions.php" => _("Manage User Sessions"),
     ],
     _("Project") => [
         "copy_pages.php" => _("Copy Pages"),

--- a/tools/site_admin/manage_site_access_privileges.php
+++ b/tools/site_admin/manage_site_access_privileges.php
@@ -5,6 +5,7 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'user_is.inc');
 include_once($relPath.'User.inc');
 include_once($relPath.'access_log.inc');
+include_once('sa_common.inc');
 
 require_login();
 
@@ -77,18 +78,6 @@ if ($username) {
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-function show_username_form(?string $username): void
-{
-    echo "<form method='GET'>\n";
-    echo "<p>" . _("Username") . ": ";
-    echo "<input name='username' type='text' value='$username' size='20' autocapitalize='none' required>\n";
-    echo "</p>";
-    echo "<input type='submit' value='" . attr_safe(_("Look up this user")) . "'>\n";
-    echo "</form>\n";
-}
-
-// ------------------------------------------------
 
 function show_toggles_form(?string $username, Settings $user_settings): void
 {

--- a/tools/site_admin/manage_user_sessions.php
+++ b/tools/site_admin/manage_user_sessions.php
@@ -1,0 +1,72 @@
+<?php
+$relPath = "./../../pinc/";
+include_once($relPath.'base.inc');
+include_once($relPath.'theme.inc');
+include_once($relPath.'User.inc');
+include_once('sa_common.inc');
+
+require_login();
+
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
+// --------------------------------------
+
+$username = $_POST['username'] ?? ($_GET['username'] ?? null);
+$action = get_enumerated_param($_POST, 'action', null, ['logout'], true);
+
+$title = _("Manage User Sessions");
+output_header($title, NO_STATSBAR);
+
+echo "<h1>$title</h1>\n";
+echo "<p>" . _("This page shows how many separate sessions (logins) a user has and the option of logging them out.") . "</p>";
+
+show_username_form($username);
+
+if ($username) {
+    try {
+        $user = new User($username);
+    } catch (NonexistentUserException $exception) {
+        echo "<p class='error'>" . _("Invalid username") . "</p>";
+        exit;
+    }
+
+    echo "<hr>";
+    echo "<h2>$username ($user->real_name)</h2>";
+
+    if ($action == "logout") {
+        delete_user_sessions($username);
+        echo "<p>" . _("User has been logged out.") . "</p>";
+    } else {
+        show_sessions_form($username);
+    }
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+function show_sessions_form(?string $username): void
+{
+    echo "<p>" . _("User has the following sessions. Sessions that have expired are no longer valid and will be automatically cleaned up by the system.") . "</p>";
+    echo "<table class='basic'>\n";
+    echo "<tr>\n";
+    echo "<th>" . _("SID Hash") . "</th>\n";
+    echo "<th>" . _("Expires") . "</th>\n";
+    echo "</tr>\n";
+    foreach (load_user_sessions($username) as $result) {
+        [$sid, $expiration] = $result;
+        echo "<tr>";
+        echo "<td>" . md5($sid) . "</td>";
+        $notes = $expiration < time() ? _("(session has expired)") : "";
+        echo "<td>" . icu_date_template("long+time", $expiration) . " $notes</td>";
+        echo "</tr>";
+    }
+
+    echo "</table>\n";
+
+    echo "<form method='POST'>\n";
+    echo "<input type='hidden' name='username' value='" . attr_safe($username) . "'>\n";
+    echo "<input type='hidden' name='action' value='logout'>\n";
+    echo "<p><input type='submit' name='submit' value='" . attr_safe(_("Logout User")) . "'></p>\n";
+    echo "</form>\n";
+}

--- a/tools/site_admin/sa_common.inc
+++ b/tools/site_admin/sa_common.inc
@@ -1,0 +1,11 @@
+<?php
+
+function show_username_form(?string $username): void
+{
+    echo "<form method='GET'>\n";
+    echo "<p>" . _("Username") . ": ";
+    echo "<input name='username' type='text' value='" . attr_safe($username) . "' size='20' autocapitalize='none' required>\n";
+    echo "</p>";
+    echo "<input type='submit' value='" . attr_safe(_("Look up this user")) . "'>\n";
+    echo "</form>\n";
+}


### PR DESCRIPTION
_Note: This will not be merged until after the code thaw in March._

In very rare cases admins may need to log a user out of the site. This makes that easier by including the username in the session table and a very simple UI for seeing the current sessions for a user and the option of logging them out.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/track-sessions-to-users/

Testing notes: when testing this, be sure to use the sandbox for the user you want to log out. Sessions created outside of this sandbox will not have the username associated with them and won't be logged out. When this code is deployed any site activity will add the username to the user's session thus solving the problem after deployment.