### PR TITLE
Make users.u_id UNIQUE for use as a FK in user_teams_membership

### DIFF
--- a/SETUP/db_schema.sql
+++ b/SETUP/db_schema.sql
@@ -655,7 +655,7 @@ CREATE TABLE `users` (
   `navbar_activity_menu` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`username`),
   UNIQUE KEY `api_key` (`api_key`),
-  KEY `u_id` (`u_id`),
+  UNIQUE KEY `u_id` (`u_id`),
   KEY `last_login` (`last_login`),
   KEY `t_last_activity` (`t_last_activity`),
   KEY `api_key_username` (`api_key`,`username`),

--- a/SETUP/upgrade/25/20260603_make_users_u_id_unique.php
+++ b/SETUP/upgrade/25/20260603_make_users_u_id_unique.php
@@ -1,0 +1,22 @@
+<?php
+$relPath = '../../../pinc/';
+include_once($relPath.'base.inc');
+
+header('Content-type: text/plain');
+
+// ------------------------------------------------------------
+
+echo "Making u_id INDEX in users UNIQUE..\n";
+$sql = "
+    ALTER TABLE users
+        DROP INDEX u_id,
+        ADD UNIQUE INDEX u_id (u_id);
+";
+
+echo "$sql\n";
+
+mysqli_query(DPDatabase::get_connection(), $sql) or die(mysqli_error(DPDatabase::get_connection()));
+
+// ------------------------------------------------------------
+
+echo "\nDone!\n";


### PR DESCRIPTION
MySQL 8.0 InnoDB allows foreign keys to ref an indexed but not unique column.

This is deprecated by default in MySQL 8.4 (in Ubuntu 26.04) and produces the error

`Failed to add the foreign key constraint. Missing unique key for constraint 'user_teams_membership_ibfk_1' in the referenced table 'users'`

See https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_restrict_fk_on_non_standard_key

(Found when trying to run `SETUP/install_db.php` on an Ubuntu 26.04 VM)