### PR TITLE
Prototype 2 for new site configuration infrastructure

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -181,8 +181,7 @@ class Activity
         $this->evaluation_criteria = $evaluation_criteria;
         $this->access_change_callback = $access_change_callback;
 
-        global $testing;
-        if ($testing && !is_null($this->access_minima)) { /** @phpstan-ignore-line */
+        if (SiteConfig::get()->testing && !is_null($this->access_minima)) { /** @phpstan-ignore-line */
             // Relax minima.
             foreach ($this->access_minima as $criterion_code => $minimum) {
                 if (startswith($criterion_code, 'quiz/')) {

--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -19,10 +19,7 @@ final class DPDatabase
 
     public static function connect(?string $db_server = null, ?string $db_name = null, ?string $db_user = null, ?string $db_password = null): void
     {
-        if (!isset($db_server)) {
-            include('udb_user.php');
-        }
-        self::$_db_name = $db_name;
+        self::$_db_name = $db_name ?? SiteConfig::get()->db_name;
 
         // Throw exceptions for DB call failures (PHP 8.1 default values)
         // See forum_interface.inc for some special-cases when dealing with
@@ -30,13 +27,17 @@ final class DPDatabase
         mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
         try {
-            self::$_connection = mysqli_connect($db_server, $db_user, $db_password);
+            self::$_connection = mysqli_connect(
+                $db_server ?? SiteConfig::get()->db_server,
+                $db_user ?? SiteConfig::get()->db_user,
+                $db_password ?? SiteConfig::get()->db_password
+            );
         } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to connect to database");
         }
 
         try {
-            self::$_connection->select_db($db_name);
+            self::$_connection->select_db(self::$_db_name);
         } catch (mysqli_sql_exception $e) {
             throw new DBConnectionError("Unable to locate database.");
         }

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -164,7 +164,7 @@ function get_available_page(string $projectid, string $proj_state, string $pguse
  */
 function get_available_proof_page_array(Project $project, Round $round, string $pguser): array
 {
-    global $preceding_proofer_restriction;
+    $preceding_proofer_restriction = SiteConfig::get()->preceding_proofer_restriction;
 
     validate_user_can_get_pages_in_project(new User($pguser), $project, $round);
 

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -1,0 +1,187 @@
+<?php
+
+class SiteConfig
+{
+    private static ?SiteConfig $_site_config = null;
+
+    private static array $_default_values = [
+        "maintenance" => false,
+        "maintenance_message" => "",
+        "alert_message" => "",
+        "db_server" => "localhost",
+        "forum_type" => "phpbb3",
+        "forums_json_users" => null,
+        "forums_json_posts" => null,
+        "preceding_proofer_restriction" => 'not_immediately_preceding',
+        "public_page_details" => false,
+        "uploads_subdir_trash" => "TRASH",
+        "uploads_subdir_commons" => "Commons",
+        "uploads_subdir_users" => "Users",
+        "antivirus_executable" => null,
+        "aspell_executable" => '/usr/bin/aspell',
+        "aspell_prefix" => "/usr",
+        "system_locales_dir" => '/usr/share/locale',
+        "api_enabled" => true,
+        "api_rate_limit" => false,
+        "api_rate_limit_requests_per_window" => 3600,
+        "api_rate_limit_seconds_in_window" => 3600,
+        "api_storage_keys" => [],
+        "phpmailer_smtp_config" => [],
+        "use_secure_cookies" => false,
+        "php_cli_executable" => '/usr/bin/php',
+        "site_registration_protection_code" => null,
+        "auto_post_to_project_topic" => false,
+        "ordinary_users_can_see_queue_settings" => true,
+        "external_catalog_locator" => 'lx2.loc.gov:210/LCDB',
+        "default_project_char_suites" => ["basic-latin"],
+        "testing" => false,
+        "blog_url" => "BLOG",
+    ];
+
+    // alert messages
+    public readonly bool $maintenance;
+    public readonly string $maintenance_message;
+    public readonly string $alert_message;
+
+    // database configuration
+    public readonly string $db_server;
+    public readonly string $db_user;
+    public readonly string $db_password;
+    public readonly string $db_name;
+
+    // archiving configuration
+    public readonly ?string $archive_db_name;
+    public readonly ?string $archive_projects_dir;
+
+    // directories & URLs
+    public readonly string $code_dir;
+    public readonly string $code_url;
+    public readonly string $projects_dir;
+    public readonly string $projects_url;
+    public readonly string $dyn_dir;
+    public readonly string $dyn_url;
+    public readonly string $dyn_locales_dir;
+    public readonly ?string $blog_url;
+    public readonly ?string $wiki_url;
+
+    // site identification
+    public readonly string $site_name;
+    public readonly string $site_abbreviation;
+    public readonly string $site_url;
+
+    // forums
+    public readonly string $forum_type;
+    public readonly ?string $forums_phpbb_table_prefix;
+    public readonly ?string $forums_phpbb_dir;
+    public readonly ?string $forums_phpbb_url;
+    public readonly ?string $forums_json_users;
+    public readonly ?string $forums_json_posts;
+
+    // topic forums
+    public readonly ?int $beginners_site_forum_idx;
+    public readonly ?int $waiting_projects_forum_idx;
+    public readonly ?int $projects_forum_idx;
+    public readonly ?int $pp_projects_forum_idx;
+    public readonly ?int $posted_projects_forum_idx;
+    public readonly ?int $deleted_projects_forum_idx;
+    public readonly ?int $completed_projects_forum_idx;
+    public readonly ?int $post_processing_forum_idx;
+    public readonly ?int $teams_forum_idx;
+
+    // proofreading controls
+    public readonly string $preceding_proofer_restriction;
+    public readonly bool $public_page_details;
+
+    // uploads
+    public readonly string $uploads_dir;
+    public readonly string $uploads_subdir_trash;
+    public readonly string $uploads_subdir_commons;
+    public readonly string $uploads_subdir_users;
+    public readonly ?string $antivirus_executable;
+
+    // WordCheck & locales
+    public readonly string $aspell_executable;
+    public readonly string $aspell_prefix;
+    public readonly string $system_locales_dir;
+
+    // API
+    public readonly bool $api_enabled;
+    public readonly bool $api_rate_limit;
+    public readonly int $api_rate_limit_requests_per_window;
+    public readonly int $api_rate_limit_seconds_in_window;
+    public readonly array $api_storage_keys;
+
+    // emails
+    public readonly array $phpmailer_smtp_config;
+    public readonly ?string $no_reply_email_addr;  // only used by noncvs code
+    public readonly ?string $general_help_email_addr;
+    public readonly ?string $site_manager_email_addr;
+    public readonly ?string $auto_email_addr;
+    public readonly ?string $db_requests_email_addr;
+    public readonly ?string $promotion_requests_email_addr;
+    public readonly ?string $ppv_reporting_email_addr;
+    public readonly ?string $image_sources_manager_addr;
+    public readonly ?string $translation_coordinator_email_addr;
+
+    // Misc configuration
+    public readonly bool $use_secure_cookies;
+    public readonly string $php_cli_executable;
+    public readonly ?string $site_registration_protection_code;
+    public readonly bool $auto_post_to_project_topic;
+    public readonly bool $ordinary_users_can_see_queue_settings;
+    public readonly string $external_catalog_locator;
+    public readonly array $default_project_char_suites;
+    public readonly bool $testing;
+
+    public function __construct(string $filename)
+    {
+        try {
+            require $filename;
+        } catch (Error $error) {
+            throw new RuntimeException("Configuration file $filename not found");
+        }
+
+        $ro = new ReflectionObject($this);
+        foreach (get_class_vars("SiteConfig") as $var_name => $var_value) {
+            if (str_starts_with($var_name, "_")) {
+                continue;
+            }
+
+            if (isset($$var_name)) {
+                // if it's set to something that isn't null
+                $this->$var_name = $$var_name;
+            } elseif (array_key_exists($var_name, self::$_default_values)) {
+                // set it to the default value
+                $this->$var_name = self::$_default_values[$var_name];
+            } elseif ($ro->getProperty($var_name)->getType()->allowsNull()) {
+                // if it can be null, set it to null
+                $this->$var_name = null;
+            } else {
+                throw new RuntimeException("Configuration error, $var_name is not set.");
+            }
+        }
+
+        // we make some temporary exceptions for pervasive globals
+        global $code_url, $code_dir, $projects_dir, $projects_url;
+        $code_url = $this->code_url;
+        $code_dir = $this->code_dir;
+        $projects_url = $this->projects_url;
+        $projects_dir = $this->projects_dir;
+    }
+
+    public static function load(string $filename)
+    {
+        if (self::$_site_config) {
+            return;
+        }
+
+        self::$_site_config = new SiteConfig($filename);
+    }
+
+    public static function get()
+    {
+        return self::$_site_config;
+    }
+}
+
+SiteConfig::load(__DIR__ . "/site_vars.php");

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -22,7 +22,7 @@ $relPath = dirname(__FILE__)."/";
 // store the current time to calculate total page build time
 $PAGE_START_TIME = microtime(true);
 
-include_once($relPath.'site_vars.php');
+require_once $relPath.'SiteConfig.inc';
 
 // Register autoloader
 spl_autoload_register('dp_class_autoloader');
@@ -31,7 +31,7 @@ spl_autoload_register('dp_class_autoloader');
 require_once($relPath.'../vendor/autoload.php');
 
 // Exception handlers are defined differently for HTML and the API
-set_exception_handler($testing ? 'test_exception_handler' : 'production_exception_handler');
+set_exception_handler(SiteConfig::get()->testing ? 'test_exception_handler' : 'production_exception_handler');
 
 if (!headers_sent()) {
     // Tell proxies to vary the caching based on the Accept-Language header
@@ -49,7 +49,7 @@ if (!defined('SKIP_DB_CONNECT')) {
     } catch (Exception $e) {
         // If we're in maintenance mode, don't die here - we'll more gracefully
         // error out later
-        if (!$maintenance) {
+        if (!SiteConfig::get()->maintenance) {
             throw $e;
         }
     }
@@ -76,12 +76,10 @@ function dp_class_autoloader($class)
 
 function dp_setcookie($name, $value = "", $expires = 0, $options = [])
 {
-    global $use_secure_cookies;
-
     $defaults = [
         "expires" => $expires,
         "path" => "/",
-        "secure" => $use_secure_cookies,
+        "secure" => SiteConfig::get()->use_secure_cookies,
         "samesite" => "Lax",
     ];
 

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -23,6 +23,15 @@ $maintenance_message = '<<MAINTENANCE_MESSAGE>>';
 $alert_message = '<<ALERT_MESSAGE>>';
 //---------------------------------------------------------------------------
 
+
+// Database configuration
+$db_server = '<<DB_SERVER>>';
+$db_user = '<<DB_USER>>';
+$db_password = '<<DB_PASSWORD>>';
+$db_name = '<<DB_NAME>>';
+$archive_db_name = '<<ARCHIVE_DB_NAME>>';
+
+//---------------------------------------------------------------------------
 $code_dir = '<<CODE_DIR>>';
 $code_url = '<<CODE_URL>>';
 

--- a/pinc/udb_user.php.template
+++ b/pinc/udb_user.php.template
@@ -1,7 +1,0 @@
-<?php
-
-$db_server = '<<DB_SERVER>>';
-$db_user = '<<DB_USER>>';
-$db_password = '<<DB_PASSWORD>>';
-$db_name = '<<DB_NAME>>';
-$archive_db_name = '<<ARCHIVE_DB_NAME>>';


### PR DESCRIPTION
This is a second prototype to https://github.com/DistributedProofreaders/dproofreaders/pull/1450 for a new site configuration that uses a singleton and `readonly` properties.

I don't love the way that the default values are separate from the declarations.

phpstan is particularly unhappy that we aren't assigning values to `readonly` properties in the constructor: https://github.com/cpeel/dproofreaders/actions/runs/14160960800/job/39666316801