### PR TITLE
Update to PHPStan 2.2.9

### DIFF
--- a/accounts/logout.php
+++ b/accounts/logout.php
@@ -6,7 +6,7 @@ include_once($relPath.'metarefresh.inc');
 include_once($relPath.'forum_interface.inc');
 
 if (User::is_logged_in()) {
-    logout_forum_user();  // @phpstan-ignore-line
+    logout_forum_user();
 
     dpsession_end();
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.57",
         "phpunit/phpunit": "^12.0",
-        "phpstan/phpstan": "^2.1.31"
+        "phpstan/phpstan": "^2.2"
     },
     "replace": {
         "symfony/polyfill-ctype": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -1456,11 +1456,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.42",
+            "version": "2.2.9",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1279e1ce86ba768f0780c9d889852b4e02ff40d0",
-                "reference": "1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/13d6b4f347bad222da436580c8304fa6f83e6bd0",
+                "reference": "13d6b4f347bad222da436580c8304fa6f83e6bd0",
                 "shasum": ""
             },
             "require": {
@@ -1482,6 +1482,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -1505,7 +1516,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-17T14:58:32+00:00"
+            "time": "2026-08-22T07:38:16+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,8 @@
 # https://phpstan.org/config-reference
 
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
 parameters:
     fileExtensions:
         - php
@@ -29,6 +32,10 @@ parameters:
           path: pinc/3rdparty/mediawiki/DiffEngine.php
         - message: '#Call to function wfDebug\(\) on a separate line has no effect.#'
           path: pinc/3rdparty/mediawiki/DiffEngine.php
+        - message: '#Assign to \$.* overwrites the last element from array\.$#'
+          path: pinc/3rdparty/mediawiki/DiffEngine.php
+        - message: '#If condition is always false\.$#'
+          path: pinc/3rdparty/mediawiki/DiffFormatter.php
         - message: '#Instantiated class DiffFormatter is abstract#'
           path: pinc/DifferenceEngineWrapper.inc
         - message: '#Call to function is_array\(\) with array<string> will always evaluate to true.#'

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -267,7 +267,7 @@ class RoundInfo
     public function __construct(
         public readonly string $round_id,
         public readonly string $username,
-        public readonly ?string $forum_user_id
+        public readonly ?int $forum_user_id
     ) {
     }
 }

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -382,7 +382,7 @@ class POFileIterator implements Iterator
                 return;
             }
         }
