### PR TITLE
Be explicit about site globals

### DIFF
--- a/pinc/DPage.inc
+++ b/pinc/DPage.inc
@@ -463,6 +463,7 @@ function Page_clearRound(string $projectid, string $image, Round $round, string 
 
 // The numeric values of the following array must not change as they are
 // saved in the database to indicate the bad page reason.
+global $PAGE_BADNESS_REASONS;
 $PAGE_BADNESS_REASONS = [
     1 => [
         "name" => "missing_image",

--- a/pinc/faq.inc
+++ b/pinc/faq.inc
@@ -6,6 +6,7 @@ include_once($relPath.'metarefresh.inc');
 // that is used in FAQs. Also information about forums and wiki used in FAQs.
 
 // SITE-SPECIFIC
+global $external_faq_overrides;
 $external_faq_overrides = [
     "proofreading_guidelines.php" => [
         "en" => "https://www.pgdp.net/wiki/DP_Official_Documentation:Proofreading/Proofreading_Guidelines",

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -249,6 +249,7 @@ declare_mentoring_pair('P1', 'P2');
 // This particular assignment assumes that the ELR is the first round
 // defined in this file. This is probably correct, but your site is
 // welcome to use a different round as your ELR.
+global $ELR_round;
 $ELR_round = get_Round_for_round_number(1);
 
 // On the other hand, if your site doesn't have a distinguished entry-level

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -16,6 +16,7 @@ $bracketed_character_pattern = "\\[(?:oe|OE|$mark$base|$base$mark)\\]";
 
 // This is used when splitting a text into words.
 $char_pattern = "(?:\w\pM*|$bracketed_character_pattern)";
+global $word_pattern;
 $word_pattern = "!$char_pattern+(?:'$char_pattern+)*!u";
 // (The pattern is delimited by exclamation marks rather than the usual slashes,
 // because slash is a character within the pattern.)
@@ -26,6 +27,7 @@ $word_pattern = "!$char_pattern+(?:'$char_pattern+)*!u";
 $puncCharacters = '.,;:?!*/()#@%+=[]{}<>\"$|_¬¢£¥©®§°±¶·´¸º×¦¡¿-»«¯÷¹²³¼½¾¤';
 
 // Unicode scripts that are "common" and shouldn't be highlighted
+global $common_unicode_scripts;
 $common_unicode_scripts = ["Latin", "Common", "Inherited"];
 
 // -----------------------------------------------------------------------------
@@ -1156,6 +1158,8 @@ function get_site_word_files(string $pattern = "/txt$/"): array
  */
 function get_distinct_words_in_text($text)
 {
+    global $word_pattern;
+
     // For a $text with typical-sized words, the memory consumed by the result
     // of get_all_words_in_text($text) is about 20 times the size of $text.
     // So if $text is project-sized (say, 1.5Mb), the resulting array will be
@@ -1176,8 +1180,6 @@ function get_distinct_words_in_text($text)
             // The result of get_all_words_in_text($text) would be rather large,
             // so avoid it.  The following alternative is somewhat slower but
             // more space efficient.
-            global $word_pattern;
-
             $input_words_w_freq = [];
             $offset = 0;
             $flags = PREG_OFFSET_CAPTURE;


### PR DESCRIPTION
Don't assume because something is declared outside a function that it is a global. Be explicit about globals being global when we define them.

This is a forward-looking PR in preparation for upgrading to phpunit 10 and won't be merged until after the PROD upgrade and we lift the code freeze.