### PR TITLE
Correct hair space Unicode value

### DIFF
--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -461,7 +461,7 @@ function get_utf8_to_ascii_codepoints(): array
             'U+2007', // figure space
             'U+2008', // punctuation space
             'U+2009', // thin space
-            'U+20a0', // hair space
+            'U+200a', // hair space
             'U+202f', // narrow no-break space
             'U+205f', // medium mathematical space
             'U+3000', // ideographic space


### PR DESCRIPTION
The correct Unicode value for the hair space is `U+200A` (see https://www.compart.com/en/unicode/U+200A) not `U+20A0` (see https://www.compart.com/en/unicode/U+20A0) which is the Euro-Currency sign ₠.

After this merges I'll update [this wiki page](https://www.pgdp.net/wiki/Site_conversion_to_Unicode#Unicode_to_ASCII_mapping).

Fixes #1503.

Thanks for finding this, @windymilla!