### PR TITLE
Fix page browser problem for show word context

### DIFF
--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -101,10 +101,10 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
     // declare this here to avoid use before define warning
     let getProjectData;
 
-    let resizeAction = function() {};
+    let resizeAction = function () {};
     function resize() {
         resizeAction();
-    };
+    }
 
     const topDiv = $("#page-browser");
     // the non-scrolling area which will contain the page controls
@@ -379,5 +379,5 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
 
     return {
         resize,
-    }
+    };
 }

--- a/scripts/page_browse.js
+++ b/scripts/page_browse.js
@@ -101,6 +101,11 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
     // declare this here to avoid use before define warning
     let getProjectData;
 
+    let resizeAction = function() {};
+    function resize() {
+        resizeAction();
+    };
+
     const topDiv = $("#page-browser");
     // the non-scrolling area which will contain the page controls
     const fixHead = $("<div>", { class: "fixed-box control-pane" });
@@ -199,7 +204,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                     const imageDiv = $("<div>");
                     imageWidget = makeImageWidget(imageDiv);
                     imageWidget.setup(storageKey);
-                    window.addEventListener("resize", imageWidget.reScroll);
+                    resizeAction = imageWidget.reScroll;
                     stretchDiv.append(imageDiv);
                     showImageText();
                 } else {
@@ -221,6 +226,7 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
                             imageWidget = makeImageWidget(imageDiv);
                             stretchDiv.append(imageDiv, textDiv);
                             const theSplitter = viewSplitter(stretchDiv[0], storageKey);
+                            resizeAction = theSplitter.resize;
                             if (mentorMode) {
                                 // make a text widget with splitter
                                 textWidget = makeTextWidget(textDiv, true);
@@ -369,5 +375,9 @@ function pageBrowse(params, storageKey, replaceUrl, mentorMode = false, setShowF
         }
     } else {
         selectAProject();
+    }
+
+    return {
+        resize,
     }
 }

--- a/scripts/view_splitter.js
+++ b/scripts/view_splitter.js
@@ -12,7 +12,6 @@ var viewSplitter = function (container, storageKey) {
     let splitVertical = layout.splitDirection === "vertical";
 
     const mainSplit = splitControl(container, { splitVertical: splitVertical });
-    window.addEventListener("resize", mainSplit.reLayout);
 
     const splitButton = document.createElement("button");
     splitButton.type = "button";
@@ -69,5 +68,6 @@ var viewSplitter = function (container, storageKey) {
         preSetSplitDirCallback,
         postSetSplitDirCallback,
         fireSetSplitDir,
+        resize: mainSplit.reLayout,
     };
 };

--- a/tools/page_browser.js
+++ b/tools/page_browser.js
@@ -7,5 +7,7 @@ window.addEventListener("DOMContentLoaded", function () {
         window.history.replaceState(null, "", url.href);
     }
 
-    pageBrowse(url.searchParams, "page-browse", replaceUrl, mentorMode);
+    const pageBrowser = pageBrowse(url.searchParams, "page-browse", replaceUrl, mentorMode);
+
+    window.addEventListener("resize", pageBrowser.resize);
 });

--- a/tools/project_manager/show_word_context.js
+++ b/tools/project_manager/show_word_context.js
@@ -59,7 +59,8 @@ window.addEventListener("DOMContentLoaded", function () {
     function showImage(imageFile) {
         if (!ShowImageFile) {
             params.set("imagefile", imageFile);
-            pageBrowse(params, showWordContext.storageKey, function () {}, false, setShowImageFile);
+            const pageBrowser = pageBrowse(params, showWordContext.storageKey, function () {}, false, setShowImageFile);
+            mainSplit.onResize.add(pageBrowser.resize);
         } else {
             ShowImageFile(imageFile);
         }


### PR DESCRIPTION
The image in show word context could go off the screen or not scroll far enough if the window changes size or when switching between horizontal and vertical split. This was observed by @srjfoo. This adds a function to reset the scroll function in such cases.

Sandbox at: https://www.pgdp.org/~rp31/c.branch/browse_resize
