### PR TITLE
Set runtime target for web context BackgroundJobs

### DIFF
--- a/crontab/ArchiveProjects.inc
+++ b/crontab/ArchiveProjects.inc
@@ -26,11 +26,23 @@ class ArchiveProjects extends BackgroundJob
 
         echo "Archiving page-tables for $num_projects projects...\n";
 
+        $num_projects_archived = 0;
         while ($project_data = mysqli_fetch_assoc($result)) {
+            if ($this->watch->read() >= $this->web_context_max_runtime_s) {
+                break;
+            }
+
             $project = new Project($project_data);
             archive_project($project);
+            $num_projects_archived += 1;
         }
 
-        $this->stop_message = "Archived $num_projects projects";
+        $leftover_projects = $num_projects - $num_projects_archived;
+        if ($leftover_projects) {
+            echo "Reached runtime limit, skipping archive of remaining $leftover_projects projects.\n";
+            $this->stop_message = "Archived $num_projects_archived projects, ran out of time to archive remaining $leftover_projects";
+        } else {
+            $this->stop_message = "Archived $num_projects_archived projects";
+        }
     }
 }

--- a/pinc/BackgroundJob.inc
+++ b/pinc/BackgroundJob.inc
@@ -4,8 +4,13 @@ include_once($relPath."job_log.inc");
 
 abstract class BackgroundJob
 {
-    private ?object $watch = null;
+    protected ?object $watch = null;
     private ?string $output = null;
+
+    // The maximum amount of time a BackgroundJob running within a web
+    // context should try to stay within. This should be under the TimeOut
+    // set by the web server.
+    protected int $web_context_max_runtime_s = 60;
 
     protected ?string $start_message = null;
     protected ?string $stop_message = null;


### PR DESCRIPTION
Fixes https://github.com/DistributedProofreaders/dproofreaders/issues/1457 -- see the issue for the problem we're trying to solve here.

We will need to get this in ASAP to re-enable archiving after the OS upgrade such that they safely run within the updated TimeOut needed for server stability.