### PR TITLE
Restrict quiz wizard to SAs

### DIFF
--- a/quiz/generic/wizard/checks.php
+++ b/quiz/generic/wizard/checks.php
@@ -6,6 +6,10 @@ include_once('../quiz_defaults.inc'); // $messages
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'));
 
 function evalchecks()

--- a/quiz/generic/wizard/default_messages.php
+++ b/quiz/generic/wizard/default_messages.php
@@ -6,6 +6,10 @@ include_once('../quiz_defaults.inc'); // $messages
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Messages'));
 
 echo "<h1>" . _("Default Quiz Messages") . "</h1>";

--- a/quiz/generic/wizard/general.php
+++ b/quiz/generic/wizard/general.php
@@ -5,6 +5,10 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'));
 
 

--- a/quiz/generic/wizard/messages.php
+++ b/quiz/generic/wizard/messages.php
@@ -7,6 +7,10 @@ include_once('../quiz_defaults.inc'); // $default_*
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'));
 
 function evalmessages()

--- a/quiz/generic/wizard/new_quiz.php
+++ b/quiz/generic/wizard/new_quiz.php
@@ -5,6 +5,10 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'));
 
 if ($_SESSION['quiz_data']['lastpage'] == 'start') {

--- a/quiz/generic/wizard/output.php
+++ b/quiz/generic/wizard/output.php
@@ -6,6 +6,10 @@ include_once('../quiz_defaults.inc'); // ?
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'), NO_STATSBAR);
 
 function ssqs($x)

--- a/quiz/generic/wizard/output_quiz.php
+++ b/quiz/generic/wizard/output_quiz.php
@@ -5,6 +5,10 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'));
 
 function ssqs($x)

--- a/quiz/generic/wizard/quiz_pages.php
+++ b/quiz/generic/wizard/quiz_pages.php
@@ -5,6 +5,10 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'));
 
 function evalpages()

--- a/quiz/generic/wizard/start.php
+++ b/quiz/generic/wizard/start.php
@@ -5,6 +5,10 @@ include_once($relPath.'theme.inc');
 
 require_login();
 
+if (!user_is_a_sitemanager()) {
+    die(_("You are not authorized to invoke this script."));
+}
+
 output_header(_('Quiz Wizard'));
 
 $_SESSION['quiz_data']['lastpage'] = 'start';


### PR DESCRIPTION
The quiz wizard code hasn't been substantially updated (or really used) in over a decade. Restrict access to SAs until we decide what, if anything, we want to do with it. The code needs some TLC to fix some PHP warnings at least.

https://www.pgdp.org/~cpeel/c.branch/quiz-wizard/