### PR TITLE
Fix issue #1600, allow \\ to escape a backslash in replacement string

### DIFF
--- a/SETUP/tests/jsTests/srchrepTests.js
+++ b/SETUP/tests/jsTests/srchrepTests.js
@@ -108,4 +108,17 @@ QUnit.module("srchrep tests", (hooks) => {
         );
         assert.notOk($("#undo").prop("disabled"), "Undo should be enabled.");
     });
+
+    QUnit.test("\\n is just backslash n without regex", function (assert) {
+        setTextValue("Example search -- and replace search text <i>value</i>.");
+        $("#search").val("search");
+        $("#replace").val("s\\n");
+        srchrep.doReplace();
+        assert.strictEqual(
+            window.opener.parent.docRef.editform.text_data.value,
+            "Example s\\n -- and replace s\\n text <i>value</i>.",
+            "Search replace replaces with just \\n, not newline, without regex.",
+        );
+        assert.notOk($("#undo").prop("disabled"), "Undo should be enabled.");
+    });
 });

--- a/SETUP/tests/jsTests/srchrepTests.js
+++ b/SETUP/tests/jsTests/srchrepTests.js
@@ -99,6 +99,7 @@ QUnit.module("srchrep tests", (hooks) => {
         setTextValue("Example search -- and replace search text <i>value</i>.");
         $("#search").val("search");
         $("#replace").val("s\\n");
+        $("#is_regex").prop("checked", true);
         srchrep.doReplace();
         assert.strictEqual(
             window.opener.parent.docRef.editform.text_data.value,

--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -619,10 +619,8 @@ Below the tags are several links to both popup tools and documentation.
         [Aa]{6} &mdash; six As of either case<br>
         A{2,8} &mdash; between 2 and 8 capital As<br>
         [hb]e &mdash; 'he' or 'be'<br>
+        \n &mdash; new line<br>
     </blockquote>
-</p>
-<p>
-    To replace matched text with a new line, \n may be used in the replace field.
 </p>
 
 <h4>Help</h4>

--- a/tools/proofers/srchrep.js
+++ b/tools/proofers/srchrep.js
@@ -17,23 +17,24 @@ var srchrep = (function () {
 
     function doReplace() {
         var search = document.getElementById("search").value;
-        // Handle \n for newline. And \<x> becomes just <x>. So \\ becomes a single \.
-        var replacetext = document.getElementById("replace").value.replace(/\\(.)/g, (match, esc) => {
-            switch (esc) {
-                case "n":
-                    return "\r\n";
-                default:
-                    return esc; // anything else, leave as is without the backslash
-            }
-        });
+        var replacetext = document.getElementById("replace").value;
 
         saveText();
         if (!document.getElementById("is_regex").checked) {
             search = escapeRegExp(search);
-
             // Replace $ in replace text with $$ to avoid special replacement patterns.
             // Note, $ here is in a .replace function and must be escaped so '$$' becomes '$$$$'.
             replacetext = replacetext.replace(/\$/g, "$$$$");
+        } else {
+            // Handle \n for newline. And \<x> becomes just <x>. So \\ becomes a single \.
+            replacetext = replacetext.replace(/\\(.)/g, (match, esc) => {
+                switch (esc) {
+                    case "n":
+                        return "\r\n";
+                    default:
+                        return esc; // anything else, leave as is without the backslash
+                }
+            });
         }
         opener.parent.docRef.editform.text_data.value = opener.parent.docRef.editform.text_data.value.replace(new RegExp(search, "gum"), replacetext);
         setUndoButtonDisabled(false);

--- a/tools/proofers/srchrep.js
+++ b/tools/proofers/srchrep.js
@@ -17,7 +17,16 @@ var srchrep = (function () {
 
     function doReplace() {
         var search = document.getElementById("search").value;
-        var replacetext = document.getElementById("replace").value.replace(new RegExp("\\\\n", "g"), "\r\n");
+        // Handle \n for newline. And \<x> becomes just <x>. So \\ becomes a single \.
+        var replacetext = document.getElementById("replace").value.replace(/\\(.)/g, (match, esc) => {
+            switch (esc) {
+                case "n":
+                    return "\r\n";
+                default:
+                    return esc; // anything else, leave as is without the backslash
+            }
+        });
+
         saveText();
         if (!document.getElementById("is_regex").checked) {
             search = escapeRegExp(search);


### PR DESCRIPTION
For search/replace in the proofing interface, allow `\\` to escape `\` in the replacement string.

Previously, any occurence of `\n` in the replacement string would become a newline. So `\\n` would become a backslash followed by newline. With this change, `\\` means an escaped backslash, so `\\n` becomes a backslash followed by n. Also, any occurence of a single backslash followed by any character other than n just means that character. So to use a literal backslash in the replacement string, always escape it as `\\`.

Sandbox: https://www.pgdp.org/~mrducky/c.branch/replace_newline/