### PR TITLE
Make table headers stick to the top of the page when scrolling

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1088,10 +1088,15 @@ table.availprojectlisting {
         th {
             .bold();
             .left-align();
-            .solid-border-bottom();
             img {
                 border: 0;
             }
+            /* Sticky header, solid bg, bottom shadow */
+            position: sticky;
+            top: -1px;
+            z-index: 10;
+            background: inherit;
+            box-shadow: 0 1px 0 @border-color-base;
         }
         td {
             .solid-border-bottom(@border-color-base-mediumc);
@@ -1249,11 +1254,15 @@ table.themed {
             padding: 0.1em;
         }
         th {
-            background-color: @navbar-background;
+            background: @navbar-background;
             color: @navbar-text;
             a:link, a:visited {
                 color: @navbar-text;
             }
+            /* Sticky header, solid bg, bottom shadow */
+            position: sticky;
+            top: -1px;
+            z-index: 10;
         }
     }
 }

--- a/styles/themes/charcoal.css
+++ b/styles/themes/charcoal.css
@@ -2154,7 +2154,12 @@ table.availprojectlisting tr th {
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: thin solid #565656;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
+  background: inherit;
+  box-shadow: 0 1px 0 #565656;
 }
 table.availprojectlisting tr th img {
   border: 0;
@@ -2321,8 +2326,12 @@ table.themed tr td {
   padding: 0.1em;
 }
 table.themed tr th {
-  background-color: black;
+  background: black;
   color: #cdcdcd;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
 }
 table.themed tr th a:link,
 table.themed tr th a:visited {

--- a/styles/themes/classic_grey.css
+++ b/styles/themes/classic_grey.css
@@ -2154,7 +2154,12 @@ table.availprojectlisting tr th {
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: thin solid #000000;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
+  background: inherit;
+  box-shadow: 0 1px 0 #000000;
 }
 table.availprojectlisting tr th img {
   border: 0;
@@ -2321,8 +2326,12 @@ table.themed tr td {
   padding: 0.1em;
 }
 table.themed tr th {
-  background-color: #444444;
+  background: #444444;
   color: #ffffff;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
 }
 table.themed tr th a:link,
 table.themed tr th a:visited {

--- a/styles/themes/project_gutenberg.css
+++ b/styles/themes/project_gutenberg.css
@@ -2154,7 +2154,12 @@ table.availprojectlisting tr th {
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: thin solid #000000;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
+  background: inherit;
+  box-shadow: 0 1px 0 #000000;
 }
 table.availprojectlisting tr th img {
   border: 0;
@@ -2321,8 +2326,12 @@ table.themed tr td {
   padding: 0.1em;
 }
 table.themed tr th {
-  background-color: #336633;
+  background: #336633;
   color: #ffffff;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
 }
 table.themed tr th a:link,
 table.themed tr th a:visited {

--- a/styles/themes/royal_blues.css
+++ b/styles/themes/royal_blues.css
@@ -2154,7 +2154,12 @@ table.availprojectlisting tr th {
 table.availprojectlisting tr th {
   font-weight: bold;
   text-align: left;
-  border-bottom: thin solid #000000;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
+  background: inherit;
+  box-shadow: 0 1px 0 #000000;
 }
 table.availprojectlisting tr th img {
   border: 0;
@@ -2321,8 +2326,12 @@ table.themed tr td {
   padding: 0.1em;
 }
 table.themed tr th {
-  background-color: #000099;
+  background: #000099;
   color: #ffffff;
+  /* Sticky header, solid bg, bottom shadow */
+  position: sticky;
+  top: -1px;
+  z-index: 10;
 }
 table.themed tr th a:link,
 table.themed tr th a:visited {


### PR DESCRIPTION
This helps when trying to scroll through, eg, large project lists and wanting to keep track of which column is which.

Tested with:
* rounds pages
* search results
* my projects
* release queues
* task center