### PR TITLE
Track Format Preview usage

### DIFF
--- a/SETUP/ARCHIVING.md
+++ b/SETUP/ARCHIVING.md
@@ -2,8 +2,8 @@
 
 After projects are completed, they can be archived. This includes moving the
 project files into a separate archive directory, moving the project tables into
-a separate archive database, and moving a project's page_events and
-wordcheck_events into the archive database.
+a separate archive database, and moving a project's `page_events`,
+`wordcheck_events`, and `format_preview_events` into the archive database.
 
 The database instructions in this file resemble those for the main database. See
 [INSTALL.md](INSTALL.md) for more information on how to run database commands.
@@ -31,8 +31,8 @@ project directory.
    GRANT ALL  ON dp_archive.* TO dp_user@localhost IDENTIFIED BY 'dp_password';
    ```
 
-4. Create the `page_events` and `wordcheck_events` table in the archive
-   database. Find the 'CREATE TABLE' commands for those 2 tables in
+4. Create the `page_events`, `wordcheck_events`, and `format_preview_events` tables
+   in the archive database. Find the 'CREATE TABLE' commands for those 2 tables in
    `db_schema.sql`. These commands create those tables in the main database;
    the corresponding tables in the archive database have exactly the same
    structure. So to create them, make the archive db the current database

--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -56,6 +56,21 @@ INSERT INTO charsuites
     SET name='basic-latin';
 
 --
+-- Table structure for table `format_preview_events`
+--
+
+CREATE TABLE `format_preview_events` (
+  `event_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `projectid` varchar(22) NOT NULL,
+  `image` varchar(12) NOT NULL,
+  `round_id` char(2) NOT NULL,
+  `username` varchar(25) NOT NULL,
+  `timestamp` int unsigned NOT NULL,
+  PRIMARY KEY (`event_id`),
+  UNIQUE KEY `pc_compound` (`projectid`,`image`,`round_id`,`username`)
+);
+
+--
 -- Table structure for table `image_sources`
 --
 

--- a/SETUP/site_admin_notes.txt
+++ b/SETUP/site_admin_notes.txt
@@ -21,6 +21,7 @@ to allow a three-character round-id, you'd need to do:
     ALTER TABLE page_events      MODIFY COLUMN round_id   CHAR(3);
     ALTER TABLE queue_defns      MODIFY COLUMN round_id   CHAR(3);
     ALTER TABLE wordcheck_events MODIFY COLUMN round_id   CHAR(3);
+    ALTER TABLE format_preview_events MODIFY COLUMN round_id   CHAR(3);
     ALTER TABLE best_tally_rank  MODIFY COLUMN tally_name CHAR(3);
     ALTER TABLE current_tallies  MODIFY COLUMN tally_name CHAR(3);
     ALTER TABLE past_tallies     MODIFY COLUMN tally_name CHAR(3);

--- a/SETUP/upgrade/24/20251101_create_format_preview_events.php
+++ b/SETUP/upgrade/24/20251101_create_format_preview_events.php
@@ -1,0 +1,23 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+echo "Creating format_preview_events...\n";
+$sql = "
+    CREATE TABLE `format_preview_events` (
+        `event_id` int unsigned NOT NULL AUTO_INCREMENT,
+        `projectid` varchar(22) NOT NULL,
+        `image` varchar(12) NOT NULL,
+        `round_id` char(2) NOT NULL,
+        `username` varchar(25) NOT NULL,
+        `timestamp` int unsigned NOT NULL,
+        PRIMARY KEY (`event_id`),
+        UNIQUE KEY `pc_compound` (`projectid`,`image`,`round_id`,`username`)
+    )
+";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+echo "\nDone!\n";

--- a/api/dp-openapi.yaml
+++ b/api/dp-openapi.yaml
@@ -1210,11 +1210,35 @@ paths:
         default:
           $ref: '#/components/responses/UnexpectedError'
 
+  /projects/{projectid}/pages/{pagename}/formatpreview:
+    put:
+      tags:
+      - project
+      description: Report Format Preview usage
+      parameters:
+      - $ref: '#/components/parameters/projectid'
+      - $ref: '#/components/parameters/pagename'
+      responses:
+        200:
+          description: OK
+        '400':
+          $ref: '#/components/responses/InvalidValue'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        default:
+          $ref: '#/components/responses/UnexpectedError'
+
   /projects/{projectid}/pages/{pagename}/wordcheck:
     put:
       tags:
       - project
