### PR TITLE
Make text validation JS into a module

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -27,6 +27,7 @@ strings be picked up by the JS code.
 * Authors code (`tools/authors/*`) has been removed. Biographies will be
   inserted directly into the project comments with the included upgrade script
   (cpeel)
+* Updated minimum browser versions, see [INSTALL.md](INSTALL.md).
 
 ## R202503
 Scripts supporting this upgrade are in `SETUP/upgrade/22`

--- a/SETUP/INSTALL.md
+++ b/SETUP/INSTALL.md
@@ -66,11 +66,11 @@ These middleware components match the following major distribution releases:
 
 ## Browser support
 The following are the lowest known supported browser versions for the code:
-* Chrome 61
-* Firefox 60
-* Microsoft Edge
-* Opera 48
-* Safari 11
+* Chrome 64
+* Firefox 78
+* Microsoft Edge 79
+* Opera 51
+* Safari 11.1
 
 Internet Explorer is not supported.
 

--- a/SETUP/tests/jsTests/characterValidation.js
+++ b/SETUP/tests/jsTests/characterValidation.js
@@ -1,44 +1,43 @@
-/* global QUnit testText */
-/* exported validCharRegex */
+/* global QUnit */
 
-var validCharRegex;
+import { testText } from "../../../scripts/character_test.js";
 
 QUnit.module("Character validation test", function () {
     let basicLatin = /^(?:[\n\r -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$/u;
 
     QUnit.test("In basic latin basic latin character is valid", function (assert) {
-        validCharRegex = basicLatin;
+        window.validCharRegex = basicLatin;
         assert.strictEqual(testText("abc"), true);
     });
 
     QUnit.test("In basic latin tabulate character is invalid", function (assert) {
-        validCharRegex = basicLatin;
+        window.validCharRegex = basicLatin;
         assert.strictEqual(testText("\tabc"), false);
     });
 
     QUnit.test("In basic latin Greek Α is invalid", function (assert) {
-        validCharRegex = basicLatin;
+        window.validCharRegex = basicLatin;
         assert.strictEqual(testText("Αabc"), false);
     });
 
     QUnit.test("In basic latin Astral char. is invalid", function (assert) {
-        validCharRegex = basicLatin;
+        window.validCharRegex = basicLatin;
         assert.strictEqual(testText("ab\u{1F702}c"), false);
     });
 
     QUnit.test("In basic latin A with combining diaeresis is valid when normalised, b is not", function (assert) {
-        validCharRegex = basicLatin;
+        window.validCharRegex = basicLatin;
         assert.strictEqual(testText("a\u0308bc"), true);
         assert.strictEqual(testText("ab\u0308c"), false);
     });
 
     QUnit.test("In basic Greek, Greek Α is valid", function (assert) {
-        validCharRegex = /^(?:[\n\rΑ-ΡΣ-Ωα-ω -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$/u;
+        window.validCharRegex = /^(?:[\n\rΑ-ΡΣ-Ωα-ω -~¡-¬®-ÿŒœŠšŽžŸƒ‹›])$/u;
         assert.strictEqual(testText("Αabc"), true);
     });
 
     QUnit.test("characters with combining marks", function (assert) {
-        validCharRegex = /^(?:S̤|T̤|Z̤|s̤|t̤|z̤|[\n\r Ā-āĒ-ēĪ-īŌ-ōŚ-śŠ-šŪ-ūʾ-ʿḌ-ḍḤ-ḥḪ-ḫḲ-ḳḷḹṀ-ṇṚ-ṝṢ-ṣṬ-ṭẒ-ẖ])$/u;
+        window.validCharRegex = /^(?:S̤|T̤|Z̤|s̤|t̤|z̤|[\n\r Ā-āĒ-ēĪ-īŌ-ōŚ-śŠ-šŪ-ūʾ-ʿḌ-ḍḤ-ḥḪ-ḫḲ-ḳḷḹṀ-ṇṚ-ṝṢ-ṣṬ-ṭẒ-ẖ])$/u;
         assert.strictEqual(testText("S\u0324"), true); // S with macron below
         assert.strictEqual(testText("U\u0324"), false); // U with macron below
         assert.strictEqual(testText("\u1e72"), false); // U with macron below normalised
@@ -47,7 +46,7 @@ QUnit.module("Character validation test", function () {
     });
 
     QUnit.test("Astral plane", function (assert) {
-        validCharRegex = /^(?:[\n\r 𓀀-𓀂])$/u;
+        window.validCharRegex = /^(?:[\n\r 𓀀-𓀂])$/u;
         assert.strictEqual(testText("𓀀"), true);
         assert.strictEqual(testText("\u{13000}"), true);
         assert.strictEqual(testText("𓀂"), true);

--- a/SETUP/tests/jsTests/qunit.html
+++ b/SETUP/tests/jsTests/qunit.html
@@ -14,14 +14,12 @@
   </script>
   <script src="../../../node_modules/qunit/qunit/qunit.js"></script>
   <script src="../../../node_modules/jquery/dist/jquery.min.js"></script>
-  <script src="../../../node_modules/xregexp/xregexp-all.js"></script>
   <script src="../../../tools/proofers/srchrep.js"></script>
   <script src="../../../accounts/addproofer.js"></script>
-  <script src="../../../scripts/character_test.js"></script>
   <script src="../../../tools/proofers/dp_proof.js"></script>
 
   <!-- tests -->
-  <script src="./characterValidation.js"></script>
+  <script src="./characterValidation.js" type="module"></script>
   <script src="./splitControlTests.js" type="module"></script>
   <script src="./formatPreviewTests.js" type="module"></script>
   <script src="./srchrepTests.js"></script>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ const eslintConfigPrettier = require("eslint-config-prettier");
 
 module.exports = [
     { files: ["**/*.js"] },
-    { ignores: ["pinc/3rdparty", "**/vendor", "eslint.config.js"] },
+    { ignores: ["pinc/3rdparty", "**/vendor", "eslint.config.js", "dist/**"] },
     {
         languageOptions: {
             globals: globals.browser,
@@ -23,6 +23,7 @@ module.exports = [
         },
         files: [
             "SETUP/tests/jsTests/ajaxTests.js",
+            "SETUP/tests/jsTests/characterValidation.js",
             "SETUP/tests/jsTests/formatPreviewTests.js",
             "SETUP/tests/jsTests/splitControlTests.js",
             "SETUP/tests/manual_web/split_test/switchable_split.js",
@@ -30,18 +31,23 @@ module.exports = [
             "SETUP/tests/manual_web/split_test/vertical_split.js",
             "scripts/analyse_format.js",
             "scripts/api.js",
+            "scripts/character_test.js",
             "scripts/control_bar.js",
             "scripts/file_resume.js",
             "scripts/gettext.js",
             "scripts/page_browse.js",
             "scripts/splitControl.js",
             "scripts/text_view.js",
+            "scripts/text_validator.js",
             "scripts/view_splitter.js",
             "tools/page_browser.js",
+            "tools/project_manager/handle_bad_page.js",
             "tools/project_manager/show_all_good_word_suggestions.js",
             "tools/project_manager/show_word_context.js",
             "tools/proofers/previewControl.js",
+            "tools/proofers/proof_validate.js",
             "tools/proofers/proof_image.js",
+            "tools/proofers/wordcheck.js",
         ],
     },
     pluginJs.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "d3": "^6.6.2",
         "gettext.js": "^2.0.3",
         "jquery": "^3.5.1",
-        "resumablejs": "^1.1.0",
-        "xregexp": "^4.2.4"
+        "resumablejs": "^1.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -26,18 +25,6 @@
         "prettier": "^3.5.3",
         "qunit": "^2.24.1",
         "selenium-webdriver": "^4.32.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.1.tgz",
-      "integrity": "sha512-909rVuj3phpjW6y0MCXAZ5iNeORePa6ldJvp2baWGcTjwqbBDDz6xoS5JHJ7lS88NlwLYj07ImL/8IUMtDZzTA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.30.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@bazel/runfiles": {
@@ -591,17 +578,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.42.0.tgz",
-      "integrity": "sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -2535,15 +2511,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xregexp": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
-      "integrity": "sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.12.1"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "d3": "^6.6.2",
     "gettext.js": "^2.0.3",
     "jquery": "^3.5.1",
-    "resumablejs": "^1.1.0",
-    "xregexp": "^4.2.4"
+    "resumablejs": "^1.1.0"
   }
 }

--- a/scripts/analyse_format.js
+++ b/scripts/analyse_format.js
@@ -427,7 +427,7 @@ export function analyse(txt, config) {
                     reportIssue(start, tagLen, "nlBeforeEnd", translate.gettext("Newline before end tag"));
                 }
                 // letter or number after end tag
-                if (RegExp("\\p{L}|\\p{N}", "ug").test(postChar)) {
+                if (/\p{L}|\p{N}/gu.test(postChar)) {
                     reportIssue(end, 1, "charAfterEnd", translate.gettext("Character after inline end tag"));
                 }
                 if (tagStack.length === 0) {
@@ -462,7 +462,7 @@ export function analyse(txt, config) {
                     reportIssue(start, tagLen, "nlAfterStart", translate.gettext("Newline after start tag"));
                 }
                 // letter or ,.;:
-                if (RegExp("\\p{L}|[,.;:]", "ug").test(preChar)) {
+                if (/\p{L}|[,.;:]/gu.test(preChar)) {
                     reportIssue(start - 1, 1, "charBeforeStart", translate.gettext("Character or punctuation before inline start tag"));
                 }
                 tagStack.push({ tag: tagString, start: start, tagLen: tagLen });

--- a/scripts/analyse_format.js
+++ b/scripts/analyse_format.js
@@ -1,5 +1,3 @@
-/* global XRegExp */
-
 import translate from "./gettext.js";
 
 // The formatting rules are applied as if proofers' notes were
@@ -429,7 +427,7 @@ export function analyse(txt, config) {
                     reportIssue(start, tagLen, "nlBeforeEnd", translate.gettext("Newline before end tag"));
                 }
                 // letter or number after end tag
-                if (XRegExp("\\pL|\\pN", "Ag").test(postChar)) {
+                if (RegExp("\\p{L}|\\p{N}", "ug").test(postChar)) {
                     reportIssue(end, 1, "charAfterEnd", translate.gettext("Character after inline end tag"));
                 }
                 if (tagStack.length === 0) {
@@ -464,7 +462,7 @@ export function analyse(txt, config) {
                     reportIssue(start, tagLen, "nlAfterStart", translate.gettext("Newline after start tag"));
                 }
                 // letter or ,.;:
-                if (XRegExp("\\pL|[,.;:]", "Ag").test(preChar)) {
+                if (RegExp("\\p{L}|[,.;:]", "ug").test(preChar)) {
                     reportIssue(start - 1, 1, "charBeforeStart", translate.gettext("Character or punctuation before inline start tag"));
                 }
                 tagStack.push({ tag: tagString, start: start, tagLen: tagLen });

--- a/scripts/character_test.js
+++ b/scripts/character_test.js
@@ -1,14 +1,10 @@
-/*global validCharRegex XRegExp */
-/* exported testText */
-
-// regex unicode property escape is supported in Chrome 64, Safari 11.1
-// Firefox 78, Edge 79, Opera 51. Use 3rd party http://xregexp.com/ instead
+/*global validCharRegex */
 
 // this matches any character: non-mark codepoint followed by 0 or more marks
-const charMatch = XRegExp("\\PM\\pM*", "Ag");
+export const charMatch = RegExp("\\P{M}\\p{M}*", "ug");
 
 // return false if text contains any bad characters
-function testText(text) {
+export function testText(text) {
     text = text.normalize("NFC");
     let result;
     charMatch.lastIndex = 0;

--- a/scripts/character_test.js
+++ b/scripts/character_test.js
@@ -1,7 +1,7 @@
 /*global validCharRegex */
 
 // this matches any character: non-mark codepoint followed by 0 or more marks
-export const charMatch = RegExp("\\P{M}\\p{M}*", "ug");
+export const charMatch = /\P{M}\p{M}*/gu;
 
 // return false if text contains any bad characters
 export function testText(text) {

--- a/scripts/text_validator.js
+++ b/scripts/text_validator.js
@@ -1,5 +1,6 @@
-/*global validCharRegex charMatch */
-/* exported validateText */
+/*global validCharRegex */
+
+import { charMatch } from "./character_test.js";
 
 // charMatch (constructed in character_test.js) matches any unicode character
 // possibly with combining marks: non-mark codepoint + 0 or more mark codes
@@ -18,7 +19,7 @@ function htmlSafe(str) {
     return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-var validateText;
+export var validateText;
 
 window.addEventListener("DOMContentLoaded", function () {
     var textArea = document.getElementById("text_data");

--- a/tools/project_manager/handle_bad_page.js
+++ b/tools/project_manager/handle_bad_page.js
@@ -1,4 +1,4 @@
-/*global validateText */
+import { validateText } from "../../scripts/text_validator.js";
 
 window.addEventListener("DOMContentLoaded", () => {
     const updateTextButton = document.getElementById("update_text");

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -81,10 +81,7 @@ if (!$resolution) {
 
     $valid_character_pattern = build_character_regex_filter($project->get_valid_codepoints(), "js");
     $header_args = [
-        "js_files" => [
-            "$code_url/node_modules/xregexp/xregexp-all.js",
-            "$code_url/scripts/character_test.js",
-            "$code_url/scripts/text_validator.js",
+        "js_modules" => [
             "$code_url/tools/project_manager/handle_bad_page.js",
         ],
         "js_data" => "

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, camelcase */
-/* global $ fontStyles fontFamilies MathJax validateText */
+/* global $ fontStyles fontFamilies MathJax  */
 /*
 This file controls the user interface functions. Initially nothing is displayed
 because "prevdiv" has display:none; which means it is not displayed and the page
@@ -12,6 +12,7 @@ The configuration screen is handled in the same way.
 
 import translate from "../../scripts/gettext.js";
 import { makePreview, defaultStyles } from "../../scripts/analyse_format.js";
+import { validateText } from "../../scripts/text_validator.js";
 
 window.addEventListener("DOMContentLoaded", () => {
     "use strict";

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -28,15 +28,12 @@ function echo_proof_frame_enh(PPage $ppage): void
     $header_args = [
         "css_files" => ["$code_url/styles/preview.css"],
         "js_files" => [
-            "$code_url/node_modules/xregexp/xregexp-all.js",
-            "$code_url/scripts/character_test.js",
-            "$code_url/scripts/text_validator.js",
-            "$code_url/tools/proofers/proof_validate.js",
             "$code_url/tools/proofers/text_data_processor.js",
             "$code_url/tools/proofers/process_diacritcal_markup.js",
         ],
         "js_modules" => [
             "$code_url/tools/proofers/proof_image.js",
+            "$code_url/tools/proofers/proof_validate.js",
             "$code_url/tools/proofers/previewControl.js",
         ],
         "js_data" => get_preview_font_data_js() . "

--- a/tools/proofers/proof_validate.js
+++ b/tools/proofers/proof_validate.js
@@ -1,4 +1,6 @@
-/*global validateText standardInterface switchConfirm revertConfirm */
+/*global standardInterface switchConfirm revertConfirm */
+
+import { validateText } from "../../scripts/text_validator.js";
 
 window.addEventListener("DOMContentLoaded", function () {
     // special handling for certain buttons

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -605,7 +605,7 @@ function get_page_js(int $interface_type_init_value): string
         PAGE_JS;
 }
 
-/** @return array{"js_files": string[], "js_data": string, "body_attributes": string, "css_data"?: string} */
+/** @return array{"js_modules": string[], "js_data": string, "body_attributes": string, "css_data"?: string} */
 function get_wordcheck_page_header_args(User $user, PPage $ppage): array
 {
     global $code_url, $word_check_messages;
@@ -622,13 +622,9 @@ function get_wordcheck_page_header_args(User $user, PPage $ppage): array
     ]);
 
     $header_args = [
-        "js_files" => [
-            "$code_url/node_modules/xregexp/xregexp-all.js",
-            "$code_url/tools/proofers/wordcheck.js",
-            "$code_url/scripts/character_test.js",
-        ],
         "js_modules" => [
             "$code_url/tools/proofers/proof_image.js",
+            "$code_url/tools/proofers/wordcheck.js",
         ],
         "js_data" => get_page_js($user->profile->i_type == 1 ? 2 : 3) . "
             var imageData = $image_data;

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -16,15 +16,12 @@ function echo_text_frame_std(PPage $ppage): void
     $header_args = [
         "css_files" => ["$code_url/styles/preview.css"],
         "js_files" => [
-            "$code_url/node_modules/xregexp/xregexp-all.js",
-            "$code_url/scripts/character_test.js",
-            "$code_url/scripts/text_validator.js",
-            "$code_url/tools/proofers/proof_validate.js",
             "$code_url/tools/proofers/text_data_processor.js",
             "$code_url/tools/proofers/process_diacritcal_markup.js",
         ],
         "js_modules" => [
             "$code_url/tools/proofers/previewControl.js",
+            "$code_url/tools/proofers/proof_validate.js",
         ],
         "js_data" => get_preview_font_data_js() . "
         function ldAll() {

--- a/tools/proofers/wordcheck.js
+++ b/tools/proofers/wordcheck.js
@@ -2,7 +2,9 @@
 /* exported evaluateWordChange */
 /* exported markBox */
 /* exported confirmExit */
-/* global testText wordCheckMessages */
+/* global wordCheckMessages */
+
+import { testText } from "../../scripts/character_test.js";
 
 // the number of edit boxes with bad characters
 var badBoxes = 0;
@@ -138,15 +140,18 @@ function acceptWord(wordIDprefix, wordNumber) {
 
     return false;
 }
+window.acceptWord = acceptWord;
 
 function evaluateWordChange(wordID) {
     if (isWordChanged(wordID)) markPageChanged();
 }
+window.evaluateWordChange = evaluateWordChange;
 
 // store wordID for char pickers to use
 function markBox(wordID) {
     top.txtBoxID = wordID;
 }
+window.markBox = markBox;
 
 // Confirm exit if changes have been made
 function confirmExit() {
@@ -159,3 +164,4 @@ function confirmExit() {
     // return true (ie: confirm exit) if no changes were made
     return true;
 }
+window.confirmExit = confirmExit;


### PR DESCRIPTION
This makes the text validation JS into a module. This also removes XRegExp and ups our minimum browser versions slightly.

This is the last modularization commit into `js-infra` and the next (and final!) PR is the one that adds JS packaging.

Testing suggestions:
* Confirm that the text validation code (that confirms if all the characters in a page text are in a project's character suites on page save) work in both the enhanced and standard interfaces.
* Confirm that the WordCheck JS (suggesting a word, etc) continue to work.
* We need to double-check that the text validation JS works with the new browser versions. I tested them all myself via BrowserStack but another pair (or two) of eyes on that would be appreciated.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/js-infra-03-xregexp-replace/