### PR TITLE
Centralized max script runtime target

### DIFF
--- a/pinc/BackgroundJob.inc
+++ b/pinc/BackgroundJob.inc
@@ -10,7 +10,7 @@ abstract class BackgroundJob
     // The maximum amount of time a BackgroundJob running within a web
     // context should try to stay within. This should be under the TimeOut
     // set by the web server.
-    protected int $web_context_max_runtime_s = 60;
+    protected int $web_context_max_runtime_s = MAX_RUNTIME_TARGET_S;
 
     protected ?string $start_message = null;
     protected ?string $stop_message = null;

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -124,3 +124,7 @@ $auto_post_to_project_topic = <<AUTO_POST_TO_PROJECT_TOPIC>>;
 $ordinary_users_can_see_queue_settings = <<ORDINARY_USERS_CAN_SEE_QUEUE_SETTINGS>>;
 $external_catalog_locator = '<<EXTERNAL_CATALOG_LOCATOR>>';
 $default_project_char_suites = <<DEFAULT_CHAR_SUITES>>;
+
+// The maximum runtime in seconds a script should try to stay within,
+// this should be below the TimeOut for the webserver.
+define("MAX_RUNTIME_TARGET_S", 120);

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -266,7 +266,7 @@ function virus_check($file_path, $verbose)
     // value = 0. we use -- to not parse any further arguments starting
     // with -/-- as options
     $process = new Process([$antivirus_executable, "--", $file_path]);
-    $process->setTimeout(120);
+    $process->setTimeout(MAX_RUNTIME_TARGET_S);
     try {
         $av_retval = $process->run();
     } catch (ProcessTimedOutException $exception) {


### PR DESCRIPTION
We have two places we're trying to constrain script run times, let's centralize that to a constant. This makes the code match what we're doing on PROD for ArchiveProjects BackgroundJob as well.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/max-code-runtime/