### PR TITLE
Fix small issues in unit tests

### DIFF
--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -4,6 +4,16 @@
 
 class ApiTest extends ProjectUtils
 {
+    protected function tearDown(): void
+    {
+        global $pguser;
+
+        parent::tearDown();
+
+        // reset $pguser after every test
+        $pguser = null;
+    }
+
     //---------------------------------------------------------------------------
     // helper functions
 

--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -74,7 +74,7 @@ class ApiTest extends ProjectUtils
         return $router->route($path, ['state' => $project_state, 'pagestate' => $page_state]);
     }
 
-    private function api_project_page(string $projectid, string $project_state, string $page_name, string $page_state, array $request_array = [], string $action)
+    private function api_project_page(string $projectid, string $project_state, string $page_name, string $page_state, array $request_array, string $action)
     {
         global $request_body;
 

--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -126,7 +126,12 @@ class ApiTest extends ProjectUtils
         $request_body = ["reason" => $reason];
         $path = "v1/projects/$projectid/pages/$page_name/reportbad";
         $router = ApiRouter::get_router();
-        return $router->route($path, []);
+
+        // silence the output-to-console email that is sent
+        ob_start();
+        $result = $router->route($path, []);
+        ob_end_clean();
+        return $result;
     }
 
     //---------------------------------------------------------------------------

--- a/SETUP/tests/unittests/ProjectTest.php
+++ b/SETUP/tests/unittests/ProjectTest.php
@@ -254,7 +254,7 @@ class ProjectTest extends ProjectUtils
     public function test_validate_postdnum_positive_path(): void
     {
         $project = new Project($this->valid_project_data);
-        $project->posted_num = 123;
+        $project->postednum = 123;
         $errors = $project->validate();
         $this->assertEquals([], $errors);
     }

--- a/SETUP/tests/unittests/ProjectTest.php
+++ b/SETUP/tests/unittests/ProjectTest.php
@@ -2,6 +2,16 @@
 
 class ProjectTest extends ProjectUtils
 {
+    protected function tearDown(): void
+    {
+        global $pguser;
+
+        parent::tearDown();
+
+        // reset $pguser after every test
+        $pguser = null;
+    }
+
     //------------------------------------------------------------------------
     // Project object save and delete
 

--- a/SETUP/tests/unittests/ProjectUtils.inc
+++ b/SETUP/tests/unittests/ProjectUtils.inc
@@ -62,6 +62,12 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
     // helper function to create a project
     protected function _create_project(): Project
     {
+        global $pguser;
+
+        // save existing pguser and set to the PM we know exists
+        $old_pguser = $pguser;
+        $pguser = $this->TEST_USERNAME_PM;
+
         $project = new Project();
         foreach ($this->valid_project_data as $key => $value) {
             $project->$key = $value;
@@ -69,6 +75,9 @@ class ProjectUtils extends PHPUnit\Framework\TestCase
         $project->save();
         $this->created_projectids[] = $project->projectid;
         $project->add_charsuite("basic-latin");
+
+        // restore pguser
+        $pguser = $old_pguser;
 
         return $project;
     }


### PR DESCRIPTION
This fixes some small issues in our unit tests in prep for phpunit 10 and for typing `Projects.inc`:
* Correctly handle `$pguser` when creating projects -- there needs to be a valid current user when creating projects to record that data to the event log.
* Don't bleed `$pguser` values from one test to the next. Stupid globals.
* Fix incorrect `posted_num` to `postednum`.
* Squash the "email" that is output on stdout when reporting a bad page when `$testing=1`.