### PR TITLE
Handle edgecase of adding files to deleted projects

### DIFF
--- a/pinc/DPDatabase.inc
+++ b/pinc/DPDatabase.inc
@@ -187,7 +187,7 @@ final class DPDatabase
         );
         $result = self::query($sql);
         $row = $result->fetch_assoc();
-        $table_encoding = $row['TABLE_COLLATION'];
+        $table_encoding = $row['TABLE_COLLATION'] ?? "";
         $result->free();
 
         return stripos($table_encoding, 'utf8mb4') === 0;

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -8,7 +8,7 @@ function user_can_add_project_pages($projectid)
     $state = $project->state;
 
     // SAs can futz with project pages in any state
-    if (user_is_a_sitemanager()) {
+    if ($project->pages_table_exists && user_is_a_sitemanager()) {
         return true;
     }
 

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -42,12 +42,15 @@ abort_if_cant_edit_project($projectid);
 echo "<h1>$title</h1>";
 
 $project = new Project($projectid);
-if (!$project->is_utf8) {
-    echo "<p>"
-        . _("Pages cannot be added to the project in its current state.")
-        . " "
-        . _("Project table is not UTF-8.")
-        . "</p>";
+if (!$project->pages_table_exists || !$project->is_utf8) {
+    echo "<p>";
+    echo _("Pages cannot be added to the project in its current state.") . " ";
+    if (!$project->pages_table_exists) {
+        echo _("Project table not found, it may have been deleted or archived.");
+    } else {
+        echo _("Project table is not UTF-8.");
+    }
+    echo "</p>";
     exit();
 }
 


### PR DESCRIPTION
This addresses an edgecase: If a project has been deleted it doesn't show up in information_schema and thus doesn't have a TABLE_COLLATION. If the user gets to add_files with an old project page it would raise a warning and deprecation message. The page correctly tells the user that they can't load the project but gives an incorrect reason why (the project table isn't UTF-8) rather than the real reason (the project table doesn't exist).

This PR also prevents SAs getting to add_files if the project table doesn't exist.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/minor-db-warning/