### PR TITLE
Narrow the "is local" redirection check

### DIFF
--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -37,8 +37,15 @@ function metarefresh(int $seconds, string $url, string $title = "", string $body
     }
 
     // If $allow_external is FALSE and the URL isn't local, redirect the
-    // user to the homepage.
-    if (!$allow_external && !str_starts_with($absolute_url, $code_url)) {
+    // user to the homepage. Local is defined as the URLs having the same
+    // scheme, host, and port -- ignoring any path.
+    $absolute_url_parts = parse_url($absolute_url);
+    $code_url_parts = parse_url($code_url);
+    if (!$allow_external && !(
+        ($absolute_url_parts["scheme"] == $code_url_parts["scheme"]) &&
+        ($absolute_url_parts["host"] == $code_url_parts["host"]) &&
+        (($absolute_url_parts["port"] ?? "") == ($code_url_parts["port"] ?? ""))
+    )) {
         $absolute_url = "$code_url/index.php";
     }
 


### PR DESCRIPTION
Rather than a strict prefix check for `$code_url`, let any URL that matches the `$code_url` schema/host/port count as local. This will allow, for instance, noncvs pages that require a login to log the user in and then return back to the noncvs page. Right now in this flow the user is dumped back to the Activity Hub and has to navigate back.

This will allow us to redirect users to sandboxes on login on TEST as well.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/refine-login-redirect-check/

Test by:
1. logging out of TEST
2. going to https://www.pgdp.org/~cpeel/c.branch/refine-login-redirect-check/?destination=https://www.pgdp.org/noncvs/control_panel.php
3. log in and you should be redirected back to the control panel