### PR TITLE
Upgrade phpstan to 2.x

### DIFF
--- a/accounts/logout.php
+++ b/accounts/logout.php
@@ -6,7 +6,7 @@ include_once($relPath.'metarefresh.inc');
 include_once($relPath.'forum_interface.inc');
 
 if (User::is_logged_in()) {
-    logout_forum_user();
+    logout_forum_user();  // @phpstan-ignore-line
 
     dpsession_end();
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.57",
         "phpunit/phpunit": "^10.0",
-        "phpstan/phpstan": "^1.12"
+        "phpstan/phpstan": "^2.1.31"
     },
     "replace": {
         "symfony/polyfill-ctype": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "569cf175f31b64e8c19f1ad65981ed16",
+    "content-hash": "1d90e54a563e955a67cd5ff656e2b80b",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -1508,20 +1508,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.19",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c42ba9bab7a940ed00092ecb1c77bad98896d789"
-            },
+            "version": "2.1.31",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c42ba9bab7a940ed00092ecb1c77bad98896d789",
-                "reference": "c42ba9bab7a940ed00092ecb1c77bad98896d789",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -1562,7 +1557,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-19T15:42:21+00:00"
+            "time": "2025-10-10T14:14:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4384,8 +4379,8 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,12 +23,16 @@ parameters:
         # Errors in third party code, and our interfaces to it
         - message: '#Property .* does not accept false#'
           path: pinc/3rdparty/mediawiki/DairikiDiff.php
-        - message: '#Comparison operation .* results in an error#'
+        - message: '#Parameter &\$changed by-ref type of method DiffEngine::shiftBoundaries\(\) expects .* given#'
           path: pinc/3rdparty/mediawiki/DiffEngine.php
         - message: '#^Parameter \#2 \$.* of function array_fill expects int, float given\.$#'
           path: pinc/3rdparty/mediawiki/DiffEngine.php
+        - message: '#Call to function wfDebug\(\) on a separate line has no effect.#'
+          path: pinc/3rdparty/mediawiki/DiffEngine.php
         - message: '#Instantiated class DiffFormatter is abstract#'
           path: pinc/DifferenceEngineWrapper.inc
+        - message: '#Call to function is_array\(\) with array<string> will always evaluate to true.#'
+          path: pinc/3rdparty/mediawiki/WordLevelDiff.php
 
         - message: '#invoked with \d+ parameter(s?), \d+((-\d+)?) required#'
         - message: '#Variable .* might not be defined#'

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -8,12 +8,12 @@ class CharSuiteNotEnabledException extends Exception
 class PickerSet
 {
     public string $name;
-    /** @var (?string[])[] */
+    /** @var list<list<?string>> */
     private array $subsets;
     /** @var string[] */
     private array $titles;
 
-    /** @param (?string[])[] $codepoints */
+    /** @param list<list<?string>> $codepoints */
     public function add_subset(string $name, array $codepoints, ?string $title = null)
     {
         $this->subsets[$name] = $codepoints;
@@ -25,13 +25,13 @@ class PickerSet
         }
     }
 
-    /** @return (?string[])[] */
+    /** @return list<list<?string>> */
     public function get_subsets(): array
     {
         return $this->subsets;
     }
 
-    /** @return array{name: string, title: string, rows: (?string[])[][]}[] */
+    /** @return array{name: string, title: string, rows: list<list<list<?string>>>}[] */
     public function get_verbose_subsets(): array
     {
         $verbose_subsets = [];

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -248,7 +248,7 @@ class Project
                 $this->$key = $value;
             }
             $this->_create_source = "array";
-        } elseif ($arg === null) {
+        } elseif ($arg === null) {  // @phpstan-ignore-line
             $this->_init_fields_to_defaults();
             $this->_create_source = "empty";
         } else {

--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -112,7 +112,7 @@ function dump_request_info()
     // give them a last chance to save the page text.
 
     foreach (['_GET', '_POST'] as $array_name) {
-        $array = @${$array_name} ?? null; // PHP is a dynamic language! :)
+        $array = @${$array_name}; // PHP is a dynamic language! :)
         if ($array) {
             echo "$array_name\n";
             echo html_safe(json_encode($array, JSON_PRETTY_PRINT));

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -52,9 +52,7 @@ function dpsession_resume(): void
         );
 
         // set global variable $pguser
-        if (isset($_SESSION['pguser'])) {
-            $pguser = $_SESSION['pguser'];
-        }
+        $pguser = $_SESSION['pguser'];
         $user_is_logged_in = true;
     } else {
         session_unset();

--- a/pinc/dpsql.inc
+++ b/pinc/dpsql.inc
@@ -86,7 +86,7 @@ function dpsql_dump_themed_query_result($result, $start_at = 0, $show_rank = DPS
             throw new ServerError(DPDatabase::log_error());
         }
         $type[$c] = $field_data->type;
-        $align = ($type[$c] == 'int' && $ralign_ints) ? " style='text-align: right;'" : '';
+        $align = (is_mysqli_field_type_int($type[$c]) && $ralign_ints) ? " style='text-align: right;'" : '';
         echo "<th$align>\n";
         echo $field_data->name;
         echo "</th>\n";
@@ -102,8 +102,8 @@ function dpsql_dump_themed_query_result($result, $start_at = 0, $show_rank = DPS
         }
 
         for ($c = 0; $c < $n_query_cols; $c++) {
-            echo '<td' . (($type[$c] == 'int' && $ralign_ints) ? " style='text-align: right;'" : '') . '>';
-            echo ($type[$c] == 'int') ? number_format($row[$c]) : $row[$c];
+            echo '<td' . ((is_mysqli_field_type_int($type[$c]) && $ralign_ints) ? " style='text-align: right;'" : '') . '>';
+            echo is_mysqli_field_type_int($type[$c]) ? number_format($row[$c]) : $row[$c];
             echo "</td>\n";
         }
         echo "</tr>\n";
@@ -131,4 +131,13 @@ function dpsql_fetch_columns($res)
         }
     }
     return $columns;
