### PR TITLE
Site cron to prune non_activated_users

### DIFF
--- a/SETUP/dp.cron.template
+++ b/SETUP/dp.cron.template
@@ -20,3 +20,4 @@
 50 0 1 * * JOB=NotifyOldPP; <<PHP_CLI_EXECUTABLE>> <<CODE_DIR>>/crontab/run_background_job.php $JOB
 50 0 15 * * JOB=NotifyOldPP; <<PHP_CLI_EXECUTABLE>> <<CODE_DIR>>/crontab/run_background_job.php $JOB
 50 0 28 * * JOB=PruneJobLogs; <<PHP_CLI_EXECUTABLE>> <<CODE_DIR>>/crontab/run_background_job.php $JOB
+50 0 28 * * JOB=PruneNonActivatedUsers; <<PHP_CLI_EXECUTABLE>> <<CODE_DIR>>/crontab/run_background_job.php $JOB

--- a/crontab/PruneNonActivatedUsers.inc
+++ b/crontab/PruneNonActivatedUsers.inc
@@ -1,0 +1,10 @@
+<?php
+
+// Prune non_activated_users entries
+class PruneNonActivatedUsers extends BackgroundJob
+{
+    public function work()
+    {
+        NonactivatedUser::prune(90); // ~3 months
+    }
+}

--- a/pinc/NonactivatedUser.inc
+++ b/pinc/NonactivatedUser.inc
@@ -264,4 +264,21 @@ class NonactivatedUser
         $user->load('email', $email);
         return $user;
     }
+
+    /**
+     * Prune old records
+     */
+    public static function prune(int $days_to_keep): void
+    {
+        $cutoff = new DateTimeImmutable(sprintf("%d days ago", $days_to_keep));
+        $sql = sprintf(
+            "
+            DELETE
+            FROM non_activated_users
+            WHERE date_created < %d
+            ",
+            $cutoff->format("U")
+        );
+        DPDatabase::query($sql);
+    }
 }


### PR DESCRIPTION
Add a cron job to finally prune this table. The 3 months is pending approval by the GM and other squirrels.

This was tested manually on TEST (with a date of 365 days ago for testing purposes) and you can see it ran correctly at https://www.pgdp.org/c/tools/site_admin/show_job_log.php?days_ago=1&job=PruneNonActivatedUsers&event=