### PR TITLE
Remove user-preferred proofreading font used elsewhere

### DIFF
--- a/faq/font_sample.php
+++ b/faq/font_sample.php
@@ -2,18 +2,11 @@
 $relPath = '../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
-include_once($relPath.'prefs_options.inc');
 
 // Note: The text used for font sample images is stored in font_sample.txt
 
 $title = _("Proofreading Font Comparison");
 output_header($title, NO_STATSBAR);
-
-// determine user's current proofreading font, if any and use that as the compare_font
-[$proofreading_font, , $proofreading_font_family] = get_user_proofreading_font();
-if (!$proofreading_font) {
-    $proofreading_font = 'monospace';
-}
 
 // print page header
 echo "<h1>$title</h1>\n";
@@ -24,7 +17,6 @@ echo "<h2>" . _("Available Proofreading Fonts") . "</h2>";
 
 echo "<p>" . sprintf(_("The following fonts can be selected in your <a href='%s'>preferences</a> for use in the proofreading interface. Browser default is whatever font your browser renders monospace text in unless told otherwise, often Courier or Courier New. The other fonts are available as web fonts and can be selected and used without having them installed on your computer."), "$code_url/userprefs.php?tab=1") . "</p>";
 
-$show_user_custom_font = true;
 foreach (get_available_proofreading_font_faces() as $index => $name) {
     if ($index == 1) { // other
         continue;
@@ -37,17 +29,7 @@ foreach (get_available_proofreading_font_faces() as $index => $name) {
         $font = $name;
     }
 
-    if ($font == $proofreading_font) {
-        $show_user_custom_font = false;
-    }
-
-    show_font_specimen($name, $font, $proofreading_font);
-}
-
-if ($show_user_custom_font) {
-    echo "<h2 style='clear: both;'>" . _("Custom Proofreading Font") . "</h2>";
-    echo "<p>" . _("Your current proofreading font is one you've specified by name. This is what a specimen looks like in that font.") . "</p>";
-    show_font_specimen($proofreading_font, $proofreading_font);
+    show_font_specimen($name, $font);
 }
 
 echo "<h2 id='DPSansMono' style='clear: both;'>DP Sans Mono</h2>";
@@ -78,25 +60,19 @@ $character_sets = [
 
 echo "<div style='float: left; padding-right: 1em; margin-bottom: 1em;'>";
 echo "<span style='font-family: monospace;'>" . BROWSER_DEFAULT_STR . "</span><br>";
-if ($proofreading_font !== 'monospace' && $proofreading_font != 'DP Sans Mono') {
-    echo "<span style=\"font-family: $proofreading_font_family;\">" . html_safe($proofreading_font) . "</span><br>";
-}
 echo "<span style='font-family: DP Sans Mono;'>DP Sans Mono</span>";
 echo "</div>";
 
 foreach ($character_sets as $set) {
     echo "<div style='float: left; padding-right: 0.5em; margin-bottom: 1em;'>";
     echo "<span style='font-family: monospace;'>$set</span><br>";
-    if ($proofreading_font !== 'monospace' && $proofreading_font != 'DP Sans Mono') {
-        echo "<span style=\"font-family: $proofreading_font_family;\">$set</span><br>";
-    }
     echo "<span style='font-family: DP Sans Mono;'>$set</span>";
     echo "</div>";
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_font_specimen($name, $font, $proofreading_font = null)
+function show_font_specimen($name, $font)
 {
     echo "<div style='float: left; margin-right: 1em; margin-top: 0;'>";
     //echo "<h3>$name</h3>";
@@ -107,9 +83,5 @@ function show_font_specimen($name, $font, $proofreading_font = null)
     echo "0123456789<br>";
     echo "!@#$%^&*()[]{}&lt;&gt;'\";:.,\/?<br>";
     echo "</p>";
-
-    if ($font == $proofreading_font) {
-        echo "<p><i>" . _("This is your current proofreading font.") . "</i></p>";
-    }
     echo "</div>";
 }

--- a/pinc/DifferenceEngineWrapperTable.inc
+++ b/pinc/DifferenceEngineWrapperTable.inc
@@ -1,7 +1,6 @@
 <?php
 // This file inherits from DifferenceEngineWrapper to facilitate
 // formatting diffs in an HTML table.
-include_once($relPath."prefs_options.inc"); // get_user_proofreading_font()
 include_once($relPath."DifferenceEngineWrapper.inc");
 include_once($relPath."3rdparty/mediawiki/TableDiffFormatter.php");
 
@@ -62,11 +61,6 @@ class DifferenceEngineWrapperTable extends DifferenceEngineWrapper
  */
 function get_DifferenceEngine_css_data()
 {
-    [, $font_size, $font_family] = get_user_proofreading_font();
-    if ($font_size != '') {
-        $font_size = "font-size: $font_size;";
-    }
-
     return "
 .diff-otitle,
 .diff-ntitle {
@@ -76,8 +70,7 @@ function get_DifferenceEngine_css_data()
 .diff-addedline,
 .diff-deletedline,
 .diff-context {
-    font-family: $font_family;
-    $font_size
+    font-family: DP Sans Mono;
 }
 /* Adjust padding to prevent descenders from being chopped off. Task 1936 */
 .diff-deletedline .diffchange,

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1726,6 +1726,7 @@ td.has-diff {
 
 .gs-char {
     font-size: 1.5em;
+    font-family: DP Sans Mono;
 }
 
 .gs-codepoint {

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -2731,6 +2731,7 @@ td.has-diff {
 /* CharSuite Explorer */
 .gs-char {
   font-size: 1.5em;
+  font-family: DP Sans Mono;
 }
 .gs-codepoint {
   font-size: 0.7em;

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2731,6 +2731,7 @@ td.has-diff {
 /* CharSuite Explorer */
 .gs-char {
   font-size: 1.5em;
+  font-family: DP Sans Mono;
 }
 .gs-codepoint {
   font-size: 0.7em;

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2731,6 +2731,7 @@ td.has-diff {
 /* CharSuite Explorer */
 .gs-char {
   font-size: 1.5em;
+  font-family: DP Sans Mono;
 }
 .gs-codepoint {
   font-size: 0.7em;

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2731,6 +2731,7 @@ td.has-diff {
 /* CharSuite Explorer */
 .gs-char {
   font-size: 1.5em;
+  font-family: DP Sans Mono;
 }
 .gs-codepoint {
   font-size: 0.7em;

--- a/tools/charsuites.php
+++ b/tools/charsuites.php
@@ -4,7 +4,6 @@ include_once($relPath."base.inc");
 include_once($relPath."theme.inc");
 include_once($relPath."unicode.inc");
 include_once($relPath."CharSuites.inc");
-include_once($relPath."prefs_options.inc");
 include_once($relPath."Project.inc"); // get_projectID_param()
 
 require_login();
@@ -30,12 +29,9 @@ if ($charsuite_name && !$projectid) {
     }
 }
 
-[, , $font_family, ] = get_user_proofreading_font();
-$extra_args['css_data'] = ".gs-char { font-family: $font_family; }";
-
 if ($charsuite) {
     $title = _("Character Suite");
-    output_header($title, NO_STATSBAR, $extra_args);
+    output_header($title, NO_STATSBAR);
     echo "<h1>" . html_safe($title) . "</h1>";
     echo "<p><a href='?'>" . _("View all character suites") . "</a></p>";
     echo "<p>";
@@ -48,7 +44,7 @@ if ($charsuite) {
 } elseif ($projectid) {
     $project = new Project($projectid);
     $title = _("Project Character Suites");
-    output_header($title, NO_STATSBAR, $extra_args);
+    output_header($title, NO_STATSBAR);
     echo "<h1>" . html_safe($title) . "</h1>";
     echo "<p>" . sprintf(
         _("Character Suites for <a href='%s'>%s</a>."),
@@ -61,7 +57,7 @@ if ($charsuite) {
     }
 } else {
     $title = _("All Character Suites");
-    output_header($title, NO_STATSBAR, $extra_args);
+    output_header($title, NO_STATSBAR);
     echo "<h1>" . html_safe($title) . "</h1>";
     echo "<p>";
     echo _("Below are all enabled character suites in the system.");


### PR DESCRIPTION
In the new proofreading interface, the PI will control what font the user is proofreading in and store that either in the local browser cache or as an opaque client JSON blob on the server -- the server won't know what the font is. The simplest thing to do is to just use `DP Sans Mono` outside the PI.

This only materially impacts:
* Page diffs -- the most user-visible
* Character suite pages

Sandbox: https://www.pgdp.org/~cpeel/c.branch/remove-proofer-font-outside-pi/