-      description: Report wordcheck reults
+      description: Report WordCheck usage and results
       parameters:
       - $ref: '#/components/parameters/projectid'
       - $ref: '#/components/parameters/pagename'

--- a/api/v1.inc
+++ b/api/v1.inc
@@ -48,6 +48,7 @@ $router->add_route("GET", "v1/projects/:projectid/pagedetails", "api_v1_project_
 $router->add_route("GET", "v1/projects/:projectid/pages", "api_v1_project_pages");
 $router->add_route("PUT", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename", "api_v1_project_page");
+$router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/formatpreview", "api_v1_project_page_format_preview");
 $router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/reportbad", "api_v1_project_page_report_bad");
 $router->add_route("PUT", "v1/projects/:projectid/pages/:pagename/wordcheck", "api_v1_project_page_wordcheck");
 $router->add_route("GET", "v1/projects/:projectid/pages/:pagename/pagerounds/:pageroundid", "api_v1_project_page_round");

--- a/api/v1_projects.inc
+++ b/api/v1_projects.inc
@@ -943,6 +943,24 @@ function api_v1_project_page(string $method, array $data, array $query_params)
     }
 }
 
+/** @param array<string,string|string[]> $query_params */
+function api_v1_project_page_format_preview(string $method, array $data, array $query_params): void
+{
+    try {
+        $project = $data[":projectid"];
+        $proof_project = new ProofProject($project);
+
+        $project_page = $data[":pagename"];
+        $proof_project_page = new ProofProjectPage($proof_project, $project_page);
+
+        $proof_project_page->fp_report();
+    } catch (ProjectException $exception) {
+        throw new NotFoundError($exception->getMessage(), $exception->getCode());
+    } catch (UserAccessException $exception) {
+        throw new ForbiddenError($exception->getMessage(), $exception->getCode());
+    }
+}
+
 /** @param array<string, string|string[]> $query_params */
 function api_v1_project_page_report_bad(string $method, array $data, array $query_params): void
 {

--- a/crontab/PrunePageData.inc
+++ b/crontab/PrunePageData.inc
@@ -44,6 +44,16 @@ class PrunePageData extends BackgroundJob
             );
             DPDatabase::query($sql);
 
+            // then format_preview_events
+            $sql = sprintf(
+                "
+                DELETE FROM $database.format_preview_events
+                WHERE projectid = '%s'
+                ",
+                DPDatabase::escape($project_id)
+            );
+            DPDatabase::query($sql);
+
             // then page_events
             $sql = sprintf(
                 "

--- a/pinc/FormatPreview.inc
+++ b/pinc/FormatPreview.inc
@@ -1,0 +1,74 @@
+<?php
+
+class FormatPreview
+{
+    /**
+     * Save a Format Preview event.
+     */
+    public static function save_event(string $projectid, string $round, string $page, string $proofer): void
+    {
+        $setters = join(", ", [
+            set_col_str("projectid", $projectid),
+            set_col_str("image", $page),
+            set_col_str("round_id", $round),
+            set_col_str("username", $proofer),
+            set_col_num("timestamp", time()),
+        ]);
+        $sql = sprintf(
+            "
+            INSERT INTO format_preview_events
+                SET $setters
+            ON DUPLICATE KEY UPDATE
+                timestamp = %d
+            ",
+            time()
+        );
+        DPDatabase::query($sql);
+    }
+
+    /**
+     * Delete any format_preview_events for this project.
+     *
+     * This is called when deleting a project.
+     */
+    public static function delete_project_events(string $projectid): void
+    {
+        $sql = sprintf(
+            "
+            DELETE FROM format_preview_events
+            WHERE projectid='%s'
+            ",
+            DPDatabase::escape($projectid)
+        );
+        DPDatabase::query($sql);
+    }
+
+    /**
+     * Copy format_preview_events from one project to another.
+     *
+     * This is called when copying pages into a project.
+     *
+     * @param string[] $images
+     */
+    public static function copy_project_events(string $src_projectid, string $dest_projectid, array $images = []): void
+    {
+        if ($images) {
+            $images_where = " AND image in (" . surround_and_join(array_map("DPDatabase::escape", $images), '"', '"', ",") . ")";
+        } else {
+            $images_where = "";
+        }
+
+        $sql = sprintf(
+            "
+            INSERT INTO format_preview_events
+                (projectid, image, round_id, username, timestamp)
+            SELECT '%s', image, round_id, username, timestamp
+            FROM format_preview_events
+            WHERE projectid = '%s' $images_where
+            ",
+            DPDatabase::escape($dest_projectid),
+            DPDatabase::escape($src_projectid)
+        );
+        DPDatabase::query($sql);
+    }
+}

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -665,6 +665,7 @@ class Project
         }
 
         delete_project_wordcheck_events($this->projectid);
