### PR TITLE
Allow projects to be "parked"

### DIFF
--- a/pinc/ProjectState.inc
+++ b/pinc/ProjectState.inc
@@ -6,7 +6,7 @@ class ProjectState
         public readonly string $name,
         public readonly string $medium_label,
         public readonly string $label,
-        public readonly int $forum,
+        public readonly ?int $forum,
         public readonly string $phase,
         public readonly string $star_metal
     ) {
@@ -228,6 +228,18 @@ function declare_project_states(array $rounds, array $pools): void
         _("Project Complete"),
         SiteConfig::get()->completed_projects_forum_idx,
         'COMPLETE',
+        ''
+    ));
+
+    // for "parking" a project
+
+    define("PROJ_PARKED", "project_parked");
+    ProjectStates::add_state(new ProjectState(
+        PROJ_PARKED,
+        _("Project Parked"),
+        _("Project Parked"),
+        SiteConfig::get()->parked_projects_forum_idx,
+        'PARKED',
         ''
     ));
 

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -1159,6 +1159,29 @@ function create_project_transitions(): array
     );
 
     // -----------------------------------------------------------------------------
+    // Transitions to PROJ_PARKED.
+
+    foreach (ProjectStates::get_states() as $from_state) {
+        if (in_array($from_state, [PROJ_NEW, PROJ_DELETE, PROJ_PARKED, PROJ_COMPLETE, PROJ_SUBMIT_PG_POSTED])) {
+            continue;
+        }
+
+        $project_transitions[] = new ProjectTransition(
+            $from_state,
+            PROJ_PARKED,
+            'site_manager',
+            [
+                'project_restriction' => null,
+                'action_name' => _('Park Project'),
+                'confirmation_question' => _('Are you sure you want to park this project?'),
+                'detour' => null,
+                'settings_template' => "modifieddate='<TIMESTAMP>'",
+                'collateral_actions' => null,
+            ]
+        );
+    }
+
+    // -----------------------------------------------------------------------------
     // Transitions to PROJ_DELETE.
 
     foreach (ProjectStates::get_states() as $from_state) {
@@ -1189,6 +1212,7 @@ function create_project_transitions(): array
             ]
         );
     }
+
     return $project_transitions;
 }
 

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -59,6 +59,7 @@ class SiteConfig
     public ?int $posted_projects_forum_idx;
     public ?int $deleted_projects_forum_idx;
     public ?int $completed_projects_forum_idx;
+    public ?int $parked_projects_forum_idx;
     public ?int $post_processing_forum_idx;
     public ?int $teams_forum_idx;
 


### PR DESCRIPTION
A new "parked" state allows projects to be moved outside the usual project workflow to get fixed or worked on.

Projects can be parked from the project page by a site admin. To move projects out of a parked state, the project jump page needs to be used.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/proj_parked/

This PR will need to be rebased after https://github.com/DistributedProofreaders/dproofreaders/pull/1592 goes in.