### PR TITLE
Fix navigation bug when opening image from the standard proofing interface

### DIFF
--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -77,10 +77,10 @@ function echo_text_frame_std(PPage $ppage): void
     echo "&nbsp;";
 
     $comments_url = $ppage->url_for_project_comments(true);
-    echo _("View").": <a href=\"$comments_url\" title=\"". attr_safe(_("View Project Comments in New Window"))."\" target=\"viewcomments\">"._("Project Comments")."</a> ";
+    echo _("View").": <a href=\"$comments_url\" title=\"". attr_safe(_("View Project Comments in New Window"))."\" target=\"_blank\">"._("Project Comments")."</a> ";
 
     $image_url = $ppage->url_for_display_image(true);
-    echo "| <a href=\"$image_url\" title=\"". attr_safe(_("View Image in New Window"))."\" target=\"lg_image\">"._("Image")."</a> "; ?>
+    echo "| <a href=\"$image_url\" title=\"". attr_safe(_("View Image in New Window"))."\" target=\"_blank\">"._("Image")."</a> "; ?>
 
       </div> <!-- proofdiv -->
     </div>


### PR DESCRIPTION
Fix navigation bug when opening comments or image from the standard proofing interface
This fixes the bug described [here in the forum](https://www.pgdp.net/phpBB3/viewtopic.php?t=83760). The problem was caused by the proofing interface trying to re-use a browser tab every time the user clicked on the Image link, even if the user was using that tab for something else now. This fix will really open a new tab now, rather than try to steal back an existing tab. The text that pops up when you hover over the Image link has always said "View Image in New Window". This fix makes that a reality, it really opens in a new tab/window.

Sandbox available for testing: [https://www.pgdp.org/~mrducky/c.branch/image_navigation/](https://www.pgdp.org/~mrducky/c.branch/image_navigation/)