+}
+
+function is_mysqli_field_type_int(int $type): bool
+{
+    return $type == MYSQLI_TYPE_TINY ||
+        $type == MYSQLI_TYPE_SHORT ||
+        $type == MYSQLI_TYPE_LONG ||
+        $type == MYSQLI_TYPE_LONGLONG ||
+        $type == MYSQLI_TYPE_INT24;
 }

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -207,7 +207,7 @@ function process_and_display_project_filter_form($username, $filter_type, $filte
     ];
     // overwrite the default display state of the form fields with any
     // custom display requests
-    if ($custom_display_fields && is_array($custom_display_fields)) {
+    if ($custom_display_fields) {
         $display_fields = array_merge($display_fields, $custom_display_fields);
     }
     // if there is data save it, else get saved data

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -961,9 +961,6 @@ function set_col_str(string $colname, string $s): string
  */
 function set_col_num(string $colname, int $i): string
 {
-    if (!is_numeric($i)) {
-        throw new InvalidArgumentException("$i is not a number");
-    }
     return sprintf("%s=%d", $colname, $i);
 }
 

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -257,7 +257,8 @@ function _insert_post(
         $subject = utf8_encode_ucr($subject);
     }
 
-    $poll = $uid = $bitfield = $options = '';
+    $poll = $uid = $bitfield = '';
+    $options = 0;
     generate_text_for_storage($text, $uid, $bitfield, $options, true, true, true);
 
     $data = [

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -260,7 +260,7 @@ $ELR_round = get_Round_for_round_number(1);
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 new Pool(
-    'PP', // @phpstan-ignore-line PHPStan 1.10 reports a string-to-int conv here, seems like a bug
+    'PP',
     _('Post-Processing'),
     ['F1' => 400],
     'REQ-AUTO',
@@ -308,7 +308,7 @@ new Stage(
 // -----------------------------------------------------------------------------
 
 new Pool(
-    'PPV', // @phpstan-ignore-line PHPStan 1.10 reports a string-to-int conv here, seems like a bug
+    'PPV',
     _('Post-Processing Verification'),
     [],
     'NOREQ', // "Peer approval. Also gives F2 access."

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -791,7 +791,7 @@ function load_project_good_word_suggestions($projectid, $start_time = 0)
         [$time, $round, $page, $proofer, $words] = $event;
 
         if (count($words)) {
-            if (!is_array(@$wordsArray[$round][$page])) {
+            if (!isset($wordsArray[$round][$page])) {
                 $wordsArray[$round][$page] = [];
             }
             $wordsArray[$round][$page] = array_merge($wordsArray[$round][$page], $words);

--- a/tasks.php
+++ b/tasks.php
@@ -1182,7 +1182,7 @@ function TaskForm(object $task): void
     } else {
         echo "<input type='hidden' name='action' value='edit'>\n";
         echo "<input type='hidden' name='task_id' value='$task->task_id'>";
-        $title = "#$task->task_id: " . html_safe($task->task_summary); /** @phpstan-ignore-line */
+        $title = "#$task->task_id: " . html_safe($task->task_summary);
     }
     if ($task->opened_by == $requester_u_id && !user_is_a_sitemanager() && !user_is_taskcenter_mgr()) {
         echo "<input type='hidden' name='percent_complete' value='$task->percent_complete'>";
@@ -1209,7 +1209,7 @@ function TaskForm(object $task): void
     property_echo_select_tr('task_status', $task->task_status, $tasks_status_array);
     property_echo_select_tr('task_assignee', $task->task_assignee, $task_assignees_array);
     if ((user_is_a_sitemanager() || user_is_taskcenter_mgr()) && !empty($task->task_id)) {
-        property_echo_select_tr('percent_complete', $task->percent_complete, TASK_PERCENT_COMPLETE); /** @phpstan-ignore-line */
+        property_echo_select_tr('percent_complete', $task->percent_complete, TASK_PERCENT_COMPLETE);
     }
     echo "</table>";
     echo "</div>";

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -340,7 +340,7 @@ class Loader
             }
         }
 
-        ksort($this->page_file_table, SORT_STRING);
+        ksort($this->page_file_table, SORT_STRING);  // @phpstan-ignore-line
 
         // echo "<pre>"; var_dump($this->page_file_table); echo "</pre>";
 
@@ -596,7 +596,6 @@ class Loader
         }
 
         // There's a file in source dir.
-        assert(count($src_exts) == 1);
         [$src_ext] = $src_exts;
         $src_file = $base . $src_ext;
 
@@ -631,7 +630,6 @@ class Loader
         }
 
         // There's a file in the source dir *and* info in the db.
-        assert(count($db_exts) == 1);
         [$db_ext] = $db_exts;
         $db_file = $base . $db_ext;
 

--- a/tools/project_manager/marc_inspector.php
+++ b/tools/project_manager/marc_inspector.php
@@ -118,9 +118,9 @@ foreach ($record as $r) {
         if (array_key_exists($field, $field_info)) {
             $info = $field_info[$field];
             $attr = " class='bold' title='" . attr_safe($info["tooltip"]) . "'";
-            if (array_key_exists("url", $info)) {
+            if (array_key_exists("url", $info)) {  /** @phpstan-ignore-line */
                 $match[2] = "<a href='{$info['url']}'{$attr}>{$field}</a>";
-            } else { /** @phpstan-ignore-line */
+            } else {
                 $match[2] = "<span {$attr}>{$field}</span>";
             }
             $label = $match[1] . $match[2] . $match[3];

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -31,7 +31,7 @@ if ($action == "update") {
         if (preg_match("/cb_(projectID[0-9a-f]{13})_(\d+)/", $key, $matches)) {
             $projectid = $matches[1];
             $word = decode_word($val);
-            if (!is_array(@$newProjectWords[$projectid])) {
+            if (!isset($newProjectWords[$projectid])) {
                 $newProjectWords[$projectid] = [];
             }
             array_push($newProjectWords[$projectid], $word);

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -275,8 +275,6 @@ class PPage
             return; // to let the caller do the appropriate normal thing
         }
 
-        assert($dpl_reached);
-
         if ($saved) {
             $title = _("Saved, but at limit");
             $sentence = sprintf(

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -74,7 +74,7 @@ output_link_box($username);
 echo "<h1>" . get_usertext($page_header) . "</h1>";
 
 $allowed_stages = array_keys(get_stages_user_can_work_in($username));
-$can_view_post_processing = in_array("PP", $allowed_stages) or in_array("PPV", $allowed_stages);
+$can_view_post_processing = (in_array("PP", $allowed_stages) or in_array("PPV", $allowed_stages));
 $proof_heading = _("Proofreading & Formatting Projects");
 $pool_heading = _("Post-Processing Projects");
 if ($can_view_post_processing) {

--- a/tools/proofers/processtext.php
+++ b/tools/proofers/processtext.php
@@ -278,7 +278,7 @@ try {
                 $languages[] = $_POST["aux_language"];
             }
             if (isset($_POST["remove_language"])) {
-                $languages = array_diff($languages, array_keys($_POST["remove_language"] ?? []));
+                $languages = array_diff($languages, array_keys($_POST["remove_language"]));
             }
             $accepted_words = explode(' ', $_POST["accepted_words"]);
             $_SESSION["is_header_visible"] = get_integer_param($_POST, 'is_header_visible', 0, 0, 1);

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -342,7 +342,7 @@ function spellcheck_apply_corrections()
 
         // now iterate over the lines and offsets doing the corrections
         foreach ($affectedRows as $affectedRow) {
-            foreach ($offsetList[$affectedRow] as $offsetKey) { /** @phpstan-ignore-line Fixed in https://github.com/phpstan/phpstan/issues/9403 */
+            foreach ($offsetList[$affectedRow] as $offsetKey) {
                 $i = $offsetLookup["{$affectedRow}_{$offsetKey}"];
 
                 // hidden values line|offset|word length


### PR DESCRIPTION
Upgrades phpstan to 2.x and fixes https://github.com/DistributedProofreaders/dproofreaders/issues/1529. These are mostly minor code-quality things where we were doing checks that didn't need to be done and the CI passing should be sufficient for testing.

That said, phpstan did catch a bug that has been in the code since at least 2017 when we moved to the mysqli extension. In some of the stats code where we render tables directly from SQL statements in the old dpsql code, integer columns were suppose to be right-aligned but weren't. The fix resulted in the columns being right-aligned and if we decide we don't actually want that behavior I can fix it a different way.

Compare:
* https://www.pgdp.org/c/stats/pm_stats.php
* https://www.pgdp.org/~cpeel/c.branch/upgrade-phpstan/stats/pm_stats.php

Sandbox: https://www.pgdp.org/~cpeel/c.branch/upgrade-phpstan/