### PR TITLE
Remove unnecessary page_controls.inc usage

### DIFF
--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -6,7 +6,6 @@ include_once($relPath.'LPage.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'slim_header.inc');
 include_once($relPath.'Stopwatch.inc');
-include_once($relPath.'page_controls.inc');
 include_once($relPath.'post_files.inc');
 include_once("./word_freq_table.inc");
 
@@ -33,8 +32,7 @@ $header_args = [
     "js_modules" => [
         "$code_url/tools/project_manager/show_word_context.js",
     ],
-    "js_data" => get_proofreading_interface_data_js() . "
-        var showWordContext = $details;",
+    "js_data" => "var showWordContext = $details;",
 
     "body_attributes" => 'class="no-margin overflow-hidden" style="height: 100vh; width: 100vw;"',
 ];

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -5,7 +5,6 @@ include_once($relPath.'wordcheck_engine.inc');
 include_once($relPath.'LPage.inc');
 include_once($relPath.'Project.inc');
 include_once($relPath.'slim_header.inc');
-include_once($relPath.'page_controls.inc'); // get_proofreading_interface_data_js()
 include_once($relPath.'post_files.inc'); // page_info_query()
 include_once("./word_freq_table.inc"); // enforce_edit_authorization(), decode_word()
 
@@ -32,9 +31,7 @@ $header_args = [
     "js_modules" => [
         "$code_url/tools/project_manager/show_word_context.js",
     ],
-    "js_data" => get_proofreading_interface_data_js() . "
-        var showWordContext = $details;",
-
+    "js_data" => "var showWordContext = $details;",
     "body_attributes" => 'class="no-margin overflow-hidden" style="height: 100vh; width: 100vw;"',
 ];
 


### PR DESCRIPTION
While working on cleaning up the new PI branch I discovered that we use `page_controls.inc` here but we don't need to. We only need `get_proofreading_interface_data_js()` if we're using the text pane of the Page Browser, but the context windows only show the image.

Testing will be confirming that the WordCheck PM tools, like showing the context of a proofreader suggestion, all still work and there are no errors on the browser console.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/remove-extraneous-page-controls