+        FormatPreview::delete_project_events($this->projectid);
 
         // Formerly, if the project was in the 'New' state, we would here
         // delete it from the projects table and log a 'deletion' event.

--- a/pinc/ProofProject.inc
+++ b/pinc/ProofProject.inc
@@ -110,6 +110,26 @@ class ProofProjectPage extends LPage
             $accepted_words
         );
     }
+
+    public function fp_report(): void
+    {
+        global $pguser;
+
+        _Page_require(
+            $this->projectid,
+            $this->imagefile,
+            [$this->round->page_out_state, $this->round->page_temp_state],
+            $this->round->user_column_name,
+            $pguser,
+            'report'
+        );
+        FormatPreview::save_event(
+            $this->projectid,
+            $this->round->id,
+            $this->imagefile,
+            $pguser
+        );
+    }
 }
 
 class ProofProject

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -177,6 +177,7 @@ function archive_ancillary_data_for_project(Project $project, string $indent, bo
     // okay, proceed
     move_project_rows_to_archive_db($projectid, 'page_events     ', $indent, $dry_run);
     move_project_rows_to_archive_db($projectid, 'wordcheck_events', $indent, $dry_run);
+    move_project_rows_to_archive_db($projectid, 'format_preview_events', $indent, $dry_run);
 }
 
 // -----------------------------------------------------------------------------

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -60,6 +60,7 @@ function get_rounds_to_display($project)
  *             "username": "username",
  *             "user_page_tally": "117"
  *             "wordcheck_ran": "0",
+ *             "format_preview_ran": "0",
  *             "modified_timestamp": "1175026200",
  *         },
  *         "P2": {
@@ -103,14 +104,18 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         $include_ocr = in_array("OCR", $only_rounds);
     }
 
-    // load wordcheck_event counts for this table for lookup in building the
-    // page table later, this is faster than doing subqueries in single SQL
+    // load wordcheck_event and format_preview_events for this table,
+    // this is faster than doing subqueries in a single SQL
     $round_ids_to_load_wordcheck_events = [];
+    $round_ids_to_load_format_preview_events = [];
     foreach ($rounds_to_display as $round) {
         if (!is_formatting_round($round)) {
             $round_ids_to_load_wordcheck_events[] = $round->id;
+        } else {
+            $round_ids_to_load_format_preview_events[] = $round->id;
         }
     }
+
     if ($round_ids_to_load_wordcheck_events) {
         $sql = sprintf(
             "
@@ -130,6 +135,26 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
         }
     } else {
         $wordcheck_events = [];
+    }
+
+    if ($round_ids_to_load_format_preview_events) {
+        $sql = sprintf(
+            "
+            SELECT image, username, round_id
+            FROM format_preview_events
+            WHERE projectid = '%s' and round_id in (%s)
+            ",
+            DPDatabase::escape($project->projectid),
+            surround_and_join($round_ids_to_load_format_preview_events, "'", "'", ",")
+        );
+        $res = DPDatabase::query($sql);
+
+        $format_preview_events = [];
+        while ([$image, $username, $round_id] = mysqli_fetch_row($res)) {
+            $format_preview_events["$image$username$round_id"] = 1;
+        }
+    } else {
+        $format_preview_events = [];
     }
 
     $rounds_with_data = get_rounds_with_data($project);
@@ -225,8 +250,10 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
 
             if (is_formatting_round($round)) {
                 $wordcheck_ran = null;
+                $format_preview_ran = $format_preview_events[$row['image'] . $row[$round->user_column_name] . $round->id] ?? 0;
             } else {
                 $wordcheck_ran = $wordcheck_events[$row['image'] . $row[$round->user_column_name] . $round->id] ?? 0;
+                $format_preview_ran = null;
             }
 
             $pagerounds[$round->id] = [
@@ -235,6 +262,7 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
                 "username" => $row[$round->user_column_name],
                 "user_page_tally" => (int)$row["$rn.user_page_tally"],
                 "wordcheck_ran" => $wordcheck_ran,
+                "format_preview_ran" => $format_preview_ran,
                 "modified_timestamp" => $row[$round->time_column_name],
             ];
         }
@@ -649,7 +677,15 @@ function echo_cells_for_round(
             $wordcheck_status = '&nbsp;<span title="' . _('This page was not WordChecked.') . '">&#x2717;</span>';
         }
 
