### PR TITLE
Correctly pass in the TRANSLATORS string

### DIFF
--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -202,7 +202,7 @@ class POFile
             "xgettext",
             "--language", "javascript",
             "--from-code", "UTF-8",
-            "--add-comments", "TRANSLATORS",
+            "--add-comments=TRANSLATORS",
             "--sort-by-file",
             "--files-from", $input_tempfile,
             "--output", "-",


### PR DESCRIPTION
`--add-comments` can be used as a boolean flag (included or not) or passed a string, the latter requires the `=`. This should fix the POT generation from JS.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-js-xgettext/