### PR TITLE
WordCheck highlights all uncommon script characters when all languages are deselected

### DIFF
--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -55,7 +55,7 @@ function spellcheck_text($orig_text, $projectid, $imagefile, $languages, $accept
         [$badWordHash, $languages, $messages] =
             get_bad_word_levels_for_project_text($orig_text, $projectid, $languages, $accepted_words);
     } else {
-        [$badWordHash, $languages, $messages] = [ [], [], [] ];
+        [$badWordHash, $languages, $messages] = [[], [], []];
     }
 
     [$uncommonScriptWords, $uncommonScripts] =


### PR DESCRIPTION
[Feature request from Tony Browne.](https://www.pgdp.net/phpBB3/viewtopic.php?t=85193)
When there are no languages included for the spell check, then suppress all bad word indications so that no `<input>` boxes appear in the text. This allows the uncommon script highlighting to work for the entire text.

sandbox [here](https://www.pgdp.org/~mrducky/c.branch/uncommon_scripts/)