### PR TITLE
Don't show post-comments to unauth users

### DIFF
--- a/project.php
+++ b/project.php
@@ -672,7 +672,7 @@ function do_project_info_table(): void
 
     $postcomments = get_formatted_postcomments($project->projectid);
 
-    if ($postcomments != '') {
+    if (User::is_logged_in() && $postcomments != '') {
         if ($available_for_SR) {
             $class = 'sr-instructions';
             echo_row_b(_("Instructions for Smooth Reading"), '', $class);


### PR DESCRIPTION
This resolves a TypeError when `$pguser` isn't set and we try to determine if they can work in a stage. But we shouldn't show unauthenticated users post comments anyway.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-type-error/