### PR TITLE
Prepare for removing the daily page limit from French projects

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,6 +33,8 @@ parameters:
           path: pinc/DifferenceEngineWrapper.inc
         - message: '#Call to function is_array\(\) with array<string> will always evaluate to true.#'
           path: pinc/3rdparty/mediawiki/WordLevelDiff.php
+        - message: '#Function get_dpl_enforcement_for_user\(\) never returns null.*#'
+          path: pinc/daily_page_limit.inc
 
         - message: '#invoked with \d+ parameter(s?), \d+((-\d+)?) required#'
         - message: '#Variable .* might not be defined#'

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -399,8 +399,8 @@ class LPage
     public function attemptSaveAsDone(string $text_data, string $pguser): array
     {
         if ($this->round->has_a_daily_page_limit()) {
-            $pre_save_dpl_count = get_dpl_count_for_user_in_round($pguser, $this->round);
-            if ($pre_save_dpl_count >= $this->round->daily_page_limit) {
+            $pre_save_dpl_count = get_dpl_enforcement_for_user($pguser, $this->round, $this->project);
+            if ($pre_save_dpl_count !== null && $pre_save_dpl_count >= $this->round->daily_page_limit) {
                 // The user has already reached their limit of this kind of page.
                 return [false, true];
             }
@@ -414,6 +414,8 @@ class LPage
 
         $dpl_has_now_been_reached = (
             $this->round->has_a_daily_page_limit()
+            &&
+            $pre_save_dpl_count !== null
             &&
             ($pre_save_dpl_count + 1 >= $this->round->daily_page_limit)
         );

--- a/pinc/daily_page_limit.inc
+++ b/pinc/daily_page_limit.inc
@@ -31,11 +31,27 @@ include_once($relPath.'TallyBoard.inc');
  * page-tally for that round since the last snapshot.
  * (i.e., the net number of save-as-dones in that round today.)
  */
-function get_dpl_count_for_user_in_round($username, $round)
+function get_dpl_count_for_user_in_round(string $username, Round $round): int
 {
     $user = new User($username);
 
     $round_tallyboard = new TallyBoard($round->id, 'U');
 
     return $round_tallyboard->get_delta_since_latest_snapshot($user->u_id);
+}
+
+/**
+ * Get the current daily page limit enforcement value
+ *
+ * If the DPL is enforced for this user, it returns the number of pages
+ * the user has done in the specified round. If the DPL is not enforced
+ * for this user/round/project for some reason, return Null.
+ */
+function get_dpl_enforcement_for_user(string $username, Round $round, Project $project): ?int
+{
+    // This function is a placeholder for sites to add any per-project
+    // customizations that might bypass the DPL enforcement. So while it
+    // doesn't currently return null, it might after site-specific updates.
+
+    return get_dpl_count_for_user_in_round($username, $round);
 }

--- a/project.php
+++ b/project.php
@@ -18,7 +18,7 @@ include_once($relPath.'links.inc'); // new_window_link
 include_once($relPath.'project_edit.inc'); // check_user_can_load_projects
 include_once($relPath.'forum_interface.inc'); // get_last_post_time_in_topic & get_url_*()
 include_once($relPath.'faq.inc');
-include_once($relPath.'daily_page_limit.inc'); // get_dpl_count_for_user_in_round
+include_once($relPath.'daily_page_limit.inc'); // get_dpl_enforcement_for_user
 include_once($relPath.'special_colors.inc'); // load_special_days
 
 // This page originally allowed unauthenticated users and showed them a limited
@@ -264,8 +264,11 @@ function decide_blurbs(): array
     //
     $page_limit_warning = "";
     if ($round->has_a_daily_page_limit()) {
-        $user_dpl_count = get_dpl_count_for_user_in_round($pguser, $round);
-        if ($user_dpl_count >= $round->daily_page_limit) {
+        $user_dpl_count = get_dpl_enforcement_for_user($pguser, $round, $project);
+        if ($user_dpl_count === null) {
+            $msg = _('This project is currently exempt from the daily page limit.');
+            $page_limit_warning = "<br>\n<span class='warning'>$msg</span>\n";
+        } elseif ($user_dpl_count >= $round->daily_page_limit) {
             // User has reached this round's DPL.
             $msg = sprintf(
                 _('%1$s limits you to %2$d page-saves per day, and you have already reached that limit today.'),


### PR DESCRIPTION
The GM has requested that we allow some projects, such as those in French, to bypass enforcement of the daily page limits. This PR includes the commit that will be merged into `master` that creates the framework to allow some projects to bypass the DPL. This includes a new string on the project page for these projects.

A follow-up commit will go into `pgdp-production` that will remove the DPL for French projects (either `French` or `French with <blah>`).

Sandbox: https://www.pgdp.org/~cpeel/c.branch/prep-for-dpl-hacking/