### PR TITLE
api/index.php: Fix search link rel header URLs in the result

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -176,7 +176,8 @@ function api_send_pagination_header($query_params, $total_rows, $per_page, $page
     // it. Most notably, the `php -S` CLI server we use for testing.
     // See https://www.php.net/manual/en/reserved.variables.server.php
     $proto = !empty($_SERVER['HTTPS'] ?? '') ? 'https://' : 'http://';
-    $script_uri = $proto . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+    $url_path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    $script_uri = $proto . $_SERVER['HTTP_HOST'] . $url_path;
     $link_base = $script_uri . "?";
     if (stripos($link_base, $_GET["url"]) === false) {
         $link_base .= "url=" . $_GET["url"] . "&";


### PR DESCRIPTION
Because $_SERVER['REQUEST_URI'] includes the ?query=foo part of the URL, the link rel URLs we were building included two copies of the query, and thus were syntactically invalid as well as doubling in length each time a client read and followed a rel="next" URL in the Link header.

As an example, if a client did a query like

```
<$ROOT/api/v1/projects?per_page=1&page=1&field[]=pages_total&state[]=P3.proj_avail>
```

it would get a response with (edited for clarity)

```
<$ROOT/api/v1/projects?per_page=1&page=1&field[]=pages_total&state[]=P3.proj_avail?field[]=pages_total&state[]=P3.proj_avail&per_page=1&page=1>; rel="first",
<$ROOT/api/v1/projects?per_page=1&page=1&field[]=pages_total&state[]=P3.proj_avail?field[]=pages_total&state[]=P3.proj_avail&per_page=1&page=2>; rel="next",
<$ROOT/api/v1/projects?per_page=1&page=1&field[]=pages_total&state[]=P3.proj_avail?field[]=pages_total&state[]=P3.proj_avail&per_page=1&page=8>; rel="last"
```

Note the two `?`s in each response URL, and the differing order of the `per_page` and `page` parameters vs the client URL.

Since we already have all the parameters in `$params`, just get the base URL path using `parse_url`, and re-build and append the query.