### PR TITLE
Suppress the image flash when opening the page image viewer

### DIFF
--- a/scripts/control_bar.js
+++ b/scripts/control_bar.js
@@ -548,6 +548,7 @@ function makeImageWidget(container, align = "C") {
             sine = 0;
             cosine = 1;
             image.src = src;
+            setImageStyle();
         },
 
         reScroll: reScroll,


### PR DESCRIPTION
Is it still worthwhile to try to fix this image flash issue? I saw the discussion about this, so thought I might have an idea for another solution. I tested only with Chrome on Windows, I don't have a Mac or iPad.

The idea of this fix is to calculate the image styling immediately when adding the image source URL, so by the time the browser has a chance to render the image the styling is already calculated.

_Update from cpeel_: sandbox at https://www.pgdp.org/~cpeel/c.branch/no_image_flash/