### PR TITLE
Quiz tips

### DIFF
--- a/pinc/quizzes.inc
+++ b/pinc/quizzes.inc
@@ -10,7 +10,7 @@ define('SIX_MONTHS_IN_SECONDS', 15778463);
 $wiki_url = SiteConfig::get()->wiki_url;
 $default_feedbackurl = get_url_to_view_topic(55121);
 $old_texts_url = "$wiki_url/Proofing_old_texts";
-$Greek_translit_url = "$wiki_url/Transliterating_Greek";
+$Greek_translit_url = "$wiki_url/The_Greek_Alphabet";
 $ae_oe_ligatures_url = "$wiki_url/Ae_and_oe_ligatures";
 $thorn_url = "$wiki_url/Thorn";
 $fraktur_url = "$wiki_url/Common_Fraktur_OCR_errors";

--- a/pinc/quizzes.inc
+++ b/pinc/quizzes.inc
@@ -10,7 +10,7 @@ define('SIX_MONTHS_IN_SECONDS', 15778463);
 $wiki_url = SiteConfig::get()->wiki_url;
 $default_feedbackurl = get_url_to_view_topic(55121);
 $old_texts_url = "$wiki_url/Proofing_old_texts";
-$Greek_translit_url = "$wiki_url/The_Greek_Alphabet";
+$Greek_translit_url = "$wiki_url/Greek/The_Greek_Alphabet";
 $ae_oe_ligatures_url = "$wiki_url/Ae_and_oe_ligatures";
 $thorn_url = "$wiki_url/Thorn";
 $fraktur_url = "$wiki_url/Common_Fraktur_OCR_errors";

--- a/quiz/generic/data/qd_p_aeoe_1.inc
+++ b/quiz/generic/data/qd_p_aeoe_1.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Ligatures Proofreading Quiz, page %d"), 1);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "Colleges.' But his chef-d'ceuvre was his\nemphatic recognition of all the doctors, both the\nproctors, as if the numerical antithesis threw\nthose excellent personages into a charming\ntableau vinant.'\n\nThey proceeded down High Street, and then\nsaw Mr. Baternan, a bore at least of the second\nmagnitude. It is very difficult duly to delineate\na borc in a narrative, for the very reason that he\nis a bore. But eventually the truth bursts on\nyou, apparent dirae facies, you are in the\nclutches of a bore. You may yield, or you may\nflee; you cannot conquer.";
 $solutions = ["Colleges.' But his chef-d'œuvre was his\nemphatic recognition of all the doctors, both the\nproctors, as if the numerical antithesis threw\nthose excellent personages into a charming\ntableau vivant.\"\n\nThey proceeded down High Street, and then\nsaw Mr. Bateman, a bore at least of the second\nmagnitude. It is very difficult duly to delineate\na bore in a narrative, for the very reason that he\nis a bore. But eventually the truth bursts on\nyou, apparent diræ facies, you are in the\nclutches of a bore. You may yield, or you may\nflee; you cannot conquer."];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("If something is not clear in the image, please leave a [**note] in the text or ask in the project discussion rather than guessing.") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_basic_1.inc
+++ b/quiz/generic/data/qd_p_basic_1.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Basic Proofreading Quiz, page %d"), 1);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "THE GLORY OF MOTION.      62\n\nbefore I matriculated at Oxford, Mr. Palmer,\nM. P. for Bath, had accomplished two tbings,\nvery hard to do on our little planet: he had in-\nvented mail-coaches, arid he had married the\ndaughter of a duke. He was, therefore, just\ntwice as great a man as Galileo, who certain-\nly invented (or discovered) the satellites of\nJupiter, those very next things extant to mail-\ncoaches in the two capital points of speed and\nkeeping time, hut who did not marry the\ndaughter of a duke.\n\nFf";
 $solutions = ["before I matriculated at Oxford, Mr. Palmer,\nM. P. for Bath, had accomplished two things,\nvery hard to do on our little planet: he had invented\nmail-coaches, and he had married the\ndaughter of a duke. He was, therefore, just\ntwice as great a man as Galileo, who certainly\ninvented (or discovered) the satellites of\nJupiter, those very next things extant to mail-coaches\nin the two capital points of speed and\nkeeping time, but who did not marry the\ndaughter of a duke."];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("We remove page headers and footers because later on in the process all the pages will be joined together into one text.  If we left the header or footer on each page it would disrupt the flow of the text.") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_basic_2.inc
