### PR TITLE
Prototype for new site configuration infrastructure

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -181,8 +181,7 @@ class Activity
         $this->evaluation_criteria = $evaluation_criteria;
         $this->access_change_callback = $access_change_callback;
 
-        global $testing;
-        if ($testing && !is_null($this->access_minima)) { /** @phpstan-ignore-line */
+        if (SiteConfig::$testing && !is_null($this->access_minima)) { /** @phpstan-ignore-line */
             // Relax minima.
             foreach ($this->access_minima as $criterion_code => $minimum) {
                 if (startswith($criterion_code, 'quiz/')) {

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -19,10 +19,7 @@ final class DPDatabase
 
     public static function connect(?string $db_server = null, ?string $db_name = null, ?string $db_user = null, ?string $db_password = null): void
     {
-        if (!isset($db_server)) {
-            include('udb_user.php');
-        }
-        self::$_db_name = $db_name;
+        self::$_db_name = $db_name ?? SiteConfig::$db_name;
 
         // Throw exceptions for DB call failures (PHP 8.1 default values)
         // See forum_interface.inc for some special-cases when dealing with
@@ -30,13 +27,17 @@ final class DPDatabase
         mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
         try {
-            self::$_connection = mysqli_connect($db_server, $db_user, $db_password);
+            self::$_connection = mysqli_connect(
+                $db_server ?? SiteConfig::$db_server,
+                $db_user ?? SiteConfig::$db_user,
+                $db_password ?? SiteConfig::$db_password
+            );
         } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to connect to database");
         }
 
         try {
-            self::$_connection->select_db($db_name);
+            self::$_connection->select_db(self::$_db_name);
         } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to locate database.");
         }

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -164,7 +164,7 @@ function get_available_page(string $projectid, string $proj_state, string $pguse
  */
 function get_available_proof_page_array(Project $project, Round $round, string $pguser): array
 {
-    global $preceding_proofer_restriction;
+    $preceding_proofer_restriction = SiteConfig::$preceding_proofer_restriction;
 
     validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
 

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -1,0 +1,144 @@
+<?php
+
+class SiteConfig
+{
+    private static bool $_is_loaded = false;
+
+    // alert messages
+    public static bool $maintenance = false;
+    public static string $maintenance_message = "";
+    public static string $alert_message = "";
+
+    // database configuration
+    public static string $db_server = "localhost";
+    public static string $db_user;
+    public static string $db_password;
+    public static string $db_name;
+
+    // archiving configuration
+    public static ?string $archive_db_name;
+    public static ?string $archive_projects_dir;
+
+    // directories & URLs
+    public static string $code_dir;
+    public static string $code_url;
+    public static string $projects_dir;
+    public static string $projects_url;
+    public static string $dyn_dir;
+    public static string $dyn_url;
+    public static string $dyn_locales_dir;
+    public static ?string $blog_url;
+    public static ?string $wiki_url;
+
+    // site identification
+    public static string $site_name;
+    public static string $site_abbreviation;
+    public static string $site_url;
+
+    // forums
+    public static string $forum_type = "phpbb3";
+    public static ?string $forums_phpbb_table_prefix;
+    public static ?string $forums_phpbb_dir;
+    public static ?string $forums_phpbb_url;
+    public static ?string $forums_json_users;
+    public static ?string $forums_json_posts = null;
+
+    // topic forums
+    public static ?int $beginners_site_forum_idx;
+    public static ?int $waiting_projects_forum_idx;
+    public static ?int $projects_forum_idx;
+    public static ?int $pp_projects_forum_idx;
+    public static ?int $posted_projects_forum_idx;
+    public static ?int $deleted_projects_forum_idx;
+    public static ?int $completed_projects_forum_idx;
+    public static ?int $post_processing_forum_idx;
+    public static ?int $teams_forum_idx;
+
+    // proofreading controls
+    public static string $preceding_proofer_restriction = 'not_immediately_preceding';
+    public static bool $public_page_details = false;
+
+    // uploads
+    public static string $uploads_dir;
+    public static string $uploads_subdir_trash = "TRASH";
+    public static string $uploads_subdir_commons = "Commons";
+    public static string $uploads_subdir_users = "Users";
+    public static string $antivirus_executable;
+
+    // WordCheck & locales
+    public static string $aspell_executable = '/usr/bin/aspell';
+    public static string $aspell_prefix = "/usr";
+    public static string $system_locales_dir = '/usr/share/locale';
+
+    // API
+    public static bool $api_enabled = true;
+    public static bool $api_rate_limit = false;
+    public static int $api_rate_limit_requests_per_window = 3600;
+    public static int $api_rate_limit_seconds_in_window = 3600;
+    public static array $api_storage_keys = [];
+
+    // emails
+    public static array $phpmailer_smtp_config = [];
+    public static ?string $no_reply_email_addr;  // only used by noncvs code
+    public static ?string $general_help_email_addr;
+    public static ?string $site_manager_email_addr;
+    public static ?string $auto_email_addr;
+    public static ?string $db_requests_email_addr;
+    public static ?string $promotion_requests_email_addr;
+    public static ?string $ppv_reporting_email_addr;
+    public static ?string $image_sources_manager_addr;
+    public static ?string $translation_coordinator_email_addr;
+
+    // Misc configuration
+    public static bool $use_secure_cookies = false;
+    public static string $php_cli_executable = '/usr/bin/php';
+    public static ?string $site_registration_protection_code = null;
+    public static bool $auto_post_to_project_topic = false;
+    public static bool $ordinary_users_can_see_queue_settings = true;
+    public static string $external_catalog_locator = 'lx2.loc.gov:210/LCDB';
+    public static array $default_project_char_suites = ["basic-latin"];
+    public static bool $testing = false;
+
+    public static function load(string $filename): void
+    {
+        if (SiteConfig::$_is_loaded) {
+            return;
+        }
+
+        try {
+            require $filename;
+        } catch (Error $error) {
+            throw new RuntimeException("Configuration file $filename not found");
+        }
+
+        $ro = new ReflectionObject(new SiteConfig());
+        foreach (get_class_vars("SiteConfig") as $var_name => $var_value) {
+            if (str_starts_with($var_name, "_")) {
+                continue;
+            }
+
+            if (isset($$var_name)) {
+                // if it's set to something that isn't null
+                SiteConfig::$$var_name = $$var_name;
+            } elseif (!$ro->getProperty($var_name)->hasDefaultValue()) {
+                // if it doesn't have a default value, and the value wasn't
+                // set to something, see if we can set it to null and if not
+                // raise a configuration error.
+                if ($ro->getProperty($var_name)->getType()->allowsNull()) {
+                    SiteConfig::$$var_name = null;
+                } else {
+                    throw new RuntimeException("Configuration error, $var_name is not set.");
+                }
+            }
+        }
+
+        // we make some temporary exceptions for pervasive globals
+        global $code_url, $code_dir, $projects_dir, $projects_url;
+        $code_url = SiteConfig::$code_url;
+        $code_dir = SiteConfig::$code_dir;
+        $projects_url = SiteConfig::$projects_url;
+        $projects_dir = SiteConfig::$projects_dir;
+    }
+}
+
+SiteConfig::load(__DIR__ . "/site_vars.php");

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -22,7 +22,7 @@ $relPath = dirname(__FILE__)."/";
 // store the current time to calculate total page build time
 $PAGE_START_TIME = microtime(true);
 
-include_once($relPath.'site_vars.php');
+require_once $relPath.'SiteConfig.inc';
 
 // Register autoloader
 spl_autoload_register('dp_class_autoloader');
@@ -31,7 +31,7 @@ spl_autoload_register('dp_class_autoloader');
 require_once($relPath.'../vendor/autoload.php');
 
 // Exception handlers are defined differently for HTML and the API
-set_exception_handler($testing ? 'test_exception_handler' : 'production_exception_handler');
+set_exception_handler(SiteConfig::$testing ? 'test_exception_handler' : 'production_exception_handler');
 
 if (!headers_sent()) {
     // Tell proxies to vary the caching based on the Accept-Language header
@@ -49,7 +49,7 @@ if (!defined('SKIP_DB_CONNECT')) {
     } catch (Exception $e) {
         // If we're in maintenance mode, don't die here - we'll more gracefully
         // error out later
-        if (!$maintenance) {
+        if (!SiteConfig::$maintenance) {
             throw $e;
         }
     }
@@ -76,12 +76,10 @@ function dp_class_autoloader($class)
 
 function dp_setcookie($name, $value = "", $expires = 0, $options = [])
 {
-    global $use_secure_cookies;
-
     $defaults = [
         "expires" => $expires,
         "path" => "/",
-        "secure" => $use_secure_cookies,
+        "secure" => SiteConfig::$use_secure_cookies,
         "samesite" => "Lax",
     ];
 

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -23,6 +23,15 @@ $maintenance_message = '<<MAINTENANCE_MESSAGE>>';
 $alert_message = '<<ALERT_MESSAGE>>';
 //---------------------------------------------------------------------------
 
+
+// Database configuration
+$db_server = '<<DB_SERVER>>';
+$db_user = '<<DB_USER>>';
+$db_password = '<<DB_PASSWORD>>';
+$db_name = '<<DB_NAME>>';
+$archive_db_name = '<<ARCHIVE_DB_NAME>>';
+
+//---------------------------------------------------------------------------
 $code_dir = '<<CODE_DIR>>';
 $code_url = '<<CODE_URL>>';
 
@@ -78,9 +87,6 @@ $uploads_subdir_trash = "TRASH";
 $uploads_subdir_commons = "Commons";
 $uploads_subdir_users = "Users";
 
-$uploads_host = '<<UPLOADS_HOST>>';
-$uploads_account = '<<UPLOADS_ACCOUNT>>';
-$uploads_password = '<<UPLOADS_PASSWORD>>';
 $antivirus_executable = '<<ANTIVIRUS_EXECUTABLE>>';
 
 // -----------------------------------------------------------------------------

--- a/pinc/udb_user.php.template
+++ b/pinc/udb_user.php.template
@@ -1,7 +1,0 @@
-<?php
-
-$db_server = '<<DB_SERVER>>';
-$db_user = '<<DB_USER>>';
-$db_password = '<<DB_PASSWORD>>';
-$db_name = '<<DB_NAME>>';
-$archive_db_name = '<<ARCHIVE_DB_NAME>>';


### PR DESCRIPTION
This PR is a prototype for a new site configuration infrastructure (see https://github.com/DistributedProofreaders/dproofreaders/issues/1256) that will allow us to:
1. stop using global variables -- beyond not using globals being a best practice, this makes phpunit much happier
2. have the configuration variables be typed (yay!)
3. allow variables to have default values, allowing us to add new ones more easily

Now, instead of the config values being in the global context, they are only accessible in the SiteConfig static object, so:
```php
global $preceding_proofer_restriction;
echo $preceding_proofer_restriction;
```
becomes
```php
echo SiteConfig::$preceding_proofer_restriction;
```

The new method re-uses the existing `site_vars.php` file which means there are no changes required to how the code is configured, just how we use those configuration variables. If we went forward with this approach, a second PR would later move away from the bash-based configuration model to just using the PHP file directly.

Keeping the configurations in a PHP file was intentional because PHP files are cached in the opcache and do not need to go to disk or be processed upon access, unlike a yaml, json, or ini-based file.

I have a fully-converted branch ([site-config](https://github.com/cpeel/dproofreaders/tree/site-config)) that updates all config variables uses (with the exception of the 4 mentioned at the end of `SiteConfig::load()`) passes all unit tests and smoke tests but it's huge and I wanted to focus the initial review on the proposed system rather than all of the individual changes. If we agree that this approach makes sense I'll close this PR and open a new one with the full set of changes.

Specific questions I'd like your feedback on:
* Thoughts on the `SiteConfig` class, both as a structure, its status as a static (ie: singleton).
* The verbosity of needing `SiteConfig::` prefixed to use the configs -- this explicitness seems like a good thing to me, but it is wordier.

I evaluated using an existing package like Symfony's [Config](https://symfony.com/doc/current/components/config.html) package but it's huge and very complex and I don't think we need that complexity.