### PR TITLE
Remove FTP-based file uploads support

### DIFF
--- a/SETUP/configuration.sh
+++ b/SETUP/configuration.sh
@@ -216,29 +216,13 @@ _SITE_REGISTRATION_PROTECTION_CODE=
 # -------------------------------
 
 # To load images and text into projects, these files must reside on the
-# web server. There are two common ways to accomplish this:
-#   1) Via the built-in project upload script (recommended)
-#   2) Via an FTP server that you configure and manage separately
-#
-# Previously at pgdp.net, Project Managers were given access to a shared
-# ftp-only "uploads" account. Each PM created a personal directory (named
-# according to their DP login id) within the shared account's home
-# directory. This has since been replaced with the remote_file_manager.php
-# script.
+# web server. This is done with the built-in file upload script,
+# remote_file_manager.php.
 
 # The location where project information (text and images) are written
 # to by remote_file_manager.php and read from for loading into projects.
 # The web server must have read/write permissions on this directory.
-# If using FTP, this should be the root directory for the
-# _UPLOADS_ACCOUNT user.
 _UPLOADS_DIR=/home/dpscans
-
-# If using FTP, set the following parameters to have them echoed to
-# users as reminders. If _UPLOADS_HOST is blank, these will not be
-# displayed to users.
-_UPLOADS_HOST=www.example.org
-_UPLOADS_ACCOUNT=dpscans
-_UPLOADS_PASSWORD=PICK_A_PASSWORD
 
 # remote_file_manager.php will scan uploaded files for viruses
 # if an antivirus scanner, like clamscan, is installed. Any scanner

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -78,9 +78,6 @@ $uploads_subdir_trash = "TRASH";
 $uploads_subdir_commons = "Commons";
 $uploads_subdir_users = "Users";
 
-$uploads_host = '<<UPLOADS_HOST>>';
-$uploads_account = '<<UPLOADS_ACCOUNT>>';
-$uploads_password = '<<UPLOADS_PASSWORD>>';
 $antivirus_executable = '<<ANTIVIRUS_EXECUTABLE>>';
 
 // -----------------------------------------------------------------------------

--- a/project.php
+++ b/project.php
@@ -914,7 +914,6 @@ function do_edit_above(): void
 function do_early_uploads(): void
 {
     global $project, $code_url, $pguser;
-    global $uploads_host, $uploads_account, $uploads_password;
     if (!$project->can_be_managed_by_current_user) {
         return;
     }
@@ -938,7 +937,7 @@ function do_early_uploads(): void
         echo _("Add/Replace text and images from directory or zip file:");
         echo "<br>\n";
         $initial_rel_source = "Users/$user_dir/";
-        echo "~$uploads_account/ <input type='text' name='rel_source' size='50' value='$initial_rel_source' required>";
+        echo "~uploads/ <input type='text' name='rel_source' size='50' value='$initial_rel_source' required>";
         echo "<br>\n";
         echo "<p>\n";
         echo _("Remember to upload the illustration files as well as the page files!");
@@ -951,18 +950,7 @@ function do_early_uploads(): void
 
     if ($add_reminder) {
         echo "<p>";
-        echo sprintf(_("To upload your files to %s, use the <a href='tools/project_manager/remote_file_manager.php'>remote file manager</a>."), "~$uploads_account");
-
-        // if the site has $uploads_host set, show the FTP details
-        if ($uploads_host) {
-            echo "<br>";
-            echo sprintf(
-                _('For FTP uploads, use host=%1$s account=%2$s password=%3$s'),
-                "<b>$uploads_host</b>",
-                "<b>$uploads_account</b>",
-                "<i>" . html_safe($uploads_password) . "</i>"
-            );
-        }
+        echo sprintf(_("To upload your files to %s, use the <a href='tools/project_manager/remote_file_manager.php'>remote file manager</a>."), "~uploads");
 
         echo "</p>";
     }

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -122,15 +122,9 @@ $curr_relpath = get_current_dir_relative_path($home_dirname);
 $curr_abspath = "$uploads_dir/$curr_relpath";
 // The absolute path of the current directory.
 
-// $uploads_account is not required and may not be defined if they have not
-// set up FTP uploads. If it's blank, lets use a different string instead.
-// The point is to provide a "nice" representation of the absolute path
-// that doesn't reveal details of the upper reaches of the filesystem.
-if ($uploads_account) {
-    $curr_displaypath = "~$uploads_account/$curr_relpath";
-} else {
-    $curr_displaypath = "~uploads/$curr_relpath";
-}
+// Provide a "nice" representation of the absolute path that doesn't reveal
+// details of the upper reaches of the filesystem.
+$curr_displaypath = "~uploads/$curr_relpath";
 
 // For convenience, here are a couple of encoded forms:
 $hae_curr_relpath = attr_safe($curr_relpath);


### PR DESCRIPTION
pgdp.net hasn't allowed FTP file uploads for almost a decade and even sharing credentials for something like SCP is not a best practice, so remove it altogether.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/remove-ftp-uploads/