### PR TITLE
Add gettext support for JS & introduce ES6 modules

### DIFF
--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -66,10 +66,10 @@ These middleware components match the following major distribution releases:
 
 ## Browser support
 The following are the lowest known supported browser versions for the code:
-* Chrome 57
-* Firefox 52
+* Chrome 61
+* Firefox 60
 * Microsoft Edge
-* Opera 44
+* Opera 48
 * Safari 11
 
 Internet Explorer is not supported.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,13 @@ module.exports = [
             camelcase: "warn",
         },
     },
+    {
+        languageOptions: {
+            globals: globals.browser,
+            sourceType: "module",
+        },
+        files: ["scripts/gettext.js", "scripts/file_resume.js"],
+    },
     pluginJs.configs.recommended,
     eslintConfigPrettier,
 ];

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -170,6 +170,8 @@ elseif ($func == "changeenable") {
     $enable = isset($_REQUEST['enable_locale']);
     set_locale_translation_enabled($locale, $enable);
 
+    build_translation_js();
+
     if ($enable) {
         $enable_string = _("Enabled");
     } else {
@@ -485,6 +487,7 @@ function do_upload($locale)
     $po_file = new POFile("$dyn_locales_dir/$locale/LC_MESSAGES/messages.po");
     try {
         $po_file->compile();
+        build_translation_js();
 
         echo "<p>" . _("File successfully uploaded and compiled.") . "</p>";
     } catch (Exception $exception) {
@@ -560,4 +563,42 @@ function validate_locale($locale, $check_dir_exists = true)
         die(sprintf(_("locale %s is not valid"), $locale));
     }
     return $locale;
+}
+
+function build_translation_js()
+{
+    global $dyn_locales_dir;
+
+    $locale_json = [];
+    foreach (get_installed_locale_translations() as $locale) {
+        $po_filename = "$dyn_locales_dir/$locale/LC_MESSAGES/messages.po";
+        if (!is_locale_translation_enabled($locale)) {
+            continue;
+        }
+
+        if (!$tempfile = tempnam(sys_get_temp_dir(), "translation_js")) {
+            throw new RuntimeException("Unable to create temporary file");
+        }
+        // TODO: Instead of including the entire messages file, just pull out
+        // the strings used in *.js files (unless the files doesn't have any
+        // JS files in which case fall back to loading them all).
+        $pofile = new POFile($po_filename);
+        $pofile->convert_to_json($tempfile);
+        $locale_json[str_replace("_", "-", $locale)] = json_decode(file_get_contents($tempfile));
+        unlink($tempfile);
+    }
+
+    // use "var" not "const" because Safari <12 can't see those within modules
+    // due to some scoping weirdness
+    $file_contents = <<<EOF
+        /* exported translations */
+
+        var translations = %s;
+
+        EOF;
+
+    file_put_contents(
+        "$dyn_locales_dir/translations.js",
+        sprintf($file_contents, json_encode($locale_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES))
+    );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "d3": "^6.6.2",
+        "gettext.js": "^2.0.3",
         "jquery": "^3.5.1",
         "resumablejs": "^1.1.0",
         "xregexp": "^4.2.4"
@@ -941,6 +942,15 @@
       "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
       "license": "ISC"
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1321,6 +1331,50 @@
         "node": "^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/gettext-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-2.0.0.tgz",
+      "integrity": "sha512-FDs/7XjNw58ToQwJFO7avZZbPecSYgw8PBYhd0An+4JtZSrSzKhEvTsVV2uqdO7VziWTOGSgLGD5YRPdsCjF7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/gettext-to-messageformat": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/gettext-to-messageformat/-/gettext-to-messageformat-0.3.1.tgz",
+      "integrity": "sha512-UyqIL3Ul4NryU95Wome/qtlcuVIqgEWVIFw0zi7Lv14ACLXfaVDCbrjZ7o+3BZ7u+4NS1mP/2O1eXZoHCoas8g==",
+      "license": "MIT",
+      "dependencies": {
+        "gettext-parser": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gettext-to-messageformat/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/gettext.js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/gettext.js/-/gettext.js-2.0.3.tgz",
+      "integrity": "sha512-11gyttZWBUBkenEVgPMqJTL9TIKaH4PW6ZCMZr+lNXrgiYHXBg+bOGAc8OjfLE8lvi0dgwtqrSfScd310PlKJw==",
+      "license": "MIT",
+      "dependencies": {
+        "po2json": "^1.0.0-beta-3"
+      },
+      "bin": {
+        "po2json-gettextjs": "bin/po2json"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1397,9 +1451,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -1924,6 +1976,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/po2json": {
+      "version": "1.0.0-beta-3",
+      "resolved": "https://registry.npmjs.org/po2json/-/po2json-1.0.0-beta-3.tgz",
+      "integrity": "sha512-taS8y6ZEGzPAs0rygW9CuUPY8C3Zgx6cBy31QXxG2JlWS3fLxj/kuD3cbIfXBg30PuYN7J5oyBa/TIRjyqFFtg==",
+      "license": "LGPL-2.0-or-later",
+      "dependencies": {
+        "commander": "^6.0.0",
+        "gettext-parser": "2.0.0",
+        "gettext-to-messageformat": "0.3.1"
+      },
+      "bin": {
+        "po2json": "bin/po2json"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "peerDependencies": {
+        "commander": "^6.0.0",
+        "gettext-parser": "2.0.0",
+        "gettext-to-messageformat": "0.3.1"
+      }
+    },
+    "node_modules/po2json/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2091,7 +2174,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "d3": "^6.6.2",
+    "gettext.js": "^2.0.3",
     "jquery": "^3.5.1",
     "resumablejs": "^1.1.0",
     "xregexp": "^4.2.4"

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -126,9 +126,9 @@ class POFile
         return $content_type;
     }
 
-    public function create_template($basedir, $pot_filename)
+    private function create_pot_from_php(string $basedir): string
     {
-        // create the new template in a temporary file in case xtext fails
+        // create the new template in a temporary file
         if (!$tempfile = tempnam(sys_get_temp_dir(), "xtext")) {
             throw new RuntimeException("Unable to create temporary file");
         }
@@ -139,6 +139,8 @@ class POFile
             "./vendor/bin/xtext",
             "-x", "./vendor",
             "-x", "./SETUP",
+            "-x", "./node_modules",
+            "-x", "./pinc/3rdparty",
             "-i", "*.php",
             "-i", "*.inc",
             "-c", "TRANSLATORS",
@@ -149,6 +151,103 @@ class POFile
                 file_put_contents($tempfile, $buffer, FILE_APPEND);
             }
         });
+        if (!$process->isSuccessful()) {
+            unlink($tempfile);
+            throw new RuntimeException($process->getErrorOutput());
+        }
+
+        // the file we return needs a .pot extension to make xgettext happy
+        rename($tempfile, "$tempfile.pot");
+        return "$tempfile.pot";
+    }
+
+    private function create_pot_from_js(string $basedir): string
+    {
+        // create the new template in a temporary file
+        if (!$pot_tempfile = tempnam(sys_get_temp_dir(), "xgettext-pot")) {
+            throw new RuntimeException("Unable to create temporary file");
+        }
+
+        // and we need an input file for xgettext
+        if (!$input_tempfile = tempnam(sys_get_temp_dir(), "xgettext-input")) {
+            throw new RuntimeException("Unable to create temporary file");
+        }
+
+        // Find all the JS files we want to translate
+        $dir_iter = new RecursiveDirectoryIterator($basedir, RecursiveDirectoryIterator::SKIP_DOTS);
+
+        // Walk through our iterator writing JS filenames to our input file
+        if (!$input_fh = fopen($input_tempfile, "w")) {
+            throw new RuntimeException("Error opening temporary file for writing");
+        }
+
+        foreach (new RecursiveIteratorIterator($dir_iter) as $filename) {
+            $filename = str_replace($basedir, ".", $filename);
+            if (str_starts_with($filename, "./SETUP") or
+                str_starts_with($filename, "./vendor") or
+                str_starts_with($filename, "./node_modules") or
+                str_starts_with($filename, "./pinc/3rdparty")) {
+                continue;
+            }
+            if (str_ends_with($filename, ".js")) {
+                if ($filename == "./eslint.config.js") {
+                    continue;
+                }
+                fwrite($input_fh, "$filename\n");
+            }
+        }
+        fclose($input_fh);
+
+        $process = new Process([
+            "xgettext",
+            "--language", "javascript",
+            "--from-code", "UTF-8",
+            "--add-comments", "TRANSLATORS",
+            "--sort-by-file",
+            "--files-from", $input_tempfile,
+            "--output", "-",
+        ], $basedir);
+        $process->run(function ($type, $buffer) use ($pot_tempfile) {
+            if (Process::OUT === $type) {
+                file_put_contents($pot_tempfile, $buffer, FILE_APPEND);
+            }
+        });
+        unlink($input_tempfile);
+        if (!$process->isSuccessful()) {
+            unlink($pot_tempfile);
+            throw new RuntimeException($process->getErrorOutput());
+        }
+
+        // the file we return needs a .pot extension to make xgettext happy
+        rename($pot_tempfile, "$pot_tempfile.pot");
+        return "$pot_tempfile.pot";
+    }
+
+    public function create_template($basedir, $pot_filename)
+    {
+        $php_pot = $this->create_pot_from_php($basedir);
+        $js_pot = $this->create_pot_from_js($basedir);
+
+        // now merge the two POTs together into a temporary file
+        if (!$tempfile = tempnam(sys_get_temp_dir(), "xgettext-merge")) {
+            throw new RuntimeException("Unable to create temporary file");
+        }
+
+        $process = new Process([
+            "xgettext",
+            "--sort-by-file",
+            "--join-existing",
+            "--output", $tempfile,
+            $php_pot,
+            $js_pot,
+        ], $basedir);
+        $process->run(function ($type, $buffer) use ($tempfile) {
+            if (Process::OUT === $type) {
+                file_put_contents($tempfile, $buffer, FILE_APPEND);
+            }
+        });
+        unlink($php_pot);
+        unlink($js_pot);
         if (!$process->isSuccessful()) {
             unlink($tempfile);
             throw new RuntimeException($process->getErrorOutput());

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -308,6 +308,22 @@ class POFile
             throw new RuntimeException($process->getErrorOutput());
         }
     }
