### PR TITLE
Only store strings in JS files in translations.js

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -17,6 +17,11 @@ This release requires PHP 8.1 or later.
 Starting this release, the deployment process requires `npm` to pull down
 JavaScript code that is served up to the browser. See [INSTALL.md](INSTALL.md).
 
+Some translated strings were moved from PHP files to JS files. If you have
+site translations enabled, after upgrading the code you must regenerate the
+PO template and refresh the PO file for each enabled language to have the
+strings be picked up by the JS code.
+
 ### Changes
 
 * Authors code (`tools/authors/*`) has been removed. Biographies will be

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -154,14 +154,15 @@ function get_installed_system_locales()
  *   - "all" - all installed locale translations
  *   - "enabled" - locale translation is enabled
  *   - "disabled" - locale translation is disabled
+ * @return string[]
  */
-function get_installed_locale_translations($state = "all")
+function get_installed_locale_translations(string $state = "all", bool $reload_cache = false): array
 {
     global $dyn_locales_dir;
 
     static $translation_cache = null;
 
-    if ($translation_cache !== null) {
+    if ($translation_cache !== null && ! $reload_cache) {
         return $translation_cache[$state];
     }
 


### PR DESCRIPTION
To make the size of `translations.js` much, much smaller, only store strings found in JS files. The file is small enough that pretty-printing it isn't that much overhead and is much easier to view / debug.

This requires that sites regenerate their .pot and merge existing .po files with the new template so we call this out clearly in the `CHANGELOG.md`

Sandbox: https://www.pgdp.org/~cpeel/c.branch/js-infra-only-js-strings/