### PR TITLE
Include timezone in AutoModify logs

### DIFF
--- a/crontab/AutoModify.inc
+++ b/crontab/AutoModify.inc
@@ -17,7 +17,7 @@ class AutoModify extends BackgroundJob
         if (! is_dir($logs_dir)) {
             mkdir($logs_dir, 0777, true);
         }
-        $this->logfile = sprintf("$logs_dir/%s.txt", date("Y-m-d_H:i:s"));
+        $this->logfile = sprintf("$logs_dir/%s.txt", date("Y-m-d_H:i:s_T"));
         $this->filehandle = fopen($this->logfile, "wt");
         ob_start([$this, 'flush'], 1024);
 


### PR DESCRIPTION
Fixes #1463 with the least effort possible.

Example of string on PROD:
```php
<?php
echo(date("Y-m-d_H:i:s_T") . "\n");
```

```bash
cpeel@prod8:~$ php test.php
2025-11-23_19:04:31_EST
```