-        echo "<td $cell_class_attr>" . private_message_link($R_username, null) . " ($R_pages_completed)$wordcheck_status</td>\n";
+        if ($round_data["format_preview_ran"] === null) {
+            $format_preview_status = '';
+        } elseif ($round_data["format_preview_ran"]) {
+            $format_preview_status = '&nbsp;<span title="' . _('Format Preview was used on this page.') . '">&check;</span>';
+        } else {
+            $format_preview_status = '&nbsp;<span title="' . _('Format Preview was not used on this page.') . '">&#x2717;</span>';
+        }
+
+        echo "<td $cell_class_attr>" . private_message_link($R_username, null) . " ($R_pages_completed)$wordcheck_status$format_preview_status</td>\n";
     } else {
         echo "<td></td>\n";
     }

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -399,6 +399,7 @@ function output_page_list_table(Round $mentored_round, string $projectid)
     echo "<th>" . _("Saved") . "</th>";
     echo "<th>" . _("Proofreader") . "</th>";
     echo "<th>" . _("WordCheck Events") . "</th>";
+    echo "<th>" . _("Format Preview Events") . "</th>";
     echo "<th>" . _("Current Page State") . "</th>";
     echo "<th>" . _("Current Proofreader") . "</th>";
     echo "</tr>";
@@ -432,7 +433,15 @@ function output_page_list_table(Round $mentored_round, string $projectid)
                     AND round_id = '$mentored_round->id'
                     AND username = p.{$mentored_round->user_column_name}
                     AND image = p.image
-            ) AS wc_events
+            ) AS wc_events,
+            (
+                SELECT count(*)
+                FROM format_preview_events
+                WHERE projectid = '$projectid'
+                    AND round_id = '$mentored_round->id'
+                    AND username = p.{$mentored_round->user_column_name}
+                    AND image = p.image
+            ) AS fp_events
         FROM $projectid AS p
         ORDER BY $order
     ";
@@ -443,6 +452,7 @@ function output_page_list_table(Round $mentored_round, string $projectid)
         echo "<td>" . icu_date("yyyy MMM dd HH:mm", $row["saved_date"]) . "</td>";
         echo "<td>" . $row["username"] . "</td>";
         echo "<td>" . $row["wc_events"] . "</td>";
+        echo "<td>" . $row["fp_events"] . "</td>";
         echo "<td>" . $row["state"] . "</td>";
         echo "<td>" . $row["current_username"] . "</td>";
         echo "</tr>";

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, camelcase */
-/* global $ fontStyles fontFamilies MathJax  */
+/* global $ fontStyles fontFamilies MathJax imageData */
 /*
 This file controls the user interface functions. Initially nothing is displayed
 because "prevdiv" has display:none; which means it is not displayed and the page
@@ -11,6 +11,7 @@ The configuration screen is handled in the same way.
 */
 
 import translate from "../../scripts/gettext.js";
+import { ajax } from "../../scripts/api.js";
 import { makePreview, defaultStyles } from "../../scripts/analyse_format.js";
 import { validateText } from "../../scripts/text_validator.js";
 
@@ -108,6 +109,12 @@ window.addEventListener("DOMContentLoaded", () => {
             return previewStyles.suppress[key];
         });
         someSupp.style.display = warn ? "inline" : "none";
+
+        try {
+            ajax("PUT", `v1/projects/${imageData.projectId}/pages/${imageData.image}/formatpreview`);
+        } catch (error) {
+            alert(error.message);
+        }
     }
 
     // this makes a copy of the style data

