### PR TITLE
Upgrade GitHub action versions

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -2,7 +2,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
     - name: Install NPM packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.cfg.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, composer
         uses: ./.github/actions/setup-php
         with:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.cfg.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node, NPM
         uses: ./.github/actions/setup-node
       - name: Run js unit tests
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.cfg.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, composer
         uses: ./.github/actions/setup-php
         with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, composer
         uses: ./.github/actions/setup-php
         with:
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, composer
         uses: ./.github/actions/setup-php
         with:
@@ -109,7 +109,7 @@ jobs:
     runs-on: ${{ matrix.cfg.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP, composer
         uses: ./.github/actions/setup-php
         with:


### PR DESCRIPTION
Github is encouraging users to update some of the actions due to an upcoming node version deprecation -- note the "annotation" at the top of https://github.com/DistributedProofreaders/dproofreaders/actions/runs/23518173121/job/68455292460

This just revs the versions of the actions, it doesn't impact any of our code itself. If the CI passes that's validation that it's working.