+
+    public function convert_to_json($json_filename)
+    {
+        global $code_dir;
+
+        $process = new Process([
+            "node",
+            "node_modules/gettext.js/bin/po2json",
+            $this->po_filename,
+            $json_filename,
+        ], $code_dir);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new RuntimeException($process->getErrorOutput());
+        }
+    }
 }
 
 

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -14,7 +14,7 @@ define('SHOW_STATSBAR', true);
  */
 function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true)
 {
-    global $code_url, $site_abbreviation;
+    global $code_url, $dyn_url, $dyn_dir, $site_abbreviation;
 
     static $was_output = false;
     if ($was_output) {
@@ -86,6 +86,11 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
         "$code_url/scripts/api.js",
     ];
 
+    // The translation.js file may not exist
+    if (is_file("$dyn_dir/locale/translations.js")) {
+        $js_files[] = "$dyn_url/locale/translations.js";
+    }
+
     // Per-page JS
     if (isset($extra_args['js_files'])) {
         $js_files = array_merge($js_files, $extra_args['js_files']);
@@ -94,6 +99,15 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
     foreach ($js_files as $js_file) {
         $cache_fixer = get_local_file_browser_cache_key($js_file);
         echo "<script src='$js_file$cache_fixer'></script>\n";
+    }
+
+    // JS modules
+    $js_modules = [];
+    if (isset($extra_args['js_modules'])) {
+        $js_modules = array_merge($js_modules, $extra_args['js_modules']);
+    }
+    foreach ($js_modules as $js_file) {
+        echo "<script src='$js_file' type='module'></script>\n";
     }
 
     // Per-page Javascript
@@ -146,11 +160,12 @@ function output_html_footer($extra_args = [])
  */
 function get_local_file_browser_cache_key($url)
 {
-    global $code_url, $code_dir;
+    global $code_url, $code_dir, $dyn_url, $dyn_dir;
 
     $cache_fixer = "";
-    if (strpos($url, $code_url) !== false) {
-        $local_file = $code_dir . substr($url, strlen($code_url));
+    if (strpos($url, $code_url) !== false || strpos($url, $dyn_url) !== false) {
+        $local_file = str_replace($code_url, $code_dir, $url);
+        $local_file = str_replace($dyn_url, $dyn_dir, $local_file);
 
         // PHP files should never be cached
         if (str_ends_with($local_file, ".php")) {

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -355,7 +355,7 @@ function lang_html_header($langcode = false)
         return '';
     }
 
-    $string = "lang='" . short_lang_code($langcode) . "'";
+    $string = "lang='" . str_replace("_", "-", $langcode) . "'";
     if (lang_direction($langcode) == "RTL") {
         $string .= " dir='RTL'";
     }

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -52,26 +52,15 @@ function get_upload_args()
 {
     global $code_url;
 
-    $upload_messages = [
-        'working' => _("Working, please wait..."),
-        'uploadFailed' => _("Upload failed"),
-        'finalizingUpload' => _("Upload complete. Running file checks, please wait..."),
-        'invalidChars' => _("The filename contains invalid characters"),
-        'nameTooLong' => _("The filename must have no more than 200 characters"),
-        'mustBeZip' => _("File name extension must be '.zip'"),
-        'fileTooBig' => _("The file is too big (see note)."),
-        'noFile' => _("No file selected"),
-    ];
-    $upload_messages = json_encode($upload_messages);
-
     return [
         'js_files' => [
             "$code_url/node_modules/resumablejs/resumable.js",
+        ],
+        'js_modules' => [
             "$code_url/scripts/file_resume.js",
         ],
         'js_data' => "
             var uploadTarget = '$code_url/tools/upload_resumable_file.php';
-            var uploadMessages = $upload_messages;
             var maxResumeSize = " . RESUMABLE_UPLOAD_SIZE . ";
             var maxNormSize = " . get_max_upload_size() . ";
             ",

--- a/scripts/file_resume.js
+++ b/scripts/file_resume.js
@@ -1,4 +1,7 @@
-/*global Resumable uploadTarget uploadMessages maxResumeSize maxNormSize */
+/*global Resumable uploadTarget maxResumeSize maxNormSize */
+
+import translate from "./gettext.js";
+
 window.addEventListener("DOMContentLoaded", function () {
     // This function has a server-side pair in pinc/upload_file.inc:is_valid_filename()
     // which should be updated if the below logic changes.
@@ -7,16 +10,16 @@ window.addEventListener("DOMContentLoaded", function () {
         // and end with .zip (length is enforced a few lines down)
         var validChars = /^\w[\w-]*\.\w+$/;
         if (!validChars.test(name)) {
-            alert(uploadMessages.invalidChars + ": '" + name + "'");
+            alert(translate.gettext("The filename contains invalid characters") + ": '" + name + "'");
             return false;
         }
         var zipTest = /^.+\.zip$/;
         if (!zipTest.test(name)) {
-            alert(uploadMessages.mustBeZip);
+            alert(translate.gettext("File name extension must be '.zip'"));
             return false;
         }
         if (name.length > 200) {
-            alert(uploadMessages.nameTooLong);
+            alert(translate.gettext("The filename must have no more than 200 characters"));
             return false;
         }
         return true;
@@ -96,7 +99,7 @@ window.addEventListener("DOMContentLoaded", function () {
     document.getElementById("old_submit").addEventListener("click", function (ev) {
         let file = document.getElementById("old_browse").files[0];
         if (file.size >= maxNormSize) {
-            alert(uploadMessages.fileTooBig);
+            alert(translate.gettext("The file is too big (see note)."));
             ev.preventDefault();
             return false;
         }
@@ -104,7 +107,7 @@ window.addEventListener("DOMContentLoaded", function () {
             // won't work if we disable the buttons so hide them
             document.getElementById("old_browse").style.display = "none";
             document.getElementById("old_submit").style.display = "none";
-            showProgress(uploadMessages.working);
+            showProgress(translate.gettext("Working, please wait..."));
             ev.preventDefault();
             submitWithHash(file);
         } else {
@@ -120,7 +123,7 @@ window.addEventListener("DOMContentLoaded", function () {
             // a file has been selected
             resumable.upload();
         } else {
-            alert(uploadMessages.noFile);
+            alert(translate.gettext("No file selected"));
         }
     });
 
@@ -141,7 +144,7 @@ window.addEventListener("DOMContentLoaded", function () {
         document.querySelector('input[name="resumable_filename"]').value = file.fileName;
         document.querySelector('input[name="resumable_identifier"]').value = file.uniqueIdentifier;
         document.querySelector('input[name="mode"]').value = "resumable";
-        showProgress(uploadMessages.finalizingUpload);
+        showProgress(translate.gettext("Upload complete. Running file checks, please wait..."));
         submitWithHash(file.file);
     });
 
@@ -149,7 +152,7 @@ window.addEventListener("DOMContentLoaded", function () {
     resumable.on("fileError", function (file, message) {
         document.getElementById("resumable_browse").style.display = "";
         document.getElementById("resumable_submit").style.display = "";
-        showProgress(uploadMessages.uploadFailed + "<br>" + message);
+        showProgress(translate.gettext("Upload failed") + "<br>" + message);
     });
 
     // As the file upload progresses, show a percentage complete

--- a/scripts/gettext.js
+++ b/scripts/gettext.js
@@ -1,0 +1,23 @@
+/* global translations */
+import gettext from "../node_modules/gettext.js/dist/gettext.esm.js";
+
+export var translate = gettext();
+
+var loadTranslations = function () {
+    console.debug("Loading translations");
+    if (typeof translations !== "undefined") {
+        Object.entries(translations).forEach(([key, value]) => {
+            var headers = value[""];
+            delete value[""];
+            translate.setMessages("messages", key, value, headers["plural-forms"]);
+        });
+    } else {
+        console.debug("No translations found.");
+    }
+};
+
+window.addEventListener("DOMContentLoaded", () => {
+    loadTranslations();
+});
+
+export default translate;


### PR DESCRIPTION
This adds "first-class" support for gettext in the javascript code just like we have for PHP. The localization script pulls the strings out of the javascript code and the PHP code and combines them together into a single `.pot` for the translators. When translations are enabled/disabled or updated, a new `translations.js` file is created that contains the translated strings¹ and is made available to the JS code.

The big advantage of this change is that we no longer need to have strings translated in PHP scripts shoved into JS code via JSON and passed around various functions, we can just use them directly. This PR implements this for the Remote File Manager upload strings as a working demonstration.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/js-gettext/

This code is the first instance of using [JS modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) and that adds a few positives, some changes, and a big complication to how we've used JS in the past.
* Modules let us do some very sensible things like having JS files include the other files they need directly instead of indirectly through the HTML page (see how `scripts/file_resume.js` includes the new `gettext.js` file). This is a huge boon because it is much more intuitive to have JS files manage their own dependencies. I have an in-progress branch that updates the page browser code and its dependencies to a module.
* The use of modules will allow us to develop self-contained "applications", which we have one of already: the page browser. The upcoming new proofreading interface is another example. Both of these "applications" use the API directly and modules can allow for a better local development experience than continually futzing with the HTML to manage transitive dependencies. 
* It slightly increases our minimum supported browser versions (see the `SETUP/INSTALL.md` diff for details).
* We have to tell browsers to treat files that are included in the HTML as modules, thus the new `js_modules` to indicate these files. We also have to tell eslint that they are modules, not scripts, thus the changes in `eslint.config.js` (thanks to @chrismiceli for help with this part!).
* Perhaps most critically, and a downside, because of how ES6 modules are included in other files this breaks how we manage browser caching. Using modules with our current JS caching infra would quickly lead to old JS code being used after new code is deployed because browsers wouldn't realize the code referenced in the modules had changed.

That last one is the biggest challenge as it requires us to use a JS bundler to bundle our JS code as part of a new deployment step we haven't had in the past. I have some working prototypes to show this is possible and will require some iterations to have something ready for review and merging.

To make iterative progress on our JS infra, this PR is targeted to a new temporary branch `js-infra` which will contain the JS code changes until they are at the point where they could be merged to `master` and deployed safely. Having a temp branch lets us have smaller, reviewable PRs. I expect this temp branch will exist for maybe 4-6 weeks.

¹ right now this file is really big because it contains all the strings for the entire site for each language. We can further optimize this by just including the strings used in the JS code. I'm not really worried about it, however, since this file will change very infrequently and we let browsers aggressively cache our JS code so the user impact of the large file is very low.