### PR TITLE
Update MathJax to version 4 for format preview.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "d3": "^6.6.2",
         "gettext.js": "^2.0.3",
         "jquery": "^3.5.1",
+        "mathjax": "^4.1.3",
         "resumablejs": "^1.1.0"
       },
       "devDependencies": {
@@ -351,6 +352,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mathjax/mathjax-newcm-font": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.3.tgz",
+      "integrity": "sha512-gzAB3dFHilHX1l5x2xUqRL+1jDQt3Fyza1DkEMVXWC4E8SvsGdlgEza47HYi2WhVcgfkvf4zgUGzuhbq3Pjlew==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -2583,6 +2590,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mathjax": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.3.tgz",
+      "integrity": "sha512-BN/8Pkgn7G1pIDYJqd9md+JHsE/jydSYbyOZnSdSA0WziuVO8mRxdYiWFumkVVly/8U+hm9DpIIoWuvySverzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mathjax/mathjax-newcm-font": "^4.1.3"
       }
     },
     "node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "d3": "^6.6.2",
     "gettext.js": "^2.0.3",
     "jquery": "^3.5.1",
+    "mathjax": "^4.1.3",
     "resumablejs": "^1.1.0"
   },
   "browserslist": [

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -26,13 +26,11 @@ if (!headers_sent()) {
         "default-src 'self'",
         // allow inline styles
         "style-src 'self' 'unsafe-inline'",
-        // allow inline scripts until we remove them, and cdn.jsdelivr.net
-        // for MathJAX
-        "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net",
+        // allow inline scripts until we remove them
+        "script-src 'self' 'unsafe-inline'",
         // MathJAX 4 dynamically loads fonts and a worker
         "font-src 'self' data:",
         "worker-src 'self' blob:",
-        "connect-src 'self' cdn.jsdelivr.net",
         // allow images from anywhere (due to project comments)
         "img-src 'self' *",
         // Disallow other sites from embedding pages in frames/iframes;

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -29,6 +29,10 @@ if (!headers_sent()) {
         // allow inline scripts until we remove them, and cdn.jsdelivr.net
         // for MathJAX
         "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net",
+        // MathJAX 4 dynamically loads fonts and a worker
+        "font-src 'self' data:",
+        "worker-src 'self' blob:",
+        "connect-src 'self' cdn.jsdelivr.net",
         // allow images from anywhere (due to project comments)
         "img-src 'self' *",
         // Disallow other sites from embedding pages in frames/iframes;

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -15,7 +15,7 @@ import { ajax } from "../../scripts/api.js";
 import { makePreview, defaultStyles } from "../../scripts/analyse_format.js";
 import { validateText } from "../../scripts/text_validator.js";
 
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
     "use strict";
     var supp_set = ["charBeforeStart", "sideNoteBlank"];
     // this is a wrapper round text_preview which enables the padding
@@ -88,14 +88,14 @@ window.addEventListener("DOMContentLoaded", () => {
         previewColorStyle.innerHTML = styleString;
     }
 
-    function writePreviewText() {
+    async function writePreviewText() {
         // makePreview is defined in analyse_format.js
         preview = makePreview(txtarea.value, viewMode, wrapMode, previewStyles);
         prevWin.style.whiteSpace = preview.ok && wrapMode ? "normal" : "pre";
         prevWin.innerHTML = preview.txtout;
         if (preview.ok && previewStyles.allowMathPreview) {
             try {
-                MathJax.typeset([prevWin]);
+                await MathJax.typesetPromise([prevWin]);
             } catch (exception) {
                 alert("MathJax error: " + exception);
             }
@@ -190,7 +190,7 @@ window.addEventListener("DOMContentLoaded", () => {
             };
             const mathJaxScriptElement = document.createElement("script");
             mathJaxScriptElement.type = "text/javascript";
-            mathJaxScriptElement.src = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js";
+            mathJaxScriptElement.src = "https://cdn.jsdelivr.net/npm/mathjax@4/tex-svg.js";
             const scriptLoadPromise = new Promise(function (resolve) {
                 mathJaxScriptElement.onload = function () {
                     resolve();
@@ -205,7 +205,7 @@ window.addEventListener("DOMContentLoaded", () => {
     }
 
     initStyle();
-    initView();
+    await initView();
     setupFont();
 
     function colorChange(event) {
@@ -404,8 +404,9 @@ window.addEventListener("DOMContentLoaded", () => {
             saveStyle();
             // if loading MathJax, wait for it to finish
             initView().then(function () {
-                writePreviewText();
-                hideConfig();
+                writePreviewText().then(function () {
+                    hideConfig();
+                });
             });
         },
 

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -187,7 +187,7 @@ window.addEventListener("DOMContentLoaded", async () => {
             window.MathJax = {
                 loader: { load: ["input/tex", "output/svg", "[tex]/unicode"] },
                 tex: { packages: { "[+]": ["unicode"] } },
-                output: {font: "mathjax-newcm", fontPath: "../../node_modules/@mathjax/mathjax-newcm-font"},
+                output: { font: "mathjax-newcm", fontPath: "../../node_modules/@mathjax/mathjax-newcm-font" },
             };
             const mathJaxScriptElement = document.createElement("script");
             mathJaxScriptElement.type = "text/javascript";

--- a/tools/proofers/previewControl.js
+++ b/tools/proofers/previewControl.js
@@ -187,13 +187,14 @@ window.addEventListener("DOMContentLoaded", async () => {
             window.MathJax = {
                 loader: { load: ["input/tex", "output/svg", "[tex]/unicode"] },
                 tex: { packages: { "[+]": ["unicode"] } },
+                output: {font: "mathjax-newcm", fontPath: "../../node_modules/@mathjax/mathjax-newcm-font"},
             };
             const mathJaxScriptElement = document.createElement("script");
             mathJaxScriptElement.type = "text/javascript";
-            mathJaxScriptElement.src = "https://cdn.jsdelivr.net/npm/mathjax@4/tex-svg.js";
+            mathJaxScriptElement.src = "../../node_modules/mathjax/tex-svg.js";
             const scriptLoadPromise = new Promise(function (resolve) {
                 mathJaxScriptElement.onload = function () {
-                    resolve();
+                    MathJax.startup.promise.then(resolve);
                 };
                 document.body.appendChild(mathJaxScriptElement);
             });


### PR DESCRIPTION
Use npm to install mathjax locally, and serve it locally, no longer using the jsdelivr CDN.
Adjust async behavior to await for MathJax.
Update Content-Security-Policy to allow MathJax to dynamically load a worker and fonts.
Fix old bug that showed a mathjax error (this exists in production).

The motivation for this is to use the same version of mathjax in both Format Preview and also the separate m2svg tool. This helps to avoid inconsistencies between the two tools, which are often used together for the same project.

To reproduce the old bug with the mathjax error:
1. Initial condition, Preview Math is disabled in format preview configuration.
2. Start proofing a page.
3. Click Preview to enter the format preview view.
4. Click Configure, then enable Preview Math, then click OK.
5. Expected: you see the preview view, with no error messages.
6. Actual: you see a pop-up error about MathJax.typeset is not a function.

I tested with math markup from PR #1527, which also has the expected output in preview mode.

To verify new consistency with m2svg 3.4.0, use this markup:
`Math with text inside: \(a + b = c + d + \text{\&c.}\)`
Expected output is `a + b = c + d + &c.` where a b c d are italic, &c is not italic. (The production version, with mathjax 3, shows it as `a + b = c + d + \&c.`)

I also tried various sequences of enabling/disabling Preview Math in the format preview configuration.

Sandbox at: https://www.pgdp.org/~mrducky/c.branch/mathjax4