### PR TITLE
external_catalog_search.php: Remove attrs unsupported by z3950.loc.gov

### DIFF
--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -9,44 +9,6 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'MARCRecord.inc');
 include_once($relPath.'pg.inc');
 
-$title_attrs = [
-    // Bib-1 Use, Title (attribute 4)
-    // "A word, phrase, character, or group of characters, normally appearing in an item,
-    // that names the item or the work contained in it.
-    // Matches 130, 21X-24X, 440, 490, 730, 740, 830, 840, subfield $t in 400, 410, 410, 600,
-    // 610, 611, 700, 710, 711, 800, 810, 811"
-    // That leads to broad matches, similar to the KTIL LoC advanced search, but
-    // sometimes is necessary due to missing fields in MARC records.
-    // https://catalog.loc.gov/vwebv/ui/en_US/htdocs/help/searchExamples.html#KTIL
-
-    4 => _("Title (wide)"),
-    // Bib-1 Use, Title Uniform (attribute 6)
-    // "The particular title by which a work is to be identified for cataloging purposes.
-    // Matches [MARC fields] 130, 240, 730; subfield $t in 700, 710, 711."
-    // Seems to have the same behavior as the KTUT advanced search on the LoC website
-    // https://catalog.loc.gov/vwebv/ui/en_US/htdocs/help/searchExamples.html#KTUT
-    6 => _("Title (narrow)"),
-];
-
-$author_attrs = [
-    // Bib-1 Use, Author-name-personal (attribute 1004)
-    // "A person's real name, pseudonym, title of nobility nickname, or initials.
-    // (Differs from attribute "Author-name" in that personal name subject
-    // headings are not included.)
-    // [Matches MARC fields] 100, 400, 700, 800"
-    // Seems similar to KPNC advanced search on LoC website.
-    // https://catalog.loc.gov/vwebv/ui/en_US/htdocs/help/searchExamples.html#KPNC
-    1004 => _("Author name (personal)"),
-
-    // Bib-1 Use, Author-name (attribute 1003).
-    // "A personal or corporate author or a conference or meeting name.
-    // (No subject name headings are included.)
-    // [Matches MARC fields] 100, 110, 111, 400, 410, 411, 700, 710, 711, 800, 810, 811)"
-    // That leads to broad matches, similar to the KNAM advanced search.
-    // https://catalog.loc.gov/vwebv/ui/en_US/htdocs/help/searchExamples.html#KNAM
-    1003 => _("Author name (all)"),
-];
-
 $serial_attrs = [
     9 => _('LCCN'), // Library of Congress Control Number
     8 => _('ISSN'), // International Standard Serial Number
@@ -54,8 +16,8 @@ $serial_attrs = [
 ];
 
 $search_params = [
-    'title' => ['type' => 'attr', 'attrs' => $title_attrs],
-    'author' => ['type' => 'attr', 'attrs' => $author_attrs],
+    'title' => ['type' => 'text', 'name' => _("Title (wide)")],
+    'author' => ['type' => 'text', 'name' => _("Author name (all)")],
     'publisher' => ['type' => 'text', 'name' => _('Publisher')],
     'pubdate' => ['type' => 'text', 'name' => _('Publication Year (eg: 1912)')],
     'serial' => ['type' => 'attr', 'attrs' => $serial_attrs],
@@ -386,7 +348,7 @@ function display_record_table(MARCRecord $marc_record, bool $hide_nontext): void
 
 function query_format()
 {
-    global $title_attrs, $author_attrs, $serial_attrs;
+    global $serial_attrs;
     // Build a Z39.50 Type-1 query.
     // See
     // https://www.loc.gov/z3950/agency/markup/09.html Type-1 and Type-101 Queries
@@ -409,8 +371,15 @@ function query_format()
     $fullquery = [];
 
     if ($_REQUEST['title']) {
-        $attr = get_enumerated_param($_REQUEST, 'title_attr', null, array_keys($title_attrs));
-        $fullquery[] = sprintf('@attr 1=%s "%s"', $attr, $_REQUEST['title']);
+        // Bib-1 Use, Title (attribute 4)
+        // "A word, phrase, character, or group of characters, normally appearing in an item,
+        // that names the item or the work contained in it.
+        // Matches 130, 21X-24X, 440, 490, 730, 740, 830, 840, subfield $t in 400, 410, 410, 600,
+        // 610, 611, 700, 710, 711, 800, 810, 811"
+        // That leads to broad matches, similar to the KTIL LoC advanced search, but
+        // sometimes is necessary due to missing fields in MARC records.
+        // https://catalog.loc.gov/vwebv/ui/en_US/htdocs/help/searchExamples.html#KTIL
+        $fullquery[] = sprintf('@attr 1=4 "%s"', $_REQUEST['title']);
     }
     if ($_REQUEST['author']) {
         // Convert author to "Surname, Forename" if it doesn't already contain a comma.
@@ -421,8 +390,13 @@ function query_format()
                 $author = substr($author, $p) . ", " . substr($author, 0, $p);
             }
         }
-        $attr = get_enumerated_param($_REQUEST, 'author_attr', null, array_keys($author_attrs));
-        $fullquery[] = sprintf('@attr 1=%s "%s"', $attr, trim($author));
+        // Bib-1 Use, Author-name (attribute 1003).
+        // "A personal or corporate author or a conference or meeting name.
+        // (No subject name headings are included.)
+        // [Matches MARC fields] 100, 110, 111, 400, 410, 411, 700, 710, 711, 800, 810, 811)"
+        // That leads to broad matches, similar to the KNAM advanced search.
+        // https://catalog.loc.gov/vwebv/ui/en_US/htdocs/help/searchExamples.html#KNAM
+        $fullquery[] = sprintf('@attr 1=1003 "%s"', trim($author));
     }
     if ($_REQUEST['serial']) {
         $attr = get_enumerated_param($_REQUEST, 'serial_attr', null, array_keys($serial_attrs));


### PR DESCRIPTION
The bib 1 attribute 1004 (Author-name-personal), and bib 1 attribute 6 (Title Uniform) cause errors in queries to z3950.loc.gov, so remove them to avoid confusing project managers.

This seems to be one underlying issue behind DP#2114 we can easily fix.