+++ b/quiz/generic/data/qd_p_basic_2.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Basic Proofreading Quiz, page %d"), 2);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "\"I'll do my best, but you can't expect much. I\nguess I can squeeze another cot into eight-seven\nfor the young man. There's -- let's see now\n-- who's in eighty-seven? Well, there's two\nBisons in the double bed, and one in the single,\nand Fat Ed Meyers in the cot and-- \"\n\nEmma McChesney stiffened to acute attention.\n\"Meyers?\" she interrupted. \"Do you mean Ed\nMeyers of the Strauss Sans-silk skirt Company?\"\n\n\"That's so.\"\n\"Did he get in to-day?\"\n\n\"Oh, he just came 15 minutes ago on the Ash-";
 $solutions = ["\n\"I'll do my best, but you can't expect much. I\nguess I can squeeze another cot into eight-seven\nfor the young man. There's--let's see now--who's\nin eighty-seven? Well, there's two\nBisons in the double bed, and one in the single,\nand Fat Ed Meyers in the cot and----\"\n\nEmma McChesney stiffened to acute attention.\n\"Meyers?\" she interrupted. \"Do you mean Ed\nMeyers of the Strauss Sans-silk Skirt Company?\"\n\n\"That's so.\"\n\n\"Did he get in to-day?\"\n\n\"Oh, he just came 15 minutes ago on the Ash-*"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("Later on during post-processing the text will be rewrapped, and as part of that process all the line breaks within paragraphs will be converted to spaces. During proofreading we remove spaces around hyphens and em-dashes so that when rewrapped, the spacing doesn't look strange.") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_basic_3.inc
+++ b/quiz/generic/data/qd_p_basic_3.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Basic Proofreading Quiz, page %d"), 3);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "bundles into the house, while Mirabell's mother\nwent on home in her automobile.\n\nCHAPTER II\n\nThe Rabbit's New Home\n\nOh, Mother! What have you?\" cried the\nvoice of a little girl, as the lady entered\nthe house with the bundle.\n\n\"Is it...something good to cat..?\" asked a\nboy's voice.\n\n\"Now, children, you must not ask too many\nquestions.\" said their mother. \"This isn't exactly\nCHRISTMAS, but it will soon be EASTER, and we";
 $solutions = ["bundles into the house, while Mirabell's mother\nwent on home in her automobile.\n\nCHAPTER II\n\nThe Rabbit's New Home\n\n\"Oh, Mother! What have you?\" cried the\nvoice of a little girl, as the lady entered\nthe house with the bundle.\n\n\"Is it ... something good to eat...?\" asked a\nboy's voice.\n\n\"Now, children, you must not ask too many\nquestions,\" said their mother. \"This isn't exactly\nCHRISTMAS, but it will soon be EASTER, and we"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("While proofreading, if you encounter something that isn't covered in the guidelines or that you are not sure how to handle, post your question in the Project Discussion thread (a link to the project-specific thread is in the Project Comments).  The Project Manager or other site volunteers will let you know how to handle it.") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_basic_4.inc
+++ b/quiz/generic/data/qd_p_basic_4.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Basic Proofreading Quiz, page %d"), 4);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "work he was printing would be good for\nnothing but waste paper, might\nnot be realised. The work\nappeared about the end of\nDecember 18|8 with 1819 on\nthe title-page. Schopenhauer\nhad meanwhile proceeded in\nSeptember to Italy, where lie\nrevised the final proofs.\n\nHigh art.\n\nSo far as the reception of the work was\nconcerned, Goethe \" had received it with\ngreat joy and began instantly to read it. An\n\nWallace, Life, p. 108.";
 $solutions = ["work he was printing would be good for\nnothing but waste paper, might\nnot be realised.[*] The work\nappeared about the end of\nDecember 1818 with 1819 on\nthe title-page. Schopenhauer\nhad meanwhile proceeded in\nSeptember to Italy, where he\nrevised the final proofs.\n\nHigh art.\n\nSo far as the reception of the work was\nconcerned, Goethe \"had received it with\ngreat joy and began instantly to read it. An\n\n* Wallace, Life, p. 108."];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("Sometimes a word or punctuation mark may seem incorrect, but it could turn out to be what the author intended. However, if you believe the printer made an error, proofread it as the image shows and and[**duplicate word] add a note describing yuor[**typo for your?] concern, as shown [**missing word here?] this sentence[**.]") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_basic_5.inc
+++ b/quiz/generic/data/qd_p_basic_5.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Basic Proofreading Quiz, page %d"), 5);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "We ask ourselves how Byron's poem\nYou have the Pyrrhic dance as yet,\nWhere is the Pyrrhic phalanx\ngone?\nOf two such lessons, why forget\nThe nobler and the manlier one?\nis related to these well known words:\n\nWhen in the course of human events, it\nbecomes necessary for one people to\ndissolve . . . political hands.\n\nNot at all. we suspect.";
 $solutions = ["We ask ourselves how Byron's poem\n\nYou have the Pyrrhic dance as yet,\nWhere is the Pyrrhic phalanx\ngone?\nOf two such lessons, why forget\nThe nobler and the manlier one?\n\nis related to these well known words:\n\nWhen in the Course of human events, it\nbecomes necessary for one people to\ndissolve ... political bands.\n\nNot at all, we suspect."];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . sprintf(_("DP Sans Mono is a custom font that helps proofreaders notice scannos. You can <a href='%1\$s' target='_blank'>compare it with other fonts</a> and select it for proofreading in your <a href='%2\$s' target='_blank'>user preferences</a>."), "../../faq/font_sample.php", "../../userprefs.php?tab=1") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_fraktur.inc
+++ b/quiz/generic/data/qd_p_fraktur.inc
@@ -6,7 +6,7 @@ $intro_title = _("Fraktur Proofreading Quiz");
 $initial_instructions = _("Try to correct the text on the bottom left, so it matches the text in the image above following the Proofreading Guidelines. There is no need to proofread the English text, as it is already correct. When done click 'check'.");
 $initial_text = "self-condemnation, the Glass and Porcelain\ndupe, the Antiquity and Coin-hunting dupe,\nand especially the Book-collecting dupe.\nDupes of every kind, however, may find their\nreproof in the simple German lines,\n\nWer Rarren offt viel preoigen will,\nBei ihnen nicht wtrd schaffen viel;\nDaun all's rvas man am beften redt,\nTer Narr zum argsten falsch verstebt,";
 $solutions = ["self-condemnation, the Glass and Porcelain\ndupe, the Antiquity and Coin-hunting dupe,\nand especially the Book-collecting dupe.\nDupes of every kind, however, may find their\nreproof in the simple German lines,\n\nWer Narren offt viel predigen will,\nBey ihnen nicht wird schaffen viel:\nDann all's was man am besten redt,\nDer Narr zum ärgsten falsch versteht,"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("The capital letters I and J are identical in fraktur.  Often (but not always) if the letter comes before a consonant it's an I, and before a vowel it's a J.  If you aren't sure, ask in the project discussion for confirmation.") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_greek_5.inc
+++ b/quiz/generic/data/qd_p_greek_5.inc
@@ -7,7 +7,7 @@ $initial_instructions = $initial_instructions__greek;
 $initial_text = "a profound impression on the coolest\nspectator, even in that age, when men\nwere more accustomed to stabbing\nthan in our delicate days of gunshot\nwounds. 'O be (BeAiaágioc) xarariAayeis\notiioco re arieSn Kai Biaaa eyy6s ri8\nectjxóri tiegitiAaxels Siacpnyeiv tayvai--\n(De Bello Gotthico, ii. 8.)";
 $solutions = ["a profound impression on the coolest\nspectator, even in that age, when men\nwere more accustomed to stabbing\nthan in our delicate days of gunshot\nwounds. [Greek: Ho de (Belisarios) kataplageis\nopisô te apestê kai Bessa engys pou\nestêkoti periplakeis diaphygein ischysi]--(De\nBello Gotthico, ii. 8.)"];
 $parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
-                                    "<p>" . sprintf(_("If you see other Greek characters that don't appear in the Greek transliteration tool, try looking at the wiki <a href='%s' target='_blank'>Transliterating Greek</a> article.  The 'Older and Obscure Items' section shows variant forms of some more letters and has links to ligature charts, which can help you to identify unusual symbols."), $Greek_translit_url) . "</p>";
+                                    "<p>" . sprintf(_("If you see other Greek characters that don't appear in the Greek transliteration tool, try looking at the wiki <a href='%s' target='_blank'>The Greek Alphabet</a> article.  The 'Older and Obscure Items' section shows variant forms of some more letters and has links to ligature charts, which can help you to identify unusual symbols."), $Greek_translit_url) . "</p>";
 
 
 // error messages

--- a/quiz/generic/data/qd_p_mod1_1.inc
+++ b/quiz/generic/data/qd_p_mod1_1.inc
@@ -9,7 +9,7 @@ $solutions = [
     "warm bath on March 8^{th} (who shall say hereafter\nthat science is unfeeling!), upon which the grateful\nsnail put his head cautiously out of his shell,\nwalked up to the top of the basin, and began to take\na survey of British institutions with his four eye-bearing\ntentacles. So strange a recovery from a\nlong torpid condition deserved an exceptional amount\nof scientific recognition. The desert snail at\n\nDesert snail.\n\nonce found himself famous. Nay, he actually sat\nfor his portrait to an eminent zoological artist, Mr.",
 ];
 $criteria = ["e-*b"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("In many books a page footer consisting of a number and/or letter will appear on some pages but not others.  These are <i>printer's marks</i>, used to assist the printer in assembling the sections of the book in order.  They often only appear every 16 pages.  Printer's marks should be deleted like any other page footer.") . "</p>";
 
 // error messages

--- a/quiz/generic/data/qd_p_mod1_2.inc
+++ b/quiz/generic/data/qd_p_mod1_2.inc
@@ -7,7 +7,7 @@ $initial_text = "364   ALICE ORVILLE.\n\n\"When folks can't do as they will, the
 $solutions = ["\n\"When folks can't do as they will, they must do\nas they can, I've heard say.\"\n\nThus we leave our adventurers and return north-*east\nto the land from which they are receding. We\ndidn't know what else to do here, reader, for we\nwere quite as tired of the characters as you were,\nand wanted to get them off our hands in some\nway. * * * A few people think E--e can tell\nstories tolerably well. But she can't, reader! We"];
 $parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
                                 // xgettext:no-php-format
-                                "<p>" . _("Enlarging the image in the proofreading interface can often help you to identify characters that may seem unclear at first.  You can use the +25% button repeatedly in the standard interface, or simply enter the size you want, such as 200%, in the enhanced interface.") . "</p>";
+                                "<p>" . _("Enlarging the image in the proofreading interface can often help you to identify characters that may seem unclear at first.  You can use the magnifying glass button with the + repeatedly to zoom in 10% per click, or simply enter the size you want, such as 200%.") . "</p>";
 
 // error messages
 

--- a/quiz/generic/data/qd_p_mod1_2.inc
+++ b/quiz/generic/data/qd_p_mod1_2.inc
@@ -5,7 +5,7 @@ $intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$s, Page %2\$d"), 
 $initial_instructions = $initial_instructions__P;
 $initial_text = "364   ALICE ORVILLE.\n\n\"When folks can't do as they will, they must do\nas they can, I've heard say.\"\n\nThus we leave our adventurers and return north-\neast to the land from which they are receding. We\ndid n't know what else to do here, reader, for we\nwere quite as tired of the characters as you wore,\nand wanted to get them off our hands in some\nway. * * * A few people think E--e can tell\nstories tolerably well. But she can't, reader! We";
 $solutions = ["\n\"When folks can't do as they will, they must do\nas they can, I've heard say.\"\n\nThus we leave our adventurers and return north-*east\nto the land from which they are receding. We\ndidn't know what else to do here, reader, for we\nwere quite as tired of the characters as you were,\nand wanted to get them off our hands in some\nway. * * * A few people think E--e can tell\nstories tolerably well. But she can't, reader! We"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                 // xgettext:no-php-format
                                 "<p>" . _("Enlarging the image in the proofreading interface can often help you to identify characters that may seem unclear at first.  You can use the magnifying glass button with the + repeatedly to zoom in 10% per click, or simply enter the size you want, such as 200%.") . "</p>";
 

--- a/quiz/generic/data/qd_p_mod1_3.inc
+++ b/quiz/generic/data/qd_p_mod1_3.inc
@@ -9,7 +9,7 @@ $solutions = [
     "pedagogue, of Birmingham manufacture, <i>viz.,\nDr</i>. Parr, had amassed a considerable quantity of\ngold plate. But growing every day more afraid\nof being murdered, which he knew that he could\nnot stand, he transferred the whole to the blacksmith;\nconceiving, no doubt, that the murder of\na blacksmith would fall more lightly on the\nsalus reipublicæ, than that of a pedagogue. But I\nhave heard this greatly disputed; and it seems\nnow generally agreed, that one good horse-shoe\nis worth about 2-1/4 Spital sermons.",
     "pedagogue, of Birmingham manufacture, viz.,\nDr. Parr, had amassed a considerable quantity of\ngold plate. But growing every day more afraid\nof being murdered, which he knew that he could\nnot stand, he transferred the whole to the blacksmith;\nconceiving, no doubt, that the murder of\na blacksmith would fall more lightly on the\nsalus reipublicæ, than that of a pedagogue. But I\nhave heard this greatly disputed; and it seems\nnow generally agreed, that one good horse-shoe\nis worth about 2-1/4 Spital sermons.",
 ];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("During proofreading we write out fractions as <kbd>1/4</kbd> rather than <kbd>¼</kbd> because not all fractions are available as single symbols. Other fractions such as 2/7 may also appear in the text and it would be inconsistent to mix the two notations.") . "</p>";
 
 // error messages

--- a/quiz/generic/data/qd_p_mod1_4.inc
+++ b/quiz/generic/data/qd_p_mod1_4.inc
@@ -5,7 +5,7 @@ $intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 
 $initial_instructions = $initial_instructions__P;
 $initial_text = "And the meteor on the grave,\nAnd the wisp on the morass;6\nWhen the falling stars are shooting,\nAnd the answer'd owls are hooting.\n\n6[Manfred was done into Italian by a translator\n\"who was unable to find in the dictionaries . . .\nany other signification of the 'wisp' of this line\nthan 'a bundle of straw.\"' Byron offered him\n2OO francs if he would destroy the MS. He at\nfirst refused, but finally signed the agree-\nment.--Life, p. 3l6, note.]";
 $solutions = ["And the meteor on the grave,\nAnd the wisp on the morass;[6]\nWhen the falling stars are shooting,\nAnd the answer'd owls are hooting,\n\n6 [Manfred was done into Italian by a translator\n\"who was unable to find in the dictionaries ...\nany other signification of the 'wisp' of this line\nthan 'a bundle of straw.'\" Byron offered him\n200 francs if he would destroy the MS. He at\nfirst refused, but finally signed the agreement.--Life,\np. 316, note.]"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("When the text is rewrapped during post-processing, the end of a line is converted into a space.  This means that during proofreading, anything that should have a space after it (such as an ellipsis) can be left at the end of a line.") . "</p>";
 
 // error messages

--- a/quiz/generic/data/qd_p_mod2_1.inc
+++ b/quiz/generic/data/qd_p_mod2_1.inc
@@ -5,7 +5,7 @@ $intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 
 $initial_instructions = $initial_instructions__P;
 $initial_text = "faintly defined over-head.   `\n\nThe\ntraveller.\n\nP----was a traveller: anybody could\nsee that he was a traveller, and if he had\nthen been in any part of the globe, there\nwould not have been the least doubt that\nhe was a traveller travelling on his travels.\nHe looked like a traveller, and was\ndressed like a traveller. He had with him:\n\na travelling-cap    a coat\na portable-desk   a compass\na travelling-shirt    a hand organ\n\nThe hand-organ played its part very\npleasantly in the cabin of the \" Balakla-";
 $solutions = ["faintly defined over-head.\n\nThe\ntraveller.\n\nP---- was a traveller; anybody could\nsee that he was a traveller, and if he had\nthen been in any part of the globe, there\nwould not have been the least doubt that\nhe was a traveller travelling on his travels.\nHe looked like a traveller, and was\ndressed like a traveller. He had with him:\n\na travelling-cap\na portable-desk\na travelling-shirt\na coat\na compass\na hand-organ\n\nThe hand-organ played its part very\npleasantly in the cabin of the \"Balakla-*"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("We unwrap multiple columns of text into a single column <i>unless</i> the arrangement is important to the meaning.  In a table there is a correspondence between the items in each row, so we need to keep that in order to preserve the author's intent.  However, if the text is in two columns simply to save space on the paper, we convert it into a single column.") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_mod2_2.inc
+++ b/quiz/generic/data/qd_p_mod2_2.inc
@@ -5,7 +5,7 @@ $intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 
 $initial_instructions = $initial_instructions__P;
 $initial_text = "its terrestrial excursions. Just above\nthe gills, lie climbing perch has\ninvented a wholly original water chamber\ncontaining within it a\nfrilled bony organ, which\nenables it to extract oxygen\n--or O2 to scientists--from\nthe stored-up water\nduring the course of its aerial peregrinations\n. While on shore it picks up\nsmall insects, worms, and grubs; but it\nalso has vegetarian tastes of us own,\nand does not despise fruits and berries";
 $solutions = ["its terrestrial excursions. Just above\nthe gills, the climbing perch has\ninvented a wholly original water chamber,\ncontaining within it a\nfrilled bony organ, which\nenables it to extract oxygen--or\nO_{2} to scientists--from\nthe stored-up water\nduring the course of its aërial peregrinations.\nWhile on shore it picks up\nsmall insects, worms, and grubs; but it\nalso has vegetarian tastes of its own,\nand does not despise fruits and berries."];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("The texts that we proofread sometimes have different spellings than what we use today, including accents in words like <kbd>coöperate</kbd> and <kbd>preëminent</kbd>. OCR programs often miss the accents, so be sure to check the image carefully when proofreading.") . "</p>";
 
 // error messages

--- a/quiz/generic/data/qd_p_mod2_4.inc
+++ b/quiz/generic/data/qd_p_mod2_4.inc
@@ -5,7 +5,7 @@ $intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 
 $initial_instructions = $initial_instructions__P;
 $initial_text = "\"It has been said,\" he began, withdrawing\nhis eyes reluctantly from an unusually large\ninsect upon the ceiling, \"that there are few\n\"situations in life that cannot be honourably\n\"settled--and without loss of time\n\"--either by suicide, a bag of gold,\n\"or by thrusting a despised anta-\n\"gonist over the edge of a precipice upon a\n\"dark night. This inoffensive person, however,\n\nA suitor\nis chosen";
 $solutions = ["\n\"It has been said,\" he began, withdrawing\nhis eyes reluctantly from an unusually large\ninsect upon the ceiling, \"that there are few\nsituations in life that cannot be honourably\nsettled--and without loss of time--either\nby suicide, a bag of gold,\nor by thrusting a despised antagonist\nover the edge of a precipice upon a\ndark night. This inoffensive person, however,\n\nA suitor\nis chosen."];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("We remove extra quote marks when they appear on every line because the text will be rewrapped in post-processing, changing the line breaks.  If we left the extra quote marks in the text they would end up in the middle of the paragraph.") . "</p>";
 
 // error messages

--- a/quiz/generic/data/qd_p_mod2_5.inc
+++ b/quiz/generic/data/qd_p_mod2_5.inc
@@ -5,7 +5,7 @@ $intro_title = sprintf(_("Moderate Proofreading Quiz: Part %1\$d, Page %2\$d"), 
 $initial_instructions = $initial_instructions__P;
 $initial_text = "don't spare him in the slightest!    ,\n\nChrys. (virtuously indignant) Is it enough, if he\nhears mere hard words from me this day than\never Clinia2 heard from Demetrius?2\n\n[EXIT.\n\nNIC. (ruefully) That servant of mine is very\nmuch like a sore eye : if you haven't got one,\nyou don't want one and don't miss it; if you\nhave, you can't keep your hands off it. Why, if\nhe hadn 't happened by good luck to be here to-\n\n^2 Characters in some familiar play.";
 $solutions = ["don't spare him in the slightest!\n\nChrys. (virtuously indignant) Is it enough, if he\nhears more hard words from me this day than\never Clinia[2] heard from Demetrius?[2]\n\n[EXIT.\n\nNIC. (ruefully) That servant of mine is very\nmuch like a sore eye: if you haven't got one,\nyou don't want one and don't miss it; if you\nhave, you can't keep your hands off it. Why, if\nhe hadn't happened by good luck to be here to-*\n\n2 Characters in some familiar play."];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("Be sure to read the Project Comments and project discussion before starting to work on a project.  There may be exceptions to the regular Proofreading Guidelines, or helpful information that will make proofreading the text easier for you.") . "</p>";
 
 // error messages

--- a/quiz/generic/data/qd_p_old_1.inc
+++ b/quiz/generic/data/qd_p_old_1.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Old Texts Proofreading Quiz, page %d"), 1);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "three in.number, refled that Shakespeare\nhas introduced three daughters into his\ntragedy of King Lear, which has often\ndrawn tears from the eyes of multitudes.'\n\nIndeed, your affe&amp;ing tale might better\nsuit the intention of an opera: were a fuffi-cient\nnumber of cats put under the tuition\nof proper matters, nobody can tell what an\naflonifhing chorus might be produced. If\nthis proposal shall be embraced, I make no\ncloubt of its being the wonder of all\nEurope,";
 $solutions = ["three in number, reflect that Shakespeare\nhas introduced three daughters into his\ntragedy of King Lear, which has often\ndrawn tears from the eyes of multitudes.\n\nIndeed, your affecting tale might better\nsuit the intention of an opera: were a sufficient\nnumber of cats put under the tuition\nof proper masters, nobody can tell what an\nastonishing chorus might be produced. If\nthis proposal shall be embraced, I make no\ndoubt of its being the wonder of all"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("Because OCR programs often use a modern dictionary to help them resolve unclear areas of the image, sometimes they will modernize the spelling.  We keep the text as the author wrote it, so when proofreading it is important to watch out for any modern spellings and return them to the older forms if necessary in order to match the image.") . "</p>";
 
 

--- a/quiz/generic/data/qd_p_old_2.inc
+++ b/quiz/generic/data/qd_p_old_2.inc
@@ -6,7 +6,7 @@ $intro_title = sprintf(_("Old Texts Proofreading Quiz, page %d"), 2);
 $initial_instructions = $initial_instructions__P;
 $initial_text = "150 \  Df Boioling.\n\nmost are fliort, ouer, or wide, and few iuftle\nin to Fortune. On one side you may *ee the\nMimick, twisting his Body into feueral\nPostures, to add to the Swiftness or Slowness\nof his Bowl; On the other Side the Orator,\nvfing his perfwafiue Intreaties to hasten or\nretard the Speed of his Bowl; if it be unre-\nfponfiue, then he cryes Short, O Short, &amp;c,\nwhen tis gone ten yards ouer the Iack. But\nnot to detain youany longer in characterizing\nthis excellent sport, I shall instruft you in some\n' , Rules,";
 $solutions = ["most are short, ouer, or wide, and few iustle\nin to Fortune. On one side you may see the\nMimick twisting his Body into seueral\nPostures, to add to the Swiftness or Slowness\nof his Bowl; On the other side the Orator,\nvsing his perswasiue Intreaties to hasten or\nretard the Speed of his Bowl; if it be vnresponsiue,\nthen he cryes Short, O Short, &c,\nwhen tis gone ten yards ouer the Iack. But\nnot to detain you any longer in characterizing\nthis excellent sport, I shall instruct you in some"];
-$parting_message = "<h3>" . _("Handy Fact") . "</h3>\n" .
+$parting_message = "<h3>" . _("Handy Tip") . "</h3>\n" .
                                     "<p>" . _("Spelling and punctuation is often inconsistent in older texts, even from one sentence to the next.  Leave it as the author wrote it, but do leave a note or ask in the project discussion if you feel that there may be a printing error.") . "</p>";
 
 

--- a/quiz/generic/quiz_defaults.inc
+++ b/quiz/generic/quiz_defaults.inc
@@ -254,7 +254,7 @@ $messages["P_fnmarkermissing"] = [
 ];
 $messages["P_fnbottombrackets"] = [
     "message_title" => _("Footnote marker bracketed at footnote text"),
-    "message_body" => _("Precede the footnote text with the same mark you used in the text, but <b>without</b> square brackets."),
+    "message_body" => _("Precede the footnote text with the same mark you used in the text, but <b>without</b> the square brackets."),
     "guideline" => "footnotes",
 ];
 $messages["P_fnbottomsuper"] = [
@@ -264,7 +264,7 @@ $messages["P_fnbottomsuper"] = [
 ];
 $messages["P_fnbottomnospace"] = [
     "message_title" => _("Footnote marker not spaced from footnote text"),
-    "message_body" => _("Precede the footnote text with the same mark you used in the text, without square brackets but <b>with a space between them</b>."),
+    "message_body" => _("Precede the footnote text with the same mark you used in the text, without the square brackets but <b>with a space between them</b>."),
     "guideline" => "footnotes",
 ];
 $messages["P_fnmarkup"] = [
@@ -274,7 +274,7 @@ $messages["P_fnmarkup"] = [
 ];
 $messages["P_fnbottommarker"] = [
     "message_title" => _("Footnote marker missing at footnote text"),
-    "message_body" => _("Precede the footnote text with the same mark you used in the text, but without square brackets."),
+    "message_body" => _("Precede the footnote text with the same mark you used in the text. In the text, the mark is surrounded by square brackets to set it off from the text. The square brackets should be omitted when labeling the footnote."),
     "guideline" => "footnotes",
 ];
 $messages["P_fnspace"] = [


### PR DESCRIPTION
A few maintenance changes for the proofreading quizzes.

* Updated quiz message for zooming in on image in mod2 page 1, and tried to make footnote messages somewhat clearer.
* Harmonized `$parting_message` to "Handy Tip".
* Updated the wiki link for Greek transliteration, page 5. This is an interim change, as the Greek transliteration quiz will shortly be removed altogether, just not in this PR.

Sandbox available [here](https://www.pgdp.org/~srjfoo/c.branch/quiz-tips/quiz/start.php).