### PR TITLE
Default to not showing the sidebar on pages

### DIFF
--- a/accounts/activate.php
+++ b/accounts/activate.php
@@ -34,7 +34,7 @@ try {
 // create a record in the users table, create a profile, stats data, etc.
 // and send a welcome mail.
 $title = _('Activate account');
-output_header($title);
+output_header($title, SHOW_STATSBAR);
 echo "<h1>$title</h1>";
 
 if (!isset($user->id)) {

--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -76,7 +76,7 @@ if (count($_POST)) {
 
             // Page shown when account is successfully created
             $title = _("Registration complete");
-            output_header($title);
+            output_header($title, SHOW_STATSBAR);
             echo "<h1>$title</h1>";
 
             // Send them an activation e-mail

--- a/accounts/login_failure.php
+++ b/accounts/login_failure.php
@@ -39,7 +39,7 @@ if (!$error) {
 }
 
 $title = _("Login Failed");
-output_header($title);
+output_header($title, SHOW_STATSBAR);
 
 echo "<br>\n";
 echo "<b>$error</b>\n";

--- a/accounts/require_login.php
+++ b/accounts/require_login.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 
 $title = _("Login Required");
-output_header($title);
+output_header($title, SHOW_STATSBAR);
 
 if (isset($_REQUEST["destination"])) {
     echo "<p>" . _("The page you requested requires a login. You will be redirected there once you have signed in.") . "</p>";

--- a/activity_hub.php
+++ b/activity_hub.php
@@ -25,7 +25,7 @@ $userSettings = & Settings::get_Settings($pguser);
 
 $title = _("Activity Hub");
 
-output_header($title);
+output_header($title, SHOW_STATSBAR);
 
 echo "<h1>$title</h1>";
 

--- a/credits.php
+++ b/credits.php
@@ -4,7 +4,7 @@ include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 
 $title = _("Credits");
-output_header($title);
+output_header($title, SHOW_STATSBAR);
 
 echo "<h1>$title</h1>";
 

--- a/faq/privacy.php
+++ b/faq/privacy.php
@@ -10,7 +10,7 @@ if (!isset($relPath)) {
     include_once($relPath.'theme.inc');
 
     if (!isset($_GET['embedded'])) {
-        output_header(_("Privacy Statement"), false);
+        output_header(_("Privacy Statement"), NO_STATSBAR);
     }
 }
 

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ include_once($relPath.'page_tally.inc');
 include_once($relPath.'site_news.inc');
 include_once($relPath.'walkthrough.inc');
 
-output_header(_("Welcome"), true);
+output_header(_("Welcome"), SHOW_STATSBAR);
 $etext_limit = 10;
 
 $image = get_page_header_image("FRONT");

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -65,13 +65,13 @@ if ($func == "download" || $func == "view") {
         // Send the template file as a plain/text document. No encoding is necessary.
         readfile($filename);
     } else {
-        output_header(_("Translation Center"), false);
+        output_header(_("Translation Center"));
         echo "<p>" . _("The requested file does not exist.") . "</p>";
     }
     exit();
 }
 
-output_header(_("Translation Center"), false);
+output_header(_("Translation Center"));
 
 // Main Translation Center page
 if (empty($func)) {

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -828,6 +828,12 @@ function show_tally_specific_stats($tally_name)
 function show_tally_vs_goal($label, $goal, $actual)
 {
     $goal = $goal == null ? 0 : $goal;
+
+    // If there's no goal, just return rather than divide by zero
+    if (! $goal) {
+        return;
+    }
+
     $percent = $actual == 0 ? 0 : $actual / $goal * 100;
     echo "<tr>";
     echo "<th>$label</th>";

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -16,7 +16,7 @@ include_once($relPath.'job_log.inc');
  * Emit the opening markup and theme tags, and register a callback
  * to close the page after the caller finishes output.
  */
-function output_header($nameofpage, $show_statsbar = true, $extra_args = [])
+function output_header($nameofpage, $show_statsbar = false, $extra_args = [])
 {
     global $code_url;
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -595,12 +595,6 @@ function html_statsbar($nameofpage)
         show_tally_specific_stats($tally_name);
     }
 
-    echo "<p class='more-link'>";
-    echo "<a href='$code_url/stats/index.php'>";
-    echo _("More Statistics...");
-    echo "</a>";
-    echo "</p>";
-
     if ($user) {
         // requestor is a logged-in user.
         echo "<hr class='divider'>\n";

--- a/stats/equilibria.php
+++ b/stats/equilibria.php
@@ -58,7 +58,7 @@ foreach ($day_options as $days) {
     $graphs[] = ["pieGraph", "equilibria_$days", display_graph($days)];
 }
 
-output_header($title, SHOW_STATSBAR, [
+output_header($title, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
     "js_data" => build_svg_graph_inits($graphs),
 ]);

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -566,6 +566,21 @@ function uploadImages($preview, $tid, $type)
         'icon' => null,
     ];
 
+    // see if $team_avatars_dir exists and if not try to create it
+    if (! is_dir($team_avatars_dir)) {
+        if (!mkdir($team_avatars_dir, 0777, true)) {
+            throw new RuntimeException(_("Error creating team avatar directory."));
+        }
+    }
+
+    // ditto $team_icons_dir
+    if (! is_dir($team_icons_dir)) {
+        if (!mkdir($team_icons_dir, 0777, true)) {
+            throw new RuntimeException(_("Error creating team icons directory."));
+        }
+    }
+
+
     if (!empty($_FILES['teamavatar']['tmp_name']) && ($type == "both" || $type == "avatar")) {
         if (strtolower(substr($_FILES['teamavatar']['name'], -4)) == ".png" || strtolower(substr($_FILES['teamavatar']['name'], -4)) == ".jpg" || strtolower(substr($_FILES['teamavatar']['name'], -4)) == ".gif") {
             if ($_FILES['teamavatar']['size'] > 2097152) {

--- a/stats/members/mdetail.php
+++ b/stats/members/mdetail.php
@@ -37,7 +37,7 @@ if ($user == User::load_current()) {
     $desc = sprintf(_("Details for user %s"), $user_referent);
 }
 
-output_header($desc, SHOW_STATSBAR, [
+output_header($desc, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
 ]);
 

--- a/stats/misc_stats1.php
+++ b/stats/misc_stats1.php
@@ -47,7 +47,7 @@ if (isset($start) && isset($end)) {
     ];
     $js_data .= build_svg_graph_inits([["barLineGraph", "graph", $graph_config]]);
 }
-output_header($title, SHOW_STATSBAR, [
+output_header($title, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
     "js_data" => $js_data,
 ]);

--- a/stats/misc_user_graphs.php
+++ b/stats/misc_user_graphs.php
@@ -14,7 +14,7 @@ $graphs = [
     ["barLineGraph", "new_users", new_users("month")],
 ];
 
-output_header($title, SHOW_STATSBAR, [
+output_header($title, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
     "js_data" => build_svg_graph_inits($graphs),
 ]);

--- a/stats/pages_proofed_graphs.php
+++ b/stats/pages_proofed_graphs.php
@@ -49,7 +49,7 @@ $graphs = [
     ],
 ];
 
-output_header($title, SHOW_STATSBAR, [
+output_header($title, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
     "js_data" => build_svg_graph_inits($graphs),
 ]);

--- a/stats/projects_Xed_graphs.php
+++ b/stats/projects_Xed_graphs.php
@@ -17,7 +17,7 @@ $graphs = [
     ["barLineGraph", "cumulative_total_proj_graph", cumulative_total_proj_graph($which)],
 ];
 
-output_header($psd->graphs_title, SHOW_STATSBAR, [
+output_header($psd->graphs_title, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
     "js_data" => build_svg_graph_inits($graphs),
 ]);

--- a/stats/teams/new_team.php
+++ b/stats/teams/new_team.php
@@ -21,7 +21,7 @@ $ticon = $_POST["ticon"] ?? "";
 
 if (isset($_POST['mkPreview'])) {
     $title = sprintf(_("Preview %s"), $teamname);
-    output_header($title, SHOW_STATSBAR, $theme_extra_args);
+    output_header($title, NO_STATSBAR, $theme_extra_args);
     $teamimages = uploadImages(1, "", "both");
     $curTeam['id'] = 0;
     $curTeam['topic_id'] = 0;
@@ -50,7 +50,7 @@ if (isset($_POST['mkPreview'])) {
     $result = DPDatabase::query($sql);
     if (mysqli_num_rows($result) > 0 || $teamname == "") {
         $name = _("Create Team");
-        output_header($name);
+        output_header($name, NO_STATSBAR);
         $teamimages = uploadImages(1, "", "both");
         $curTeam['avatar'] = $teamimages['avatar'];
         if ($teamname == "") {
@@ -60,7 +60,6 @@ if (isset($_POST['mkPreview'])) {
         }
 
         showEdit($teamname, $text_data, $teamwebpage, 1, 0);
-        echo "<br></div><br>";
     } else {
         $sql = sprintf(
             "
@@ -119,7 +118,7 @@ if (isset($_POST['mkPreview'])) {
     metarefresh(0, "$code_url/activity_hub.php", $title, $desc);
 } else {
     $name = _("Create a New Team");
-    output_header($name, SHOW_STATSBAR, $theme_extra_args);
+    output_header($name, NO_STATSBAR, $theme_extra_args);
     echo "<div class='center-align'><br>";
     showEdit("", "", "", 1, 0);
     echo "</div>";

--- a/stats/teams/tdetail.php
+++ b/stats/teams/tdetail.php
@@ -23,7 +23,7 @@ if (!$curTeam) {
 // TRANSLATORS: %s is a team name
 $title = sprintf(_("%s Statistics"), $curTeam['teamname']);
 
-output_header($title, SHOW_STATSBAR, [
+output_header($title, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
 ]);
 echo "<br><div class='center-align'>";

--- a/stats/teams/tedit.php
+++ b/stats/teams/tedit.php
@@ -36,7 +36,7 @@ if (($user->u_id != $curTeam['owner']) && (!user_is_a_sitemanager())) {
 
 if (isset($_GET['tid'])) {
     $edit = _("Edit");
-    output_header($edit . " " . $curTeam['teamname'], SHOW_STATSBAR, $theme_extra_args);
+    output_header($edit . " " . $curTeam['teamname'], NO_STATSBAR, $theme_extra_args);
     echo "<div class='center-align'><br>";
     showEdit($curTeam['teamname'], $curTeam['team_info'], $curTeam['webpage'], 0, $tid);
     echo "</div>";
@@ -46,7 +46,7 @@ if (isset($_GET['tid'])) {
     metarefresh(0, "tdetail.php?tid=$tid", $title, $desc);
 } elseif (isset($_POST['edPreview'])) {
     $preview = _("Preview");
-    output_header($preview . " " . $teamname, SHOW_STATSBAR, $theme_extra_args);
+    output_header($preview . " " . $teamname, NO_STATSBAR, $theme_extra_args);
     $teamimages = uploadImages(1, $tid, "both");
     $curTeam['teamname'] = $teamname;
     $curTeam['team_info'] = $text_data;
@@ -71,7 +71,7 @@ if (isset($_GET['tid'])) {
     $result = DPDatabase::query($sql);
     if (mysqli_num_rows($result) > 0 || $teamname == '') {
         $preview = _("Preview");
-        output_header($preview, SHOW_STATSBAR, $theme_extra_args);
+        output_header($preview, NO_STATSBAR, $theme_extra_args);
         $teamimages = uploadImages(1, $tid, "both");
         $curTeam['avatar'] = $teamimages['avatar'];
         if ($teamname == "") {

--- a/stats/user_logon_graphs.php
+++ b/stats/user_logon_graphs.php
@@ -15,7 +15,7 @@ $graphs = [
     ["stackedAreaGraph", "past_year_preceding_fourweek", user_logging_on("year", "fourweek")],
 ];
 
-output_header($title, SHOW_STATSBAR, [
+output_header($title, NO_STATSBAR, [
     "js_files" => get_graph_js_files(),
     "js_data" => build_svg_graph_inits($graphs),
 ]);

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -12,7 +12,7 @@ require_login();
 
 // Display page header.
 $title = _("For Mentors");
-output_header($title);
+output_header($title, SHOW_STATSBAR);
 
 echo "<h1>$title</h1>";
 

--- a/tools/site_admin/sitenews.php
+++ b/tools/site_admin/sitenews.php
@@ -51,7 +51,7 @@ if (isset($news_page_id)) {
     show_all_news_items_for_page($news_page_id);
 } else {
     $title = _("Site News Central");
-    output_header($title, true);
+    output_header($title, SHOW_STATSBAR);
     echo "<h1>$title</h1>";
     echo "<ul>";
     echo "\n";


### PR DESCRIPTION
The sidebar is not generally useful, but the default for the past 25 years has been to show it and opt individual pages out. Flip the default to not show the sidebar instead.

This removes the sidebar for the member and team pages, and all of the stats subpages, but keeps it for the main stats page as well as the new user registration and activation (in addition to where you would expect, like the main page, the Activity Hub, round pages, etc).

Also fixes a few small issues I found when testing this against the docker solution that didn't have goals defined, or team icons/avatars directories.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/default-sidebar-off/