### PR TITLE
Prepare for R202509 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ vendor
 SETUP/devex/dpdev-docker/container_startup_local.sh
 # build artifacts
 dist/
+# stupid macOS
+.DS_Store

--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,7 +7,7 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
-## R??????
+## R202509
 Scripts supporting this upgrade are in `SETUP/upgrade/23`
 
 ### Notices & Deprecations
@@ -26,12 +26,20 @@ strings be picked up by the JS code.
 This is the last release to include the Greek Transliteration tool in the
 proofreading interface and the Greek Transliteration quiz.
 
+In the next release, project pages will require authentication and the
+sitemap will be removed.
+
 ### Changes
 
+* Updated minimum PHP to 8.1 and upgraded dependencies to match (cpeel)
 * Authors code (`tools/authors/*`) has been removed. Biographies will be
   inserted directly into the project comments with the included upgrade script
   (cpeel)
 * Updated minimum browser versions, see [INSTALL.md](INSTALL.md).
+* Access to smoothreading now requires authentication (cpeel)
+* Quiz & tutorial updates (mrducky4, srjfoo)
+* Include PDF formats for smoothreading if available (70ray)
+* Code improvements to the Task Center (bpfoley)
 
 ## R202503
 Scripts supporting this upgrade are in `SETUP/upgrade/22`

--- a/SETUP/UPGRADE.md
+++ b/SETUP/UPGRADE.md
@@ -119,6 +119,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
 
 ### Upgrading from release R202102
 Run the scripts in the following directories in order
@@ -130,6 +131,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
 
 ### Upgrading from release R202109
 Run the scripts in the following directories in order
@@ -140,6 +142,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
 
 ### Upgrading from release R202202
 Run the scripts in the following directories in order
@@ -149,6 +152,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
 
 ### Upgrading from release R202209 or R202303
 Run the scripts in the following directories in order
@@ -157,6 +161,7 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
 
 ### Upgrading from release R202309
 Run the scripts in the following directories in order
@@ -164,17 +169,25 @@ Run the scripts in the following directories in order
 * c/SETUP/upgrade/20/
 * c/SETUP/upgrade/21/
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
 
 ### Upgrading from release R202403
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/21/
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
 
 ### Upgrading from release R202409
 Run the scripts in the following directories in order
 
 * c/SETUP/upgrade/22/
+* c/SETUP/upgrade/23/
+
+### Upgrading from release R202503
+Run the scripts in the following directories in order
+
+* c/SETUP/upgrade/23/
 
 ## Install the modified `dp.cron`
 Install the modified `dp.cron`.


### PR DESCRIPTION
Update the changelog and upgrade instructions for the upcoming R202509 release.

My goal is always to include the most "important" updates to administrators in the changelog paired with ensuring that all contributors get a mention in.

This PR will get held until right before I'm ready to cut the release sometime mid-month after our regular September deployment.