### PR TITLE
Require login for Smoothreading

### DIFF
--- a/SETUP/ci/check_require_login.php
+++ b/SETUP/ci/check_require_login.php
@@ -58,7 +58,6 @@ $ok_files = [
     "styles/design_philosophy.php",
     // Tools
     "tools/setlangcookie.php",  // allows unauth users to set their language
-    "tools/post_proofers/smooth_reading.php",
     "tools/proofers/ctrl_frame.php",  // required for unauth quiz access
     // Dev tools
     ".php-cs-fixer.dist.php",

--- a/tools/post_proofers/smooth_reading.php
+++ b/tools/post_proofers/smooth_reading.php
@@ -8,22 +8,9 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'site_news.inc');
 include_once($relPath.'showavailablebooks.inc');
 
-// ---------------------------------------
-//Page construction varies with whether the user is logged in or out
-if (isset($GLOBALS['pguser'])) {
-    $logged_in = true;
-} else {
-    $logged_in = false;
-}
+require_login();
 
-
-if ($logged_in) {
-    $header_text = _("Smooth Reading Pool");
-    $news = "SR";
-} else {
-    $header_text = _("Smooth Reading Pool Preview");
-    $news = "SR_PREV";
-}
+$header_text = _("Smooth Reading Pool");
 
 // Tell RSS feed readers which RSS feed is connected to this page
 $rss_title = _("Smooth Reading E-Texts");
@@ -33,19 +20,12 @@ $extra_args = [
     "head_data" => "<link rel='alternate' type='application/rss+xml' href='$code_url/feeds/backend.php?content=smoothreading' title='$attr_safe_rss_title' />",
 ];
 
-// we show more columns when user is logged in, so we don't have room for the stats bar
-output_header($header_text, $logged_in ? NO_STATSBAR : SHOW_STATSBAR, $extra_args);
+output_header($header_text, NO_STATSBAR, $extra_args);
 $stage = get_Stage_for_id("SR");
 $stage->page_header($header_text);
-show_news_for_page($news);
+show_news_for_page("SR");
 
 echo "<h2>" . _("Smooth Reading") . "</h2>";
-
-if (!$logged_in) {
-    echo  "<p>" . _("This Preview page shows which books are currently available for Smooth Reading. Click on a book's title to view more information about it or to download the text.") . "</p>";
-
-    echo "<p>" . _("Please note that while unregistered guests are welcome to download texts for Smooth Reading, only registered volunteers are able to upload annotated texts. A registration link is available at the top of this page.") . "</p>";
-}
 
 echo "<p>" . _("The goal of Smooth Reading is to read the text attentively, as for pleasure, with just a little more attention than usual to punctuation, etc. This is NOT full scale proofreading, and comparison with the scans is not needed. Just read it as your normal, sensitized-to-proofreading-errors self, and report any problem that disrupts the sense or the flow of the book. Note that some of these will be due to the author and/or publisher.") . "</p>";
 


### PR DESCRIPTION
Require the user to be logged in to access the Smoothreading page. From a discussion with @lhamilton1 & @srjfoo.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/sr-login-required/