### PR TITLE
Localization tweaks

### DIFF
--- a/stats/teams/teams_xml.php
+++ b/stats/teams/teams_xml.php
@@ -13,7 +13,7 @@ if (empty($_GET["id"])) {
     include_once($relPath.'theme.inc');
     output_header(_("Error"));
     echo "<p class='error'>";
-    echo sprintf(_("A team id must specified in the following format: %s"), "$code_url/stats/teams/teams_xml.php?id=*****");
+    echo sprintf(_("A team id must be specified in the following format: %s"), "$code_url/stats/teams/teams_xml.php?id=*****");
     echo "</p>";
     exit();
 }

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -84,7 +84,7 @@ echo   "<th>" . _("Max diffs to show") . "</th>";
 echo   "<td><input name='sample_limit' type='number' min='0' value='$sampleLimit' required></td>";
 echo  "</tr>";
 echo "</table>";
-echo "<input type='submit' value='Search'>";
+echo "<input type='submit' value='", attr_safe(_("Search")), "'>";
 echo "</form>";
 
 function _echo_eval_query_select($selected)

--- a/tools/site_admin/edit_mail_address_for_non_activated_user.php
+++ b/tools/site_admin/edit_mail_address_for_non_activated_user.php
@@ -73,7 +73,7 @@ if ($action == 'default' && !$username) {
         $user = new NonactivatedUser($username);
     } catch (NonexistentNonactivatedUserException $exception) {
         printf(
-            _("No user '%s' was was found in the list of non-validated users."),
+            _("No user '%s' was found in the list of non-activated users."),
             html_safe($username)
         );
         echo "<p>",


### PR DESCRIPTION
Two corrections for English strings, and adding gettext() markup for another.

These are all tweaks that the translators notified me of. Specifically, I'm curious about the markup for the "Search" button in `review_work`. Does it need the `attr_safe`? I used the "Search" button from the project search form as a model.

Sandbox at [more-translation-strings/](https://www.pgdp.org/~srjfoo/c.branch/more-translation-strings/).