### PR TITLE
Include the Common script for apostrophes

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -1327,7 +1327,7 @@ function filter_words_to_script(array $words, string $script): array
 {
     $script_words = [];
     foreach ($words as $word) {
-        if (array_diff(utf8_string_scripts($word), [$script, "Inherited"]) === []) {
+        if (array_diff(utf8_string_scripts($word), [$script, "Inherited", "Common"]) === []) {
             $script_words[] = $word;
         }
     }


### PR DESCRIPTION
Without the Common script, words with apostrophes are filtered out of aspell results in WordCheck. [Task 2100](https://www.pgdp.net/c/tasks.php?action=show&task_id=2100)

Beyond fixing the bug, we need to ensure that this doesn't break the use of the Ancient Greek dictionary, because that's the whole reason we added and use this function in the first place:
```
commit e1353291eacd255392534bd4101211ca0fa2cc2a
Author: Casey Peel <cpeel@users.noreply.github.com>
Date:   Tue Nov 3 15:29:06 2020 +0000

    Use language script as part of spellcheck

    When presented with text containing two different scripts, aspell
    behaves differently based on the dictionary. Words containing non-Latin
    characters are ignored completely with the English dictionary, yet
    words containing Latin characters are flagged as spelling errors with
    the Ancient Greek dictionary.

    To fix this, restrict misspelled words (as returned from aspell) to
    only words that contain the script of the language we're checking.
    This ensures that only words with Latin characters are returned when
    checking against the English or French dictionary, and only Greek
    words are returned when using the Ancient Greek dictionary.
```

This particular line was changed in this commit which is probably what broke it at a cursory glance but I haven't tested it for sure:
```
commit 8c80ee0261baff6c9a4a5207e137c0e8ae4b872d
Author: Casey Peel <cpeel@users.noreply.github.com>
Date:   Sun Sep 24 22:58:00 2023 +0000

    Highlight non-Latin Unicode scripts in WordCheck

    To improve proofreaders ability to differentiate look-alike characters,
    highlight non-Latin characters in WordCheck like we do for punctuation.
    This removes the current behavior where words containing multiple
    Unicode scripts are flagged as bad in lieu of highlighting the
    characters instead.
```

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-apostrophies-in-wordcheck/