### PR TITLE
Combine apt-get and apt-install in Dockerfile

### DIFF
--- a/SETUP/devex/dpdev-docker/Dockerfile
+++ b/SETUP/devex/dpdev-docker/Dockerfile
@@ -5,10 +5,10 @@ RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 RUN echo "memory_limit = 512M" >> "$PHP_INI_DIR/php.ini"
 
 # Install dependency packages
-RUN apt-get update
+
 # DP deps: mariadb-client gettext aspell aspell-fr pngcheck
 # Handy dev deps: unzip git
-RUN apt-get install -y mariadb-client gettext aspell aspell-fr pngcheck git unzip locales locales-all
+RUN apt-get update -y && apt-get install -y mariadb-client gettext aspell aspell-fr pngcheck git unzip locales locales-all
 
 # Install PHP extensions (mbstring and xml already included in image)
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/


### PR DESCRIPTION
This is a best practice for Dockerfile that should help prevent stale dependencies as Docker cache each command into separate layers.

Source: https://docs.docker.com/build/building/best-practices/

> Always combine RUN apt-get update with apt-get install in the same RUN statement.