### PR TITLE
Decrease cached time for PP graph

### DIFF
--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -35,8 +35,8 @@ function _get_pages_posted_data($start_timestamp)
 
 // Get the total pages for projects that have posted in current month
 $start_timestamp = mktime(0, 0, 0, (int)date('m'), 1, (int)date('Y'));
-// cache pages posted data for 1 day
-$pp_pages_total = query_graph_cache("_get_pages_posted_data", [$start_timestamp], 60 * 60 * 24);
+// cache pages posted data for 1 hour
+$pp_pages_total = query_graph_cache("_get_pages_posted_data", [$start_timestamp], 60 * 60);
 
 // calculate the goal percent as long as $pp_page_goal isn't zero
 if ($pp_page_goal != 0) {


### PR DESCRIPTION
Cache the PP stats graph for only an hour instead of a day. This query is using an index against the projects table so the performance impact is minimal.