### PR TITLE
page_info_fetch: Fix PHP 8.5 'cannot use bool as array' warns

### DIFF
--- a/pinc/post_files.inc
+++ b/pinc/post_files.inc
@@ -142,7 +142,8 @@ function write_project_comments($project, $fp)
 function get_page_texts($pages_res)
 {
     $page_texts = [];
-    while ([$page_text, $imagename, $proofer_names] = page_info_fetch($pages_res)) {
+    while (($row = page_info_fetch($pages_res)) !== false) {
+        [$page_text, $imagename, $proofer_names] = $row;
         $page_texts[] = $page_text;
     }
     return $page_texts;
@@ -156,7 +157,8 @@ function get_page_texts($pages_res)
 function join_page_texts($pages_res)
 {
     $text = "";
-    while ([$text_data, $filename, $proofer_names] = page_info_fetch($pages_res)) {
+    while (($row = page_info_fetch($pages_res)) !== false) {
+        [$text_data, $filename, $proofer_names] = $row;
         $text .= $text_data . "\r\n";
     }
     return $text;
@@ -174,7 +176,8 @@ function join_proofed_text($pages_res, $include_proofers, $save_files, $fp)
     $eol = $carriagereturn.$linefeed;
 
     $filedata = "";
-    while ([$text_data, $filename, $proofer_names] = page_info_fetch($pages_res)) {
+    while (($row = page_info_fetch($pages_res)) !== false) {
+        [$text_data, $filename, $proofer_names] = $row;
         $info_str = "-----File: $filename---";
         if ($include_proofers) {
             $info_str .= "\\";

--- a/pinc/project_quick_check.inc
+++ b/pinc/project_quick_check.inc
@@ -492,7 +492,8 @@ function _test_project_for_bad_bytes($projectid)
     $n_bad_pages = 0;
     $valid_codepoints = $project->get_valid_codepoints();
 
-    while ([$text, $imagename, $proofers] = page_info_fetch($pages_res)) {
+    while (($row = page_info_fetch($pages_res)) !== false) {
+        [$text, $imagename, $proofers] = $row;
         $round_num = get_round_num_from_proofers($proofers);
         if ($round_num == 0) {
             $round_name = 'OCR';

--- a/tools/project_manager/show_project_wordcheck_stats.php
+++ b/tools/project_manager/show_project_wordcheck_stats.php
@@ -62,7 +62,8 @@ $total["num_pages"] = $project->n_pages;
 $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
 $page_stats = [];
 // iterate through all the pages gathering stats
-while ([$page_text, $page, $proofer_names] = page_info_fetch($pages_res)) {
+while (($row = page_info_fetch($pages_res)) !== false) {
+    [$page_text, $page, $proofer_names] = $row;
     // find which words would be flagged for this page
     $page_words_w_freq = get_distinct_words_in_text($page_text);
 

--- a/tools/project_manager/show_word_context.php
+++ b/tools/project_manager/show_word_context.php
@@ -70,7 +70,8 @@ $pages_res = page_info_query($projectid, Rounds::get_last()->id, 'LE');
 // iterate through all the pages until we find $wordInstances of the word
 // we're looking for
 $foundInstances = 0;
-while ([$page_text, $page, $proofer_names] = page_info_fetch($pages_res)) {
+while (($row = page_info_fetch($pages_res)) !== false) {
+    [$page_text, $page, $proofer_names] = $row;
     // get a context string
     [$context_strings, $totalLines] = _get_word_context_from_text($page_text, $word);
     if (!count($context_strings)) {


### PR DESCRIPTION
`page_info_fetch()` returns a list of 3 items, or false depending on if there's more information. false cannot be used in a destructuring assignment, and PHP 8.5 warns about this.

(Spotted while running smoke tests in an Ubuntu 26.04/PHP 8.5 VM)