### PR TITLE
Add initial function type hints, for PHPStan level 6

### DIFF
--- a/SETUP/phpstan_bootstrap.inc
+++ b/SETUP/phpstan_bootstrap.inc
@@ -8,11 +8,11 @@ define('SKIP_DB_CONNECT', true);
 
 
 // BEGIN dummy exception handlers
-function test_exception_handler($exception)
+function test_exception_handler(Throwable $exception): void
 {
 }
 
-function production_exception_handler($exception)
+function production_exception_handler(Throwable $exception): void
 {
 }
 // END dummy exception handlers

--- a/api/ApiRouter.inc
+++ b/api/ApiRouter.inc
@@ -102,7 +102,7 @@ class ApiRouter
         $this->_validators[$label] = $function;
     }
 
-    /** @return array{0: string, 1: callable} */
+    /** @return list{string, callable} */
     private function get_validator(string $path, string $part, TrieNode $node): array
     {
         if (isset($node->children)) {

--- a/api/index.php
+++ b/api/index.php
@@ -241,7 +241,7 @@ function handle_cors_headers()
 // set or defined in this file as the handlers may be used before the functions
 // are defined.
 
-function production_exception_handler($exception)
+function production_exception_handler(Throwable $exception): void
 {
     if ($exception instanceof ApiException) {
         $response_code = $exception->status_code;
@@ -256,7 +256,7 @@ function production_exception_handler($exception)
     api_output_response($response, $response_code);
 }
 
-function test_exception_handler($exception)
+function test_exception_handler(Throwable $exception): void
 {
     production_exception_handler($exception);
 }

--- a/crontab/ArchiveProjects.inc
+++ b/crontab/ArchiveProjects.inc
@@ -6,7 +6,7 @@ class ArchiveProjects extends BackgroundJob
 {
     public bool $requires_web_context = true;
 
-    public function work()
+    public function work(): void
     {
         $sql = sprintf(
             "

--- a/crontab/CleanDownloadTemp.inc
+++ b/crontab/CleanDownloadTemp.inc
@@ -6,7 +6,7 @@ class CleanDownloadTemp extends BackgroundJob
 {
     public bool $requires_web_context = true;
 
-    public function work()
+    public function work(): void
     {
         $download_temp_dir = realpath(SiteConfig::get()->dyn_dir . "/download_tmp");
         if (! is_dir($download_temp_dir)) {

--- a/crontab/CleanUploadsTrash.inc
+++ b/crontab/CleanUploadsTrash.inc
@@ -6,7 +6,7 @@ class CleanUploadsTrash extends BackgroundJob
 {
     public bool $requires_web_context = true;
 
-    public function work()
+    public function work(): void
     {
         $trash_dir = realpath(SiteConfig::get()->uploads_dir . "/" . SiteConfig::get()->uploads_subdir_trash);
         if (! is_dir($trash_dir)) {

--- a/crontab/ExtendSiteTallyGoals.inc
+++ b/crontab/ExtendSiteTallyGoals.inc
@@ -5,7 +5,7 @@
 // Extend the current site tally goals into the future
 class ExtendSiteTallyGoals extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         $res = DPDatabase::query("
             SELECT MAX(date) FROM site_tally_goals

--- a/crontab/NotifyOldPP.inc
+++ b/crontab/NotifyOldPP.inc
@@ -11,7 +11,7 @@ class NotifyOldPP extends BackgroundJob
     private int $notifications_sent = 0;
     private int $notifications_failed = 0;
 
-    public function work()
+    public function work(): void
     {
         $projects_by_PPer = get_pp_projects_past_threshold();
 

--- a/crontab/PruneJobLogs.inc
+++ b/crontab/PruneJobLogs.inc
@@ -4,7 +4,7 @@ include_once($relPath."job_log.inc");
 // Prune job_log entries
 class PruneJobLogs extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         prune_job_log_entries(SiteConfig::get()->days_to_retain_job_logs);
     }

--- a/crontab/PruneNonActivatedUsers.inc
+++ b/crontab/PruneNonActivatedUsers.inc
@@ -3,7 +3,7 @@
 // Prune non_activated_users entries
 class PruneNonActivatedUsers extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         NonactivatedUser::prune(SiteConfig::get()->days_to_retain_pending_accounts);
     }

--- a/crontab/PrunePageData.inc
+++ b/crontab/PrunePageData.inc
@@ -3,7 +3,7 @@
 // Find projects that were posted to PG a while ago and prune page data.
 class PrunePageData extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         $database = SiteConfig::get()->archive_db_name ? SiteConfig::get()->archive_db_name : SiteConfig::get()->db_name;
 

--- a/crontab/RecordProjectStateCounts.inc
+++ b/crontab/RecordProjectStateCounts.inc
@@ -5,7 +5,7 @@
 // Record current project state counts
 class RecordProjectStateCounts extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         $date_string = date('Y-m-d');
         $sql = sprintf(

--- a/crontab/RecordUserCounts.inc
+++ b/crontab/RecordUserCounts.inc
@@ -5,7 +5,7 @@
 // Record active user counts.
 class RecordUserCounts extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         // Each L_<interval> field gives the number of distinct users
         // who logged in sometime in the <interval> preceding the row's timestamp.

--- a/crontab/SendSmoothreadingNotifications.inc
+++ b/crontab/SendSmoothreadingNotifications.inc
@@ -7,7 +7,7 @@ include_once($relPath.'Project.inc');
 // Send SR finish notifications
 class SendSmoothreadingNotifications extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         // Assume smooth read deadlines are at exact hours
         // Select all projects whose smooth reading deadline is within the past hour.

--- a/crontab/TakeTallySnapshots.inc
+++ b/crontab/TakeTallySnapshots.inc
@@ -21,7 +21,7 @@ class TakeTallySnapshots extends BackgroundJob
         $this->start_message = "Tally snapshot ascribed as $this->midnight";
     }
 
-    public function work()
+    public function work(): void
     {
         $watch = new Stopwatch();
 

--- a/crontab/ToggleSpecialDayQueues.inc
+++ b/crontab/ToggleSpecialDayQueues.inc
@@ -12,7 +12,7 @@
  */
 class ToggleSpecialDayQueues extends BackgroundJob
 {
-    public function work()
+    public function work(): void
     {
         /*
         We want the queue for a special day to be open

--- a/pinc/Activity.inc
+++ b/pinc/Activity.inc
@@ -51,6 +51,7 @@ class Activities
     // This maps the static container class names to the class types
     // they contain. This makes the functions in this base class return the
     // correct subset of items when called from the child classes.
+    /** @var array<string, string> */
     private static $container_to_class_mapping = [
         "Activities" => "Activity",
         "Rounds" => "Round",
@@ -73,6 +74,7 @@ class Activities
 
     /**
      * The return of this function is untyped for now (see the comment above `$_activities` for why).
+     * @return mixed[]
      */
     public static function get_all(): array
     {
@@ -91,7 +93,7 @@ class Activities
      *
      * @param int|string $value
      */
-    protected static function _get(string $attribute, $value)
+    protected static function _get(string $attribute, $value): mixed
     {
         // fast-track lookup by ID
         if ($attribute == "id") {
@@ -115,7 +117,7 @@ class Activities
     /**
      * The return of this function is untyped for now (see the comment above `$_activities` for why).
      */
-    public static function get_by_id(string $id)
+    public static function get_by_id(string $id): mixed
     {
         return self::$_activities[self::_get_class_mapping()][$id] ?? null;
     }
@@ -131,7 +133,7 @@ class Activity
      *   (Should probably conform to the rules for a PHP variable name.)
      * @param string $name
      *   A gettext-translated name for the activity.
-     * @param array $access_minima
+     * @param array<string, int> $access_minima
      *   A (possibly empty) array of minimum requirements that a user must satisfy
      *   in order to be allowed to participate in this activity
      *   (barring special permission).
@@ -160,7 +162,6 @@ class Activity
     public function __construct(
         public readonly string $id,
         public readonly string $name,
-        /** @var array<string,int> */
         public array $access_minima,
         public readonly string $after_satisfying_minima,
         public readonly string $evaluation_criteria,
@@ -221,7 +222,7 @@ class Activity
      * that the user has completed. Otherwise, consult the database.
      */
     // TODO(jchaffraix): Add a class for the UserAccess object for type soundness.
-    public function user_access(?string $username, $n_pages_completed = null): object
+    public function user_access(?string $username, ?int $n_pages_completed = null): object
     {
         if (is_null($username)) {
             $uao = new StdClass(); // user access object

--- a/pinc/BackgroundJob.inc
+++ b/pinc/BackgroundJob.inc
@@ -24,7 +24,7 @@ abstract class BackgroundJob
         $this->watch = new Stopwatch();
     }
 
-    public function start(?string $message = null)
+    public function start(?string $message = null): void
     {
         $this->watch->start();
         ob_start();
@@ -33,7 +33,7 @@ abstract class BackgroundJob
         }
     }
 
-    public function stop(?string $message = null, ?bool $succeeded = null)
+    public function stop(?string $message = null, ?bool $succeeded = null): void
     {
         $this->output = ob_get_contents();
         ob_end_clean();
@@ -47,7 +47,7 @@ abstract class BackgroundJob
         insert_job_log_entry(get_class($this), "END", $message, $succeeded);
     }
 
-    public function go()
+    public function go(): void
     {
         $hit_error = false;
         try {
@@ -75,5 +75,5 @@ abstract class BackgroundJob
     }
 
     // work() should throw an exception on failure
-    abstract public function work();
+    abstract public function work(): void;
 }

--- a/pinc/CharacterSelector.inc
+++ b/pinc/CharacterSelector.inc
@@ -4,15 +4,16 @@ include_once($relPath."unicode.inc"); // convert_codepoint_ranges_to_characters(
 
 class CharacterSelector
 {
+    /** @var (?PickerSet)[] */
     private array $picker_sets;
 
-    public function __construct($projectid)
+    public function __construct(string $projectid)
     {
         $project = get_project_or_quiz($projectid);
         $this->picker_sets = $project->get_pickersets();
     }
 
-    public function draw()
+    public function draw(): void
     {
         // The code in tools/proofers/character_selector.js uses these ids and
         // classes and adds the MRU buttons if this code is changed, that code
@@ -40,7 +41,7 @@ class CharacterSelector
                 $selector_string .= "<button type='button' id='$safe_code' class='selector_button' title='$title'>" . html_safe($code) . "</button>";
                 $row_string .= "<div class='$safe_code key-block'>\n";
                 foreach ($picker as $row) {
-                    $row_string .= $this->draw_row(convert_codepoint_ranges_to_characters($row));
+                    $row_string .= $this->format_row(convert_codepoint_ranges_to_characters($row));
                 }
                 $row_string .= "</div>\n";
             }
@@ -52,7 +53,8 @@ class CharacterSelector
         echo "<div id='char-selector' class='nowrap'>$selector_string$row_string</div>\n";
     }
 
-    public function draw_row($chars)
+    /** @param array<?string> $chars */
+    private function format_row(array $chars): string
     {
         $row = "<div class='table-row'>";
 

--- a/pinc/ImageUtils.inc
+++ b/pinc/ImageUtils.inc
@@ -60,7 +60,7 @@ class ImageUtils
     /**
      * Validates integrity of the specified image using external tools.
      *
-     * @returns array<int, string>
+     * @return list{int, string}
      */
     public function validate_integrity(string $filename): array
     {

--- a/pinc/LPage.inc
+++ b/pinc/LPage.inc
@@ -17,8 +17,7 @@ include_once($relPath.'forum_interface.inc'); // get_forum_user_id()
  *
  * If successful, it returns [ $imagename, $state ],
  * on failure it returns NULL;
- *
- * @return ?array{0:string, 1:string}
+ * @return ?list{string, string}
  */
 function get_available_page_array(Project $project, Round $round, string $pguser, string $preceding_proofer_restriction): ?array
 {
@@ -160,7 +159,7 @@ function get_available_page(string $projectid, string $proj_state, string $pguse
  * Returns an array [image, state] unless no page is available,
  * in which case throw an exception.
  *
- * @return array{0:string, 1:string}
+ * @return list{string, string}
  */
 function get_available_proof_page_array(Project $project, Round $round, string $pguser): array
 {
@@ -325,16 +324,16 @@ class LPage
         return Page_getText($this->projectid, $this->imagefile, $desired_column_name);
     }
 
-    /** @return array|string */
-    public function get_filename()
+    public function get_filename(): SplFileInfo|string
     {
         return pathinfo($this->imagefile, PATHINFO_FILENAME);
     }
 
+
+    /** @return RoundInfo[] */
     public function get_info(): array
     {
         $round_info_array = [];
-
         foreach ($this->round->other_rounds_with_visible_usernames as $other_round_id) {
             $other_round = get_Round_for_round_id($other_round_id);
             $username = $this->get_username_for_round($other_round);
@@ -386,7 +385,7 @@ class LPage
      * - if this function says that the page was not saved,
      * - it can only be because the user already reached the daily page limit.
      *
-     * @return array{0:bool, 1:bool}
+     * @return list{bool, bool}
      */
     public function attemptSaveAsDone(string $text_data, string $pguser): array
     {

--- a/pinc/MARCRecord.inc
+++ b/pinc/MARCRecord.inc
@@ -230,7 +230,7 @@ class InvalidMARCRecord extends Exception
 //  ]
 
 /**
- * @property-read array $yaz_array
+ * @property-read string[][] $yaz_array
  * @property string $title
  * @property string $author
  * @property-read string $lccn
@@ -247,7 +247,9 @@ class InvalidMARCRecord extends Exception
 class MARCRecord
 {
     // MARC record in the yaz_search 'array' format
+    /** @var string[][] */
     private $record = [];
+    /** @var array<int|string, string> */
     private $literary_form_array = [
         "a" => "Art",
         "b" => "Biography",
@@ -281,6 +283,7 @@ class MARCRecord
     ];
 
     // https://www.loc.gov/marc/bibliographic/bdleader.html
+    /** @var array<int|string, string> */
     private $type_of_record_array = [
         "a" => "Language material", // "resources that are basically textual in nature"
         "c" => "Notated music",
@@ -298,14 +301,11 @@ class MARCRecord
         "t" => "Manuscript language material", // material in handwriting, typescript, or computer printout including printed materials completed by hand or by keyboard
     ];
 
-    private $force_utf8;
-
-    public function __construct($force_utf8 = true)
+    public function __construct(private readonly bool $force_utf8 = true)
     {
-        $this->force_utf8 = $force_utf8;
     }
 
-    public function __get($field)
+    public function __get(string $field): string
     {
         $func = "get_$field";
         $string = $this->{$func}();
@@ -318,16 +318,19 @@ class MARCRecord
         return $string;
     }
 
-    public function load_yaz_array($yaz_array)
+    /** @param string[][] $yaz_array */
+    public function load_yaz_array(array $yaz_array): void
     {
         $this->record = $yaz_array;
     }
 
-    public function get_yaz_array()
+    /** @return string[][] */
+    public function get_yaz_array(): array
     {
         return $this->record;
     }
 
+    /** @return Generator<int> */
     private function _key_search(string $tag, string $subfield)
     {
         foreach ($this->record as $key => $value) {
@@ -346,12 +349,13 @@ class MARCRecord
             }
         }
     }
-    private function _find_first(string $tag, string $subfield)
+    private function _find_first(string $tag, string $subfield): mixed
     {
         return $this->_key_search($tag, $subfield)->current();
     }
 
-    private function _find_all(string $tag, string $subfield)
+    /** @return mixed[] */
+    private function _find_all(string $tag, string $subfield): array
     {
         return iterator_to_array($this->_key_search($tag, $subfield));
     }
@@ -566,7 +570,7 @@ class MARCRecord
         return rtrim(ltrim(implode(", ", $marc_publisher), "["), "]");
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $directory = "";
         $data = "";

--- a/pinc/NonactivatedUser.inc
+++ b/pinc/NonactivatedUser.inc
@@ -23,25 +23,29 @@ class NonuniqueNonactivatedUserException extends Exception
  */
 class NonactivatedUser
 {
+    /** @var array<string, mixed> */
     private $table_row;
 
     // List of fields that can never be set outside of this class
+    /** @var string[] */
     private $unsettable_fields = [
         "id",
         "date_created",
     ];
 
     // List of fields that when set should never change
+    /** @var string[] */
     private $immutable_fields = [
         "username",
     ];
 
     // Fields are assumed to be strings unless included here
+    /** @var string[] */
     private $integer_fields = [
         "email_updates",
     ];
 
-    public function __construct($username = null)
+    public function __construct(?string $username = null)
     {
         if ($username !== null) {
             $this->load("username", $username);
@@ -51,7 +55,7 @@ class NonactivatedUser
     // The __set() and __get() methods allow access to user fields without
     // creating accessors for them all individually.
     // See the PHP docs for "magic methods".
-    public function __set($name, $value)
+    public function __set(string $name, mixed $value): void
     {
         if (in_array($name, $this->unsettable_fields)) {
             throw new DomainException(
@@ -74,17 +78,17 @@ class NonactivatedUser
         $this->table_row[$name] = $value;
     }
 
-    public function __get($name)
+    public function __get(string $name): mixed
     {
         return $this->table_row[$name];
     }
 
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         return isset($this->table_row[$name]);
     }
 
-    private function load($field, $value, $strict = true)
+    private function load(string $field, mixed $value, bool $strict = true): void
     {
         if (!in_array($field, $this->integer_fields)) {
             $escaped_value = sprintf("'%s'", DPDatabase::escape($value));
@@ -136,7 +140,7 @@ class NonactivatedUser
         mysqli_free_result($result);
     }
 
-    public function save()
+    public function save(): void
     {
         $todays_date = time();
 
@@ -208,7 +212,7 @@ class NonactivatedUser
         }
     }
 
-    public function delete()
+    public function delete(): void
     {
         if (!isset($this->id)) {
             return;

--- a/pinc/PageUnformatter.inc
+++ b/pinc/PageUnformatter.inc
@@ -5,7 +5,7 @@
  */
 class PageUnformatter
 {
-    private function find_close($text, $offset)
+    private function find_close(string $text, int $offset): int
     {
         // find next unmatched ]
         $nest_level = 0;
@@ -28,7 +28,7 @@ class PageUnformatter
         }
     }
 
-    private function remove_user_notes($text)
+    private function remove_user_notes(string $text): string
     {
         $start = strpos($text, "[**");
         if (false === $start) { // not found
@@ -41,7 +41,7 @@ class PageUnformatter
         return substr($text, 0, $start) . $this->remove_user_notes(substr($text, $end + 1));
     }
 
-    private function advance_end($text, $end)
+    private function advance_end(string $text, int $end): int
     {
         // for continuing footnote etc., if * follows ] remove it
         $new_start = $end + 1;
@@ -51,7 +51,7 @@ class PageUnformatter
         return $new_start;
     }
 
-    private function adjust_footnotes($text)
+    private function adjust_footnotes(string $text): string
     {
         // remove "[Footnote" and ":" and "]", if ref. is an upper-case letter replace with *
         $match = preg_match("/\[Footnote (?:(\d+|[a-z])|[A-Z]):/", $text, $matches, PREG_OFFSET_CAPTURE);
@@ -75,7 +75,7 @@ class PageUnformatter
         return substr($text, 0, $start) . $note_ref . substr($text, $right_start, $end - $right_start) . $this->adjust_footnotes(substr($text, $new_start));
     }
 
-    private function adjust_notes($text)
+    private function adjust_notes(string $text): string
     {
         // Illustration with text, Sidenote, continuation Footnote without a ref.
         $match = preg_match("/\*\[Footnote:|\*?\[Sidenote:|\*?\[Illustration:/", $text, $matches, PREG_OFFSET_CAPTURE);
@@ -94,7 +94,7 @@ class PageUnformatter
         return substr($text, 0, $start) . substr($text, $right_start, $end - $right_start) . $this->adjust_notes(substr($text, $new_start));
     }
 
-    public function remove_formatting($text, $unwrap)
+    public function remove_formatting(string $text, bool $unwrap): string
     {
         $text = str_replace("\r\n", "\n", $text);
         // these can leave blank lines which will be removed later

--- a/pinc/Pool.inc
+++ b/pinc/Pool.inc
@@ -31,13 +31,13 @@ class Pool extends Stage
      *   as shown to the user and as a field in the projects table
      *   (e.g. "postprocessor" when listing books available for PPV).
      *   Used by `pinc/showavailablebooks.inc`
+     * @param array<string, int> $access_minima
      * @param string[] $blather
      *   An array of strings to echo on the pool's home page.
      */
     public function __construct(
         string $id,
         string $name,
-        /** @var array<string,int> */
         array $access_minima,
         string $after_satisfying_minima,
         string $evaluation_criteria,

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -159,13 +159,10 @@ class ProjectTransitionException extends ProjectException
 
 class ProjectPage
 {
-    public $page_name;
-    public $page_state;
-
-    public function __construct(string $pagename, string $pagestate)
-    {
-        $this->page_name = $pagename;
-        $this->page_state = $pagestate;
+    public function __construct(
+        public readonly string $page_name,
+        public readonly string $page_state
+    ) {
     }
 }
 
@@ -193,7 +190,7 @@ class Project
 {
     use CharSuiteSet;
 
-    private $_create_source = null;
+    private ?string $_create_source = null;
     public string $nameofwork;
     public ?string $state;
     public string $special_code;
@@ -234,7 +231,7 @@ class Project
     public int $int_level;
 
     /** @param string|array<string, mixed>|null $arg */
-    public function __construct(mixed $arg = null)
+    public function __construct($arg = null)
     {
         if (is_string($arg)) {
             // $arg is the projectid.
@@ -832,8 +829,8 @@ class Project
     // by joining them with the string " with ". These functions provide a
     // common place for encoding / decoding them.
 
-    /** @param array{0: string, 1?: string} $languages */
-    public static function encode_languages(array $languages): string
+    /** @param list{string}|list{string, string} $languages */
+    public static function encode_languages($languages): string
     {
         // handle the case where the second language is empty
         if (count($languages) == 2 && $languages[1] == '') {
@@ -910,7 +907,7 @@ class Project
     }
 
     /** @param string[]|CharSuite[] $charsuites */
-    public function set_charsuites(mixed $charsuites): void
+    public function set_charsuites(array $charsuites): void
     {
         // We want to allow the project to keep any character suites
         // it already had, even if the character suite was disabled
@@ -940,7 +937,7 @@ class Project
     }
 
     /** @param string|CharSuite $charsuite */
-    public function add_charsuite(mixed $charsuite): void
+    public function add_charsuite($charsuite): void
     {
         $charsuite = CharSuites::resolve($charsuite);
 
@@ -1230,7 +1227,7 @@ class Project
     }
 
     /** @return string[] */
-    public function get_page_states(): array
+    public function get_page_states()
     {
         $states = [];
 
@@ -1337,7 +1334,7 @@ class Project
     }
 
     /** @return string[] */
-    public function get_illustrations(): array
+    public function get_illustrations()
     {
         // Illustrations are the set of files in the project directory that
         // do not match existing image names in the database.
@@ -2091,7 +2088,7 @@ function get_page_image_param(array $arr, string $key, bool $allownull = false):
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // Image source functions
 
-/** @return array<string, mixed> */
+/** @return array<string, array<string, mixed>> */
 function load_image_sources(): array
 {
     static $image_sources = [];

--- a/pinc/ProjectSearchForm.inc
+++ b/pinc/ProjectSearchForm.inc
@@ -7,6 +7,7 @@ class ProjectSearchWidget
     protected string $id;
     protected string $label;
     protected string $invert_label;
+    /** @var list{string, string} */
     private array $q_contrib;
     private string $separator;
     private bool $can_be_multiple = false;
@@ -14,8 +15,10 @@ class ProjectSearchWidget
     private bool $has_invert = false;
     private string $type;
     private int $size;
+    /** @var array<string, string> */
     private array $options;
 
+    /** @param array<string, mixed> $properties */
     public function __construct(array $properties)
     {
         foreach ($properties as $property => $value) {
@@ -132,6 +135,7 @@ class ProjectSearchWidget
         return $contribution;
     }
 
+    /** @param mixed[] $values */
     public function sql_from_multi(array $values, string $column_name, string $comparator): ?string
     {
         // if any $value is an array, someone is mucking with the URL
@@ -157,6 +161,7 @@ class ProjectSearchWidget
 
 class SpecialDayWidget extends ProjectSearchWidget
 {
+    /** @param array<mixed> $values */
     public function sql_from_multi(array $values, string $column_name, string $comparator): ?string
     {
         // if any $value is an array, someone is mucking with the URL
@@ -201,6 +206,7 @@ class HoldWidget extends ProjectSearchWidget
 
 class ProjectSearchForm
 {
+    /** @var ProjectSearchWidget[] */
     private array $widgets;
 
     public function __construct()

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -399,6 +399,7 @@ class HoldColumn extends Column
 
 class ColumnData
 {
+    /** @var Column[] */
     public array $columns;
 
     public function __construct(
@@ -594,7 +595,7 @@ class ProjectSearchResults
         $this->sort_sql .= ", $sec_sort_sql asc";
     }
 
-    /** @return array{0: bool|mysqli_result, 1: int} */
+    /** @return list{bool|mysqli_result, int} */
     private function _search(string $where_condition, int $results_offset): array
     {
         // load a count of the total number of projects

--- a/pinc/ProjectState.inc
+++ b/pinc/ProjectState.inc
@@ -337,11 +337,8 @@ function get_project_status_descriptors(): array
  * - plotting a graph of
  * projects having that status.
  *
- * @param string $which
- *   A word denoting a possible status of a project, one of:
- *   `created`, `proofed`, `PPd`, or `posted`.
- *
- * @return object
+ * @param 'created'|'proofed'|'PPd'|'posted' $which
+ *   A word denoting a possible status of a project
  */
 function get_project_status_descriptor(string $which): object
 {

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -172,6 +172,8 @@ class ProjectTransition
      *
      * It should perhaps also be the only place that modifies these columns:
      *     modifieddate checkedoutby postproofer postcomments
+     *
+     * @param array{details?: string} $extras
      */
     public function do_state_change(Project $project, string $who, array $extras): string
     {
@@ -393,6 +395,7 @@ function project_pre_release_check(Project $project, Round $round): array
 
 class ProjectTransitions
 {
+    /** @var ProjectTransition[] */
     private static $_project_transitions = [];
 
     /** @return ProjectTransition[] */

--- a/pinc/ProofProject.inc
+++ b/pinc/ProofProject.inc
@@ -8,12 +8,14 @@ class ProofProjectPage extends LPage
         parent::__construct($proof_project->project, $project_page->page_name, $project_page->page_state, 0);
     }
 
+    /** @return array<string, mixed> */
     public function pp_checkout(string $user): array
     {
         parent::checkout($user);
         return $this->render_page_data();
     }
 
+    /** @return array<string, mixed> */
     public function attempt_checkin(string $page_text): array
     {
         global $pguser;
@@ -43,6 +45,7 @@ class ProofProjectPage extends LPage
         return ["message" => $sentence, "status" => $status_code];
     }
 
+    /** @return array<string, mixed> */
     public function save(string $page_text): array
     {
         global $pguser;
@@ -51,6 +54,7 @@ class ProofProjectPage extends LPage
         return $this->get_page_text_data();
     }
 
+    /** @return array<string, mixed> */
     public function save_and_revert(string $page_text): array
     {
         global $pguser;
@@ -60,6 +64,7 @@ class ProofProjectPage extends LPage
         return $this->get_page_text_data();
     }
 
+    /** @return array<string, mixed> */
     public function pp_resume_page(): array
     {
         global $pguser;
@@ -68,6 +73,7 @@ class ProofProjectPage extends LPage
         return $this->render_page_data();
     }
 
+    /** @return array<string, mixed> */
     private function render_page_data(): array
     {
         return
@@ -81,6 +87,7 @@ class ProofProjectPage extends LPage
             ];
     }
 
+    /** @return array<string, mixed> */
     public function get_page_text_data(): array
     {
         return [
@@ -90,6 +97,7 @@ class ProofProjectPage extends LPage
         ];
     }
 
+    /** @param string[] $accepted_words */
     public function wc_report(array $accepted_words): void
     {
         global $pguser;
@@ -134,8 +142,8 @@ class ProofProjectPage extends LPage
 
 class ProofProject
 {
-    public $project;
-    public $round;
+    public readonly Project $project;
+    public readonly Round $round;
 
     public function __construct(Project $project)
     {
@@ -148,6 +156,7 @@ class ProofProject
         $this->round = $project_round;
     }
 
+    /** @return array<string, mixed> */
     public function checkout(): array
     {
         global $pguser;

--- a/pinc/ProofreadingToolbox.inc
+++ b/pinc/ProofreadingToolbox.inc
@@ -5,7 +5,7 @@ include_once($relPath.'CharacterSelector.inc');
 class ToolButton
 {
     public string $html;
-    public function __construct($accesskey, $title, $label, $onclick)
+    public function __construct(string $accesskey, string $title, string $label, string $onclick)
     {
         $access_string = $accesskey ? "accesskey='" . attr_safe($accesskey) . "'" : '';
         $this->html = "<button type='button' class='proofbutton' onclick='$onclick' $access_string title='" . attr_safe($title) . "'>$label</button>\n";
@@ -16,7 +16,7 @@ class ToolButton
 class PopupLink
 {
     public string $html;
-    public function __construct($label, $url, $window_name, $width, $height)
+    public function __construct(string $label, string $url, string $window_name, int $width, int $height)
     {
         $js = "return openToolboxPopup('$url', $width, $height, '$window_name');";
         $this->html = "<a href='#' class='nowrap' onClick=\"$js\"\n>$label</a>\n";
@@ -65,7 +65,7 @@ class ProofreadingToolbox
         ];
     }
 
-    public function output($projectid, $round)
+    public function output(string $projectid, Round $round): void
     {
         echo "<div class='display-flex' id='toolbox'>";
         $character_selector = new CharacterSelector($projectid);
@@ -79,7 +79,7 @@ class ProofreadingToolbox
         echo '</div>';
     }
 
-    private function draw_tools($round)
+    private function draw_tools(Round $round): void
     {
         global $code_url;
 
@@ -116,7 +116,12 @@ class ProofreadingToolbox
         echo "</div>";
     }
 
-    private function array_extract($source, $keys)
+    /**
+     * @param array<string, mixed> $source
+     * @param 'ALL'|string[] $keys
+     * @return array<string, mixed>
+     */
+    private function array_extract(array $source, string|array $keys): array
     {
         if ($keys == 'ALL') {
             return $source;

--- a/pinc/RandomRule.inc
+++ b/pinc/RandomRule.inc
@@ -10,12 +10,14 @@
  */
 class RandomRule
 {
+    /** @var array<string, string> */
     private array $table_row = [];
 
     // Because these are static class variables we can't use _() to translate
     // them. But they're only used in the Admin interface so that's probably
     // OK anyway. If, in the future, we want to translate them we can move
     // them to a class function (get_document_values()) instead.
+    /** @var array<string, string> */
     public static $document_values = [
         "proofreading_guidelines.php" => "Proofreading Guidelines",
         "formatting_guidelines.php" => "Formatting Guidelines",
@@ -28,7 +30,7 @@ class RandomRule
         }
     }
 
-    public function __get(string $name)
+    public function __get(string $name): ?string
     {
         return $this->table_row[$name];
     }
@@ -146,7 +148,7 @@ class RandomRule
      *
      * Useful primarily for the administrative interface.
      *
-     * @return array{"document": string, "langcode": string, "count": int}[]
+     * @return array{document: string, langcode: string, count: int}[]
      */
     public static function get_summary(): array
     {

--- a/pinc/Settings.inc
+++ b/pinc/Settings.inc
@@ -58,37 +58,24 @@ class Settings
 
     /**
      * Set a setting to true
-     *
-     * @param string $settingCode
-     *
-     * @return void
      */
-    public function set_true($settingCode)
+    public function set_true(string $settingCode): void
     {
         $this->set_boolean($settingCode, true);
     }
 
     /**
      * Set a setting to false
-     *
-     * @param string $settingCode
-     *
-     * @return void
      */
-    public function set_false($settingCode)
+    public function set_false(string $settingCode): void
     {
         $this->set_boolean($settingCode, false);
     }
 
     /**
      * A wrapper around set_value() for boolean values.
-     *
-     * @param string $settingCode
-     * @param bool $boolval
-     *
-     * @return void
      */
-    public function set_boolean($settingCode, $boolval)
+    public function set_boolean(string $settingCode, bool $boolval): void
     {
         $this->set_value($settingCode, ($boolval ? 'yes' : null));
     }
@@ -96,12 +83,8 @@ class Settings
     /**
      * Return True iff the setting exists and its value is 'yes',
      * otherwise, return False.
-     *
-     * @param string $settingCode
-     *
-     * @return bool
      */
-    public function get_boolean($settingCode)
+    public function get_boolean(string $settingCode): bool
     {
         return ($this->get_value($settingCode) === 'yes');
     }
@@ -122,8 +105,7 @@ class Settings
         DPDatabase::query($sql);
     }
 
-    /** @param mixed $value */
-    private function _insert_setting_value(string $settingCode, $value): void
+    private function _insert_setting_value(string $settingCode, mixed $value): void
     {
         $sql = sprintf(
             "
@@ -138,8 +120,7 @@ class Settings
         DPDatabase::query($sql);
     }
 
-    /** @param mixed $value */
-    private function _delete_setting_value(string $settingCode, $value): void
+    private function _delete_setting_value(string $settingCode, mixed $value): void
     {
         $sql = sprintf(
             "
@@ -160,13 +141,8 @@ class Settings
      *
      * If this is a multi-valued setting this will become a single-valued setting.
      * If $value is NULL, remove the setting.
-     *
-     * @param string $settingCode
-     * @param mixed $value
-     *
-     * @return void
      */
-    public function set_value($settingCode, $value)
+    public function set_value(string $settingCode, mixed $value): void
     {
         if ($this->username == '') {
             // If we don't have a username set, don't try to write anything
@@ -189,13 +165,8 @@ class Settings
      * If no record exists, return `$default`. Otherwise return what's in the
      * Value column. Note: if setting is really boolean, this will NOT return
      * True, but 'yes' (a string).
-     *
-     * @param string $settingCode
-     * @param mixed $default
-     *
-     * @return mixed
      */
-    public function get_value($settingCode, $default = null)
+    public function get_value(string $settingCode, mixed $default = null): mixed
     {
         $values = $this->get_values($settingCode);
 
@@ -216,13 +187,8 @@ class Settings
 
     /**
      * Load a setting value into the $settings_array data structure
-     *
-     * @param string $setting
-     * @param mixed $value
-     *
-     * @return void
      */
-    private function _load_value($setting, $value)
+    private function _load_value(string $setting, mixed $value): void
     {
         if (isset($this->settings_array[$setting])) {
             $this->settings_array[$setting][] = $value;
@@ -236,13 +202,8 @@ class Settings
      * exists.
      *
      * This allows a setting to have multiple values.
-     *
-     * @param string $settingCode
-     * @param mixed $value
-     *
-     * @return void
      */
-    public function add_value($settingCode, $value)
+    public function add_value(string $settingCode, mixed $value): void
     {
         $this->_load_value($settingCode, $value);
         $this->_insert_setting_value($settingCode, $value);
@@ -250,13 +211,8 @@ class Settings
 
     /**
      * Remove a setting:value pair
-     *
-     * @param string $settingCode
-     * @param mixed $value
-     *
-     * @return void
      */
-    public function remove_value($settingCode, $value)
+    public function remove_value(string $settingCode, mixed $value): void
     {
         if (array_key_exists($settingCode, $this->settings_array) && in_array($value, $this->settings_array[$settingCode])) {
             $this->settings_array[$settingCode] = array_diff(
@@ -270,12 +226,8 @@ class Settings
 
     /**
      * Returns an array of values for the setting
-     *
-     * @param string $settingCode
-     *
-     * @return mixed
      */
-    public function get_values($settingCode)
+    public function get_values(string $settingCode): mixed
     {
         if (!array_key_exists($settingCode, $this->settings_array)) {
             return [];
@@ -288,10 +240,8 @@ class Settings
 
     /**
      * Count the number of settings for this user
-     *
-     * @return int
      */
-    public function settings_count()
+    public function settings_count(): int
     {
         return count($this->settings_array);
     }
@@ -331,12 +281,9 @@ class Settings
      * Return a list of unique usernames that have a specific setting
      * specified (and optionally with a specific value).
      *
-     * @param string $setting
-     * @param mixed $value
-     *
      * @return string[]
      */
-    public static function get_users_with_setting($setting, $value = null): array
+    public static function get_users_with_setting(string $setting, mixed $value = null): array
     {
         $usernames = [];
         $sql = sprintf(

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -84,9 +84,11 @@ class SiteConfig
     public bool $api_rate_limit = false;
     public int $api_rate_limit_requests_per_window = 3600;
     public int $api_rate_limit_seconds_in_window = 3600;
+    /** @var string[] */
     public array $api_storage_keys = [];
 
     // emails
+    /** @var array<string, string|int> */
     public array $phpmailer_smtp_config = [];
     public ?string $no_reply_email_addr;  // only used by noncvs code
     public ?string $general_help_email_addr;
@@ -105,6 +107,7 @@ class SiteConfig
     public bool $auto_post_to_project_topic = false;
     public bool $ordinary_users_can_see_queue_settings = true;
     public string $external_catalog_locator = 'lx2.loc.gov:210/LCDB';
+    /** @var string[] */
     public array $default_project_char_suites = ["basic-latin"];
     public bool $testing = false;
 
@@ -145,7 +148,7 @@ class SiteConfig
         $projects_dir = $this->projects_dir;
     }
 
-    public static function load(string $filename)
+    public static function load(string $filename): void
     {
         if (self::$_site_config) {
             return;

--- a/pinc/Stage.inc
+++ b/pinc/Stage.inc
@@ -29,13 +29,13 @@ class Stage extends Activity
      *   The path (relative to `$code_url/faq/`) of a document that tells you
      *   everything you need to know about working in this stage.
      *   Or NULL if there is no such document.
+     * @param array<string,int> $access_minima
      * @param string $relative_url
      *   The "home" location (relative to `$code_url/`) of the stage.
      */
     public function __construct(
         string $id,
         string $name,
-        /** @var array<string,int> */
         array $access_minima,
         string $after_satisfying_minima,
         string $evaluation_criteria,

--- a/pinc/TableDocumentation.inc
+++ b/pinc/TableDocumentation.inc
@@ -4,6 +4,15 @@ class TableDocumentation
 {
     public function __construct(
         private readonly string $display_name,
+        /** @var array{
+         *           Field: string,
+         *           Type: string,
+         *           Null: string,
+         *           Key: string,
+         *           Default: string,
+         *           Extra: string
+         *       }[]
+         */
         private readonly array $columns_information
     ) {
     }
@@ -51,7 +60,8 @@ class TableDocumentation
         ]);
     }
 
-    public function get_column_names(): array
+    /** @return string[] */
+    public function get_column_names()
     {
         $column_names = [];
 
@@ -67,12 +77,14 @@ class TableDocumentation
      *
      * Every cell is padded right with spaces to ensure every column is as wide as the widest cell in that column.
      *
-     * @param array $contents the data that is shown within the table
-     * @param array $table_columns the columns to display
+     * @param list<array<string, string>> $contents
+     *     the data that is shown within the table
+     * @param string[] $table_columns
+     *     the columns to display
      *
-     * @return array array of strings -- the generate markdown table
+     * @return string[] -- the generateid markdown table
      */
-    public static function create_markdown_table(array $contents, array $table_columns): array
+    public static function create_markdown_table($contents, $table_columns)
     {
         // For each column find the length of the longest value (used for padding in the table)
         $column_lengths = [];
@@ -115,12 +127,14 @@ class TableDocumentation
      * Removes column definitions for columns which are not included in the second argument and adds the column definitions
      * for any column in the second argument which does not have a column definition.
      *
-     * @param array $lines an array of strings -- the lines of the text
-     * @param array $column_names column names of the current columns in the table
+     * @param string[] $lines
+     *      lines of the text
+     * @param string[] $column_names
+     *      column names of the current columns in the table
      *
-     * @return array an array of strings containing the text with updated column definitions
+     * @return string[] lines of text with updated column definitions
      */
-    public static function update_column_definitions(array $lines, array $column_names): array
+    public static function update_column_definitions($lines, $column_names)
     {
         $lines_with_updated_column_definitions = [];
         $encountered_columns = [];
@@ -156,12 +170,14 @@ class TableDocumentation
     /**
      * Replaces first markdown table with the second argument.
      *
-     * @param array $lines an array of strings -- the lines of the text
-     * @param array $new_table an array of strings -- the new table
-     *
-     * @return array an array of strings containing the text with the first table replaced with the second argument
+     * @param string[] $lines
+     *      the lines of the text
+     * @param string[] $new_table
+     *      the new table
+     * @return string[]
+     *      the text with the first table replaced with the second argument
      */
-    public static function replace_first_table(array $lines, array $new_table): array
+    public static function replace_first_table($lines, $new_table)
     {
         $lines_with_new_table = [];
         $reached_table = false;
@@ -185,11 +201,13 @@ class TableDocumentation
     /**
      * Detects the first markdown table in the text.
      *
-     * @param array $lines an array of strings -- the lines of the text
+     * @param string[] $lines
+     *    the lines of the text
      *
-     * @return array an array of strings containing the first markdown table in the text
+     * @return string[]
+     *    lines containing the first markdown table in the text
      */
-    public static function detect_first_table_in_text(array $lines): array
+    public static function detect_first_table_in_text($lines)
     {
         $first_table_lines = [];
 
@@ -214,11 +232,13 @@ class TableDocumentation
      *
      * ## `something_useful`
      *
-     * @param array $lines an array of strings -- the lines of the text
+     * @param string[] $lines
+     *      the lines of the text
      *
-     * @return array an array of strings containing the column names detected in text
+     * @return string[]
+     *      column names detected in text
      */
-    public static function detect_columns_in_text(array $lines): array
+    public static function detect_columns_in_text($lines)
     {
         // array_values is used to reindex the array
         return array_values(preg_filter('/^## `([a-zA-Z0-9_]+)`/', '$1', $lines));

--- a/pinc/Team.inc
+++ b/pinc/Team.inc
@@ -6,7 +6,7 @@ class Team
 {
     // static functions
 
-    public static function log_recent_join($tid, $uid)
+    public static function log_recent_join(int $tid, int $uid): void
     {
         $sql = sprintf(
             "
@@ -21,7 +21,7 @@ class Team
         DPDatabase::query($sql);
     }
 
-    public static function active_member_count($tid)
+    public static function active_member_count(int $tid): int
     {
         $sql = sprintf(
             "

--- a/pinc/ThemedTable.inc
+++ b/pinc/ThemedTable.inc
@@ -13,7 +13,16 @@ class ThemedTable
     /** @var string[] */
     private array $column_alignments;
 
-    public function __construct($n_cols, $title, $options = [])
+    /**
+     * @param array{
+     *            theme_striped?: mixed,
+     *            border?: int,
+     *            width?: int|string,
+     *            subtitle?: string,
+     *        } $options
+     *    TODO: Make these into keyword args
+     */
+    public function __construct(int $n_cols, string $title, array $options = [])
     {
         $this->n_cols = $n_cols;
 
@@ -35,8 +44,6 @@ class ThemedTable
                 case 'subtitle':
                     $subtitle = $option_value;
                     break;
-                default:
-                    throw new UnexpectedValueException("ThemedTable created with invalid option: '$option_name'");
             }
         }
 
@@ -68,7 +75,7 @@ class ThemedTable
      *
      * If you don't call this method, <td> tags will be output without a 'width' attribute.
      */
-    public function set_column_widths()
+    public function set_column_widths(): void
     {
         // There should be an arg (width) for each column.
         assert(func_num_args() == $this->n_cols);
@@ -78,7 +85,7 @@ class ThemedTable
         assert(array_sum($this->column_widths) == 100);
     }
 
-    public function set_column_alignments()
+    public function set_column_alignments(): void
     {
         assert(func_num_args() == $this->n_cols);
         $this->column_alignments = func_get_args();
@@ -86,19 +93,20 @@ class ThemedTable
         // Should check that they're sensible.
     }
 
-    public function column_headers()
+    public function column_headers(): void
     {
         $args = func_get_args();
         $this->_row($args, true);
     }
 
-    public function row()
+    public function row(): void
     {
         $args = func_get_args();
         $this->_row($args, false);
     }
 
-    public function _row($cell_texts, $is_header)
+    /** @param string[]|string[][] $cell_texts */
+    public function _row(array $cell_texts, bool $is_header): void
     {
         if ($this->n_cols > 1 && count($cell_texts) == 1 && is_array($cell_texts[0])) {
             $cell_texts = $cell_texts[0];
@@ -145,7 +153,7 @@ class ThemedTable
         echo "</tr>\n";
     }
 
-    public function hr($width)
+    public function hr(int $width): void
     {
         echo "\n";
         echo "<tr>";
@@ -155,7 +163,7 @@ class ThemedTable
         echo "</tr>";
     }
 
-    public function end()
+    public function end(): void
     {
         echo "</table><p>";
     }

--- a/pinc/User.inc
+++ b/pinc/User.inc
@@ -112,10 +112,12 @@ class DailyLimitExceededException extends UserAccessException
  */
 class User
 {
-    private $table_row;
-    private $current_profile;
+    /** @var array<string, mixed> */
+    private array $table_row;
+    private ?UserProfile $current_profile = null;
 
     // List of fields that when set for a user should never change
+    /** @var string[] */
     private $immutable_fields = [
         "reg_token",
         "username",
@@ -123,6 +125,7 @@ class User
     ];
 
     // Fields are assumed to be integers unless included here
+    /** @var string[] */
     private $string_fields = [
         "reg_token",
         "real_name",
@@ -135,7 +138,7 @@ class User
     ];
 
 
-    public function __construct($username = null)
+    public function __construct(?string $username = null)
     {
         if ($username !== null) {
             $this->load("username", $username);
@@ -145,7 +148,7 @@ class User
     // The __set() and __get() methods allow access to user fields without
     // creating accessors for them all individually.
     // See the PHP docs for "magic methods".
-    public function __set($name, $value)
+    public function __set(string $name, mixed $value): void
     {
         if (isset($this->$name) && in_array($name, $this->immutable_fields)) {
             throw new DomainException(
@@ -189,7 +192,7 @@ class User
         }
     }
 
-    public function __get($name)
+    public function __get(string $name): mixed
     {
         switch ($name) {
             case "profile":
@@ -235,12 +238,12 @@ class User
         }
     }
 
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         return isset($this->table_row[$name]);
     }
 
-    private function load($field, $value, $strict = true)
+    private function load(string $field, mixed $value, bool $strict = true): void
     {
         if (in_array($field, $this->string_fields)) {
             $escaped_value = sprintf("'%s'", DPDatabase::escape($value));
@@ -292,12 +295,13 @@ class User
         mysqli_free_result($result);
     }
 
-    public function save()
+    public function save(): void
     {
         throw new NotImplementedException();
     }
 
-    public function load_teams()
+    /** @return int[] */
+    public function load_teams(): array
     {
         $sql = sprintf(
             "
@@ -316,7 +320,7 @@ class User
         return $teams;
     }
 
-    public function add_team($team_id)
+    public function add_team(int $team_id): void
     {
         if (in_array($team_id, $this->load_teams())) {
             return;
@@ -335,7 +339,7 @@ class User
         Team::log_recent_join($team_id, $this->u_id);
     }
 
-    public function remove_team($team_id)
+    public function remove_team(int $team_id): void
     {
         $sql = sprintf(
             "
@@ -359,27 +363,27 @@ class User
     // allows the caller to specify if the suffix should be included
     // without forcing the logic of what needs it into this class.
 
-    public function grant_access($activity, $requester, $use_access_suffix = true)
+    public function grant_access(string $activity, string $requester, bool $use_access_suffix = true): void
     {
         $this->_change_access("grant", $activity, $requester, $use_access_suffix);
     }
 
-    public function revoke_access($activity, $requester, $use_access_suffix = true)
+    public function revoke_access(string $activity, string $requester, bool $use_access_suffix = true): void
     {
         $this->_change_access("revoke", $activity, $requester, $use_access_suffix);
     }
 
-    public function request_access($activity, $use_access_suffix = true)
+    public function request_access(string $activity, bool $use_access_suffix = true): void
     {
         $this->_change_access("request", $activity, 'n/a', $use_access_suffix);
     }
 
-    public function deny_access($activity, $requester, $use_access_suffix = true)
+    public function deny_access(string $activity, string $requester, bool $use_access_suffix = true): void
     {
         $this->_change_access("deny_request_for", $activity, $requester, $use_access_suffix);
     }
 
-    private function _change_access($action_type, $activity, $requester, $use_access_suffix)
+    private function _change_access(string $action_type, string $activity, string $requester, bool $use_access_suffix): void
     {
         if ($use_access_suffix) {
             $suffix = '.access';
@@ -450,12 +454,8 @@ class User
      * Load a User record by u_id
      *
      * Example: `$user = User::load_from_uid($u_id);`
-     *
-     * @param int $u_id
-     *
-     * @return User
      */
-    public static function load_from_uid($u_id)
+    public static function load_from_uid(int $u_id): User
     {
         $user = new User();
         $user->load('u_id', $u_id);
@@ -466,12 +466,8 @@ class User
      * Load a User record by registration token
      *
      * Example: `$user = User::load_from_registration_token($reg_token);`
-     *
-     * @param string $reg_token
-     *
-     * @return User
      */
-    public static function load_from_registration_token($reg_token)
+    public static function load_from_registration_token(string $reg_token): User
     {
         $user = new User();
         $user->load('reg_token', $reg_token);
@@ -482,12 +478,8 @@ class User
      * Load a User record by API key
      *
      * Example: `$user = User::load_from_api_key($api_key);`
-     *
-     * @param string $api_key
-     *
-     * @return User
      */
-    public static function load_from_api_key($api_key)
+    public static function load_from_api_key(string $api_key): User
     {
         $user = new User();
         $user->load('api_key', $api_key);
@@ -499,14 +491,10 @@ class User
      *
      * Example: `$user = User::load_from_email($email);`
      *
-     * @param string $email
-     *
      * @throws NonuniqueUserException
      *   The email address is not guaranteed to be unique.
-     *
-     * @return User
      */
-    public static function load_from_email($email)
+    public static function load_from_email(string $email): User
     {
         $user = new User();
         $user->load('email', $email);
@@ -517,7 +505,7 @@ class User
      * Determine if the specified username is associated
      * with a valid user without the overhead of creating an object.
      */
-    public static function is_valid_user($username, $strict = true)
+    public static function is_valid_user(string $username, bool $strict = true): bool
     {
         $sql = sprintf(
             "
@@ -555,8 +543,9 @@ class User
 
     /**
      * Return possible user referrer options
+     * @return array<string, string>
      */
-    public static function get_referrer_options()
+    public static function get_referrer_options(): array
     {
         return [
             "pg" => _("Project Gutenberg"),
@@ -587,7 +576,7 @@ $valid_username_chars_statement_for_elsewhere = _("(Valid characters are: a-z A-
  * If not, return a string detailing the problem.
  * (This is used at both registration and login.)
  */
-function check_username($username, $registering = false)
+function check_username(string $username, bool $registering = false): string
 {
     // This is the length of the 'username' field in the 'users' table.
     $username_max_len = 25;

--- a/pinc/UserProfile.inc
+++ b/pinc/UserProfile.inc
@@ -29,15 +29,18 @@ class NonexistentUserProfileException extends Exception
  */
 class UserProfile
 {
+    /** @var array<string, mixed> */
     private $table_row;
 
     // List of fields that when set for a profile should never change
+    /** @var string[] */
     private $immutable_fields = [
         "id",
         "u_ref",
     ];
 
     // Fields are assumed to be integers unless included here
+    /** @var string[] */
     private $string_fields = [
         "profilename",
         "v_fntf_other",
@@ -70,8 +73,7 @@ class UserProfile
         $this->table_row[$name] = $value;
     }
 
-    /** @return mixed */
-    public function __get(string $name)
+    public function __get(string $name): mixed
     {
         return $this->table_row[$name];
     }

--- a/pinc/UserSuggestions.inc
+++ b/pinc/UserSuggestions.inc
@@ -10,6 +10,7 @@ class ProjectSuggestion extends Project
     public float $priority;
     public string $round;
 
+    /** @param array<string, mixed> $project_array */
     public function __construct(array $project_array)
     {
         foreach (["percent_done", "created", "priority", "round"] as $field) {
@@ -31,6 +32,7 @@ class UserSuggestions
         $this->_username = $username;
     }
 
+    /** @return array<string, mixed> */
     private function _get_cached_criteria(): array
     {
         // We cache this in the session table so we don't calculate it on every
@@ -44,6 +46,7 @@ class UserSuggestions
         }
     }
 
+    /** @param array<string, mixed> $criteria */
     private function _set_cached_criteria(array $criteria): void
     {
         // only cache for the user looking at their own suggestions
@@ -61,6 +64,10 @@ class UserSuggestions
         }
     }
 
+    /**
+     * @param array<string, mixed> $criteria
+     * @return array<string, float>
+     */
     private function _calculate_normalized_weights(array $criteria): array
     {
         $new_criteria = [];
@@ -71,6 +78,7 @@ class UserSuggestions
         return $new_criteria;
     }
 
+    /** @return array<string, mixed> */
     public function get_criteria(bool $flush_cache = false): array
     {
         $criteria = $this->_get_cached_criteria();
@@ -172,6 +180,10 @@ class UserSuggestions
         return $criteria;
     }
 
+    /**
+     * @param 'impact'|'familiar'|'style'|'different'|'getting-started' $round_view
+     * @return list{array<string, mixed>[], string}
+     */
     public function get_suggestions(string $round_view): array
     {
         global $ELR_round;
@@ -406,6 +418,7 @@ class UserSuggestions
         return [$return_projects, $explain_why];
     }
 
+    /** @return array<string, int> */
     private function _get_user_counts_for_project_field(string $field, int $limit = 8): array
     {
         // $field *must* be a valid field in the projects table!
@@ -435,6 +448,10 @@ class UserSuggestions
     }
 }
 
+/**
+ * @param array{priority: mixed, ...} $a
+ * @param array{priority: mixed, ...} $b
+ */
 function compare_array_by_priority(array $a, array $b): int
 {
     if ($a["priority"] == $b["priority"]) {

--- a/pinc/abort.inc
+++ b/pinc/abort.inc
@@ -2,7 +2,7 @@
 include_once($relPath.'slim_header.inc'); // html_safe()
 include_once($relPath.'links.inc');
 
-function abort($error_message)
+function abort(string $error_message): never
 {
     slim_header(_("Error"));
 
@@ -34,7 +34,7 @@ function abort($error_message)
     exit;
 }
 
-function provide_escape_links()
+function provide_escape_links(): void
 {
     global $code_url;
 
@@ -82,8 +82,9 @@ function provide_escape_links()
  * and a non-empty value.
  *
  * Return the value, or NULL if none found.
+ * @param string[] $possible_names
  */
-function get_parameter_value($possible_names)
+function get_parameter_value(array $possible_names): mixed
 {
     foreach ($possible_names as $possible_name) {
         $v = @$_GET[$possible_name];
@@ -99,7 +100,7 @@ function get_parameter_value($possible_names)
     return null;
 }
 
-function dump_request_info()
+function dump_request_info(): void
 {
     $now = time();
     $date = date('Y-m-d H:i:s', $now);

--- a/pinc/access_log.inc
+++ b/pinc/access_log.inc
@@ -1,6 +1,7 @@
 <?php
 
-function log_access_change($subject_username, $modifier_username, $activity_id, $action_type)
+/** @return mysqli_result|bool */
+function log_access_change(string $subject_username, string $modifier_username, string $activity_id, string $action_type)
 {
     $setters = join(", ", [
         set_col_num("timestamp", time()),
@@ -16,7 +17,7 @@ function log_access_change($subject_username, $modifier_username, $activity_id, 
     return DPDatabase::query($sql);
 }
 
-function get_first_granted_date($username, $stage)
+function get_first_granted_date(string $username, string $stage): ?int
 {
     $sql = sprintf(
         "
@@ -42,7 +43,8 @@ function get_first_granted_date($username, $stage)
     }
 }
 
-function get_latest_access_change_entry($username, $activity_id)
+/** @return array<string, mixed>|null|false */
+function get_latest_access_change_entry(string $username, string $activity_id): array|null|false
 {
     $sql = sprintf(
         "

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -19,7 +19,7 @@ use Symfony\Component\Process\Process;
  * @param bool $dry_run
  *   if true, do not actually archive, but rather echo information about what would happen
  */
-function archive_project(Project $project, bool $dry_run = false)
+function archive_project(Project $project, bool $dry_run = false): void
 {
     $archive_projects_dir = SiteConfig::get()->archive_projects_dir;
     $archive_db_name = SiteConfig::get()->archive_db_name;
@@ -118,7 +118,7 @@ function archive_project(Project $project, bool $dry_run = false)
  * @param bool $dry_run
  *   if true, do not actually archive, but rather echo information about what would happen
  */
-function archive_ancillary_data_for_project_etc(Project $project, string $indent, bool $dry_run)
+function archive_ancillary_data_for_project_etc(Project $project, string $indent, bool $dry_run): void
 {
     archive_ancillary_data_for_project($project, $indent, $dry_run);
 
@@ -152,7 +152,7 @@ function archive_ancillary_data_for_project_etc(Project $project, string $indent
  * @param bool $dry_run
  *   if true, do not actually archive, but rather echo information about what would happen
  */
-function archive_ancillary_data_for_project(Project $project, string $indent, bool $dry_run)
+function archive_ancillary_data_for_project(Project $project, string $indent, bool $dry_run): void
 {
     $projectid = $project->projectid;
 
@@ -197,7 +197,7 @@ function archive_ancillary_data_for_project(Project $project, string $indent, bo
  * @param bool $dry_run
  *   if true, do not actually archive, but rather echo information about what would happen
  */
-function move_project_rows_to_archive_db(string $projectid, string $table_name, string $indent, bool $dry_run)
+function move_project_rows_to_archive_db(string $projectid, string $table_name, string $indent, bool $dry_run): void
 {
     $archive_db_name = SiteConfig::get()->archive_db_name;
 

--- a/pinc/autorelease.inc
+++ b/pinc/autorelease.inc
@@ -2,7 +2,7 @@
 include_once($relPath.'send_mail.inc');
 include_once($relPath.'release_queue.inc');
 
-function autorelease()
+function autorelease(): void
 {
     echo "Starting autorelease\n";
 
@@ -11,7 +11,8 @@ function autorelease()
     }
 }
 
-function attempt_to_release($round, $project, $queue_name)
+/** @param array<string, mixed> $project */
+function attempt_to_release(Round $round, array $project, string $queue_name): bool
 {
     $projectid = $project['projectid'];
 
@@ -48,7 +49,7 @@ function attempt_to_release($round, $project, $queue_name)
 
 
 
-function autorelease_for_round($round)
+function autorelease_for_round(Round $round): void
 {
     echo "\n";
     echo "Starting autorelease for round {$round->id}...\n";
@@ -207,11 +208,11 @@ function autorelease_for_round($round)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 function maybe_release_projects(
-    $round,
-    $qd,
-    $observe_release_restrictions,
-    $release_at_most_one
-) {
+    Round $round,
+    ?Object $qd,
+    bool $observe_release_restrictions,
+    bool $release_at_most_one
+): Object {
     $n_projects = new StdClass();
 
     $and_extra_condition = ($qd ? "AND ($qd->cooked_project_selector)" : "");
@@ -350,11 +351,14 @@ class ReleaseRestrictor
     /** @var array<string, ReleaseRestrictor> */
     public static array $restrictors = [];
 
-    public $this_round_authors;
+    /** @var array<string, int> */
+    public array $this_round_authors;
+    /** @var array<string, int> */
     public $this_round_pms;
+    /** @var array<string, int> */
     public $fresh_released_pms;
 
-    public function __construct($round)
+    public function __construct(Round $round)
     {
         // ----------------------------------------------------------
         // First, get the set of all authors with works in this round
@@ -411,7 +415,8 @@ class ReleaseRestrictor
 
     // =========================================================================
 
-    public function approves_project($project)
+    /** @param array<string, mixed> $project */
+    public function approves_project(array $project): bool
     {
         $is_special = !empty($project['special_code']);
         if ($is_special) {
@@ -460,7 +465,8 @@ class ReleaseRestrictor
 
     // =========================================================================
 
-    public function update_for_released_project($project)
+    /** @param array<string, mixed> $project */
+    public function update_for_released_project(array $project): void
     {
         // special authors (anon, etc) have to have their counts incremented
         $authorsname = $project['authorsname'];
@@ -520,7 +526,7 @@ class ReleaseRestrictor
  * but contains slightly different information.
  * Maybe they could be merged.
  */
-function AP_setup($round)
+function AP_setup(Round $round): void
 {
     // If we had one table with all page info,
     // we could set up this table with a single
@@ -555,13 +561,13 @@ function AP_setup($round)
     }
 }
 
-function AP_teardown($round)
+function AP_teardown(Round $round): void
 {
     $sql = "DROP TABLE active_page_counts";
     DPDatabase::query($sql);
 }
 
-function AP_add_project($round, $projectid)
+function AP_add_project(Round $round, string $projectid): void
 {
     validate_projectID($projectid);
     $sql = sprintf(
@@ -577,7 +583,7 @@ function AP_add_project($round, $projectid)
     DPDatabase::query($sql);
 }
 
-function AP_evaluate_criteria($round, $cooked_project_selector, $projects_target, $pages_target)
+function AP_evaluate_criteria(Round $round, string $cooked_project_selector, int $projects_target, int $pages_target): bool
 {
     $release_criterion = format_queue_targets_as_condition($projects_target, $pages_target);
 

--- a/pinc/bad_bytes.inc
+++ b/pinc/bad_bytes.inc
@@ -637,7 +637,7 @@ $_character_data = [
     0xfffd => ['name' => "replacement character"],
 ];
 
-function define_bad_byte_sequences()
+function define_bad_byte_sequences(): void
 {
     global $_bad_byte_sequences, $_character_data;
 
@@ -703,7 +703,7 @@ function define_bad_byte_sequences()
  *
  * For example, interpreting it as encoded in ISO-8859-1?
  */
-function _utf8_encode_string($seq)
+function _utf8_encode_string(string $seq): string
 {
     $result = "";
     foreach (str_split($seq) as $byte) {
@@ -712,7 +712,7 @@ function _utf8_encode_string($seq)
     return $result;
 }
 
-function _utf8_encode_code_point($cp)
+function _utf8_encode_code_point(int $cp): string
 {
     if ($cp <= 0x007f) {
         // utf8 encodes as 1 byte
@@ -742,7 +742,7 @@ function _utf8_encode_code_point($cp)
     }
 }
 
-function _install_bad_sequence($bytes, $code_point, $why_bad)
+function _install_bad_sequence(string $bytes, int $code_point, string $why_bad): void
 {
     global $_anchored_bad_bytes_regex, $_bad_byte_sequences;
 
@@ -780,7 +780,8 @@ define_bad_byte_sequences();
 define("BOM", "\u{feff}");
 
 // note that this can change $text
-function find_bad_byte_sequences_in_text(&$text)
+/** @return array<string, int> */
+function find_bad_byte_sequences_in_text(string &$text): array
 {
     global $_unanchored_bad_bytes_regex, $_bad_byte_sequences;
 
@@ -850,7 +851,8 @@ function find_bad_byte_sequences_in_text(&$text)
     return $occurrences;
 }
 
-function get_remarks_for_bad_byte_sequence($raw)
+/** @return list{string, string} */
+function get_remarks_for_bad_byte_sequence(string $raw): array
 {
     global $_bad_byte_sequences, $_character_data;
 
@@ -880,7 +882,7 @@ function get_remarks_for_bad_byte_sequence($raw)
     return [$intended_character, $why_bad];
 }
 
-function string_to_hex($str)
+function string_to_hex(string $str): string
 {
     $hex = "";
     foreach (str_split($str) as $byte) {

--- a/pinc/base.inc
+++ b/pinc/base.inc
@@ -85,7 +85,7 @@ if (SiteConfig::get()->maintenance && !@$maintenance_override) {
 // set or defined in this file as the handlers may be used before the functions
 // are defined.
 
-function production_exception_handler($exception)
+function production_exception_handler(Throwable $exception): void
 {
     global $maintenance;
 
@@ -110,7 +110,7 @@ function production_exception_handler($exception)
     echo "\n</p>";
 }
 
-function test_exception_handler($exception)
+function test_exception_handler(Throwable $exception): void
 {
     // Show what users would see on PROD. We don't want to call
     // production_exception_handler() here because we don't want the special
@@ -124,7 +124,7 @@ function test_exception_handler($exception)
     throw $exception;
 }
 
-function require_login()
+function require_login(): void
 {
     global $code_url;
     global $relPath;

--- a/pinc/button_defs.inc
+++ b/pinc/button_defs.inc
@@ -16,7 +16,8 @@ define('REVERT_TO_LAST_SAVE_DISABLED', 'O');
 define('SHOW_ALL_TEXT', 'P');
 define('PREVIEW', 'S');
 
-function echo_button($button_id, $which_interface)
+/** @param 's'|'a' $which_interface */
+function echo_button(string $button_id, string $which_interface): void
 {
     $CRLF = '\r\n';
     if ($which_interface == 's') {
@@ -184,7 +185,7 @@ function echo_button($button_id, $which_interface)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function echo_img($id)
+function echo_img(string $id): void
 {
     switch ($id) {
         case PROJECT_COMMENTS:

--- a/pinc/codepoint_validator.inc
+++ b/pinc/codepoint_validator.inc
@@ -1,6 +1,6 @@
 <?php
 
-function render_validator()
+function render_validator(): void
 {
     $bad_char_message = _("The text contains invalid characters that will be <span class='bad-char'>highlighted</span> if possible");
     $quit_text = _("Quit");

--- a/pinc/dpsession.inc
+++ b/pinc/dpsession.inc
@@ -17,7 +17,7 @@ $pguser = null;
  *
  * Record the session variable 'pguser' (from $userID)
  */
-function dpsession_begin($userID)
+function dpsession_begin(string $userID): void
 {
     global $pguser;
 
@@ -80,7 +80,7 @@ function dpsession_resume(): void
 /**
  * End a session.
  */
-function dpsession_end()
+function dpsession_end(): void
 {
     session_unset();
     session_destroy();
@@ -89,7 +89,7 @@ function dpsession_end()
 // -----------------------------------------------------------------------------
 // User-centric session management functions
 
-/** @return array<array{0: string, 1: int}> */
+/** @return list{string, int}[] */
 function load_user_sessions(string $username): array
 {
     $sql = sprintf(
@@ -125,7 +125,7 @@ function delete_user_sessions(string $username): void
 // -----------------------------------------------------------------------------
 // Internal session helper functions
 
-function _update_user_activity_time($update_login_time_too)
+function _update_user_activity_time(bool $update_login_time_too): void
 {
     global $pguser;
 
@@ -237,7 +237,7 @@ class DPSessionHandler implements SessionHandlerInterface
     }
 }
 
-function _session_set_handlers_and_start()
+function _session_set_handlers_and_start(): void
 {
     static $session_handler = null;
     if (! $session_handler) {
@@ -252,17 +252,17 @@ function _session_set_handlers_and_start()
 // -----------------------------------------------------------------------------
 // The 'debouncer' variable
 
-function dpsession_page_set($info)
+function dpsession_page_set(string $info): void
 {
     $_SESSION['debouncer'] = $info;
 }
 
-function dpsession_page_is_set()
+function dpsession_page_is_set(): bool
 {
     return isset($_SESSION['debouncer']);
 }
 
-function dpsession_page_get()
+function dpsession_page_get(): string
 {
     return $_SESSION['debouncer'];
 }

--- a/pinc/dpsql.inc
+++ b/pinc/dpsql.inc
@@ -113,6 +113,7 @@ function dpsql_dump_themed_query_result(mysqli_result $result, int $start_at = 0
 
 /**
  * Return an array of arrays, one for each column of the result-set.
+ * @return mixed[][]
  */
 function dpsql_fetch_columns(mysqli_result $res): array
 {

--- a/pinc/email_address.inc
+++ b/pinc/email_address.inc
@@ -6,7 +6,7 @@
  * If it is, return an empty string.
  * If it isn't, return a string detailing the problem.
  */
-function check_email_address($email_address)
+function check_email_address(string $email_address): string
 {
     $email_address_max_len = 100;
     // This is the length of the 'email' field in the 'users' table.

--- a/pinc/genres.inc
+++ b/pinc/genres.inc
@@ -4,8 +4,9 @@
  * Return an associative array of genres in the format
  *     english_name => translated_name
  * sorted by the translated name
+ * @return array<string, string>
  */
-function load_genre_translation_array()
+function load_genre_translation_array(): array
 {
     $genres = [
         'Other' => _('Other'),
@@ -94,7 +95,7 @@ function load_genre_translation_array()
     return $genres;
 }
 
-function maybe_create_temporary_genre_translation_table()
+function maybe_create_temporary_genre_translation_table(): void
 {
     $genres = load_genre_translation_array();
 

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -21,7 +21,7 @@ include_once($relPath.'languages.inc');
  *   same.
  * - If everything else fails, default to en_US.
  */
-function get_desired_language()
+function get_desired_language(): string
 {
     // This function maybe called multiple times within a page load.
     // Only do the calculations to determine the locale once.
@@ -53,7 +53,7 @@ function get_desired_language()
     return get_valid_locale_for_translation($locale);
 }
 
-function configure_gettext($locale)
+function configure_gettext(string $locale): void
 {
     $locale .= ".UTF-8";
 
@@ -79,10 +79,10 @@ function configure_gettext($locale)
 /**
  * Get the language (locale) for the specified user.
  *
- * @param string|object $user
+ * @param null|string|User $user
  *   User object or a username. If NULL, the current user's locale is returned.
  */
-function get_user_language($user = null)
+function get_user_language(null|string|User $user = null): string
 {
     if (!$user) {
         $locale = get_desired_language();
@@ -97,8 +97,10 @@ function get_user_language($user = null)
 
 /**
  * Configure gettext for a specific user, useful for sending emails.
+ * @param null|string|User $user
+ *   User object or a username. If NULL, the current user's locale is returned.
  */
-function configure_gettext_for_user($user = null)
+function configure_gettext_for_user(null|string|User $user = null): void
 {
     $locale = get_user_language($user);
     configure_gettext($locale);
@@ -108,14 +110,14 @@ function configure_gettext_for_user($user = null)
 // (an alias for 'gettext') will be defined.
 // If it's not defined, define it to simply return its argument.
 if (! function_exists('_')) {
-    function _($str)
+    function _(string $str): string
     {
         return $str;
     }
 }
 
 if (! function_exists('ngettext')) {
-    function ngettext($singular, $plural, $number)
+    function ngettext(string $singular, string $plural, int $number): string
     {
         return ($number == 1) ? $singular : $plural;
     }
@@ -125,7 +127,7 @@ if (! function_exists('ngettext')) {
 // mean two different things.
 // http://php.net/manual/en/book.gettext.php#89975
 if (!function_exists('pgettext')) {
-    function pgettext($context, $msgid)
+    function pgettext(string $context, string $msgid): string
     {
         $contextString = "{$context}\004{$msgid}";
         $translation = dcgettext('messages', $contextString, LC_MESSAGES);
@@ -142,8 +144,9 @@ if (!function_exists('pgettext')) {
  * format.
  *
  * https://unicode-org.github.io/icu/userguide/format_parse/datetime/
+ * @param null|string|User $user
  */
-function icu_date($pattern, $timestamp = null, $user = null)
+function icu_date(string $pattern, ?int $timestamp = null, null|string|User $user = null): string
 {
     $locale = get_user_language($user);
     if (!$timestamp) {
@@ -157,8 +160,9 @@ function icu_date($pattern, $timestamp = null, $user = null)
 
 /**
  * Return a localized date from a predefined template
+ * @param null|string|User $user
  */
-function icu_date_template($template, $timestamp = null, $user = null)
+function icu_date_template(string $template, ?int $timestamp = null, null|string|User $user = null): string
 {
     $templates = [
         // TRANSLATORS: ICU-formatted date in long form

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -45,7 +45,7 @@ function get_pages_proofed_maybe_simulated(?string $username = null): int
     return $pagesproofed;
 }
 
-function welcome_see_beginner_forum(int $pagesproofed, $page_id, ?string $username = null): void
+function welcome_see_beginner_forum(int $pagesproofed, string $page_id, ?string $username = null): void
 {
     global $code_url, $ELR_round;
 
@@ -254,7 +254,7 @@ function maybe_output_new_proofer_project_message(Project $project): void
  * Output a callout and encourage the user to work in the round with the
  * highest backlog that they can work in.
  */
-function encourage_highest_round(?string $username, $round_id = null): void
+function encourage_highest_round(?string $username, ?string $round_id = null): void
 {
     global $code_url, $ELR_round, $ACCESS_CRITERIA;
 

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -12,8 +12,10 @@ define('SHOW_STATSBAR', true);
 /**
  * Output the opening HTML page code, including pulling in common styles,
  * page title, etc.
+ *
+ * @param array<string, mixed> $extra_args
  */
-function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true)
+function output_html_header(?string $nameofpage, array $extra_args = [], bool $show_statsbar = true): void
 {
     global $code_url;
 
@@ -158,8 +160,10 @@ function output_html_header($nameofpage, $extra_args = [], $show_statsbar = true
 
 /**
  * Output HTML page footer to close the page
+ *
+ * @param array<string, mixed> $extra_args
  */
-function output_html_footer($extra_args = [])
+function output_html_footer(array $extra_args = []): void
 {
     // close up the page
 
@@ -180,7 +184,7 @@ function output_html_footer($extra_args = [])
  * Apache will ignore this but when the value changes the browser will reread
  * the file. PHP's statcache should make this fast.
  */
-function get_local_file_browser_cache_key($url)
+function get_local_file_browser_cache_key(string $url): string
 {
     global $code_url, $code_dir;
 

--- a/pinc/image_check.inc
+++ b/pinc/image_check.inc
@@ -3,7 +3,7 @@
 $page_image_size_limit = 100; // kb
 $page_image_minimum_dimension = 1000; // pixels
 
-function get_image_size_error($image_size)
+function get_image_size_error(int $image_size): ?string
 {
     global $page_image_size_limit;
     $result = null;
@@ -14,7 +14,7 @@ function get_image_size_error($image_size)
     return $result;
 }
 
-function get_image_small_dimension_error($width, $height)
+function get_image_small_dimension_error(int $width, int $height): ?string
 {
     global $page_image_minimum_dimension;
     $result = null;

--- a/pinc/job_log.inc
+++ b/pinc/job_log.inc
@@ -36,6 +36,7 @@ function insert_job_log_entry(string $filename, string $event, ?string $comments
     DPDatabase::query($sql);
 }
 
+/** @return array<string, mixed>[] */
 function get_job_log_entries(int $timestamp, ?string $filename = null, ?string $event = null, ?bool $succeeded = null): array
 {
     $filename_where = $filename ? sprintf("AND filename = '%s'", DPDatabase::escape($filename)) : "";

--- a/pinc/links.inc
+++ b/pinc/links.inc
@@ -5,7 +5,7 @@ include_once($relPath.'forum_interface.inc');
  * Returns a string containing a snippet of HTML
  * for a link that opens in a new window.
  */
-function new_window_link($href, $linktext)
+function new_window_link(string $href, string $linktext): string
 {
     global $code_url;
 
@@ -23,7 +23,7 @@ function new_window_link($href, $linktext)
  * Returns a string containing a snippet of HTML
  * for a link that opens in a specific target.
  */
-function recycle_window_link($href, $linktext, $target)
+function recycle_window_link(string $href, string $linktext, string $target): string
 {
     global $code_url;
 
@@ -45,7 +45,7 @@ function recycle_window_link($href, $linktext, $target)
  * Specifying a NULL $target parameter will return a link to send
  * a PM in the current window.
  */
-function private_message_link($proofer_username, $target = "_blank")
+function private_message_link(string $proofer_username, ?string $target = "_blank"): string
 {
     global $code_url;
 
@@ -72,8 +72,7 @@ function private_message_link($proofer_username, $target = "_blank")
 
 /**
  * Returns HTML-safe URL for the given project page.
- *
- * @param array $query_param_array
+ * @param ?string[] $query_param_array
  *   Query parameters (without ?/&), e.g. ["detail_level=4"].
  *   Should be `urlencode()` d if necessary
  *
@@ -81,7 +80,7 @@ function private_message_link($proofer_username, $target = "_blank")
  *   Page anchor (without #), e.g "holds"
  *   Should be `urlencode()` d if necessary
  */
-function project_page_link_url($projectid, $query_param_array = null, $anchor_link = "")
+function project_page_link_url(string $projectid, ?array $query_param_array = null, string $anchor_link = ""): string
 {
     global $code_url;
 
@@ -99,8 +98,7 @@ function project_page_link_url($projectid, $query_param_array = null, $anchor_li
 
 /**
  * Returns a string containing an HTML link to return to a project page.
- *
- * @param array $query_param_array
+ * @param ?string[] $query_param_array
  *   Query parameters (without ?/&), e.g. ["detail_level=4"].
  *   Should be `urlencode()` d if necessary
  *
@@ -108,7 +106,7 @@ function project_page_link_url($projectid, $query_param_array = null, $anchor_li
  *   Page anchor (without #), e.g "holds"
  *   Should be `urlencode()` d if necessary
  */
-function return_to_project_page_link($projectid, $query_param_array = null, $anchor_link = "")
+function return_to_project_page_link(string $projectid, ?array $query_param_array = null, string $anchor_link = ""): string
 {
     $url = project_page_link_url($projectid, $query_param_array, $anchor_link);
     return sprintf(
@@ -122,7 +120,7 @@ function return_to_project_page_link($projectid, $query_param_array = null, $anc
 /**
  * Returns a string containing a snippet of HTML to return to a round page.
  */
-function return_to_round_page_link($round_id)
+function return_to_round_page_link(string $round_id): string
 {
     global $code_url;
 
@@ -138,7 +136,7 @@ function return_to_round_page_link($round_id)
 /**
  * Returns a string containing a snippet of HTML to return to the Activity Hub.
  */
-function return_to_activity_hub_link()
+function return_to_activity_hub_link(): string
 {
     global $code_url;
 

--- a/pinc/list_projects.inc
+++ b/pinc/list_projects.inc
@@ -4,7 +4,7 @@ include_once($relPath.'pg.inc');
 /**
  * Output a list of projects giving very brief information about each
  */
-function list_projects_tersely(string $metal, string $order_clause, string $limit_clause)
+function list_projects_tersely(string $metal, string $order_clause, string $limit_clause): void
 {
     if ($metal == "gold") {
         $where_condition = SQL_CONDITION_GOLD;
@@ -45,7 +45,7 @@ function list_projects_tersely(string $metal, string $order_clause, string $limi
  *
  * url_base is the URL with the beginning of a query string, eg "foo.php?x=10&amp;" or "foo.php?"
  */
-function list_projects(string $metal, string $order_clause, string $url_base, int $per_page = 20, int $offset = 0)
+function list_projects(string $metal, string $order_clause, string $url_base, int $per_page = 20, int $offset = 0): void
 {
     global $code_url;
 
@@ -188,7 +188,7 @@ function list_projects(string $metal, string $order_clause, string $url_base, in
  * This function takes into account that some books are processed as several
  * projects.
  */
-function total_completed_projects()
+function total_completed_projects(): int
 {
     $psd = get_project_status_descriptor('posted');
     $sql = "

--- a/pinc/manifest.inc
+++ b/pinc/manifest.inc
@@ -1,8 +1,6 @@
 <?php
 
-/**
- * @return string[]
- */
+/** @return string[] */
 function get_js_manifest(string $basedir = ""): array
 {
     global $code_dir;
@@ -33,9 +31,7 @@ function get_js_manifest(string $basedir = ""): array
     return [];
 }
 
-/**
- * @param string[] $manifest
- */
+/** @param string[] $manifest */
 function generate_cached_js_manifest(string $basedir, array $manifest): void
 {
     if (!$manifest) {

--- a/pinc/mentoring.inc
+++ b/pinc/mentoring.inc
@@ -1,4 +1,5 @@
 <?php
+/** @return Round[] */
 function get_mentoring_rounds(): array
 {
     $mentoring_rounds = [];
@@ -11,7 +12,7 @@ function get_mentoring_rounds(): array
     return $mentoring_rounds;
 }
 
-function mentor_banner(Round $round)
+function mentor_banner(Round $round): void
 {
     global $code_url;
 

--- a/pinc/new_user_mails.inc
+++ b/pinc/new_user_mails.inc
@@ -10,7 +10,7 @@ include_once($relPath.'forum_interface.inc');
 // This is because this function may be called by a site admin to send
 // a mail to a completely different user (e.g. a Polish user shouldn't
 // get a Spanish mail because one of the site admins is Spanish).
-function send_activate_mail($email, $real_name, $reg_token, $username, $u_intlang)
+function send_activate_mail(string $email, string $real_name, string $reg_token, string $username, string $u_intlang): void
 {
     $code_url = SiteConfig::get()->code_url;
     $site_name = SiteConfig::get()->site_name;
@@ -47,7 +47,7 @@ function send_activate_mail($email, $real_name, $reg_token, $username, $u_intlan
     send_mail($email, $activate, $body);
 }
 
-function send_welcome_mail($email, $real_name, $username)
+function send_welcome_mail(string $email, string $real_name, string $username): void
 {
     global $ELR_round;
 

--- a/pinc/page_controls.inc
+++ b/pinc/page_controls.inc
@@ -1,5 +1,5 @@
 <?php
-function get_proofreading_interface_data_js()
+function get_proofreading_interface_data_js(): string
 {
     $font_data = [
         "faces" => get_font_styles(),

--- a/pinc/phpbb3.inc
+++ b/pinc/phpbb3.inc
@@ -44,9 +44,8 @@ if (is_file($phpbb_root_path . 'includes/functions_compatibility.' . $phpEx)) {
 
 // -----------------------------------------------------------------------------
 
-function phpbb3_encode_and_hash_password(
-    $password
-) {
+function phpbb3_encode_and_hash_password(string $password): string
+{
     // phpBB3 code does pre-processing on the password as it comes in from
     // the web browser. We need to do the same pre-processing before
     // hashing the password if we want ours to match theirs.
@@ -56,11 +55,11 @@ function phpbb3_encode_and_hash_password(
 }
 
 function phpbb3_create_user(
-    $username,
-    $password,
-    $email,
-    $lang
-) {
+    string $username,
+    string $password,
+    string $email,
+    string $lang
+): int|false {
     $forums_phpbb_table_prefix = SiteConfig::get()->forums_phpbb_table_prefix;
 
     // get the group_id for the REGISTERED user group
@@ -91,13 +90,13 @@ function phpbb3_create_user(
 }
 
 function phpbb3_create_topic(
-    $forum_id,
-    $post_subject,
-    $post_text,
-    $poster_name,
-    $poster_is_real,
-    $make_poster_watch_topic
-) {
+    int $forum_id,
+    string $post_subject,
+    string $post_text,
+    string $poster_name,
+    bool $poster_is_real,
+    ?int $make_poster_watch_topic
+): int {
     $post_result = _insert_post(
         $forum_id,
         0, // causes a new topic to be created
@@ -115,12 +114,12 @@ function phpbb3_create_topic(
 
 // -----------------------------------------------------------------------------
 
-function phpbb3_move_topic($topic_id, $forum_id)
+function phpbb3_move_topic(int $topic_id, int $forum_id): void
 {
     move_topics($topic_id, $forum_id);
 }
 
-function phpbb3_sync_forum($forum_id)
+function phpbb3_sync_forum(int $forum_id): void
 {
     $forum_ids = [$forum_id];
     sync('forum', 'forum_id', $forum_ids, true, true);
@@ -129,12 +128,12 @@ function phpbb3_sync_forum($forum_id)
 // -----------------------------------------------------------------------------
 
 function phpbb3_add_post(
-    $topic_id,
-    $post_subject,
-    $post_text,
-    $poster_name,
-    $poster_is_real
-) {
+    int $topic_id,
+    string $post_subject,
+    string $post_text,
+    string $poster_name,
+    bool $poster_is_real
+): void {
     $forums_phpbb_table_prefix = SiteConfig::get()->forums_phpbb_table_prefix;
 
     // Which forum is the topic in?
@@ -172,16 +171,17 @@ function phpbb3_add_post(
  * - attachsig is deduced from poster's preferences;
  * - we override $user_ip;
  * - we disable smilies
+ * @return array<string, mixed>
  */
 function _insert_post(
-    $forum_id,
-    $topic_id,
-    $post_subject,
-    $post_text,
-    $poster_name,
-    $poster_is_real,
-    $watch_topic = null
-) {
+    int $forum_id,
+    int $topic_id,
+    string $post_subject,
+    string $post_text,
+    string $poster_name,
+    bool $poster_is_real,
+    ?int $watch_topic = null
+): array {
     $forums_phpbb_table_prefix = SiteConfig::get()->forums_phpbb_table_prefix;
     global $db, $user, $auth;
 
@@ -334,7 +334,7 @@ function _insert_post(
 /**
  * Die with a non-zero exit code.
  */
-function die_nz($string)
+function die_nz(string $string): never
 {
     echo $string, "\n";
     exit(1);

--- a/pinc/prefs_options.inc
+++ b/pinc/prefs_options.inc
@@ -20,7 +20,8 @@ define('BROWSER_DEFAULT_STR', _("Browser default"));
 // The 1 => '' entry is also special, as it indicates that the user wants
 // to use the value in x_fntf_other instead.
 
-function get_available_proofreading_font_faces()
+/** @return array<int, string> */
+function get_available_proofreading_font_faces(): array
 {
     return [
         0 => '', // browser default
@@ -32,7 +33,8 @@ function get_available_proofreading_font_faces()
     ];
 }
 
-function get_available_proofreading_font_sizes()
+/** @return array<int, string> */
+function get_available_proofreading_font_sizes(): array
 {
     return [
         0 => '', // browser default
@@ -53,11 +55,14 @@ function get_available_proofreading_font_sizes()
     ];
 }
 
-// And a function to return user's current proofreading font and size
-// This returns [ $font_face, $font_size, $font_family_string, $font_size_string ]
-//
-// $full_font_family is the current selection from get_full_font_families() below.
-function get_user_proofreading_font($interface = null)
+/**
+ * A function to return user's current proofreading font and size
+ *
+ * @return list{string, string, string, string}
+ *     returns [$font_face, $font_size, $font_family_string, $font_size_string]
+ *     $full_font_family is the current selection from get_full_font_families()
+ */
+function get_user_proofreading_font(?int $interface = null): array
 {
     $proofreading_font_faces = get_available_proofreading_font_faces();
     $proofreading_font_sizes = get_available_proofreading_font_sizes();
@@ -96,8 +101,9 @@ function get_user_proofreading_font($interface = null)
  *
  * The array is indexed like get_available_proofreading_font_faces()
  * this is used in the format preview font selector.
+ * @return string[]
  */
-function get_font_styles($interface = null)
+function get_font_styles(?int $interface = null): array
 {
     $font_styles = get_available_proofreading_font_faces();
     $font_styles[0] = BROWSER_DEFAULT_STR;
@@ -116,8 +122,10 @@ function get_font_styles($interface = null)
  * Font faces with spaces in them are escaped in _single quotes_.
  * The array is indexed like get_available_proofreading_font_faces()
  * This is used above and to select fonts in the format preview.
+ *
+ * @return string[]
  */
-function get_full_font_families($interface = null)
+function get_full_font_families(?int $interface = null): array
 {
     $full_font_family = [];
     $proofreading_font_faces = get_available_proofreading_font_faces();
@@ -137,7 +145,7 @@ function get_full_font_families($interface = null)
     return $full_font_family;
 }
 
-function get_user_proofreading_font_other($interface = null)
+function get_user_proofreading_font_other(?int $interface = null): string
 {
     $user = User::load_current();
 
@@ -158,12 +166,13 @@ function get_user_proofreading_font_other($interface = null)
 }
 
 // This string is appended to the user's proofreading font for a fallback
-function get_proofreading_font_family_fallback()
+function get_proofreading_font_family_fallback(): string
 {
     return "monospace";
 }
 
-function get_rank_neighbor_options()
+/** @return string[] */
+function get_rank_neighbor_options(): array
 {
     return ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18', '20'];
 }

--- a/pinc/project_edit.inc
+++ b/pinc/project_edit.inc
@@ -2,7 +2,7 @@
 include_once($relPath.'user_is.inc');
 
 
-function user_can_add_project_pages($projectid)
+function user_can_add_project_pages(string $projectid): bool
 {
     $project = new Project($projectid);
     $state = $project->state;
@@ -29,7 +29,7 @@ function user_can_add_project_pages($projectid)
  * Politely abort if the current user
  * is not allowed to edit the specified project
  */
-function abort_if_cant_edit_project($projectid)
+function abort_if_cant_edit_project(string $projectid): void
 {
     try {
         $project = new Project($projectid);
@@ -60,7 +60,7 @@ function abort_if_cant_edit_project($projectid)
     }
 }
 
-function check_user_can_load_projects($exit_if_not)
+function check_user_can_load_projects(bool $exit_if_not): void
 {
     if (user_has_project_loads_disabled()) {
         echo "

--- a/pinc/project_trans.inc
+++ b/pinc/project_trans.inc
@@ -9,8 +9,10 @@ include_once($relPath.'ProjectTransition.inc');
  * Otherwise, return an empty string.
  *
  * This function produces no output except for debugging messages.
+ *
+ * @param array{details?: string} $extras
  */
-function project_transition(string $projectid, string $new_state, string $who, array $extras = [])
+function project_transition(string $projectid, string $new_state, string $who, array $extras = []): string
 {
     $project = new Project($projectid);
 

--- a/pinc/release_queue.inc
+++ b/pinc/release_queue.inc
@@ -46,7 +46,9 @@ function cook_project_selector(string $project_selector): string
         );
 }
 
-/** @return array{0: ?int, 1: ?int} */
+/**
+ * @return list{?int, ?int}
+ */
 function _get_queue_length(string $cooked_project_selector, string $project_waiting_state): array
 {
     $state_clause = set_col_str("state", $project_waiting_state);
@@ -99,19 +101,19 @@ function _get_queue_length(string $cooked_project_selector, string $project_wait
  * }
  * ```
  *
- * @param null|Round $round
+ * @param ?Round $round
  *   Return the queues for the specified round, or all rounds if null.
  * @param string $show
  *   Select which queues to return:
  *   * all - Don't filter out any queues
  *   * enabled - Filter out queues which aren't enabled
  *   * populated - Filter out queues which aren't enabled *OR* contain no projects
- * @param null|string|array $name_selector
+ * @param null|string|string[] $name_selector
  *   Select which queues to return in the query where:
  *   * null - Don't filter out any queues
  *   * string - Filter out queues whose name does not contain string
  *   * array - Filter out queues whose name contains none of the strings
- * @param null|string|array $group_selector
+ * @param null|string|string[] $group_selector
  *   Select which groups and queues to return:
  *   * null - Don't filter out any groups/queues.
  *   * string - Filter out queues/groups whose group name does not contain string
@@ -119,7 +121,7 @@ function _get_queue_length(string $cooked_project_selector, string $project_wait
  * @param boolean $show_groups
  *   If true, return dummy group objects as well as queues
  *
- * @return Generator<array>
+ * @return Generator<array<string, mixed>>
  */
 function fetch_queues_data(?Round $round, string $show, bool $show_groups, $name_selector = null, $group_selector = null)
 {
@@ -203,9 +205,9 @@ function fetch_queues_data(?Round $round, string $show, bool $show_groups, $name
  * @param string $name
  *   The release queue's name
  *
- * @return array|null
+ * @return ?array<string, mixed>
  **/
-function fetch_queue_data_by_name($round, $name)
+function fetch_queue_data_by_name(Round $round, string $name): ?array
 {
     $sql = sprintf(
         "
@@ -225,6 +227,7 @@ function fetch_queue_data_by_name($round, $name)
 
 /**
  * Return queue data array for a specified release queue
+ * @return ?array<string, mixed>
  **/
 function fetch_queue_data(int $queueid): ?array
 {
@@ -243,6 +246,10 @@ function fetch_queue_data(int $queueid): ?array
     return _queue_data($res);
 }
 
+/**
+ * @param array<string, string> $row
+ * @return array<string, mixed>
+ */
 function _queue_data(array $row, ?int $length = null, ?int $unheld_length = null): array
 {
     $round = Rounds::get_by_id($row["round_id"]);
@@ -275,7 +282,7 @@ function _queue_data(array $row, ?int $length = null, ?int $unheld_length = null
  * @param boolean $unheld_only
  *   Only return projects that aren't in the hold state.
  *
- * @return Generator<array>
+ * @return Generator<array<string, mixed>>
  **/
 function fetch_queue_projects_data(Round $round, string $project_selector, bool $unheld_only)
 {
@@ -323,7 +330,7 @@ function fetch_queue_projects_data(Round $round, string $project_selector, bool 
  * @param string $name
  *   The name of the release queue
  *
- * @return array{"days_ago": int, "projects_released": int, "pages_released": int}[]
+ * @return array{days_ago: int, projects_released: int, pages_released: int}[]
  **/
 function fetch_queue_stats_data(Round $round, string $name): array
 {

--- a/pinc/send_mail.inc
+++ b/pinc/send_mail.inc
@@ -18,14 +18,14 @@ use PHPMailer\PHPMailer\Exception;
  *   Email subject
  * @param string $message
  *   Email body
- * @param string $from
+ * @param ?string $from
  *   Optional argument for who the email is from. May either take the form
  *   `user@example.com` or `Example User <user@example.com>`.
- * @param string $reply_to
+ * @param ?string $reply_to
  *   Optional argument for who the email is from. May either take the form
  *   `user@example.com` or `Example User <user@example.com>`.
  */
-function send_mail($to, $subject, $message, $from = null, $reply_to = null)
+function send_mail(string $to, string $subject, string $message, ?string $from = null, ?string $reply_to = null): bool
 {
     // If From & Reply-To given, use them
     // If only From given, use it, and don't include Reply-To at all
@@ -104,7 +104,7 @@ function send_mail($to, $subject, $message, $from = null, $reply_to = null)
     return $success;
 }
 
-function send_mail_project_manager($project, $info, $prefix)
+function send_mail_project_manager(Project $project, string $info, string $prefix): bool
 {
     $projectid = $project->projectid;
     $nameofwork = $project->nameofwork;
@@ -130,8 +130,10 @@ function send_mail_project_manager($project, $info, $prefix)
  *
  * We intentionally don't translate anything because we don't know
  * what the recipient's language is at this point.
+ *
+ * @return list{string, string}
  */
-function get_standard_email_footers()
+function get_standard_email_footers(): array
 {
     $automated_message = "This is an automated message.";
     $text_footer = implode("\n", [
@@ -156,8 +158,10 @@ function get_standard_email_footers()
  *
  * Split a string of form `user@example.com` or `Example User <user@example.com>`
  * into the name and the email address. Name will be null if not specified.
+ *
+ * @return list{string, string}
  */
-function get_name_address($string)
+function get_name_address(string $string): array
 {
     $string = rtrim($string, '>');
     $results = explode(' <', $string);
@@ -175,7 +179,7 @@ function get_name_address($string)
  *
  * Appends two spaces which are then rendered as <br> in HTML
  */
-function mdmail_append_linebreak($line)
+function mdmail_append_linebreak(string $line): string
 {
     return $line . '  ';
 }
@@ -183,7 +187,7 @@ function mdmail_append_linebreak($line)
 /**
  * Return string for horizontal rule for a Markdown email
  */
-function mdmail_horizontal_rule()
+function mdmail_horizontal_rule(): string
 {
     return '---';
 }
@@ -193,7 +197,7 @@ function mdmail_horizontal_rule()
  *
  * Prepends 4 non-breaking spaces
  */
-function mdmail_indent_line($line)
+function mdmail_indent_line(string $line): string
 {
     return str_repeat("\u{a0}", 4) . $line;
 }
@@ -203,7 +207,7 @@ function mdmail_indent_line($line)
  *
  * Prepends number of hashes corresponding to level
  */
-function mdmail_heading($level, $line)
+function mdmail_heading(int $level, string $line): string
 {
     return str_repeat('#', $level) . ' ' . $line;
 }

--- a/pinc/showavailablebooks.inc
+++ b/pinc/showavailablebooks.inc
@@ -9,7 +9,7 @@ include_once($relPath.'post_processing.inc');
 
 // -----------------------------------------------------------------------------
 
-function show_projects_for_round($round, $show_filter_block = true, $allow_special_colors_legend = true)
+function show_projects_for_round(Round $round, bool $show_filter_block = true, bool $allow_special_colors_legend = true): void
 {
     $initial_project_selector = "state = '{$round->project_available_state}'";
 
@@ -38,7 +38,7 @@ function show_projects_for_round($round, $show_filter_block = true, $allow_speci
 
 // -----------------------------------------------------------------------------
 
-function show_projects_for_smooth_reading()
+function show_projects_for_smooth_reading(): void
 {
     global $pguser, $code_url;
 
@@ -156,7 +156,7 @@ function show_projects_for_smooth_reading()
  * 2. an optional "Special Days" color legend, and
  * 3. a listing of projects.
  *
- * @param object $stage
+ * @param Stage $stage
  *   An instance of the Stage class (or a subclass thereof).
  *   This is used for various things, but most importantly,
  *   $stage->id is deemed to identify this listing.
@@ -166,23 +166,23 @@ function show_projects_for_smooth_reading()
  *   user's filter.
  * @param bool $show_filter_block
  *   Should we show the filter widget?
- * @param ?array $filter_custom_display_fields
+ * @param ?array<string, bool> $filter_custom_display_fields
  *   An array naming any custom fields that should appear in the filter widget.
  * @param bool $allow_special_colors_legend
  *   Should we show the special colors legend?
  *   (This can be overridden by the corresponding user preference.)
- * @param array $columns
+ * @param array<string, list{string, string}> $columns
  *   Which columns should appear in the listing.
  */
 function show_projects_for_stage(
-    $stage,
-    $initial_project_selector,
-    $show_filter_block,
-    $filter_custom_display_fields,
-    $allow_special_colors_legend,
-    $columns,
-    $optional_join_clause = ""
-) {
+    Stage $stage,
+    string $initial_project_selector,
+    bool $show_filter_block,
+    ?array $filter_custom_display_fields,
+    bool $allow_special_colors_legend,
+    array $columns,
+    string $optional_join_clause = ""
+): void {
     global $pguser;
 
     // SR is a special snowflake that prints its own header
@@ -231,7 +231,7 @@ function show_projects_for_stage(
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_projects_for_pool($pool, $checkedout_or_available)
+function show_projects_for_pool(Pool $pool, string $checkedout_or_available): void
 {
     global $pguser, $pp_alert_threshold_days;
 
@@ -344,11 +344,11 @@ function show_projects_for_pool($pool, $checkedout_or_available)
  * @param string $filtered_project_selector
  *   An SQL condition (on the 'projects' table) specifying
  *   which projects to list.
- * @param array $columns
+ * @param array<string, list{?string, string}> $columns
  *   The columns to include in the table, this is an associative
  *   array with the key being the column name and the value
  *   being an array consisting of:
- *   - the column's name for the purposes of ext_sort
+ *   - the column's name for the purposes of ext_sort (or null)
  *   - the column's header-label.
  * @param string $ext_sort_param_name
  *   The parameter-name to use when specifying a sort order
@@ -367,16 +367,16 @@ function show_projects_for_pool($pool, $checkedout_or_available)
  *   If needed. Default to "", but useful/necessary for PP
  */
 function show_project_listing(
-    $filtered_project_selector,
-    $columns,
-    $ext_sort_param_name,
-    $ext_sort_setting_name,
-    $default_ext_sort,
-    $anchor,
+    string $filtered_project_selector,
+    array $columns,
+    string $ext_sort_param_name,
+    string $ext_sort_setting_name,
+    string $default_ext_sort,
+    string $anchor,
     $stage,
-    $optional_join_clause = "",
-    $optional_select_clause = ""
-) {
+    string $optional_join_clause = "",
+    string $optional_select_clause = ""
+): void {
     global $code_url, $pguser;
 
     // Some columns (notably those with numbers in them)
@@ -611,7 +611,7 @@ function show_project_listing(
  * - $curr_sql_sort_col - name of the column to sort by
  * - $curr_sql_sort_dir - direction to sort by (asc or desc)
  *
- * @param array $columns
+ * @param array<string, list{?string, string}> $columns
  *   An associative array containing the valid columns in the table
  * @param string $ext_sort_param_name
  *   The parameter-name to use in the URL query-string
@@ -623,10 +623,15 @@ function show_project_listing(
  * @param string $default_ext_sort
  *   The sort to use when one isn't specified by url-parameter or db-setting.
  *
- * @return array
+ * @return list{string, 'asc'|'desc'}
+ *   The sort column name, and the sort direction (asc/desc)
  */
-function process_sorting_control($columns, $ext_sort_param_name, $ext_sort_setting_name, $default_ext_sort)
-{
+function process_sorting_control(
+    array $columns,
+    string $ext_sort_param_name,
+    string $ext_sort_setting_name,
+    string $default_ext_sort
+): array {
     global $pguser;
 
     $local_trace = false; // set to TRUE when debugging

--- a/pinc/showstartexts.inc
+++ b/pinc/showstartexts.inc
@@ -1,7 +1,7 @@
 <?php
 include_once($relPath.'list_projects.inc');
 
-function showstartexts($etext_limit, $type)
+function showstartexts(int $etext_limit, string $type): void
 {
     global $code_url;
 

--- a/pinc/site_news.inc
+++ b/pinc/site_news.inc
@@ -14,7 +14,7 @@ foreach (Stages::get_all() as $stage) {
     $NEWS_PAGES[$stage->id] = $stage->name;
 }
 
-function get_news_subject($news_page_id)
+function get_news_subject(string $news_page_id): string
 {
     global $NEWS_PAGES;
     return $NEWS_PAGES[$news_page_id];
@@ -22,7 +22,7 @@ function get_news_subject($news_page_id)
 
 // -----------------------------------------------------------------------------
 
-function get_news_page_last_modified_date($news_page_id)
+function get_news_page_last_modified_date(string $news_page_id): ?int
 {
     $sql = sprintf(
         "
@@ -55,7 +55,7 @@ function get_news_page_last_modified_date($news_page_id)
  * where the news items are designated for the given page,
  * or for every page.
  */
-function show_news_for_page($news_page_id)
+function show_news_for_page(string $news_page_id): void
 {
     global $code_url;
 

--- a/pinc/smoothread.inc
+++ b/pinc/smoothread.inc
@@ -16,13 +16,8 @@ include_once($relPath.'user_project_info.inc'); // notify_project_event_subscrib
  * Currently only a check for existence of record and field being > 0 is done. The latter
  * would allow the extension for a timestamp and the resetting to 0 if revoked in order
  * to still show users that have once committed but then revoked that commitment.
- *
- * @param string $projectid
- * @param string $username
- *
- * @return bool
  */
-function sr_user_is_committed($projectid, $username)
+function sr_user_is_committed(string $projectid, string $username): bool
 {
     $sql = sprintf(
         "
@@ -47,13 +42,8 @@ function sr_user_is_committed($projectid, $username)
  * Currently the record is only inserted with the committed field being set to one.
  * This allows the future extension for a timestamp and the resetting to 0 if revoked in
  * order to still show users that have once committed but then revoked that commitment.
- *
- * @param string $projectid
- * @param string $username
- *
- * @return void
  */
-function sr_commit($projectid, $username)
+function sr_commit(string $projectid, string $username): void
 {
     $sql = sprintf(
         "
@@ -70,13 +60,8 @@ function sr_commit($projectid, $username)
 
 /**
  * Delete a commitment from a user to SR a specific project
- *
- * @param string $projectid
- * @param string $username
- *
- * @return void
  */
-function sr_withdraw_commitment($projectid, $username)
+function sr_withdraw_commitment(string $projectid, string $username): void
 {
     $sql = sprintf(
         "
@@ -93,11 +78,9 @@ function sr_withdraw_commitment($projectid, $username)
 /**
  * Provide list of users with SR-commitment to project
  *
- * @param string $projectid
- *
  * @return string[]
  */
-function sr_get_committed_users($projectid)
+function sr_get_committed_users(string $projectid): array
 {
     $sql = sprintf(
         "
@@ -121,12 +104,8 @@ function sr_get_committed_users($projectid)
 
 /**
  * Return number of users with SR-commitment to project
- *
- * @param string $projectid
- *
- * @return int
  */
-function sr_number_users_committed($projectid)
+function sr_number_users_committed(string $projectid): int
 {
     return count(sr_get_committed_users($projectid));
 }
@@ -136,12 +115,8 @@ function sr_number_users_committed($projectid)
  *
  * This calls a transient page executing the database function for inserting commitment
  * and provides the current URI for return to current page.
- *
- * @param string $projectid
- *
- * @return void
  */
-function sr_echo_commitment_form($projectid)
+function sr_echo_commitment_form(string $projectid): void
 {
     global $code_url;
 
@@ -161,12 +136,8 @@ function sr_echo_commitment_form($projectid)
  *
  * This calls a transient page executing the database function for inserting commitment
  * and provides the current URI for return to current page.
- *
- * @param string $projectid
- *
- * @return void
  */
-function sr_echo_withdrawal_form($projectid)
+function sr_echo_withdrawal_form(string $projectid): void
 {
     global $code_url;
 
@@ -185,7 +156,7 @@ function sr_echo_withdrawal_form($projectid)
  * Record and notify for smooth reading upload and deadline extension
  * which do not involve a state change
  */
-function handle_smooth_reading_change($project, $postcomments, $days, $extend)
+function handle_smooth_reading_change(Project $project, string $postcomments, int $days, bool $extend): void
 {
     global $pguser;
 

--- a/pinc/unicode.inc
+++ b/pinc/unicode.inc
@@ -7,7 +7,7 @@ use voku\helper\UTF8;
  *
  * @return string|false
  */
-function utf8_normalize(string $string)
+function utf8_normalize(string $string): string|bool
 {
     $normalizer = new Normalizer();
     return $normalizer->normalize($string);
@@ -27,10 +27,8 @@ function utf8_combined_chr(string $codepoint): string
 
 /**
  * Given a character, return the Unicode script it belongs to
- *
- * @param int|string $char
  */
-function utf8_char_script($char): string
+function utf8_char_script(int|string $char): string
 {
     $enum = IntlChar::getIntPropertyValue($char, IntlChar::PROPERTY_SCRIPT);
     return IntlChar::getPropertyValueName(IntlChar::PROPERTY_SCRIPT, $enum);
@@ -77,8 +75,10 @@ function utf8_string_scripts(string $string): array
  * Returns an associative array where the key is the nonnormalized codepoint
  * and the value is the normalized version. If all codepoints are normalized
  * it returns an empty array.
+ * @param string|string[] $codepoints
+ * @return array<string, string>
  */
-function get_nonnormalized_codepoints($codepoints)
+function get_nonnormalized_codepoints($codepoints): array
 {
     $characters = convert_codepoint_ranges_to_characters($codepoints);
     $nonnorm_codepoints = [];
@@ -95,10 +95,8 @@ function get_nonnormalized_codepoints($codepoints)
 
 /**
  * Given a single character, or a combined character, return its name
- *
- * @param string $characters
  */
-function utf8_character_name($characters): string
+function utf8_character_name(string $characters): string
 {
     $title_pieces = [];
     foreach (UTF8::str_split($characters) as $char) {
@@ -140,7 +138,8 @@ function split_multiscript_string(string $string): array
     return $chunks;
 }
 
-function split_graphemes($string)
+/** @return Generator<string> */
+function split_graphemes(string $string)
 {
     $next = 0;
     $maxbytes = strlen($string);
@@ -162,8 +161,9 @@ function split_graphemes($string)
 
 /**
  * Split a Unicode string into codepoints keeping combining characters together
+ * @return string[]
  */
-function utf8_codepoints_combining($string)
+function utf8_codepoints_combining(string $string): array
 {
     $codepoints = [];
     foreach (split_graphemes($string) as $grapheme) {
@@ -175,15 +175,17 @@ function utf8_codepoints_combining($string)
 /**
  * Given a string, return a string of codepoints in U+ format
  */
-function string_to_codepoints_string($string, $imploder = " ")
+function string_to_codepoints_string(string $string, string $imploder = " "): string
 {
     return implode($imploder, UTF8::codepoints($string, true));
 }
 
 /**
  * Filter to only characters in $string that are in $valid_codepoints.
+ *
+ * @param string[] $valid_codepoints
  */
-function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement = "")
+function utf8_filter_to_codepoints(string $string, array $valid_codepoints, string $replacement = ""): string
 {
     $pattern_string = build_character_regex_filter($valid_codepoints);
     $result = "";
@@ -200,8 +202,10 @@ function utf8_filter_to_codepoints($string, $valid_codepoints, $replacement = ""
 
 /**
  * Filter out any characters in $string that are in $remove_codepoints
+ *
+ * @param string[] $remove_codepoints
  */
-function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement = "")
+function utf8_filter_out_codepoints(string $string, array $remove_codepoints, string $replacement = ""): string
 {
     $pattern_string = build_character_regex_filter($remove_codepoints);
     $result = "";
@@ -223,7 +227,7 @@ function utf8_filter_out_codepoints($string, $remove_codepoints, $replacement = 
  *
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
  */
-function get_unicode_regex_class($codepoint, $lang = 'php')
+function get_unicode_regex_class(string $codepoint, string $lang = 'php'): string
 {
     $hex = str_replace("U+", "", $codepoint);
     if ($lang == "php") {
@@ -241,12 +245,12 @@ function get_unicode_regex_class($codepoint, $lang = 'php')
  * return a regular expression character class to match a single
  * character.
  *
- * @param array $codepoints
+ * @param string[] $codepoints
  *
  * @param string $lang
  *   Consuming language (php or js).
  */
-function build_character_regex_filter($codepoints, $lang = 'php')
+function build_character_regex_filter(array $codepoints, string $lang = 'php'): string
 {
     $char_class = "";
     $alternatives = [];
@@ -313,9 +317,10 @@ function convert_codepoint_ranges_to_characters($codepoints): array
 /**
  * Return an array of invalid characters and their count
  *
+ * @param string[] $codepoints
  * @return array<string, int>
  */
-function get_invalid_characters(string $string, $codepoints): array
+function get_invalid_characters(string $string, array $codepoints): array
 {
     $string = utf8_filter_out_codepoints($string, $codepoints);
     $char_count = [];
@@ -336,8 +341,10 @@ function get_invalid_characters(string $string, $codepoints): array
  *
  * Returns `[ $success, $message ]` where $success is TRUE if the file is
  * already UTF-8 or was successfully converted. $message is a more detailed message.
+ *
+ * @return list{bool, string}
  */
-function convert_text_file_to_utf8(string $filename)
+function convert_text_file_to_utf8(string $filename): array
 {
     $text = file_get_contents($filename);
     $encoding = guess_string_encoding($text);

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -26,7 +26,7 @@ define("RESUMABLE_UPLOAD_SIZE", 1024 * 1024 * 1024);  // 1GB
  *
  * http://andrewcurioso.com/blog/archive/2010/detecting-file-size-overflow-in-php.html
  */
-function detect_too_large()
+function detect_too_large(): void
 {
     if ($_SERVER['REQUEST_METHOD'] == 'POST' && empty($_POST) &&
         empty($_FILES) && ($_SERVER['CONTENT_LENGTH'] ?? 0) > 0) {
@@ -34,21 +34,24 @@ function detect_too_large()
     }
 }
 
-function get_max_upload_size()
+function get_max_upload_size(): int
 {
     return return_bytes(ini_get("upload_max_filesize"));
 }
 
-function get_big_upload_blurb()
+function get_big_upload_blurb(): string
 {
     global $db_requests_email_addr;
 
     return sprintf(_("If you are trying to upload a very big zip file and the upload does not succeed, upload a small placeholder zip file instead and email %s for assistance."), "<span class='nowrap'>$db_requests_email_addr</span>");
 }
 
-// This supplies the arguments for the header in the page containing the upload
-// form below
-function get_upload_args()
+/**
+ * This supplies the arguments for the header in the page containing the upload
+ * form below
+ * @return array<string, string|string[]>
+ */
+function get_upload_args(): array
 {
     global $code_url;
 
@@ -82,7 +85,7 @@ function get_upload_args()
  * It contains a 'choose file' button and a labeled submit button
  * and shows appropriate messages to the user.
  */
-function show_upload_form($form_content, $submit_label)
+function show_upload_form(string $form_content, string $submit_label): void
 {
     $standard_blurb = _("The file must be Zipped (not gzip, tar, etc.) and have the .zip extension. The file name must consist of ASCII letters, digits, underscores, and/or hyphens. It must not begin with a hyphen and be no longer than 200 characters.");
 
@@ -146,9 +149,11 @@ class NoFileUploadedException extends Exception
  * throws NoFileUploadedException if there is no file
  * throws a FileUploadException if there is a problem
  * if an exception is thrown any file will have been deleted.
- * verbose will echo progress messages - must disable apache gzip compression
+ * @param bool $verbose
+ *   echo progress messages - must disable apache gzip compression
+ * @return array{tmp_name: string, name: string}
  */
-function validate_uploaded_file($verbose)
+function validate_uploaded_file(bool $verbose): array
 {
     $file_path = "";
     $mode = get_enumerated_param($_REQUEST, 'mode', 'upload', ['upload', 'resumable']);
@@ -220,14 +225,14 @@ function validate_uploaded_file($verbose)
     return $file_info;
 }
 
-function empty_check($file_size)
+function empty_check(int $file_size): void
 {
     if (0 == $file_size) {
         throw new FileUploadException(_("File is empty"));
     }
 }
 
-function zip_check($original_name, $file_path)
+function zip_check(string $original_name, string $file_path): void
 {
     if (substr($original_name, -4) != ".zip") {
         throw new FileUploadException(_("File name extension must be '.zip'"));
@@ -244,7 +249,7 @@ function zip_check($original_name, $file_path)
 }
 
 // echos messages if verbose
-function virus_check($file_path, $verbose)
+function virus_check(string $file_path, bool $verbose): void
 {
     $antivirus_executable = SiteConfig::get()->antivirus_executable;
     if (!$antivirus_executable) {
@@ -274,7 +279,7 @@ function virus_check($file_path, $verbose)
     show_upload_message($verbose, _("No infection found"));
 }
 
-function show_upload_message($verbose, $message)
+function show_upload_message(bool $verbose, string $message): void
 {
     if (!$verbose) {
         return;
@@ -285,7 +290,7 @@ function show_upload_message($verbose, $message)
 
 // This function has a client-side pair in scripts/file_resume.js:validate()
 // which should be updated if the below logic changes.
-function is_valid_filename($filename, $restrict_extension = false)
+function is_valid_filename(string $filename, bool|string $restrict_extension = false): bool
 {
     // Filenames can't be longer than 200 characters total
     if (strlen($filename) > 200) {
@@ -309,7 +314,7 @@ function is_valid_filename($filename, $restrict_extension = false)
 
 // This function is used in remote_file_manager to enforce valid
 // directory names. It pairs with is_valid_filename() above.
-function is_valid_dirname($dirname)
+function is_valid_dirname(string $dirname): bool
 {
     // Directory names can't be longer than 200 characters total
     if (strlen($dirname) > 200) {

--- a/pinc/user_is.inc
+++ b/pinc/user_is.inc
@@ -69,7 +69,7 @@ function user_can_see_user_access_chart_of(?string $subject_username): bool
     // We also allow PFs to see access charts.
 }
 
-/** @return array{0:bool, 1:bool} */
+/** @return list{bool, bool} */
 function user_can_modify_access_of(?string $subject_username): array
 {
     // Currently, $subject_username is ignored unless $testing is true.

--- a/pinc/walkthrough.inc
+++ b/pinc/walkthrough.inc
@@ -3,7 +3,7 @@
 // SITE-SPECIFIC
 // Functions that deal with the walkthrough housed in $dyn_dir
 
-function get_walkthrough_url($langcode = null)
+function get_walkthrough_url(?string $langcode = null): string
 {
     // if no langcode was passed in, try to get the user's language
     if (!$langcode) {

--- a/project.php
+++ b/project.php
@@ -212,7 +212,7 @@ function do_expected_state(): void
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-/** @return array{0:?string, 1:?string} */
+/** @return list{?string, ?string} */
 function decide_blurbs(): array
 {
     global $project, $pguser, $code_url;
@@ -1296,8 +1296,15 @@ function do_history(): void
 
 /**
  * If the project's event-history has gaps, fill them with pseudo-events.
- *
- * @return array{'timestamp':?int, 'who':string, 'event_type':string, 'details1':string, 'details2':string, 'details3':string}[]
+ * @param array<string, mixed>[] $in_events
+ * @return array{
+ *      timestamp: ?int,
+ *      who: string,
+ *      event_type: string,
+ *      details1: string,
+ *      details2: string,
+ *      details3: string
+ *      }[]
  */
 // TODO(jchaffraix): Add a class for ProjectEvent and switch to this function to it.
 function fill_gaps_in_events(array $in_events): array
@@ -1358,7 +1365,7 @@ function fill_gaps_in_events(array $in_events): array
         ];
         $out_events[] = $pseudo_event;
     }
-    return $out_events;
+    return $out_events; // @phpstan-ignore return.type
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/stats/release_queue.php
+++ b/stats/release_queue.php
@@ -266,7 +266,7 @@ function _show_queue_details(Round $round, string $name, bool $unheld_only): voi
     echo "</table>";
 }
 
-/** @return array{0: int, 1: int} */
+/** @return list{int, int} */
 function _get_num_projects_and_pages_available(Round $round): array
 {
     $sql = sprintf(

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -177,10 +177,18 @@ class Loader
     private int $image_field_len;
     /** @var array<string, string> */
     private array $ignored_files;
-    /** @var string[] */
-    /** @var array<string, array{'error_msgs': string[], 'warning_msgs': string[]}> */
+    /** @var array<string, array{error_msgs: string[], warning_msgs: string[]}> */
     private array $non_page_files;
-    /** @var array<string, array{'text': array{'src'?: string[], 'db'?: string[], 'action': string}, 'image': array{'src'?: string[], 'db'?: string[], 'action': string}, 'error_msgs': string[], 'warning_msgs': string[]}> */
+    /** @var array<
+     *           string,
+     *           array{
+     *               text: array{src?: string[], db?: string[], action: string},
+     *               image: array{src?: string[], db?: string[], action: string},
+     *               error_msgs: string[],
+     *               warning_msgs: string[]
+     *           }
+     *       >
+     */
     private array $page_file_table;
     /** @var array<string, string> */
     private array $db_text_for_base;

--- a/tools/proofers/PPage.inc
+++ b/tools/proofers/PPage.inc
@@ -45,6 +45,7 @@ function url_for_pi_do_particular_page(string $projectid, string $proj_state, st
 
 // -----------------------------------------------------------------------------
 
+/** @param array<string, mixed> $request_params */
 function get_requested_PPage(array $request_params): PPage
 {
     $projectid = get_projectID_param($request_params, 'projectid');
@@ -346,6 +347,7 @@ class PPage
         $this->lpage->saveAsInProgress($page_text, $user);
     }
 
+    /** @return list{bool, bool} */
     public function attemptSaveAsDone(string $page_text, string $user): array
     {
         return $this->lpage->attemptSaveAsDone($page_text, $user);

--- a/tools/proofers/spellcheck_text.inc
+++ b/tools/proofers/spellcheck_text.inc
@@ -611,7 +611,14 @@ function get_page_js(int $interface_type_init_value): string
         PAGE_JS;
 }
 
-/** @return array{"js_modules": string[], "js_data": string, "body_attributes": string, "css_data"?: string} */
+/**
+ * @return array{
+ *      js_modules: string[],
+ *      js_data: string,
+ *      body_attributes: string,
+ *      css_data?: string
+ *      }
+ */
 function get_wordcheck_page_header_args(User $user, PPage $ppage): array
 {
     global $code_url, $word_check_messages;


### PR DESCRIPTION
This is a first sweep of adding function argument and return type hints to files in `pinc/` with the intention of making the entire codebase pass PHPStan's level 6 warnings.

This patchset adds a large number of hopefully straightforward to review type hints and almost nothing else.