### PR TITLE
Add more unit tests for WordCheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup MySQL, install schema
         uses: ./.github/actions/setup-mysql-db
       - name: Install aspell dependencies for WordCheck tests
-        run: sudo apt --fix-broken install aspell aspell-en
+        run: sudo apt --fix-broken install aspell aspell-en aspell-fr
       - name: Run phpunit tests
         run: cd SETUP/tests/unittests && ../../../vendor/bin/phpunit
   jsunit:
@@ -120,7 +120,7 @@ jobs:
       - name: Setup MySQL, install schema
         uses: ./.github/actions/setup-mysql-db
       - name: Install aspell dependencies for WordCheck tests
-        run: sudo apt --fix-broken install aspell aspell-en
+        run: sudo apt --fix-broken install aspell aspell-en aspell-fr
       - name: Setup smoke test environment
         run: SETUP/tests/smoketests/smoketest_setup.sh
       - name: Run pageload smoketest

--- a/SETUP/tests/unittests/WordCheckEngineTest.php
+++ b/SETUP/tests/unittests/WordCheckEngineTest.php
@@ -228,4 +228,48 @@ class WordCheckEngineTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected_words, $uncommon_words);
         $this->assertEquals($expected_scripts, $scripts);
     }
+
+    // Regression tests for Task 2100
+    private $ENGLISH_TEXT = <<<EOTEXT
+        perfectly valid English words
+        blearg blearg's
+        EOTEXT;
+
+    public function testEnglish()
+    {
+        $languages = ["English"];
+        $words = get_distinct_words_in_text($this->ENGLISH_TEXT);
+
+        [$bad_words, $messages] =
+            get_bad_words_via_external_checker($words, $languages);
+
+        $this->assertEquals(["blearg", "blearg's"], $bad_words);
+    }
+
+    private $FRENCH_TEXT = <<<EOTEXT
+        mots français valides
+        bonjuor l'absolulion
+        EOTEXT;
+
+    public function testFrench()
+    {
+        $languages = ["French"];
+        $words = get_distinct_words_in_text($this->FRENCH_TEXT);
+
+        [$bad_words, $messages] =
+            get_bad_words_via_external_checker($words, $languages);
+
+        $this->assertEquals(["bonjuor", "l'absolulion"], $bad_words);
+    }
+
+    public function testEnglishFrench()
+    {
+        $languages = ["English", "French"];
+        $words = get_distinct_words_in_text($this->ENGLISH_TEXT . ' ' . $this->FRENCH_TEXT);
+
+        [$bad_words, $messages] =
+            get_bad_words_via_external_checker($words, $languages);
+
+        $this->assertEquals(["blearg", "blearg's", "bonjuor", "l'absolulion"], $bad_words);
+    }
 }


### PR DESCRIPTION
This adds regression testing for the bug found in [Task 2100](https://www.pgdp.net/c/tasks.php?task_id=2100) and closes #1444. We have pretty decent unit tests already, we just had a gap here.