### PR TITLE
Add link to project word list interface

### DIFF
--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -157,7 +157,8 @@ foreach ($projects as $projectid => $projectdata) {
 
     echo "<hr>";
     echo "<h3>$projectname</h3>";
-    echo "<p><b>" . pgettext("project state", "State") . ":</b> $projectstate</p>";
+    echo "<p><b>" . pgettext("project state", "State") . ":</b> $projectstate";
+    echo " | <a href='$code_url/tools/project_manager/edit_project_word_lists.php?projectid=$projectid'>" . _("Edit project word lists") ."</a></p>";
 
     echo_checkbox_selects($projectid);
 


### PR DESCRIPTION
On the Show All Proofreader Suggestions page, include a link to the project's edit word list interface for each project. Requested as part of Task 1874.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/good-word-suggestions-proj-link/