### PR TITLE
Set apt to noninteractive mode when building

### DIFF
--- a/SETUP/devex/dpdev-docker/Dockerfile
+++ b/SETUP/devex/dpdev-docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM php:8.1-apache
 
+# Set apt to noninteractive mode for the build.
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Configure PHP for development and increase memory for phpstan
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 RUN echo "memory_limit = 512M" >> "$PHP_INI_DIR/php.ini"


### PR DESCRIPTION
This removes warnings when doing some apt operations, like:

> debconf: unable to initialize frontend: Dialog
> debconf: (TERM is not set, so the dialog frontend is not usable.)
> debconf: falling back to frontend: Readline
> debconf: unable to initialize frontend: Readline
> debconf: (This frontend requires a controlling tty.)
> debconf: falling back to frontend: Teletype
> debconf: unable to initialize frontend: Teletype
> debconf: (This frontend requires a controlling tty.)
> debconf: falling back to frontend: Noninteractive

We must use ARG and not ENV per this SO thread:

https://serverfault.com/questions/618994/when-building-from-dockerfile-debian-ubuntu-package-install-debconf-noninteract