-        if ($block) {
+        if ($block) { /** @phpstan-ignore if.alwaysFalse */
             $this->current_block = $block;
             $this->block_count++;
             return;

--- a/pinc/bootstrap.inc
+++ b/pinc/bootstrap.inc
@@ -31,7 +31,7 @@ spl_autoload_register('dp_class_autoloader');
 require_once($relPath.'../vendor/autoload.php');
 
 // Exception handlers are defined differently for HTML and the API
-set_exception_handler(SiteConfig::get()->testing ? 'test_exception_handler' : 'production_exception_handler');
+set_exception_handler(SiteConfig::get()->testing ? test_exception_handler(...) : production_exception_handler(...));
 
 if (!headers_sent()) {
     // Tell proxies to vary the caching based on the Accept-Language header
@@ -66,7 +66,7 @@ include_once($relPath.'misc.inc');
 //----------------------------------------------------------------------------
 
 // Autoloading functions for DP classes in pinc/
-function dp_class_autoloader($class)
+function dp_class_autoloader(string $class): void
 {
     global $relPath;
     if (is_file($relPath.$class.".inc")) {
@@ -74,7 +74,16 @@ function dp_class_autoloader($class)
     }
 }
 
-function dp_setcookie($name, $value = "", $expires = 0, $options = [])
+/**
+ * @param array{
+ *            expires?: int,
+ *            path?: string,
+ *            secure?: bool,
+ *            httponly?: bool,
+ *            samesite?: 'Lax'|'None'|'Strict'
+ *        } $options
+ */
+function dp_setcookie(string $name, string $value = "", int $expires = 0, $options = []): bool
 {
     $defaults = [
         "expires" => $expires,

--- a/pinc/forum_interface_json.inc
+++ b/pinc/forum_interface_json.inc
@@ -12,14 +12,14 @@ if (!SiteConfig::get()->testing) {
 
 class ForumJson
 {
-    protected $json_file;
+    protected string $json_file;
 
-    protected function configure($json_file)
+    protected function configure(string $json_file): void
     {
         $this->json_file = $json_file;
     }
 
-    protected function save_to_json($data)
+    protected function save_to_json(mixed $data): bool
     {
         return file_put_contents(
             $this->json_file,
@@ -27,7 +27,7 @@ class ForumJson
         ) !== false;
     }
 
-    protected function load_from_json()
+    protected function load_from_json(): mixed
     {
         if (! is_file($this->json_file)) {
             return [];
@@ -39,7 +39,7 @@ class ForumJson
 
 class ForumJsonUser extends ForumJson
 {
-    public function __construct($json_file = null)
+    public function __construct(?string $json_file = null)
     {
         if ($json_file) {
             $this->configure($json_file);
@@ -48,7 +48,7 @@ class ForumJsonUser extends ForumJson
         }
     }
 
-    public function add($username, $password, $email)
+    public function add(string $username, string $password, string $email): bool
     {
         $users = $this->load_from_json();
 
@@ -74,7 +74,10 @@ class ForumJsonUser extends ForumJson
         return $this->save_to_json($users);
     }
 
-    public function load($username)
+    /**
+     * @return ?array<string, mixed>
+     */
+    public function load(string $username): ?array
     {
         $users = $this->load_from_json();
         return $users[$username] ?? null;
@@ -83,7 +86,7 @@ class ForumJsonUser extends ForumJson
 
 class ForumJsonPost extends ForumJson
 {
-    public function __construct($json_file = null)
+    public function __construct(?string $json_file = null)
     {
         if ($json_file) {
             $this->configure($json_file);
@@ -92,12 +95,18 @@ class ForumJsonPost extends ForumJson
         }
     }
 
-    public function add_topic($subject, $text, $poster)
+    /**
+     * @return array<string, mixed>
+     */
+    public function add_topic(string $subject, string $text, string $poster): array
     {
         return $this->add_post(null, $subject, $text, $poster);
     }
 
-    public function add_post($topic_id, $subject, $text, $poster)
+    /**
+     * @return array<string, mixed>
+     */
+    public function add_post(?int $topic_id, string $subject, string $text, string $poster): array
     {
         $posts = $this->load_from_json();
 
@@ -130,7 +139,10 @@ class ForumJsonPost extends ForumJson
         return $posts[$id];
     }
 
-    public function load_topic($topic_id)
+    /**
+     * @return ?mixed[]
+     */
+    public function load_topic(int $topic_id): ?array
     {
         $posts = $this->load_from_json();
 
@@ -148,28 +160,35 @@ class ForumJsonPost extends ForumJson
         }
     }
 
-    public function load_post($post_id)
+    public function load_post(int $post_id): mixed
     {
         $posts = $this->load_from_json();
         return $posts[$post_id] ?? [];
     }
 }
 
-function forum_password_hash($password)
+function forum_password_hash(string $password): string
 {
     return password_hash($password, PASSWORD_DEFAULT);
 }
 
-function create_forum_user($username, $password, $email, $password_is_digested = false)
+function create_forum_user(string $username, string $password, string $email, bool $password_is_digested = false): string|true
 {
     if (!$password_is_digested) {
         $password = forum_password_hash($password);
     }
     $userManager = new ForumJsonUser();
-    return $userManager->add($username, $password, $email);
+    if ($userManager->add($username, $password, $email) !== true) {
+        return "user creation error";
+    } else {
+        return true;
+    }
 }
 
-function login_forum_user($username, $password)
+/**
+ * @return list{bool, string}
+ */
+function login_forum_user(string $username, string $password): array
 {
     $userManager = new ForumJsonUser();
     $user = $userManager->load($username);
@@ -184,16 +203,20 @@ function login_forum_user($username, $password)
     }
 }
 
-function logout_forum_user()
+function logout_forum_user(): void
 {
 }
 
-function get_reset_password_url()
+function get_reset_password_url(): string
 {
     return "";
 }
 
-function get_forum_user_details($username)
+/**
+ * @return ?array<string, mixed>
+ * @phpstan-ignore return.unusedType
+ */
+function get_forum_user_details(string $username): ?array
 // Given a username, return details about the user.
 // Returns an associative array. See $interested_columns for the keys.
 // If the user isn't found, the function returns NULL.
@@ -243,8 +266,10 @@ function get_forum_user_details($username)
     return $return_data;
 }
 
-function get_forum_user_id($username)
-// Given a forum username, return the forum user ID.
+/**
+ * Given a forum username, return the forum user ID.
+ */
+function get_forum_user_id(string $username): ?int
 {
     // Use a local in-memory cache so we don't pummel the database
     // for pages that end up calling this for the same small set
@@ -270,13 +295,14 @@ function get_forum_user_id($username)
     return $user["id"];
 }
 
-function get_forum_rank_title($rank)
+// @phpstan-ignore return.unusedType
+function get_forum_rank_title(int $rank): ?string
 // Given a forum rank number, return the text title of that rank.
 {
     return "Tester";
 }
 
-function get_forum_email_address($username)
+function get_forum_email_address(string $username): string
 // Given a forum username, return the email address.
 {
     $user_details = get_forum_user_details($username);
@@ -284,19 +310,19 @@ function get_forum_email_address($username)
     return $user_details["email"] ?? "";
 }
 
-function get_url_for_forum()
+function get_url_for_forum(): string
 // Return a URL to the base of the forum
 {
     return "";
 }
 
-function get_url_for_forum_user_login()
+function get_url_for_forum_user_login(): string
 // Return a URL that a user can use to manually log in to the forums.
 {
     return "";
 }
 
-function get_url_to_compose_message_to_user($username)
+function get_url_to_compose_message_to_user(string $username): string
 // Given a forum username, return a URL that can be used to
 // access a form to send the user a message.
 {
@@ -309,38 +335,39 @@ function get_url_to_view_forum(int $forum_id): string
     return "";
 }
 
-function get_url_to_view_topic($topic_id)
+function get_url_to_view_topic(int $topic_id): string
 // Given a topic id, return a URL that can be used to view the topic.
 {
     return "";
 }
 
-function get_url_to_view_post($post_id)
+function get_url_to_view_post(int $post_id): string
 // Given a post id, return a URL that can be used to view the post.
 {
     return "";
 }
 
-function get_url_for_user_avatar($username)
+// @phpstan-ignore return.unusedType
+function get_url_for_user_avatar(string $username): ?string
 // Given a forum username, return a URL that can be used to load the user's
 // avatar. If no avatar is defined, this function returns NULL.
 {
     return null;
 }
 
-function get_url_to_edit_profile()
+function get_url_to_edit_profile(): string
 // Return a URL that can be used to edit the current user's profile.
 {
     return "";
 }
 
-function get_url_to_view_profile($user_id = 0)
+function get_url_to_view_profile(int $user_id = 0): string
 // Return a URL that can be used to view a given user's profile.
 {
     return "";
 }
 
-function get_url_for_inbox()
+function get_url_for_inbox(): string
 // Return the URL for accessing the current user's inbox.
 {
     return "";
@@ -349,22 +376,25 @@ function get_url_for_inbox()
 /**
  * Return the URL for searching the forums
  */
-function get_url_for_search($query)
+function get_url_for_search(string $query): string
 {
     return "";
 }
 
-function get_number_of_unread_messages($username)
+// * @phpstan-ignore return.unusedType
+function get_number_of_unread_messages(string $username): ?int
 // Given a forum username, return the number of unread messages.
 {
     return null;
 }
 
-function does_topic_exist($topic_id)
-// Confirm a specific topic ID exists.
-// Returns:
-//     FALSE - doesn't exist
-//     TRUE  - does exist
+/**
+ * Confirm a specific topic ID exists.
+ * Returns:
+ *     FALSE - doesn't exist
+ *     TRUE  - does exist
+ */
+function does_topic_exist(int $topic_id): bool
 {
     $postManager = new ForumJsonPost();
     $posts = $postManager->load_topic($topic_id);
@@ -376,16 +406,13 @@ function does_topic_exist($topic_id)
     }
 }
 
-function get_last_post_time_in_topic($topic_id)
-// Given a forum topic, return the time of the last post
-// in UNIX time format (seconds since UNIX epoch).
-// If no topic is found, function returns NULL.
+/**
+ * Given a forum topic, return the time of the last post
+ * in UNIX time format (seconds since UNIX epoch).
+ * If no topic is found, function returns NULL.
+ */
+function get_last_post_time_in_topic(int $topic_id): ?int
 {
-    // Validate that $topic_id is an integer and if not, return NULL
-    if (!is_numeric($topic_id)) {
-        return null;
-    }
-
     $postManager = new ForumJsonPost();
     $posts = $postManager->load_topic($topic_id);
 
@@ -403,14 +430,17 @@ function get_last_post_time_in_topic($topic_id)
     return $max_post_time;
 }
 
-function get_topic_details($topic_id)
-// Returns the following details about a topic as an associative array.
-//     topic_id         - the ID of the topic (for completeness)
-//     title            - the title of the topic
-//     num_replies      - the number of replies in the topic
-//     forum_name       - name of the forum the topic is in
-//     forum_id         - the id of the forum the topic is in
-//     creator_username - the username of the topic creator
+/**
+ * @return array<string, mixed>
+ *    Returns the following details about a topic as an associative array.
+ *        topic_id         - the ID of the topic (for completeness)
+ *        title            - the title of the topic
+ *        num_replies      - the number of replies in the topic
+ *        forum_name       - name of the forum the topic is in
+ *        forum_id         - the id of the forum the topic is in
+ *        creator_username - the username of the topic creator
+ */
+function get_topic_details(int $topic_id): array
 {
     $postManager = new ForumJsonPost();
     $posts = $postManager->load_topic($topic_id);
@@ -441,12 +471,12 @@ function get_topic_details($topic_id)
 // -----------------------------------------------------------------------------
 
 function topic_create(
-    $forum_id,
-    $post_subject,
-    $post_text,
-    $poster_name,
-    $poster_is_real,
-    $make_poster_watch_topic
+    int $forum_id,
+    string $post_subject,
+    string $post_text,
+    string $poster_name,
+    bool $poster_is_real,
+    ?bool $make_poster_watch_topic
 ): ?int {
     $postManager = new ForumJsonPost();
     $topic = $postManager->add_topic($post_subject, $post_text, $poster_name);
@@ -456,24 +486,24 @@ function topic_create(
 // -----------------------------------------------------------------------------
 
 function topic_add_post(
-    $topic_id,
-    $post_subject,
-    $post_text,
-    $poster_name,
-    $poster_is_real
-) {
+    int $topic_id,
+    string $post_subject,
+    string $post_text,
+    string $poster_name,
+    bool $poster_is_real
+): void {
     $postManager = new ForumJsonPost();
     $postManager->add_post($topic_id, $post_subject, $post_text, $poster_name);
 }
 
 // -----------------------------------------------------------------------------
 
-function topic_change_forum($topic_id, $to_forum_id)
+function topic_change_forum(int $topic_id, int $to_forum_id): void
 {
 }
 
 // -----------------------------------------------------------------------------
 
-function forum_resynch($forum_id)
+function forum_resynch(int $forum_id): void
 {
 }

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -36,7 +36,7 @@ use Symfony\Component\Process\Process;
 /**
  * Return a table name with the phpBB table prefix prepended to it
  */
-function phpbb_table($table)
+function phpbb_table(string $table): string
 {
     return SiteConfig::get()->forums_phpbb_table_prefix . "_" . $table;
 }
@@ -47,7 +47,7 @@ function phpbb_table($table)
  *
  * Fall back to English if $langcode is not installed on the system.
  */
-function phpbb_lang($locale = false)
+function phpbb_lang(string|false $locale = false): string
 {
     if ($locale === false) {
         $locale = get_desired_language();
@@ -86,7 +86,7 @@ function phpbb_lang($locale = false)
  * non_activated_users table and use it directly when creating the account
  * post-activation.
  */
-function forum_password_hash($password)
+function forum_password_hash(string $password): string
 {
     // phpBB3 hashing function is involved, so we'll call it directly
     // instead of duplicating it here, but we don't want to pollute
@@ -108,7 +108,7 @@ function forum_password_hash($password)
  * Note: Use a strict comparison operator (=== or !==) against TRUE
  * to evaluate the pass/fail status of this function.
  */
-function create_forum_user($username, $password, $email, $password_is_digested = false)
+function create_forum_user(string $username, string $password, string $email, bool $password_is_digested = false): string|true
 {
     // Use the phpBB3 API to create the user, but do so via phpbb3.inc
     // as to not mix the DP and phpBB3 codespace.
@@ -144,7 +144,7 @@ function create_forum_user($username, $password, $email, $password_is_digested =
     return true;
 }
 
-function phpbb_user_error_handler($errno, $errstr, $errfile, $errline)
+function phpbb_user_error_handler(int $errno, string $errstr, string $errfile, int $errline): bool
 {
     if (in_array($errno, [E_USER_ERROR, E_USER_NOTICE])) {
         throw new ValueError($errstr);
@@ -155,21 +155,21 @@ function phpbb_user_error_handler($errno, $errstr, $errfile, $errline)
 
 /**
  * Log in the user to the forums.
- *
- * Returns:
- * - [TRUE, '']  - user successfully logged in
- * - [FALSE, $reason] - login failed and the reason why, valid $reasons:
- *   - incorrect_username
- *   - incorrect_password
- *   - too_many_attempts
- *   - unknown
+ * @return list{bool, string}
+ *     Returns:
+ *     - [true, '']  - user successfully logged in
+ *     - [false, $reason] - login failed and the reason why, valid $reasons:
+ *       - incorrect_username
+ *       - incorrect_password
+ *       - too_many_attempts
+ *       - unknown
  */
-function login_forum_user($username, $password)
+function login_forum_user(string $username, string $password)
 {
     $forums_phpbb_dir = SiteConfig::get()->forums_phpbb_dir;
 
     if (!is_dir($forums_phpbb_dir)) {
-        return false;
+        return [false, 'uknown'];
     }
 
     // phpbb code sets variables (e.g. $db) upon include assuming they are
@@ -275,7 +275,7 @@ function login_forum_user($username, $password)
 /**
  * Log out the currently-authenticated user from the forum.
  */
-function logout_forum_user()
+function logout_forum_user(): void
 {
     global $pguser;
 
@@ -316,7 +316,7 @@ function logout_forum_user()
     mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 }
 
-function get_reset_password_url()
+function get_reset_password_url(): string
 {
     return get_url_for_forum() . "/ucp.php?mode=sendpassword";
 }
@@ -324,10 +324,11 @@ function get_reset_password_url()
 /**
  * Given a username, return details about the user.
  *
- * Returns an associative array. See $interested_columns for the keys.
- * If the user isn't found, the function returns NULL.
+ * @return ?array<string, mixed>
+ *     Returns an associative array. See $interested_columns for the keys.
+ *     If the user isn't found, the function returns NULL.
  */
-function get_forum_user_details($username)
+function get_forum_user_details(string $username): ?array
 {
     $interested_columns = [
         "id",         // forum user id
@@ -421,7 +422,7 @@ function get_forum_user_details($username)
 /**
  * Given a forum username, return the forum user ID.
  */
-function get_forum_user_id($username)
+function get_forum_user_id(string $username): ?int
 {
     // Use a local in-memory cache so we don't pummel the database
     // for pages that end up calling this for the same small set
@@ -458,7 +459,7 @@ function get_forum_user_id($username)
 /**
  * Given a forum rank number, return the text title of that rank.
  */
-function get_forum_rank_title($rank)
+function get_forum_rank_title(int $rank): ?string
 {
     $query = sprintf(
         "
@@ -484,7 +485,7 @@ function get_forum_rank_title($rank)
 /**
  * Given a forum username, return the email address.
  */
-function get_forum_email_address($username)
+function get_forum_email_address(string $username): string
 {
     $user_details = get_forum_user_details($username);
 
@@ -494,7 +495,7 @@ function get_forum_email_address($username)
 /**
  * Return a URL to the base of the forum
  */
-function get_url_for_forum()
+function get_url_for_forum(): string
 {
     return SiteConfig::get()->forums_phpbb_url;
 }
@@ -502,7 +503,7 @@ function get_url_for_forum()
 /**
  * Return a URL that a user can use to manually log in to the forums.
  */
-function get_url_for_forum_user_login()
+function get_url_for_forum_user_login(): string
 {
     return get_url_for_forum() . "/ucp.php?mode=login";
 }
@@ -511,7 +512,7 @@ function get_url_for_forum_user_login()
  * Given a forum username, return a URL that can be used to
  * access a form to send the user a message.
  */
-function get_url_to_compose_message_to_user($username)
+function get_url_to_compose_message_to_user(string $username): string
 {
     $userid = get_forum_user_id($username);
 
@@ -529,7 +530,7 @@ function get_url_to_view_forum(int $forum_id): string
 /**
  * Given a topic id, return a URL that can be used to view the topic.
  */
-function get_url_to_view_topic($topic_id)
+function get_url_to_view_topic(int $topic_id): string
 {
     return get_url_for_forum() . "/viewtopic.php?t=$topic_id";
 }
@@ -537,7 +538,7 @@ function get_url_to_view_topic($topic_id)
 /**
  * Given a post id, return a URL that can be used to view the post.
  */
-function get_url_to_view_post($post_id)
+function get_url_to_view_post(int $post_id): string
 {
     return get_url_for_forum() . "/viewtopic.php?p=$post_id#$post_id";
 }
@@ -548,7 +549,7 @@ function get_url_to_view_post($post_id)
  *
  * If no avatar is defined, this function returns NULL.
  */
-function get_url_for_user_avatar($username)
+function get_url_for_user_avatar(int $username): ?string
 {
     $user_details = get_forum_user_details($username);
 
@@ -577,7 +578,7 @@ function get_url_for_user_avatar($username)
 /**
  * Return a URL that can be used to edit the current user's profile.
  */
-function get_url_to_edit_profile()
+function get_url_to_edit_profile(): string
 {
     return get_url_for_forum() . "/ucp.php";
 }
@@ -585,7 +586,7 @@ function get_url_to_edit_profile()
 /**
  * Return a URL that can be used to view a given user's profile.
  */
-function get_url_to_view_profile($user_id)
+function get_url_to_view_profile(int $user_id): string
 {
     return get_url_for_forum() . "/memberlist.php?mode=viewprofile&u=$user_id";
 }
@@ -593,7 +594,7 @@ function get_url_to_view_profile($user_id)
 /**
  * Return the URL for accessing the current user's inbox.
  */
-function get_url_for_inbox()
+function get_url_for_inbox(): string
 {
     return get_url_for_forum() . "/ucp.php?i=pm&folder=inbox";
 }
@@ -601,7 +602,7 @@ function get_url_for_inbox()
 /**
  * Return the URL for searching the forums
  */
-function get_url_for_search(string $query, bool $encode = true)
+function get_url_for_search(string $query, bool $encode = true): string
 {
     return get_url_for_forum() . "/search.php?keywords=" . ($encode ? urlencode($query) : $query);
 }
@@ -609,7 +610,7 @@ function get_url_for_search(string $query, bool $encode = true)
 /**
  * Given a forum username, return the number of unread messages.
  */
-function get_number_of_unread_messages($username)
+function get_number_of_unread_messages(string $username): ?int
 {
     $forum_userid = get_forum_user_id($username);
 
@@ -638,10 +639,8 @@ function get_number_of_unread_messages($username)
 
 /**
  * Confirm a specific topic ID exists.
- *
- * @return bool
  */
-function does_topic_exist($topic_id)
+function does_topic_exist(int $topic_id): bool
 {
     $query = sprintf(
         "
@@ -667,12 +666,8 @@ function does_topic_exist($topic_id)
  *
  * If no topic is found, function returns NULL.
  */
-function get_last_post_time_in_topic($topic_id)
+function get_last_post_time_in_topic(int $topic_id): ?int
 {
-    // Validate that $topic_id is an integer and if not, return NULL
-    if (!is_numeric($topic_id)) {
-        return null;
-    }
     $query = sprintf(
         "
         SELECT MAX(post_time) as max_post_time
@@ -704,8 +699,9 @@ function get_last_post_time_in_topic($topic_id)
  * - forum_name       - name of the forum the topic is in
  * - forum_id         - the id of the forum the topic is in
  * - creator_username - the username of the topic creator
+ * @return array<string, mixed>
  */
-function get_topic_details($topic_id)
+function get_topic_details(int $topic_id): array
 {
     $forums_phpbb_dir = SiteConfig::get()->forums_phpbb_dir;
 
@@ -750,12 +746,12 @@ function get_topic_details($topic_id)
  * A proxy for phpbb3_create_topic() in external phpbb3.inc
  */
 function topic_create(
-    $forum_id,
-    $post_subject,
-    $post_text,
-    $poster_name,
-    $poster_is_real,
-    $make_poster_watch_topic
+    int $forum_id,
+    string $post_subject,
+    string $post_text,
+    string $poster_name,
+    bool $poster_is_real,
+    ?bool $make_poster_watch_topic
 ): ?int {
     $args = func_get_args();
     $topic_id = call_phpbb_function('create_topic', $args);
@@ -777,12 +773,12 @@ function topic_create(
  * A proxy for phpbb3_add_post() in external phpbb3.inc
  */
 function topic_add_post(
-    $topic_id,
-    $post_subject,
-    $post_text,
-    $poster_name,
-    $poster_is_real
-) {
+    int $topic_id,
+    string $post_subject,
+    string $post_text,
+    string $poster_name,
+    bool $poster_is_real
+): void {
     $args = func_get_args();
     call_phpbb_function('add_post', $args);
 }
@@ -795,7 +791,7 @@ function topic_add_post(
  * It's risky to combine DP and phpBB code in the same PHP context,
  * so we run the phpBB code in a separate process.
  */
-function call_phpbb_function($func_name, $args)
+function call_phpbb_function(string $func_name, mixed $args): ?string
 {
     // If $DEBUG is TRUE, output some additional debugging information useful
     // for figuring out where the calls into phpbb*.inc went wrong.
@@ -808,7 +804,7 @@ function call_phpbb_function($func_name, $args)
     $forums_phpbb_dir = SiteConfig::get()->forums_phpbb_dir;
     if (!is_dir($forums_phpbb_dir)) {
         echo "Warning: unable to call '$func_name' because \$forums_phpbb_dir ($forums_phpbb_dir) does not exist.\n";
-        return;
+        return null;
     }
 
     // The phpbb3.inc assumes it's running from $code_dir/pinc/ so we need
@@ -834,16 +830,14 @@ function call_phpbb_function($func_name, $args)
 
 // -----------------------------------------------------------------------------
 
-function topic_change_forum($topic_id, $to_forum_id)
+function topic_change_forum(int $topic_id, int $to_forum_id): void
 {
-    assert($topic_id != '');
-
     call_phpbb_function('move_topic', [$topic_id, $to_forum_id]);
 }
 
 // -----------------------------------------------------------------------------
 
-function forum_resynch($forum_id)
+function forum_resynch(int $forum_id): void
 {
     call_phpbb_function('sync_forum', [$forum_id]);
 }

--- a/pinc/iso_lang_list.inc
+++ b/pinc/iso_lang_list.inc
@@ -114,10 +114,13 @@ function get_script_for_langcode(string $langcode): string
 // and then have a mapping of language codes to language names in the
 // desired locale.
 
-/** @return array{"lang_name": string, "lang_code": string, "preferred"?: bool}[] */
-function get_iso_language_list(): array
+/** @return array{lang_name: string, lang_code: string, preferred?: bool}[] */
+function get_iso_language_list()
 {
-    return [
+    // Type hint to stop PHPStan from blowing up trying to infer type for
+    // huge list.
+    /** @var array{lang_name: string, lang_code: string, preferred?: bool}[] */
+    $langs = [
         ["lang_name" => "Abkhazian", "lang_code" => "abk"],
         ["lang_name" => "Achinese", "lang_code" => "ace"],
         ["lang_name" => "Acoli", "lang_code" => "ach"],
@@ -613,6 +616,7 @@ function get_iso_language_list(): array
         ["lang_name" => "Zulu", "lang_code" => "zul"],
         ["lang_name" => "Zuni", "lang_code" => "zun"],
     ];
+    return $langs;
 }
 
 /**

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -9,7 +9,7 @@ include_once($relPath.'iso_lang_list.inc');
 
 use Symfony\Component\Process\Process;
 
-function lang_code($language_code)
+function lang_code(string $language_code): string|false
 {
     global $locales;
 
@@ -31,10 +31,9 @@ function lang_code($language_code)
 
 /**
  * Return the 2-letter short code for the specified locale specifier.
- *
  * If no locale is passed in, the locale of the current user is used.
  */
-function short_lang_code($langcode = false)
+function short_lang_code(string|false $langcode = false): string
 {
     if ($langcode === false) {
         $langcode = get_desired_language();
@@ -46,7 +45,7 @@ function short_lang_code($langcode = false)
 /**
  * Given a 2-letter language code, return the language name in that language.
  */
-function lang_name($langcode)
+function lang_name(string $langcode): string
 {
     global $lang_name_data;
 
@@ -60,7 +59,7 @@ function lang_name($langcode)
 /**
  * Given a 2-letter language code, return the language name in English.
  */
-function eng_name($langcode)
+function eng_name(string $langcode): string
 {
     global $eng_name_data;
 
@@ -75,7 +74,7 @@ function eng_name($langcode)
  * Given a 2-letter language code, return a name for that language both
  * in English and in the native language.
  */
-function bilingual_name($langcode)
+function bilingual_name(string $langcode): string
 {
     $a = eng_name($langcode);
     $b = lang_name($langcode);
@@ -95,12 +94,8 @@ function bilingual_name($langcode)
  * Returns either:
  * - LTR for left-to-right languages
  * - RTL for right-to-left languages
- *
- * @param mixed $langcode
- *
- * @return string
  */
-function lang_direction($langcode = false)
+function lang_direction(false|string $langcode = false): string
 {
     if ($langcode === false) {
         $langcode = get_desired_language();
@@ -119,6 +114,7 @@ function lang_direction($langcode = false)
 
 /**
  * Return all installed system locales
+ * @return string[]
  */
 function get_installed_system_locales()
 {
@@ -149,14 +145,14 @@ function get_installed_system_locales()
 /**
  * Get a list of all locale translations.
  *
- * @param string $state
+ * @param 'all'|'enabled'|'disabled' $state
  *   One of:
  *   - "all" - all installed locale translations
  *   - "enabled" - locale translation is enabled
  *   - "disabled" - locale translation is disabled
  * @return string[]
  */
-function get_installed_locale_translations(string $state = "all", bool $reload_cache = false): array
+function get_installed_locale_translations($state = "all", bool $reload_cache = false): array
 {
     static $translation_cache = null;
 
@@ -196,7 +192,7 @@ function get_installed_locale_translations(string $state = "all", bool $reload_c
     return $translation_cache[$state];
 }
 
-function is_locale_translation_enabled($locale)
+function is_locale_translation_enabled(string $locale): bool
 {
     // Locale 'en_US' is always enabled because that's the default
     // language of all the internal strings. We have to check for
@@ -209,7 +205,7 @@ function is_locale_translation_enabled($locale)
     return in_array($locale, $enabled_locales);
 }
 
-function get_valid_locale_for_translation($locale)
+function get_valid_locale_for_translation(?string $locale): string
 {
     // Fall back to en_US (English) if locale isn't set
     // or if we don't have a translation for that locale.
@@ -219,7 +215,7 @@ function get_valid_locale_for_translation($locale)
     return $locale;
 }
 
-function set_locale_translation_enabled($locale, $enable)
+function set_locale_translation_enabled(string $locale, bool $enable): void
 {
     $translation_base = SiteConfig::get()->dyn_locales_dir . "/$locale";
     $enabled_file = "$translation_base/enabled";
@@ -242,6 +238,7 @@ function set_locale_translation_enabled($locale, $enable)
  *
  * Keys are the locale and the value being the name of the
  * language and the locale.
+ * @return array<string, string>
  */
 function get_locale_translation_selection_options()
 {
@@ -277,7 +274,7 @@ function get_locale_translation_selection_options()
  * ```
  * On success it returns an installed locale. On failure it returns NULL.
  */
-function get_locale_matching_browser_accept_language($http_accept)
+function get_locale_matching_browser_accept_language(?string $http_accept): ?string
 {
     // split the languages into their respective parts
     $browser_accepts = explode(",", $http_accept ?? '');
@@ -310,7 +307,7 @@ function get_locale_matching_browser_accept_language($http_accept)
  * Given a browser's accept-language string, return a locale string
  * that most closely matches it.
  */
-function massage_browser_lang_code_to_locale($browser_lang_code)
+function massage_browser_lang_code_to_locale(string $browser_lang_code): string
 {
     // system locales are always in the format xx_YY, but browsers can
     // send accepts in many different formats (eg: en, en-us, en-US)
@@ -344,7 +341,7 @@ function massage_browser_lang_code_to_locale($browser_lang_code)
     return $browser_lang_code;
 }
 
-function lang_html_header($langcode = false)
+function lang_html_header(false|string $langcode = false): string
 {
     if (!$langcode) {
         return '';

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -579,8 +579,8 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
 if ($action == SHOW_BLANK_ENTRY_FORM) {
     echo $entry_form;
 } elseif ($action == HANDLE_ENTRY_FORM_SUBMISSION) {
-    if ($n_form_problems > 0) {
-        if ($n_form_problems == 1) {
+    if ($n_form_problems > 0) { // @phpstan-ignore greater.alwaysFalse
+        if ($n_form_problems == 1) {  // @phpstan-ignore equal.alwaysFalse, equal.invalid
             $message =
                 _("There was a problem with a form input, as detailed below. Please fix it and re-submit.");
         } else {


### PR DESCRIPTION
A lot of our legacy code leans heavily on associative arrays to pass information between different modules instead of classes with properties with well defined types.

PHPStan 2.2 has a feature called 'sealed array shapes' which allows us to define the only keys allowed in an array (and the types of their values), which give an effect which looks much like classes with properties, but without all the code churn required to implement it.

This is the first step in the process of updating PHPStan's warning level to 6 which requires us to add type hints to all function arguments, function return values, array keys/values, and iterator values. 