### PR TITLE
Only copy specific wordcheck_events

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -632,8 +632,10 @@ function delete_project_wordcheck_events($projectid)
  * Merge the word list from the source project into the destination
  * project, and also copy the wordcheck events to the destination
  * project.
+ *
+ * @param string[] $images
  */
-function merge_project_wordcheck_data($from_projectid, $to_projectid)
+function merge_project_wordcheck_data(string $from_projectid, string $to_projectid, array $images = []): void
 {
     // good words
     $from_words = load_project_good_words($from_projectid);
@@ -648,29 +650,36 @@ function merge_project_wordcheck_data($from_projectid, $to_projectid)
     save_project_bad_words($to_projectid, $to_words);
 
     // suggestions
-    copy_project_wordcheck_events($from_projectid, $to_projectid);
+    copy_project_wordcheck_events($from_projectid, $to_projectid, $images);
 }
 
 /**
  * Copy wordcheck events from one project to another project.
  *
- * This is used for instance when splitting or rejoining project parts.
+ * This is used when splitting or rejoining project parts.
+ *
+ * @param string[] $images
  */
-function copy_project_wordcheck_events($from_projectid, $to_projectid)
+function copy_project_wordcheck_events(string $from_projectid, string $to_projectid, array $images = []): void
 {
+    if ($images) {
+        $images_where = " AND image in (" . surround_and_join(array_map("DPDatabase::escape", $images), '"', '"', ",") . ")";
+    } else {
+        $images_where = "";
+    }
+
     $sql = sprintf(
         "
         INSERT INTO wordcheck_events
             (projectid, timestamp, image, round_id, username, suggestions)
         SELECT '%s', timestamp, image, round_id, username, suggestions
         FROM wordcheck_events
-        WHERE projectid = '%s'
+        WHERE projectid = '%s' $images_where
         ",
         DPDatabase::escape($to_projectid),
         DPDatabase::escape($from_projectid)
     );
     DPDatabase::query($sql);
-    // no results for an INSERT clause, so no need to free the results.
 }
 
 // -----------------------------------------------------------------------------

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -737,7 +737,7 @@ function copy_pages(
     if ($merge_wordcheck_data) {
         echo "<p>" . _("Merging WordCheck files and events.") . "</p>\n";
         if ($for_real) { /** @phpstan-ignore-line */
-            merge_project_wordcheck_data($projectid_['from'], $projectid_['to']);
+            merge_project_wordcheck_data($projectid_['from'], $projectid_['to'], $c_src_image_);
         }
     }
 }


### PR DESCRIPTION
`copy_pages` is currently copying _all_ `wordcheck_events` from the source project to the destination project. Just copy the events for the pages being copied.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/copy-only-specific-wc-events/

The best way to validate this is looking at the `wordcheck_events` table for the specific projectid before/after. A good destination project (with no `wordcheck_events`) is projectID67f88a723088b