### PR TITLE
Correct location of download temp directory

### DIFF
--- a/crontab/CleanDownloadTemp.inc
+++ b/crontab/CleanDownloadTemp.inc
@@ -8,9 +8,7 @@ class CleanDownloadTemp extends BackgroundJob
 
     public function work()
     {
-        global $dyn_dir;
-
-        $download_temp_dir = realpath("$dyn_dir/download_tmp");
+        $download_temp_dir = realpath(SiteConfig::get()->dyn_dir . "/download_tmp");
         if (! is_dir($download_temp_dir)) {
             $this->stop_message = "No download temp directory found, nothing to do.";
             return;


### PR DESCRIPTION
Correctly specify the location of the download temp directory. This has been broken since we merged in SiteConfig in late May, but this wasn't running on PROD from around the month before when I failed to update the crontab that runs it after this was moved to a BackgroundJob.

The change in the PR has been hotfixed on PROD.