### PR TITLE
Update timestamp on duplicate format preview event keys

### DIFF
--- a/pinc/FormatPreview.inc
+++ b/pinc/FormatPreview.inc
@@ -62,9 +62,12 @@ class FormatPreview
             "
             INSERT INTO format_preview_events
                 (projectid, image, round_id, username, timestamp)
-            SELECT '%s', image, round_id, username, timestamp
-            FROM format_preview_events
-            WHERE projectid = '%s' $images_where
+            SELECT * FROM (
+                SELECT '%s', image, round_id, username, timestamp
+                FROM format_preview_events
+                WHERE projectid = '%s' $images_where) AS new
+            ON DUPLICATE KEY UPDATE
+                timestamp = new.timestamp
             ",
             DPDatabase::escape($dest_projectid),
             DPDatabase::escape($src_projectid)


### PR DESCRIPTION
If, for whatever reason, the destination project already has format preview events for the source page/round/user, just update the timestamp from the source instead of raising a duplicate key error.

I'm not sure exactly how the scenario came to be where this caused the error that mws encountered, but this is the right solution to recover from it.

Sandbox: https://www.pgdp.org/~cpeel/c.branch/fix-format-preview-dup-keys/