### PR TITLE
Remove leading/trailing whitespace from credit parts

### DIFF
--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1367,8 +1367,8 @@ class Project
             'pp' => $this->postproofer,     // username
             'ip' => $this->image_preparer,  // username
             'tp' => $this->text_preparer,   // username
-            'ec' => $this->extra_credits,   // arbitrary text
-            'cp' => $this->scannercredit,    // username or arbitrary text
+            'ec' => trim($this->extra_credits), // arbitrary text
+            'cp' => trim($this->scannercredit), // username or arbitrary text
         ];
 
         foreach ($creditables as $role => $name) {
@@ -1961,7 +1961,7 @@ function get_credit_name(string $login_name): string
             $name = $login_name;
         }
     }
-    return $name;
+    return trim($name);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
Ensure that all components used to build the credits field do not have leading or trailing whitespace. This could come from a user's real name field or "other" value, scanner credit, or extra credit.

Note we don't have to do this for usernames as leading and trailing whitespace characters are not valid in usernames.

Fixes https://github.com/DistributedProofreaders/dproofreaders/issues/1570

Sandbox: https://www.pgdp.org/~cpeel/c.branch/trim-credit-components/