### PR TITLE
Update changelog about upcoming PHP version bump

### DIFF
--- a/SETUP/CHANGELOG.md
+++ b/SETUP/CHANGELOG.md
@@ -7,6 +7,14 @@ see the git history.
 [R202009](https://github.com/DistributedProofreaders/dproofreaders/releases/tag/R202009)
 first before upgrading to R202102 or later releases.**
 
+## R??????
+Scripts supporting this upgrade are in `SETUP/upgrade/24`
+
+### Notices & Deprecations
+
+This is the last release to support PHP 8.1. Future releases will only
+support PHP 8.3 and later.
+
 ## R202509
 Scripts supporting this upgrade are in `SETUP/upgrade/23`
 


### PR DESCRIPTION
In April 2026 I intend to update our minimum PHP version to 8.3. This matches the version we are already running on pgdp.net so there will be no functional changes or testing required, but it will allow us to update some of our composer dependencies and make use of some new PHP features.

PHP 8.3 is the default for Ubuntu 24.04 and Rocky Linux 10, and available for Ubuntu 22.04 and Rocky Linux 9 through external packages.

This updates the changlog for the (expected) March release.