### PR TITLE
Wordcheck handles old texts markup

### DIFF
--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -9,10 +9,12 @@ use voku\helper\UTF8;
 // Handle dp-specific notation for non-Latin-1 characters
 // See faq/proofreading_guidelines.php#d_chars
 // and tools/proofers/process_diacritcal_markup.js
+// And handle [n] [m] and [que] as parts of a word as described
+// in the Proofing old texts wiki page.
 // $base and $mark are only used to define $bracketed_character_pattern
 $base = "\w{1,2}";    // pattern for: markable base character
 $mark = '[=:.`\\\\\'/v)(~,^\\\\\*]'; // pattern for: diacritical mark
-$bracketed_character_pattern = "\\[(?:oe|OE|$mark$base|$base$mark)\\]";
+$bracketed_character_pattern = "\\[(?:oe|OE|n|m|que|$mark$base|$base$mark)\\]";
 
 // This is used when splitting a text into words.
 $char_pattern = "(?:\w\pM*|$bracketed_character_pattern)";


### PR DESCRIPTION
Reference [Proofing old texts](https://www.pgdp.net/wiki/DP_Official_Documentation:Proofreading/Proofing_old_texts#Nasal_abbreviations).
This adds support for [n] [m] and [que] markup within a word, which allows words such as cou[n]trey to be in the good word list, and not flagged by wordcheck. Similarly, the word pla[n]ting will be flagged as a whole word if it is not in the good word list.

I tested this with the project Legend Land Volume 4 (in P1), to which I added a few words to the GWL.
Sandbox at https://www.pgdp.org/~mrducky/c.branch/wordcheck