--- a/tools/proofers/proof_frame_enh.inc
+++ b/tools/proofers/proof_frame_enh.inc
@@ -20,6 +20,8 @@ function echo_proof_frame_enh(PPage $ppage): void
     $storage_key = "proof-enh" . (($user->profile->i_layout == 1) ? "-v" : "-h");
 
     $image_data = json_encode([
+        "projectId" => $project->projectid,
+        "image" => $ppage->lpage->imagefile,
         "imageUrl" => $ppage->url_for_image(),
         "storageKey" => $storage_key,
         "align" => "L",

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -616,6 +616,8 @@ function get_wordcheck_page_header_args(User $user, PPage $ppage): array
     $storage_key = "proof-enh" . (($user->profile->i_layout == 1) ? "-v" : "-h");
 
     $image_data = json_encode([
+        "projectId" => $project->projectid,
+        "image" => $ppage->lpage->imagefile,
         "imageUrl" => $ppage->url_for_image(),
         "storageKey" => $storage_key,
         "align" => "L",

--- a/tools/proofers/text_frame_std.inc
+++ b/tools/proofers/text_frame_std.inc
@@ -13,6 +13,11 @@ function echo_text_frame_std(PPage $ppage): void
     $switch_confirm = json_encode(_('Are you sure you want to save the current page and change layout?'));
     $revert_confirm = json_encode(_("Are you sure you want to save the current page and revert to the original text for this round?"));
 
+    $image_data = json_encode([
+        "projectId" => $project->projectid,
+        "image" => $ppage->lpage->imagefile,
+    ]);
+
     $header_args = [
         "css_files" => ["$code_url/styles/preview.css"],
         "js_files" => [
@@ -31,6 +36,7 @@ function echo_text_frame_std(PPage $ppage): void
         var standardInterface = true;
         var switchConfirm = '$switch_confirm';
         var revertConfirm = '$revert_confirm';
+        var imageData = $image_data;
         ",
         "body_attributes" => "id='standard_interface_text' onload='ldAll()'",
     ];

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -44,6 +44,7 @@ $action = get_enumerated_param($_POST, 'action', 'showform', ['showform', 'showa
 $transfer_notifications = get_bool_param($_POST, 'transfer_notifications', false);
 $add_deletion_reason = get_bool_param($_POST, 'add_deletion_reason', false);
 $merge_wordcheck_data = get_bool_param($_POST, 'merge_wordcheck_data', false);
+$copy_format_preview_data = get_bool_param($_POST, 'copy_format_preview_data', false);
 $repeat_project = get_enumerated_param($_POST, 'repeat_project', null, ['TO', 'FROM', 'NONE'], true);
 
 switch ($action) {
@@ -54,6 +55,7 @@ switch ($action) {
             $transfer_notifications,
             $add_deletion_reason,
             $merge_wordcheck_data,
+            $copy_format_preview_data,
             $repeat_project,
             false
         );
@@ -66,6 +68,7 @@ switch ($action) {
             $transfer_notifications,
             $add_deletion_reason,
             $merge_wordcheck_data,
+            $copy_format_preview_data,
             $repeat_project,
             true
         );
@@ -78,6 +81,7 @@ switch ($action) {
             $transfer_notifications,
             $add_deletion_reason,
             $merge_wordcheck_data,
+            $copy_format_preview_data,
             true
         );
 
@@ -87,7 +91,8 @@ switch ($action) {
             $from_image_,
             $transfer_notifications,
             $add_deletion_reason,
-            $merge_wordcheck_data
+            $merge_wordcheck_data,
+            $copy_format_preview_data
         );
         echo "\n<input type='hidden' name='action' value='docopy'>";
         echo "\n<input type='submit' name='submit_button' value='" . attr_safe(_("Do it")) ."'>";
@@ -102,6 +107,7 @@ switch ($action) {
             $transfer_notifications,
             $add_deletion_reason,
             $merge_wordcheck_data,
+            $copy_format_preview_data,
             false
         );
 
@@ -124,7 +130,8 @@ switch ($action) {
             $from_image_,
             $transfer_notifications,
             $add_deletion_reason,
-            $merge_wordcheck_data
+            $merge_wordcheck_data,
+            $copy_format_preview_data
         );
 
         echo "<input type='hidden' name='action' value='showagain'>\n";
@@ -145,6 +152,7 @@ function display_copy_pages_form(
     bool $transfer_notifications,
     bool $add_deletion_reason,
     bool $merge_wordcheck_data,
+    bool $copy_format_preview_data,
     ?string $repeat_project,
     bool $repeating
 ): void {
@@ -191,6 +199,12 @@ function display_copy_pages_form(
         $repeating,
         $merge_wordcheck_data
     );
+    do_radio_button_pair(
+        _("Copy Format Preview events into destination project:"),
+        "copy_format_preview_data",
+        $repeating,
+        $copy_format_preview_data
+    );
 
     echo "<tr><td></td><td>";
     echo "<input type='hidden' name='action' value='check'>\n";
@@ -233,7 +247,8 @@ function display_hiddens(
     array $from_image_,
     bool $transfer_notifications,
     bool $add_deletion_reason,
-    bool $merge_wordcheck_data
+    bool $merge_wordcheck_data,
+    bool $copy_format_preview_data
 ): void {
     echo "\n<input type='hidden' name='from_image_[lo]'        value='" . attr_safe($from_image_['lo']) . "'>";
     echo "\n<input type='hidden' name='from_image_[hi]'        value='" . attr_safe($from_image_['hi']) . "'>";
@@ -242,6 +257,7 @@ function display_hiddens(
     echo "\n<input type='hidden' name='transfer_notifications' value='" . ($transfer_notifications ? 1 : 0) . "'>";
     echo "\n<input type='hidden' name='add_deletion_reason'    value='" . ($add_deletion_reason ? 1 : 0) . "'>";
     echo "\n<input type='hidden' name='merge_wordcheck_data'   value='" . ($merge_wordcheck_data ? 1 : 0) . "'>";
+    echo "\n<input type='hidden' name='copy_format_preview_data' value='" . ($copy_format_preview_data ? 1 : 0) . "'>";
 }
 
 function copy_pages(
@@ -250,6 +266,7 @@ function copy_pages(
     bool $transfer_notifications,
     bool $add_deletion_reason,
     bool $merge_wordcheck_data,
+    bool $copy_format_preview_data,
     bool $just_checking
 ): void {
     if (is_null($projectid_)) {
@@ -504,6 +521,14 @@ function copy_pages(
         echo _("WordCheck files and events WILL NOT be merged");
     }
     echo "</li>\n";
+
+    echo "<li>\n";
+    if ($copy_format_preview_data) {
+        echo _("Format Preview events from the source project WILL be merged into the destination project");
+    } else {
+        echo _("Format Preview events WILL NOT be merged");
+    }
+    echo "</li>\n";
     echo "</ul>\n";
 
     if ($just_checking) {
@@ -663,6 +688,13 @@ function copy_pages(
         echo "<p>" . _("Merging WordCheck files and events.") . "</p>\n";
         if ($for_real) { /** @phpstan-ignore-line */
             merge_project_wordcheck_data($projectid_['from'], $projectid_['to'], $c_src_image_);
+        }
+    }
+
+    if ($copy_format_preview_data) {
+        echo "<p>" . _("Copying Format Preview events.") . "</p>\n";
+        if ($for_real) { /** @phpstan-ignore-line */
+            FormatPreview::copy_project_events($projectid_['from'], $projectid_['to'], $c_src_image_);
         }
     }
 }

--- a/tools/site_admin/rename_pages.php
+++ b/tools/site_admin/rename_pages.php
@@ -388,6 +388,26 @@ switch ($submit_button) {
                     ";
                 }
 
+                // now the format_preview_events table
+                $fpe_query = sprintf(
+                    "
+                    UPDATE format_preview_events
+                    SET image = '%s'
+                    WHERE projectid = '%s' AND image = '%s'
+                    ",
+                    DPDatabase::escape($new_image),
+                    DPDatabase::escape($projectid),
+                    DPDatabase::escape($old_image)
+                );
+                echo $fpe_query;
+                if ($for_real) { /** @phpstan-ignore-line */
+                    DPDatabase::query($fpe_query);
+                    $n = DPDatabase::affected_rows();
+                    echo "
+                        $n rows affected.
+                    ";
+                }
+
                 // finally, the page_events table
                 $pe_query = sprintf(
                     "


### PR DESCRIPTION
This implements [Task 2117](https://www.pgdp.net/c/tasks.php?action=show&task_id=2117) which requests that we keep track of when a user runs Format Preview just like we do for when they run WordCheck.

Unlike WordCheck which is all server-side PHP, Format Preview is all JS, so we build on top of Ray's new proofreading API framework to have Format Preview log when a user has _entered_ Format Preview. Also unlike WordCheck, we only log a single DB row for the last time a user has run Format Preview on a page, rather than every usage. Like WordCheck, we keep track of when a user runs Format Preview in any round, even though we only show status for the Formatting rounds (for WordCheck we only show status in Proofreading rounds).

In JS-land we're reusing the existing `imageData` object which is a bit of a kludge but seems reasonable until we get the new PI in place.

Of note, we wire handling of `format_preview_events` into these important places alongside `wordcheck_events`:
* Archiving
* Project deletion
* Project rename
* Page data pruning

This PR (and the sandbox) contains a second commit that will only be checked into `pgdp-production`. This commit will include a timestamp for when the code is deployed to PROD and alert users (and PMs) if the page was saved before Format Preview tracking was enabled, rather than reporting that Format Preview wasn't run on the page which would be inaccurate as we don't know if it was or not.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/format-preview-tracking/

Big thanks to @70ray for laying the groundwork that made the API side of this super easy.