### PR TITLE
Fix cursor jumping when doing character replacement

### DIFF
--- a/tools/proofers/text_data_processor.js
+++ b/tools/proofers/text_data_processor.js
@@ -1,11 +1,29 @@
 window.addEventListener("DOMContentLoaded", function () {
+    // By specifying the string adjustment value in "adjust" we don't need to
+    // calculate the character (grapheme) length which is challenging until
+    // we can use Intl.Segmenter in very modern browsers.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter
     const conversionMap = {
-        "‘": "'",
-        "“": '"',
-        "’": "'",
-        "”": '"',
-        "—": "--",
-        "…": "...",
+        "‘": {
+            replace: "'",
+        },
+        "“": {
+            replace: '"',
+        },
+        "’": {
+            replace: "'",
+        },
+        "”": {
+            replace: '"',
+        },
+        "—": {
+            replace: "--",
+            adjust: 1,
+        },
+        "…": {
+            replace: "...",
+            adjust: 2,
+        },
     };
 
     document.getElementById("text_data").addEventListener("input", (event) => {
@@ -13,9 +31,13 @@ window.addEventListener("DOMContentLoaded", function () {
         let selectionEnd = textDataElement.selectionEnd;
         textDataElement.value = [...textDataElement.value]
             .map((character) => {
-                const conversion = conversionMap[character] || character;
-                selectionEnd += conversion.length - 1;
-                return conversion;
+                if (conversionMap[character]) {
+                    const replace = conversionMap[character].replace;
+                    selectionEnd += conversionMap[character].adjust || 0;
+                    return replace;
+                } else {
+                    return character;
+                }
             })
             .join("");
         textDataElement.selectionStart = selectionEnd;


### PR DESCRIPTION
The JS to detect and automatically replace characters that aren't allowed on the site needs to adjust the cursor based on the grapheme length, not the JS internal UTF-16 string length. This solves [this issue reported in the forums](https://www.pgdp.net/phpBB3/viewtopic.php?t=84347).

I'm going to rely on @chrismiceli to tell me if there's a better way to solve this 😁 

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-text-processsor-jumping/