### PR TITLE
Fix missed SiteConfig global

### DIFF
--- a/stats/teams/team_topic.php
+++ b/stats/teams/team_topic.php
@@ -49,7 +49,7 @@ Use this area to have a discussion with your fellow teammates! :-D
 
 
     // appropriate forum to create thread in
-    $forum_id = $teams_forum_idx;
+    $forum_id = SiteConfig::get()->teams_forum_idx;
 
     $post_subject = $tname;
 


### PR DESCRIPTION
Missed global on update to SiteConfig, found in `php_errors` report. This has been hotfixed on PROD.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-missed-team-global/