### PR TITLE
Use classes with readonly properties more widely

### DIFF
--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -123,14 +123,6 @@ class Activities
 
 class Activity
 {
-    public string $id;
-    public string $name;
-    /** @var array<string,int> */
-    public array $access_minima;
-    public string $after_satisfying_minima;
-    public string $evaluation_criteria;
-    public ?string $access_change_callback;
-
     /**
      * Activity constructor
      *
@@ -166,21 +158,14 @@ class Activity
      *   where $change is one of `[ "grant", "revoke", "request", "deny_request_for" ]`
      */
     public function __construct(
-        string $id,
-        string $name,
+        public readonly string $id,
+        public readonly string $name,
         /** @var array<string,int> */
-        array $access_minima,
-        string $after_satisfying_minima,
-        string $evaluation_criteria,
-        ?string $access_change_callback
+        public array $access_minima,
+        public readonly string $after_satisfying_minima,
+        public readonly string $evaluation_criteria,
+        public readonly ?string $access_change_callback
     ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->access_minima = $access_minima;
-        $this->after_satisfying_minima = $after_satisfying_minima;
-        $this->evaluation_criteria = $evaluation_criteria;
-        $this->access_change_callback = $access_change_callback;
-
         if (SiteConfig::get()->testing && !is_null($this->access_minima)) { /** @phpstan-ignore-line */
             // Relax minima.
             foreach ($this->access_minima as $criterion_code => $minimum) {

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -61,22 +61,18 @@ class PickerSet
  */
 class CharSuite
 {
-    public string $name;
-    public string $title;
-    /** @var string[] */
-    public ?array $codepoints;
     public ?string $description = null;
-    public bool $adhoc;
     public $reference_urls = [];
     private ?PickerSet $_pickerset = null;
 
     /** @param ?string[] $codepoints */
-    public function __construct(string $name, string $title, ?array $codepoints = null, bool $adhoc = false)
-    {
-        $this->name = $name;
-        $this->title = $title;
-        $this->codepoints = $codepoints;
-        $this->adhoc = $adhoc;
+    public function __construct(
+        public readonly string $name,
+        public readonly string $title,
+        /** @var string[] */
+        public ?array $codepoints = null,
+        public readonly bool $adhoc = false
+    ) {
     }
 
     public function __get(string $name): ?PickerSet

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -264,15 +264,11 @@ function project_continuity_test(Project $project, string $orig_state, bool $no_
  */
 class RoundInfo
 {
-    public string $round_id;
-    public string $username;
-    public ?string $forum_user_id;
-
-    public function __construct(string $round_id, string $username, ?string $forum_user_id)
-    {
-        $this->round_id = $round_id;
-        $this->username = $username;
-        $this->forum_user_id = $forum_user_id;
+    public function __construct(
+        public readonly string $round_id,
+        public readonly string $username,
+        public readonly ?string $forum_user_id
+    ) {
     }
 }
 
@@ -288,20 +284,16 @@ class RoundInfo
  */
 class LPage
 {
-    public Project $project;
-    public string $projectid;
-    public string $imagefile;
-    public string $page_state;
-    public int $reverting_to_orig;
-    public Round $round;
+    public readonly string $projectid;
+    public readonly Round $round;
 
-    public function __construct(Project $project, string $imagefile, string $page_state, int $reverting_to_orig)
-    {
-        $this->project = $project;
+    public function __construct(
+        public readonly Project $project,
+        public readonly string $imagefile,
+        public string $page_state,
+        public int $reverting_to_orig
+    ) {
         $this->projectid = $project->projectid;
-        $this->imagefile = $imagefile;
-        $this->page_state = $page_state;
-        $this->reverting_to_orig = $reverting_to_orig;
 
         // It's debatable whether LPage should have a 'reverting_to_orig' property.
         // You could argue that it's an interface-level artifact,

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -15,10 +15,6 @@ class Pools extends Stages
 
 class Pool extends Stage
 {
-    public string $foo_Header;
-    public string $foo_field_name;
-    /** @var string[] */
-    public array $blather;
     public string $project_available_state;
     public string $project_checkedout_state;
     /** @var string[] */
@@ -48,9 +44,10 @@ class Pool extends Stage
         ?string $access_change_callback,
         string $description,
         ?string $document,
-        string $foo_Header,
-        string $foo_field_name,
-        array $blather
+        public readonly string $foo_Header,
+        public readonly string $foo_field_name,
+        /** @var string[] */
+        public readonly array $blather
     ) {
         parent::__construct(
             $id,
@@ -68,10 +65,6 @@ class Pool extends Stage
         //     $this->project_checkedout_state
         //     $this->project_available_state
         //     $this->states
-
-        $this->foo_Header = $foo_Header;
-        $this->foo_field_name = $foo_field_name;
-        $this->blather = $blather;
     }
 }
 

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -10,25 +10,18 @@ include_once($relPath.'genres.inc');  // maybe_create_temporary_genre_translatio
 
 class Column
 {
-    public string $id;
-    protected string $label;
-    private string $long_label;
-    private string $css_class;
-    private bool $default_display;
-    public bool $sortable;
-    protected string $db_column;
     private Settings $userSettings;
     private string $search_origin;
 
-    public function __construct(string $id, string $label, string $long_label, string $css_class, bool $default_display, bool $sortable, string $db_column)
-    {
-        $this->id = $id;
-        $this->label = $label;
-        $this->long_label = $long_label;
-        $this->css_class = $css_class;
-        $this->default_display = $default_display;
-        $this->sortable = $sortable;
-        $this->db_column = $db_column;
+    public function __construct(
+        public readonly string $id,
+        protected readonly string $label,
+        private readonly string $long_label,
+        private readonly string $css_class,
+        private readonly bool $default_display,
+        public readonly bool $sortable,
+        protected readonly string $db_column
+    ) {
     }
 
     public function get_label(): string
@@ -141,12 +134,17 @@ class Column
 
 class TimeColumn extends Column
 {
-    private string $time_format;
-
-    public function __construct(string $id, string $label, string $long_label, string $css_class, bool $default_display, bool $sortable, string $db_column, string $time_format)
-    {
+    public function __construct(
+        string $id,
+        string $label,
+        string $long_label,
+        string $css_class,
+        bool $default_display,
+        bool $sortable,
+        string $db_column,
+        private readonly string $time_format
+    ) {
         parent::__construct($id, $label, $long_label, $css_class, $default_display, $sortable, $db_column);
-        $this->time_format = $time_format;
     }
 
     public function get_label(): string
@@ -401,16 +399,14 @@ class HoldColumn extends Column
 
 class ColumnData
 {
-    protected Settings $userSettings;
-    protected string $search_origin;
     public array $columns;
 
-    public function __construct(Settings $userSettings, string $search_origin, string $time_format = '')
-    {
+    public function __construct(
+        protected readonly Settings $userSettings,
+        protected readonly string $search_origin,
+        string $time_format = ''
+    ) {
         global $pguser;
-
-        $this->userSettings = $userSettings;
-        $this->search_origin = $search_origin;
 
         $this->columns = [
             new TitleColumn('title', _("Title"), '', 'left-align', true, true, 'nameofwork'),

--- a/pinc/ProjectState.inc
+++ b/pinc/ProjectState.inc
@@ -2,27 +2,14 @@
 
 class ProjectState
 {
-    public string $name;
-    public string $medium_label;
-    public string $label;
-    public int $forum;
-    public string $phase;
-    public string $star_metal;
-
     public function __construct(
-        string $name,
-        string $medium_label,
-        string $label,
-        int $forum,
-        string $phase,
-        string $star_metal
+        public readonly string $name,
+        public readonly string $medium_label,
+        public readonly string $label,
+        public readonly int $forum,
+        public readonly string $phase,
+        public readonly string $star_metal
     ) {
-        $this->name = $name;
-        $this->medium_label = $medium_label;
-        $this->label = $label;
-        $this->forum = $forum;
-        $this->phase = $phase;
-        $this->star_metal = $star_metal;
     }
 }
 

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -11,10 +11,6 @@ define('PT_AUTO', '[AUTO]');
 
 class ProjectTransition
 {
-    public string $from_state;
-    public string $to_state;
-    public string $who_restriction;
-
     // Populated from $options
     private ?string $project_restriction; // callable
     public ?string $action_name;
@@ -42,15 +38,11 @@ class ProjectTransition
      *   - disabled_during_SR
      */
     public function __construct(
-        string $from_state,
-        string $to_state,
-        string $who_restriction,
+        public readonly string $from_state,
+        public readonly string $to_state,
+        public readonly string $who_restriction,
         array $options
     ) {
-        $this->from_state = $from_state;
-        $this->to_state = $to_state;
-        $this->who_restriction = $who_restriction;
-
         foreach ($options as $option_name => $option_value) {
             $this->$option_name = $option_value;
         }

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -5,24 +5,17 @@ include_once($relPath.'CharSuites.inc'); // CharSuiteSet
 // for groups of quizzes that go together
 class QuizLevel
 {
-    public string $level_id;
-    public string $level_name;    // name for the category of quizzes
-    public string $activity_type; // "proof" or "format"
-    public string $info;          // description or other info the user should know
-    /** @var Quiz[] */
-    public array $quizzes;        // the individual quizzes that the level contains
-
     public static $map_quiz_level_id_to_QuizLevel = [];
 
     /** @param Quiz[] $quizzes */
-    public function __construct(string $level_id, string $level_name, string $activity_type, string $info, array $quizzes)
-    {
-        $this->level_id = $level_id;
-        $this->level_name = $level_name;
-        $this->activity_type = $activity_type;
-        $this->info = $info;
-        $this->quizzes = $quizzes;
-
+    public function __construct(
+        public readonly string $level_id,
+        public readonly string $level_name,    // name for the category of quizzes
+        public readonly string $activity_type, // "proof" or "format"
+        public readonly string $info,          // description or other info the user should kno
+        /** @var Quiz[] */
+        public readonly array $quizzes         // the individual quizzes that the level contains
+    ) {
         foreach ($quizzes as $quiz) {
             $quiz->activity_type = $activity_type;
         }
@@ -34,17 +27,7 @@ class QuizLevel
 
 class Quiz
 {
-    public string $id;
-    public string $name;             // appears in the top of the quiz's table
-    public string $short_name;       // appears in the righthand frame during the quiz
-    public string $description;
-    public string $thread;           // forum thread for quiz questions & comments, if other than the default
     public string $activity_type;    // "proof" or "format"
-    public array $pages;
-    // Currently supported pass_requirements:
-    // ['maximum_age'] => time_in_seconds:
-    //     Passes recorded longer than time_in_seconds ago are not valid.
-    public array $pass_requirements;
 
     /** @var string[] */
     public static $valid_quiz_page_ids = [];
@@ -53,16 +36,18 @@ class Quiz
     /** @var array<string, Quiz> */
     public static $map_quiz_id_to_Quiz = [];
 
-    public function __construct(string $id, string $name, string $short_name, string $description, string $thread, array $pages, array $pass_requirements)
-    {
-        $this->id = $id;
-        $this->name = $name;
-        $this->short_name = $short_name;
-        $this->description = $description;
-        $this->thread = $thread;
-        $this->pages = $pages;
-        $this->pass_requirements = $pass_requirements;
-
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,        // appears in the top of the quiz's table
+        public readonly string $short_name,  // appears in the righthand frame during the quiz
+        public readonly string $description,
+        public readonly string $thread,      // forum thread for quiz questions & comments, if other than the default
+        public readonly array $pages,
+        // Currently supported pass_requirements:
+        // ['maximum_age'] => time_in_seconds:
+        //     Passes recorded longer than time_in_seconds ago are not valid.
+        public readonly array $pass_requirements
+    ) {
         assert(!isset(Quiz::$map_quiz_id_to_Quiz[$id]));
         Quiz::$map_quiz_id_to_Quiz[$id] = & $this;
 

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -20,10 +20,6 @@ class Stages extends Activities
 
 class Stage extends Activity
 {
-    public string $description;
-    public ?string $document;
-    public string $relative_url;
-
     /**
      * Stage constructor
      *
@@ -44,9 +40,9 @@ class Stage extends Activity
         string $after_satisfying_minima,
         string $evaluation_criteria,
         ?string $access_change_callback,
-        string $description,
-        ?string $document,
-        string $relative_url
+        public readonly string $description,
+        public readonly ?string $document,
+        public readonly string $relative_url
     ) {
         parent::__construct(
             $id,
@@ -56,10 +52,6 @@ class Stage extends Activity
             $evaluation_criteria,
             $access_change_callback
         );
-
-        $this->description = $description;
-        $this->document = $document;
-        $this->relative_url = $relative_url;
     }
 
 

--- a/pinc/TableDocumentation.inc
+++ b/pinc/TableDocumentation.inc
@@ -2,13 +2,10 @@
 
 class TableDocumentation
 {
-    private $display_name;
-    private $columns_information;
-
-    public function __construct(string $display_name, array $columns_information)
-    {
-        $this->display_name = $display_name;
-        $this->columns_information = $columns_information;
+    public function __construct(
+        private readonly string $display_name,
+        private readonly array $columns_information
+    ) {
     }
 
     public function generate_documentation_table(): string

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -14,20 +14,17 @@ include_once($relPath.'Project.inc'); // get_project_difficulties()
 
 class ProjectFilterElement
 {
-    private string $id;
-    public string $label;
     private bool $active;
-    protected $data;
-    protected string $state_sql;
     public array $selected_options;
 
-    public function __construct($id, $label, $data, $state_sql, $active_fields)
-    {
-        $this->id = $id;
-        $this->label = $label;
+    public function __construct(
+        private readonly string $id,
+        public readonly string $label,
+        protected readonly mixed $data,
+        protected readonly string $state_sql,
+        array $active_fields
+    ) {
         $this->active = $active_fields[$id];
-        $this->data = $data;
-        $this->state_sql = $state_sql;
         $this->selected_options = [];
     }
 
@@ -293,13 +290,10 @@ function process_and_display_project_filter_form($username, $filter_type, $filte
 
 class ProjectSearchElement
 {
-    private string $id;
-    protected $data;
-
-    public function __construct($id, $data)
-    {
-        $this->id = $id;
-        $this->data = $data;
+    public function __construct(
+        private readonly string $id,
+        protected readonly mixed $data
+    ) {
     }
 
     public function get_sql_component()

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -173,10 +173,6 @@ echo return_to_project_page_link($projectid) . "\n";
 
 class Loader
 {
-    private string $source_project_dir;
-    private string $dest_project_dir;
-    private string $projectid;
-    private bool $allow_text_loads;
     private bool $adding_pages;
     private int $image_field_len;
     /** @var array<string, string> */
@@ -193,13 +189,13 @@ class Loader
     private int $n_errors;
     private ImageUtils $checker;
 
-    public function __construct(string $source_project_dir, string $dest_project_dir, string $projectid, $allow_text_loads = true)
-    {
-        $this->source_project_dir = $source_project_dir;
-        $this->dest_project_dir = $dest_project_dir;
-        $this->projectid = $projectid;
+    public function __construct(
+        private readonly string $source_project_dir,
+        private readonly string $dest_project_dir,
+        private readonly string $projectid,
+        private readonly bool $allow_text_loads = true
+    ) {
         $this->checker = new ImageUtils();
-        $this->allow_text_loads = $allow_text_loads;
     }
 
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
This is more intended to start discussion rather than necessarily to be merged as-is.

As you can see, PHP 8.0's "property constructor promotion" is more of a win in simpler classes that are mostly "data transfer objects", and it saves less boilerplate when there's an inheritance hierarchy, or when some properties have to be explicitly declared.

However, I do like the opportunity to sprinkle more 'readonly' on properties (which says only the constructor can assign to a property, and it can only do it once). Avoiding mutable state makes it a lot easier to reason about classes.

After a couple of fixes, it passes all the smoke tests (and PHPstan is happy).

It's deployed at https://www.pgdp.org/~bfoley/c.branch/more-dto and I did some cursory poking around with the proofreading interface, project search, wordcheck, stats etc.