### PR TITLE
Revert "Avoid initial image flash."

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -250,7 +250,6 @@ function makeImageWidget(container, align = "C") {
     const grabCursor = "grab";
     // use plain js image so width or style.width is clearly differentiated
     const image = document.createElement("img");
-    image.style.visibility = "hidden";
     image.classList.add("middle-align");
 
     // When the image is rotated it has width and height as if it were not
@@ -399,7 +398,6 @@ function makeImageWidget(container, align = "C") {
     function initAll() {
         setImageStyle();
         initScroll();
-        image.style.visibility = "visible";
     }
 
     image.addEventListener("load", initAll);


### PR DESCRIPTION
Reverts DistributedProofreaders/dproofreaders#1455

There are reports that this change causes problems for some Safari users.