### PR TITLE
Fix dependency install into temp directory

### DIFF
--- a/SETUP/generate_manifest_cache.php
+++ b/SETUP/generate_manifest_cache.php
@@ -1,10 +1,8 @@
 #!/usr/bin/env php
 <?php
 if (php_sapi_name() == "cli") {
-    $relPath = $argv[1] ?? "";
-    if (! str_ends_with($relPath, "/")) {
-        $relPath = "$relPath/";
-    }
+    $basedir = $argv[1] ?? "";
+    $relPath = "$basedir/pinc/";
 } else {
     throw new RuntimeException("Script is meant to be run via CLI");
 }
@@ -16,11 +14,11 @@ if (! is_file("$relPath/base.inc")) {
 include_once($relPath."base.inc");
 include_once($relPath."html_page_common.inc");
 
-$manifest = get_js_manifest();
+$manifest = get_js_manifest($basedir);
 if (!$manifest) {
     echo "ERROR: No manifest file found, does dist/manifest.json exist?\n";
     exit(1);
 }
 
-echo "Generating dist/manifest.php...\n";
-generate_cached_js_manifest($manifest);
+echo "Generating $basedir/dist/manifest.php...\n";
+generate_cached_js_manifest($basedir, $manifest);

--- a/SETUP/install_dependencies.sh
+++ b/SETUP/install_dependencies.sh
@@ -73,7 +73,7 @@ if [ $PROD -eq 1 ]; then
     npm run build
 
     # create the manifest cache
-    $SCRIPT_DIR/generate_manifest_cache.php $DIR/pinc/
+    $SCRIPT_DIR/generate_manifest_cache.php $DIR
 
     echo "Installing only the production dependencies..."
     npm ci --omit dev --omit optional

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -203,21 +203,25 @@ function get_local_file_browser_cache_key($url)
 /**
  * @return string[]
  */
-function get_js_manifest(): array
+function get_js_manifest(string $basedir = ""): array
 {
     global $code_dir;
 
+    if (!$basedir) {
+        $basedir = $code_dir;
+    }
+
     // first, see if the PHP version of our manifest file exists, and if so
     // load it and get the opcache-cached version without hitting the disk
-    if (is_file("$code_dir/dist/manifest.php")) {
-        require_once("$code_dir/dist/manifest.php");
+    if (is_file("$basedir/dist/manifest.php")) {
+        require_once("$basedir/dist/manifest.php");
         return get_cached_js_manifest(); // @phpstan-ignore function.notFound
     }
 
     // if it doesn't exist, see if the JSON version exists and if so load
     // and process it
-    if (is_file("$code_dir/dist/manifest.json")) {
-        $raw_manifest = json_decode(file_get_contents("$code_dir/dist/manifest.json"), true) ?? [];
+    if (is_file("$basedir/dist/manifest.json")) {
+        $raw_manifest = json_decode(file_get_contents("$basedir/dist/manifest.json"), true) ?? [];
         // webpack puts "auto" in the pathname, no idea why
         foreach ($raw_manifest as $filename => $path) {
             $manifest[$filename] = str_replace("auto", "dist", $path);
@@ -232,12 +236,14 @@ function get_js_manifest(): array
 /**
  * @param string[] $manifest
  */
-function generate_cached_js_manifest(array $manifest): void
+function generate_cached_js_manifest(string $basedir, array $manifest): void
 {
-    global $code_dir;
-
     if (!$manifest) {
         return;
+    }
+
+    if (!is_dir("$basedir/dist")) {
+        throw new RuntimeException("Directory '$basedir/dist' does not exist.");
     }
 
     $serialized_manifest = serialize($manifest);
@@ -249,5 +255,5 @@ function generate_cached_js_manifest(array $manifest): void
         }
         EOF;
 
-    file_put_contents("$code_dir/dist/manifest.php", $cached_php_file);
+    file_put_contents("$basedir/dist/manifest.php", $cached_php_file);
 }


### PR DESCRIPTION
The main deployment code installs into a temporary directory (`c.new`) before it is moved into the main directory (`c`). During this time `$code_dir` points to the final destination, not the temporary directory, so we can't rely on it to find files as part of our deployment process.

The deployment scripts already know the temporary directory we're installing into, we just need to use that when we're generating our manifest cache.