### PR TITLE
Fix #1576 to allow clearing of pages with [none] user in the last round

### DIFF
--- a/SETUP/tests/unittests/ApiTest.php
+++ b/SETUP/tests/unittests/ApiTest.php
@@ -370,7 +370,7 @@ class ApiTest extends ProjectUtils
         global $pguser;
         $project = $this->_create_available_project();
         $pguser = $this->TEST_USERNAME;
-        page_tallies_add("P1", $pguser, 501);
+        page_tallies_add("P1", new User($pguser), 501);
         $response = $this->checkout($project->projectid, "P1.proj_avail");
         $this->assertEquals('001.png', $response['pagename']);
     }
@@ -389,7 +389,7 @@ class ApiTest extends ProjectUtils
         global $pguser;
         $project = $this->_create_available_project();
         $pguser = $this->TEST_OLDUSERNAME;
-        page_tallies_add("P1", $pguser, 501);
+        page_tallies_add("P1", new User($pguser), 501);
 
         // reserved for new proofreaders
         $this->expectExceptionCode(306);
@@ -404,7 +404,7 @@ class ApiTest extends ProjectUtils
         $project = $this->_create_available_project();
         $pguser = $this->TEST_USERNAME;
         // beginners limit is 40 in user_is.inc
-        page_tallies_add("P1", $pguser, 50);
+        page_tallies_add("P1", new User($pguser), 50);
 
         $this->expectExceptionCode(303);
         $this->checkout($project->projectid, "P1.proj_avail");

--- a/SETUP/tests/unittests/ProjectTest.php
+++ b/SETUP/tests/unittests/ProjectTest.php
@@ -451,7 +451,7 @@ class ProjectTest extends ProjectUtils
 
         // user done many pages
         // $page_tally_threshold 500 for new projects in reserve time
-        page_tallies_add("P1", $user->username, 501);
+        page_tallies_add("P1", $user, 501);
         validate_user_can_get_pages_in_project($user, $project, $round);
 
         // few pages, many days on site
@@ -459,7 +459,7 @@ class ProjectTest extends ProjectUtils
         validate_user_can_get_pages_in_project($user, $project, $round);
 
         // many pages, many days on site
-        page_tallies_add("P1", $user->username, 501);
+        page_tallies_add("P1", $user, 501);
         $this->expectExceptionCode(306);
         validate_user_can_get_pages_in_project($user, $project, $round);
     }
@@ -470,7 +470,7 @@ class ProjectTest extends ProjectUtils
         $this->valid_project_data["difficulty"] = "beginner";
         $project = $this->_create_available_project();
         // beginners limit is 40 in user_is.inc
-        page_tallies_add("P1", $user->username, 50);
+        page_tallies_add("P1", $user, 50);
         $round = get_Round_for_round_id("P1");
         $this->expectExceptionCode(303);
         validate_user_can_get_pages_in_project($user, $project, $round);

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -410,7 +410,7 @@ class LPage
             Page_saveAsDone($this->projectid, $this->imagefile, $this->round, $pguser, $text_data);
 
         // add to user page count
