### PR TITLE
Add 'no-dup-check' warning to catalog search

### DIFF
--- a/pinc/pg.inc
+++ b/pinc/pg.inc
@@ -6,6 +6,7 @@ global $PG_home_url;
 $PG_home_url = "https://www.gutenberg.org";
 $PG_faq_url = "https://www.gutenberg.org/help/faq.html";
 $PGLAF_upload_url = "https://upload.pglaf.org";
+$PGLAF_inprogress_url = "https://inprogress.pglaf.org";
 
 // -----------------------------------------------------------------------------
 

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -98,7 +98,6 @@ if ($action == 'show_query_form') {
 
 function show_query_form()
 {
-    global $code_url;
     global $search_params;
     global $PGLAF_inprogress_url;
 
@@ -128,9 +127,8 @@ function show_query_form()
         echo _("Please put in as much information as possible to search for your project.  The more information the better but if not accurate enough may rule out results.");
         echo "</p><p>";
         echo sprintf(
-            _("This catalog search does not check for duplicates. Before creating a project, <strong>please check for duplicates</strong> using <a href='%1\$s'>PG's In Progress search</a> and <a href='%2\$s'>DP's Project Search</a>!"),
-            $PGLAF_inprogress_url,
-            "$code_url/tools/search.php"
+            _("This catalog search does not check for duplicates. Before creating a project, <strong>please check for duplicates</strong> using <a href='%s'>PG's In Progress search</a>!"),
+            $PGLAF_inprogress_url
         );
         echo "</p>";
 

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -7,7 +7,7 @@ $relPath = '../../pinc/';
 include_once($relPath.'base.inc');
 include_once($relPath.'theme.inc');
 include_once($relPath.'MARCRecord.inc');
-
+include_once($relPath.'pg.inc');
 
 $title_attrs = [
     // Bib-1 Use, Title (attribute 4)
@@ -98,7 +98,9 @@ if ($action == 'show_query_form') {
 
 function show_query_form()
 {
+    global $code_url;
     global $search_params;
+    global $PGLAF_inprogress_url;
 
     $title = _("Create a Project");
     output_header($title);
@@ -124,6 +126,12 @@ function show_query_form()
 
         echo "<p>";
         echo _("Please put in as much information as possible to search for your project.  The more information the better but if not accurate enough may rule out results.");
+        echo "</p><p>";
+        echo sprintf(
+            _("This catalog search does not check for duplicates. Before creating a project, <strong>please check for duplicates</strong> using <a href='%1\$s'>PG's In Progress search</a> and <a href='%2\$s'>DP's Project Search</a>!"),
+            $PGLAF_inprogress_url,
+            "$code_url/tools/search.php"
+        );
         echo "</p>";
 
         $url = "external_catalog_search.php?" . search_query_params();


### PR DESCRIPTION
Some PMs may not realize that the catalog search does not check for duplicates. Add warning, and link to the pglaf in-progress search, and to the DP project search.

Sandbox [here](https://www.pgdp.org/~srjfoo/c.branch/warn-search-for-dups/tools/project_manager/external_catalog_search.php). Should only need a check to verify that the explanatory text is visible (assuming no code changes are needed).