### PR TITLE
Fix missed use of global $testing

### DIFF
--- a/pinc/automodify.inc
+++ b/pinc/automodify.inc
@@ -23,7 +23,7 @@ function automodify(?string $projectid = null): void
     $trace = false;
 
     if ($projectid) {
-        $verbose = $GLOBALS['testing'];
+        $verbose = SiteConfig::get()->testing;
         $condition = sprintf("projectid = '%s'", DPDatabase::escape($projectid));
         $single_project = true;
     } else {


### PR DESCRIPTION
Little of the DP code uses the `$GLOBALS` superglobal and I missed this use of `$testing` during the SiteConfig update.

Found via `php_errors` and hotfixed on PROD.