-        page_tallies_add($this->round->id, $pguser, +1);
+        page_tallies_add($this->round->id, new User($pguser), +1);
 
         $dpl_has_now_been_reached = (
             $this->round->has_a_daily_page_limit()
@@ -487,7 +487,7 @@ class LPage
             // Now they are 'unsaving' it, so decrement their page-count.
             // They'll get it back if/when they save-as-done again.
             // (Plugs a former page-count cheat.)
-            page_tallies_add($this->round->id, $pguser, -1);
+            page_tallies_add($this->round->id, new User($pguser), -1);
         } else {
             // Page comes from IN PROGRESS or OUT.
             // Resuming such a page has no actual effect on the page,

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -462,7 +462,7 @@ function validate_user_against_project_reserve($user, $project, $round)
                 $days_on_site = ($t_now - $user->date_created) / 86400;
                 // echo "days_on_site = $days_on_site<br>\n";
 
-                $ELR_page_tally = user_get_ELR_page_tally($user->username);
+                $ELR_page_tally = user_get_ELR_page_tally($user);
                 // echo "ELR_page_tally = $ELR_page_tally<br>\n";
 
                 if ($days_on_site < $days_on_site_threshold or $ELR_page_tally < $page_tally_threshold) {

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -31,7 +31,14 @@ function get_pages_proofed_maybe_simulated(?string $username = null): int
         $username = User::current_username();
     }
 
-    $pagesproofed = user_get_ELR_page_tally($username);
+
+    $pagesproofed = 0;
+    if ($username !== null) {
+        try {
+            $pagesproofed = user_get_ELR_page_tally(new User($username));
+        } catch (NonexistentUserException $exception) {
+        }
+    }
     $max_pagesproofed = SiteConfig::get()->testing ? null : $pagesproofed;
     $pagesproofed = get_integer_param($_GET, 'numofpages', $pagesproofed, 0, $max_pagesproofed);
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -214,7 +214,7 @@ class PageTally_Neighbor
 /**
  * Should we anonymize information about the given user?
  */
-function should_anonymize($username, $user_privacy_setting)
+function should_anonymize(?string $username, int $user_privacy_setting)
 {
     return !can_reveal_details_about($username, $user_privacy_setting);
 }
@@ -261,7 +261,7 @@ $SECONDS_TO_YESTERDAY = 1 + 3 * 60 * 60;
  * - prev_day_{goal,actual}
  * - curr_month_{goal,actual}
  */
-function get_site_page_tally_summary($tally_name)
+function get_site_page_tally_summary(string $tally_name)
 {
     $site_stats = new StdClass();
 
@@ -314,7 +314,7 @@ function get_site_page_tally_summary($tally_name)
     return $site_stats;
 }
 
-function get_site_tally_goal_summed($tally_name, $date_condition)
+function get_site_tally_goal_summed(string $tally_name, string $date_condition)
 {
     $sql = sprintf(
         "
@@ -598,7 +598,7 @@ function calculate_tally_sma(array $array, int $window): array
  *
  * In the returned array, each key is a date-string of the form "YYYY-MM-DD".
  */
-function get_pages_per_day_for_past_n_days($tally_name, $holder_type, $holder_id, $days_back)
+function get_pages_per_day_for_past_n_days(string $tally_name, string $holder_type, int $holder_id, $days_back)
 {
     global $SECONDS_TO_YESTERDAY;
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -51,11 +51,8 @@ function get_ELR_tallyboards()
  * Add $amount to the user's page tally,
  * and to the page tally of each team that the user currently belongs to.
  */
-function page_tallies_add($tally_name, $username, $amount)
+function page_tallies_add(string $tally_name, User $user, int $amount)
 {
-    // get the user's u_id, and the teams that he/she belongs to
-    $user = new User($username);
-
     // update page tally for user
     $user_tallyboard = new TallyBoard($tally_name, 'U');
     $user_tallyboard->add_to_tally($user->u_id, $amount);
@@ -88,7 +85,7 @@ function get_daily_average($start_time, $total)
 /**
  * Return the user's page tally for the Entry-Level Round.
  */
-function user_get_ELR_page_tally($username)
+function user_get_ELR_page_tally(User $user): int
 {
     [$users_ELR_page_tallyboard, ] = get_ELR_tallyboards();
 
@@ -99,9 +96,9 @@ function user_get_ELR_page_tally($username)
         "
         SELECT $user_ELR_page_tally_column
         FROM users $joined_with_user_ELR_page_tallies
-        WHERE username='%s'
+        WHERE u_id=%d
         ",
-        DPDatabase::escape($username)
+        $user->u_id
     );
     $res = DPDatabase::query($sql);
     $row = mysqli_fetch_row($res);

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -566,7 +566,7 @@ function calculate_tally_sma(array $array, int $window): array
  *
  * In the returned array, each key is a date-string of the form "YYYY-MM-DD".
  */
-function get_pages_per_day_for_past_n_days(string $tally_name, string $holder_type, int $holder_id, $days_back)
+function get_pages_per_day_for_past_n_days(string $tally_name, string $holder_type, int $holder_id, string|int $days_back)
 {
     global $SECONDS_TO_YESTERDAY;
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -166,46 +166,14 @@ function user_get_page_tally_neighborhood(string $tally_name, User $user, int $r
 
 class PageTally_Neighbor
 {
-    private bool $is_anonymized;
-    private ?string $username;
-    private ?int $date_joined;
-    private int $u_id;
-    private int $current_page_tally;
-    private int $current_page_tally_rank;
-
-    public function __construct($is_anonymized, $username, $date_joined, $u_id, $current_page_tally, $current_page_tally_rank)
-    {
-        $this->is_anonymized = $is_anonymized;
-        $this->username = $username;
-        $this->date_joined = $date_joined;
-        $this->u_id = $u_id;
-        $this->current_page_tally = $current_page_tally;
-        $this->current_page_tally_rank = $current_page_tally_rank;
-    }
-
-    public function is_anonymized()
-    {
-        return $this->is_anonymized;
-    }
-    public function get_username()
-    {
-        return $this->username;
-    }
-    public function get_date_joined()
-    {
-        return $this->date_joined;
-    }
-    public function get_u_id()
-    {
-        return $this->u_id;
-    }
-    public function get_current_page_tally()
-    {
-        return $this->current_page_tally;
-    }
-    public function get_current_page_tally_rank()
-    {
-        return $this->current_page_tally_rank;
+    public function __construct(
+        public readonly bool $is_anonymized,
+        public readonly ?string $username,
+        public readonly ?int $date_joined,
+        public readonly int $u_id,
+        public readonly int $current_page_tally,
+        public readonly int $current_page_tally_rank,
+    ) {
     }
 }
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -117,13 +117,13 @@ function user_get_ELR_page_tally(User $user): int
 /**
  * Get the user's page tally neighborhood
  * @param string $tally_name
- * @param string $username
+ * @param User $user
  * @param int $radius
  *   (maximum) number of neighbors (on each side) to include in
  *   the neighborhood. (It will include fewer than the maximum iff the target
  *   user is within $radius of the corresponding end of the ranked list.)
  *
- * Return the page-tally neighborhood of $username.
+ * Return the page-tally neighborhood of $user.
  * This is an array where keys are integers from the range [-$radius, +$radius],
  * indicating a user's position relative to the target user (w.r.t. page tally).
  * (So key=0 refers to the target user.)
@@ -132,10 +132,8 @@ function user_get_ELR_page_tally(User $user): int
  *
  * @return PageTally_Neighbor[]
  */
-function user_get_page_tally_neighborhood($tally_name, $username, $radius)
+function user_get_page_tally_neighborhood(string $tally_name, User $user, int $radius)
 {
-    $user = new User($username);
-
     $tallyboard = new TallyBoard($tally_name, 'U');
     $nb =
         $tallyboard->get_neighborhood($user->u_id, $radius);

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -809,9 +809,9 @@ function show_tally_specific_stats($tally_name)
                 if ($rel_posn == 0) {
                     echo "<span class='this-user'>";
                 }
-                echo $neighbor->get_current_page_tally_rank(), ".) ";
-                echo($neighbor->is_anonymized() ? _('Anonymous') : $neighbor->get_username()), " - ";
-                echo number_format($neighbor->get_current_page_tally());
+                echo $neighbor->current_page_tally_rank, ".) ";
+                echo($neighbor->is_anonymized ? _('Anonymous') : $neighbor->username), " - ";
+                echo number_format($neighbor->current_page_tally);
                 if ($rel_posn == 0) {
                     echo "</span>";
                 }

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -802,7 +802,7 @@ function show_tally_specific_stats($tally_name)
             $neighbors =
                 user_get_page_tally_neighborhood(
                     $tally_name,
-                    $user->username,
+                    $user,
                     $user->u_neigh
                 );
             foreach ($neighbors as $rel_posn => $neighbor) {

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -203,7 +203,14 @@ function that_user_can_work_on_beginner_pages_in_round(?string $username, Round 
         return true;
     }
 
-    $n_pages = user_get_ELR_page_tally($username);
+
+    $n_pages = 0;
+    if ($username !== null) {
+        try {
+            $n_pages = user_get_ELR_page_tally(new User($username));
+        } catch (NonexistentUserException $exception) {
+        }
+    }
     if ($round_number == 1) {
         return $n_pages <= 40;
     } elseif ($round_number == 2) {

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -507,13 +507,13 @@ function showMbrNeighbors($user, $tally_name)
             max($user->u_neigh, 4)
         );
     foreach ($neighbors as $rel_posn => $neighbor) {
-        $rank = $neighbor->get_current_page_tally_rank();
-        $pagescompleted = number_format($neighbor->get_current_page_tally());
+        $rank = $neighbor->current_page_tally_rank;
+        $pagescompleted = number_format($neighbor->current_page_tally);
 
-        if (!$neighbor->is_anonymized()) {
-            $u_id = $neighbor->get_u_id();
-            $username = $neighbor->get_username();
-            $date_created = $neighbor->get_date_joined();
+        if (!$neighbor->is_anonymized) {
+            $u_id = $neighbor->u_id;
+            $username = $neighbor->username;
+            $date_created = $neighbor->date_joined;
 
             $username_html = "<a href='".$GLOBALS['code_url']."/stats/members/mdetail.php?id=$u_id&amp;tally_name=$tally_name'>$username</a>";
             $day_html = date("m/d/Y", $date_created)." <i>("

--- a/stats/includes/member.inc
+++ b/stats/includes/member.inc
@@ -503,7 +503,7 @@ function showMbrNeighbors($user, $tally_name)
     $neighbors =
         user_get_page_tally_neighborhood(
             $tally_name,
-            $user->username,
+            $user,
             max($user->u_neigh, 4)
         );
     foreach ($neighbors as $rel_posn => $neighbor) {

--- a/tools/project_manager/page_operations.inc
+++ b/tools/project_manager/page_operations.inc
@@ -87,7 +87,12 @@ function page_clear($projectid, $image)
     // ------------------------------------------------
     // page will be cleared, so decrement page tallies for user & teams
 
-    page_tallies_add($round->id, $proofer, -1);
+    try {
+        page_tallies_add($round->id, new User($proofer), -1);
+    } catch (NonexistentUserException $exception) {
+        // Newly inserted empty pages may have an empty/[none] usernames.
+        // Clearing the page should still succeed even if tally update can't.
+    }
 
     // ------------------------------------------------
     // now clear the page


### PR DESCRIPTION
While here, do some assorted code cleanup in `page_tally.inc`. This is old code and we can take advantage of some new PHP features now.

This can be checked on test on <https://www.pgdp.org/~bfoley/c.branch/clear-round-nouser/tools/project_manager/page_detail.php?project=projectID5e2676b51011e>. This project contains a lot of pages with `[none]` as the proofreader.
