### PR TITLE
SiteConfig: Make get()'s return type the singleton.

### DIFF
--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -154,8 +154,11 @@ class SiteConfig
         self::$_site_config = new SiteConfig($filename);
     }
 
-    public static function get()
+    public static function get(): SiteConfig
     {
+        if (is_null(self::$_site_config)) {
+            throw new RuntimeException("Configuration error. SiteConfig not loaded.");
+        }
         return self::$_site_config;
     }
 }


### PR DESCRIPTION
So that phpstan can statically check SiteConfig::get()->foo, and we get a more comprehensible runtime error if SiteConfig somehow isn't loaded.