### PR TITLE
Add more function type hints and tidyups for PHPStan level 6

### DIFF
--- a/SETUP/tests/unittests/ParamValidatorTest.php
+++ b/SETUP/tests/unittests/ParamValidatorTest.php
@@ -122,20 +122,6 @@ class ParamValidatorTest extends PHPUnit\Framework\TestCase
         get_numeric_param("boolean", $this->GET, 'enum', 1, 0, 1, false);
     }
 
-    public function testNumericMinType(): void
-    {
-        $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("type numeric or null");
-        get_numeric_param("integer", $this->GET, 'enum', 1, "min", 1, false);
-    }
-
-    public function testNumericMaxType(): void
-    {
-        $this->expectException(TypeError::class);
-        $this->expectExceptionMessage("type numeric or null");
-        get_numeric_param("integer", $this->GET, 'enum', 1, 0, "max", false);
-    }
-
     public function testNumericMinLtMax(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,8 +30,6 @@ parameters:
           path: pinc/3rdparty/mediawiki/DiffEngine.php
         - message: '#^Parameter \#2 \$.* of function array_fill expects int, float given\.$#'
           path: pinc/3rdparty/mediawiki/DiffEngine.php
-        - message: '#Call to function wfDebug\(\) on a separate line has no effect.#'
-          path: pinc/3rdparty/mediawiki/DiffEngine.php
         - message: '#Assign to \$.* overwrites the last element from array\.$#'
           path: pinc/3rdparty/mediawiki/DiffEngine.php
         - message: '#If condition is always false\.$#'

--- a/pinc/CharSuites.inc
+++ b/pinc/CharSuites.inc
@@ -8,13 +8,13 @@ class CharSuiteNotEnabledException extends Exception
 class PickerSet
 {
     public string $name;
-    /** @var list<list<?string>> */
+    /** @var (?string)[][] */
     private array $subsets;
     /** @var string[] */
     private array $titles;
 
-    /** @param list<list<?string>> $codepoints */
-    public function add_subset(string $name, array $codepoints, ?string $title = null)
+    /** @param (?string)[][] $codepoints */
+    public function add_subset(string $name, array $codepoints, ?string $title = null): void
     {
         $this->subsets[$name] = $codepoints;
 
@@ -25,13 +25,13 @@ class PickerSet
         }
     }
 
-    /** @return list<list<?string>> */
+    /** @return (?string)[][] */
     public function get_subsets(): array
     {
         return $this->subsets;
     }
 
-    /** @return array{name: string, title: string, rows: list<list<list<?string>>>}[] */
+    /** @return array{name: string, title: string, rows: list{?string,?string}[][]}[] */
     public function get_verbose_subsets(): array
     {
         $verbose_subsets = [];
@@ -62,6 +62,7 @@ class PickerSet
 class CharSuite
 {
     public ?string $description = null;
+    /** @var string[] */
     public $reference_urls = [];
     private ?PickerSet $_pickerset = null;
 
@@ -119,7 +120,8 @@ class CharSuite
         return in_array($this, $enabled_sets);
     }
 
-    public function get_nonnormalized_codepoints()
+    /** @return array<string, string> */
+    public function get_nonnormalized_codepoints(): array
     {
         return get_nonnormalized_codepoints($this->codepoints);
     }
@@ -244,8 +246,16 @@ class CharSuites
 
 trait CharSuiteSet
 {
-    /** @return array{name: string, subsets: array{name: string, title: string, rows: (?string[])[][]}[]}[] */
-    public function get_verbose_pickersets(): array
+    /** @return array{
+     *              name: string,
+     *              subsets: array{
+     *                  name: string,
+     *                  title: string,
+     *                  rows: (?string)[][][]
+     *              }[]
+     *          }[]
+     */
+    public function get_verbose_pickersets()
     {
         $verbose_pickersets = [];
         foreach ($this->get_pickersets() as $pickerset) {

--- a/pinc/DifferenceEngineWrapper.inc
+++ b/pinc/DifferenceEngineWrapper.inc
@@ -26,9 +26,9 @@ include_once($relPath."3rdparty/mediawiki/DiffFormatter.php");
 
 abstract class DifferenceEngineWrapper
 {
-    private $oldText;
-    private $newText;
-    private $formatter;
+    private string $oldText;
+    private string $newText;
+    private DiffFormatter $formatter;
 
     protected function __construct(?DiffFormatter $formatter = null)
     {
@@ -38,13 +38,13 @@ abstract class DifferenceEngineWrapper
         $this->formatter = $formatter;
     }
 
-    public function setText($oldText, $newText)
+    public function setText(string $oldText, string $newText): void
     {
         $this->oldText = $oldText;
         $this->newText = $newText;
     }
 
-    public function getDiff($oldTitle, $newTitle)
+    public function getDiff(string $oldTitle, string $newTitle): string
     {
         $otext = $this->oldText;
         $ntext = $this->newText;
@@ -57,7 +57,7 @@ abstract class DifferenceEngineWrapper
         return $this->addHeader($difftext, $oldTitle, $newTitle);
     }
 
-    private function generateTextDiffBody($otext, $ntext)
+    private function generateTextDiffBody(string $otext, string $ntext): string
     {
         // lifted from DifferenceEngine::generateTextDiffBody()
         global $wgContLang;
@@ -77,37 +77,31 @@ abstract class DifferenceEngineWrapper
     }
 
     // Default implementation adds nothing
-    protected function addHeader($diff, $otitle, $ntitle, $multi = '', $notice = '')
+    protected function addHeader(string $diff, string $otitle, string $ntitle, string $multi = '', string $notice = ''): string
     {
         return $diff;
     }
 
-    private function localiseLineNumbers($text)
+    private function localiseLineNumbers(string $text): string
     {
         // lifted from DifferenceEngine::localiseLineNumbers()
         return preg_replace_callback(
             '/<!--LINE (\d+)-->/',
-            [&$this, 'localiseLineNumbersCb'],
+            fn ($match) => sprintf(_("Line %d"), $match[1]),
             $text
         );
-    }
-
-    private function localiseLineNumbersCb($line_numbers)
-    {
-        // DP-specific function
-        return sprintf(_("Line %d"), $line_numbers[1]);
     }
 }
 
 // stub classes and global instances
 class ContLang
 {
-    public function segmentForDiff($string)
+    public function segmentForDiff(string $string): string
     {
         return $string;
     }
 
-    public function unsegmentForDiff($string)
+    public function unsegmentForDiff(string $string): string
     {
         return $string;
     }
@@ -121,7 +115,7 @@ $wgContLang = new ContLang();
 if (!class_exists("Xml")) {
     class Xml
     {
-        public static function tags($tagName, $className, $contents)
+        public static function tags(string $tagName, ?string $className, string $contents): string
         {
             return "<$tagName>$contents</$tagName>";
         }
@@ -130,7 +124,8 @@ if (!class_exists("Xml")) {
 
 // MW code references wfDebug() in some places
 if (!function_exists("wfDebug")) {
-    function wfDebug($text, $dest = 'all', array $context = [])
+    /** @param array<string, string> $context */
+    function wfDebug(string $text, string $dest = 'all', array $context = []): void
     {
         // don't log any debug messages
     }

--- a/pinc/DifferenceEngineWrapperBB.inc
+++ b/pinc/DifferenceEngineWrapperBB.inc
@@ -9,7 +9,7 @@ include_once($relPath."BBDiffFormatter.inc");
  */
 class DifferenceEngineWrapperBB extends DifferenceEngineWrapper
 {
-    public function __construct($diffurl)
+    public function __construct(string $diffurl)
     {
         parent::__construct(new BBDiffFormatter($diffurl));
     }
@@ -20,12 +20,12 @@ class DifferenceEngineWrapperBB extends DifferenceEngineWrapper
  */
 class DifferenceEngineWrapperBBHTML extends DifferenceEngineWrapper
 {
-    public function __construct($diffurl)
+    public function __construct(string $diffurl)
     {
         parent::__construct(new BBDiffFormatterHTML($diffurl));
     }
 
-    protected function addHeader($diff, $otitle, $ntitle, $multi = '', $notice = '')
+    protected function addHeader(string $diff, string $otitle, string $ntitle, string $multi = '', string $notice = ''): string
     {
         $header = "";
         if (!$diff && !$otitle) {

--- a/pinc/DifferenceEngineWrapperTable.inc
+++ b/pinc/DifferenceEngineWrapperTable.inc
@@ -11,7 +11,7 @@ class DifferenceEngineWrapperTable extends DifferenceEngineWrapper
         parent::__construct(new TableDiffFormatter());
     }
 
-    protected function addHeader($diff, $otitle, $ntitle, $multi = '', $notice = '')
+    protected function addHeader(string $diff, string $otitle, string $ntitle, string $multi = '', string $notice = ''): string
     {
         // lifted from DifferenceEngine::addHeader()
         // but without any of the $userLang bits
@@ -59,7 +59,7 @@ class DifferenceEngineWrapperTable extends DifferenceEngineWrapper
 /**
  * Override default css for DP customizations
  */
-function get_DifferenceEngine_css_data($font_family)
+function get_DifferenceEngine_css_data(string $font_family): string
 {
     return "
 .diff-otitle,

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -11,32 +11,30 @@ use Symfony\Component\Process\Process;
  */
 class POFile
 {
-    private ?string $po_filename;
     private ?int $num_messages = null;
     private ?int $num_messages_translated = null;
 
-    public function __construct($po_filename = null)
+    public function __construct(private ?string $po_filename = null)
     {
-        $this->po_filename = $po_filename;
     }
 
-    public function __get($name)
+    public function __get(string $name): mixed
     {
         $func = "get_$name";
         return $this->$func();
     }
 
-    private function get_exists()
+    private function get_exists(): bool
     {
         return file_exists($this->po_filename);
     }
 
-    private function get_last_modified()
+    private function get_last_modified(): int
     {
         return filemtime($this->po_filename);
     }
 
-    private function get_messages_count()
+    private function get_messages_count(): int
     {
         if ($this->num_messages === null) {
             $this->count_translated_strings();
@@ -44,7 +42,7 @@ class POFile
         return $this->num_messages;
     }
 
-    private function get_messages_translated_count()
+    private function get_messages_translated_count(): int
     {
         if ($this->num_messages_translated === null) {
             $this->count_translated_strings();
@@ -55,7 +53,7 @@ class POFile
     /**
      * Count the total number of strings and the number of translated strings.
      */
-    private function count_translated_strings()
+    private function count_translated_strings(): void
     {
         $iterator = new POFileIterator($this->po_filename);
         $count = 0;
@@ -91,7 +89,7 @@ class POFile
      *
      * This is slightly complicated because of multiline strings, hence the gymnastics.
      */
-    private function is_block_translated($block)
+    private function is_block_translated(string $block): bool
     {
         [$msgid, $msgstr] = @explode("msgstr", $block);
         $msgstr = "msgstr$msgstr";
@@ -107,7 +105,7 @@ class POFile
      * Get the full Content-Type from the comment block at the beginning of a PO
      * file (without any trailing newline) or NULL on error.
      */
-    private function get_content_type()
+    private function get_content_type(): ?string
     {
         $fh = fopen($this->po_filename, "rt");
         if (!$fh) {
@@ -223,7 +221,7 @@ class POFile
         return "$pot_tempfile.pot";
     }
 
-    public function create_template($basedir, $pot_filename)
+    public function create_template(string $basedir, string $pot_filename): void
     {
         $php_pot = $this->create_pot_from_php($basedir);
         $js_pot = $this->create_pot_from_js($basedir);
@@ -262,7 +260,7 @@ class POFile
         }
     }
 
-    public function create_from_template($pot_filename, $locale)
+    public function create_from_template(string $pot_filename, string $locale): void
     {
         $process = new Process([
             "msginit",
@@ -277,7 +275,7 @@ class POFile
         }
     }
 
-    public function merge_from_template($template, $fuzzy = false)
+    public function merge_from_template(string $template, bool $fuzzy = false): void
     {
         $args = [
             "msgmerge",
@@ -299,7 +297,7 @@ class POFile
         touch($this->po_filename);
     }
 
-    public function compile()
+    public function compile(): void
     {
         $compiled_filename = str_replace(".po", ".mo", $this->po_filename);
 
@@ -314,7 +312,7 @@ class POFile
         }
     }
 
-    public function convert_to_json($json_filename)
+    public function convert_to_json(string $json_filename): void
     {
         global $code_dir;
 
@@ -332,16 +330,16 @@ class POFile
 }
 
 
+/** @implements Iterator<int, string> */
 class POFileIterator implements Iterator
 {
-    private $po_filename;
+    /** @var resource|null $file_handle */
     private $file_handle = null;
-    private $current_block = null;
-    private $block_count = -1;
+    private ?string $current_block = null;
+    private int $block_count = -1;
 
-    public function __construct($po_filename)
+    public function __construct(private string $po_filename)
     {
-        $this->po_filename = $po_filename;
     }
 
     public function rewind(): void
@@ -349,7 +347,7 @@ class POFileIterator implements Iterator
         if ($this->file_handle) {
             fseek($this->file_handle, 0);
         } else {
-            $this->file_handle = fopen($this->po_filename, "rt");
+            $this->file_handle = fopen($this->po_filename, "rt") ?: null;
         }
 
         $this->next();
@@ -367,7 +365,7 @@ class POFileIterator implements Iterator
 
     public function next(): void
     {
-        if (!$this->file_handle) {
+        if (!isset($this->file_handle)) {
             return;
         }
 
@@ -399,7 +397,7 @@ class POFileIterator implements Iterator
 
     public function __destruct()
     {
-        if ($this->file_handle) {
+        if (isset($this->file_handle)) {
             fclose($this->file_handle);
         }
     }

--- a/pinc/ProjectSearchResults.inc
+++ b/pinc/ProjectSearchResults.inc
@@ -493,7 +493,7 @@ class ProjectSearchResults
         $this->userSettings = & Settings::get_Settings($pguser);
         $this->search_origin = $search_origin;
         $option_data = new OptionData($this->userSettings, $this->search_origin);
-        $this->page_size = $option_data->results_per_page->get_value();
+        $this->page_size = intval($option_data->results_per_page->get_value());
         $time_format = $option_data->time_format->get_value();
 
         $column_data = new ColumnData($this->userSettings, $this->search_origin, $time_format);

--- a/pinc/ProjectSearchResultsConfig.inc
+++ b/pinc/ProjectSearchResultsConfig.inc
@@ -44,8 +44,12 @@ class ColumnSelector extends Selector
 class OptionSelector extends Selector
 {
     private string $def_value;
+    /** @var array<int|string, int|string> */
     private array $options;
 
+    /**
+     * @param array<int|string, int|string> $options
+     */
     public function __construct(string $id, string $label, string $value, array $options, Settings $userSettings, string $search_origin)
     {
         $this->id = $id;
@@ -69,7 +73,7 @@ class OptionSelector extends Selector
         return $r;
     }
 
-    public function get_value()
+    public function get_value(): string
     {
         $value = $this->userSettings->get_value("search:{$this->search_origin}.option:$this->id", $this->def_value);
 
@@ -83,7 +87,7 @@ class OptionSelector extends Selector
         return $value;
     }
 
-    public function save_value($value): void
+    public function save_value(string $value): void
     {
         // Save the value but only if it has changed and is a valid option
         if ($this->get_value() != $value && isset($this->options[$value])) {
@@ -125,6 +129,7 @@ class OptionData
 
 class ConfigForm extends ColumnData
 {
+    /** @var ColumnSelector[] */
     private array $column_selectors;
     private OptionData $option_data;
 

--- a/pinc/Quiz.inc
+++ b/pinc/Quiz.inc
@@ -5,6 +5,7 @@ include_once($relPath.'CharSuites.inc'); // CharSuiteSet
 // for groups of quizzes that go together
 class QuizLevel
 {
+    /** @var array<string, QuizLevel> */
     public static $map_quiz_level_id_to_QuizLevel = [];
 
     /** @param Quiz[] $quizzes */
@@ -36,6 +37,10 @@ class Quiz
     /** @var array<string, Quiz> */
     public static $map_quiz_id_to_Quiz = [];
 
+    /**
+     * @param array<string, string> $pages
+     * @param array<string, int> $pass_requirements
+     */
     public function __construct(
         public readonly string $id,
         public readonly string $name,        // appears in the top of the quiz's table

--- a/pinc/Round.inc
+++ b/pinc/Round.inc
@@ -47,6 +47,7 @@ class Round extends Stage
     /** @var array<string, string[]> */
     public array $pi_tools;
     public ?int $daily_page_limit;
+    /** @var array<string> */
     public array $other_rounds_with_visible_usernames;
     /** @var array<int, string> */
     private array $honorifics;
@@ -298,7 +299,7 @@ function get_Round_for_page_state(string $page_state): ?Round
 
 // ---------------------------
 
-function get_Round_for_text_column_name($text_column_name)
+function get_Round_for_text_column_name(string $text_column_name): ?Round
 {
     foreach (Rounds::get_all() as $round) {
         if ($round->text_column_name == $text_column_name) {
@@ -317,7 +318,7 @@ function get_Round_for_text_column_name($text_column_name)
  * which is not very useful. Instead, ORDER BY the result of this function,
  * and it will use the canonical order-of-declaration for page states.
  */
-function sql_collator_for_page_state($state_column)
+function sql_collator_for_page_state(string $state_column): string
 {
     return sprintf(
         "FIELD($state_column, %s)",
@@ -334,7 +335,7 @@ function sql_collator_for_page_state($state_column)
  * (the "mentored" or "mentee" round) will garner feedback by qualified users
  * ("mentors") in a subsequent round (the "mentoring" or "mentor" round).
  */
-function declare_mentoring_pair($mentee_round_id, $mentor_round_id)
+function declare_mentoring_pair(string $mentee_round_id, string $mentor_round_id): void
 {
     $mentee_round = Rounds::get_by_id($mentee_round_id);
     $mentor_round = Rounds::get_by_id($mentor_round_id);
@@ -365,7 +366,7 @@ function declare_mentoring_pair($mentee_round_id, $mentor_round_id)
  * It also doesn't need to check whether any of the project's pages
  * are actually available.
  */
-function validate_user_can_get_pages_in_project($user, $project, $round)
+function validate_user_can_get_pages_in_project(User $user, Project $project, Round $round): void
 {
     // Projects with difficulty='beginner' are treated differently in
     // various ways.
@@ -417,7 +418,7 @@ function validate_user_can_get_pages_in_project($user, $project, $round)
     // None of the above restrictions apply.
 }
 
-function validate_user_against_project_reserve($user, $project, $round)
+function validate_user_against_project_reserve(User $user, Project $project, Round $round): void
 {
     // Allow projects to be reserved for newcomers based on
     // criteria defined in get_reserve_length().
@@ -483,7 +484,7 @@ function validate_user_against_project_reserve($user, $project, $round)
  * If so, return the length of the reserve in days.
  * If not, return 0.
  */
-function get_reserve_length($project, $round)
+function get_reserve_length(Project $project, Round $round): int
 {
     // We only reserve-for-newbies in P1.
     if ($round->id != 'P1') {
@@ -544,7 +545,7 @@ function get_reserve_length($project, $round)
  * If you don't want any criteria to take precedence over column-sorts,
  * return NULL or the empty string.
  */
-function round_project_listing_presort($round)
+function round_project_listing_presort(Round $round): string
 {
     if (is_proofreading_round($round)) {
         return "
@@ -564,12 +565,12 @@ function round_project_listing_presort($round)
     }
 }
 
-function is_proofreading_round($round)
+function is_proofreading_round(Round $round): bool
 {
     return str_starts_with($round->id, 'P');
 }
 
-function is_formatting_round($round)
+function is_formatting_round(Round $round): bool
 {
     return str_starts_with($round->id, 'F');
 }
@@ -577,12 +578,7 @@ function is_formatting_round($round)
 /**
  * From an array & key, get a Round object matching the ID
  *
- * @param array $arr
- * @param string $key
- * @param Round|null $default
- * @param bool $allownull
- *
- * @return Round|null
+ * @param array<string, string> $arr
  *
  * @throws InvalidArgumentException
  */
@@ -594,12 +590,6 @@ function get_round_param(array $arr, string $key, ?Round $default = null, bool $
     }
     if (isset($arr[$key])) {
         $s = $arr[$key];
-        if (!is_string($s)) {
-            throw new InvalidArgumentException(sprintf(
-                _("Parameter '%1\$s' is not a valid type"),
-                $key
-            ));
-        }
         // Trim whitespace from both ends of the string.
         $s = trim($s);
         if ($s == '' && $allownull) {
@@ -633,16 +623,11 @@ function get_round_param(array $arr, string $key, ?Round $default = null, bool $
 /**
  * From an array & key, get a Round object or an OCR pseudo-round
  *
- * @param array $arr
- * @param string $key
- * @param Round|null $default
- * @param bool $allownull
- *
- * @return Round|stdClass|null
+ * @param array<string, string> $arr
  *
  * @throws InvalidArgumentException
  */
-function get_round_or_ocr_param(array $arr, string $key, ?Round $default = null, bool $allownull = false)
+function get_round_or_ocr_param(array $arr, string $key, ?Round $default = null, bool $allownull = false): Round|stdClass|null
 {
     // sanity checks on the args
     if (!is_null($default) && $allownull) {

--- a/pinc/SortUtility.inc
+++ b/pinc/SortUtility.inc
@@ -53,7 +53,7 @@ class SortableValue
         }
     }
 
-    public function _flipAscendDescendSqlRule($sqlRuleAscending)
+    public function _flipAscendDescendSqlRule(string $sqlRuleAscending): string
     {
         $vars = explode(',', $sqlRuleAscending);
         $newVars = [];
@@ -75,7 +75,7 @@ class SortableValue
     /**
      * Returns the name of the SortableValue.
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->_name;
     }
@@ -83,7 +83,7 @@ class SortableValue
     /**
      * Returns the label of the SortableValue.
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->_label;
     }
@@ -92,7 +92,7 @@ class SortableValue
      * Returns a SQL-snippet to be used in an ORDER BY-clause
      * depending on whether $direction is ASCENDING or DESCENDING
      */
-    public function getSQLRule($direction)
+    public function getSQLRule(int $direction): string
     {
         if ($direction == ASCENDING) {
             return $this->_sqlRuleAscending;
@@ -113,6 +113,7 @@ class SortUtility
 
     // sorting
     private ?SortableValue $_sortingValue;
+    /** @var ASCENDING|DESCENDING */
     private ?int $_sortingDirection;
 
     /**
@@ -137,7 +138,7 @@ class SortUtility
      *
      * Those are, in order: HTTP-argument, saved setting in database
      */
-    public function _checkForUserPreferenceOnSorting()
+    public function _checkForUserPreferenceOnSorting(): bool
     {
 
         // Did the user click a sorting link (or used bookmark)?
@@ -159,8 +160,9 @@ class SortUtility
      * Sets the sorting rule to use. Will not take effect if
      * there is an HTTP-argument or setting in the database
      * specifying how to sort this data.
+     * @param ASCENDING|DESCENDING $sortingDirection
      */
-    public function setSortingRule($sortingValue, $sortingDirection = ASCENDING)
+    public function setSortingRule(?SortableValue $sortingValue, int $sortingDirection = ASCENDING): void
     {
         if (!$this->_checkForUserPreferenceOnSorting()) {
             // No Sorting link clicked, no database setting searched & found
@@ -175,7 +177,7 @@ class SortUtility
      * SortableValue and X is A or D, specifying
      * ascending and descending, respectively.
      */
-    public function _parseSortingRule($sortingRule)
+    public function _parseSortingRule(string $sortingRule): bool
     {
         if (preg_match('/A$/', $sortingRule)) {
             $name = substr($sortingRule, 0, -1);
@@ -204,7 +206,7 @@ class SortUtility
      * This is the one the user has choose to sort by,
      * or the default as specified by setSortingRule(...).
      */
-    public function getSortingValue()
+    public function getSortingValue(): ?SortableValue
     {
         if (isset($this->_sortingValue)) {
             return $this->_sortingValue;
@@ -217,22 +219,16 @@ class SortUtility
         }
     }
 
-    /**
-     * Returns ASCENDING or DESCENDING specifying how to sort.
-     */
-    public function getSortingDirection()
+    /** @return ASCENDING|DESCENDING */
+    public function getSortingDirection(): int
     {
-        if (isset($this->_sortingDirection)) {
-            return $this->_sortingDirection;
-        } else {
-            return ASCENDING;
-        }
+        return $this->_sortingDirection ?? ASCENDING;
     }
 
     /**
      * Adds the SortableValue to the list.
      */
-    public function addSortableValue($sortableValue)
+    public function addSortableValue(?SortableValue $sortableValue): void
     {
         array_push($this->_collection, $sortableValue);
     }
@@ -245,7 +241,7 @@ class SortUtility
      * Any SortableValues previously added using the
      * addSortableValue(...)-function will be removed.
      */
-    public function setSortableValues()
+    public function setSortableValues(): void
     {
         $this->_collection = func_get_args();
     }
@@ -253,7 +249,7 @@ class SortUtility
     /**
      * Returns the number of SortableValues managed by this SortUtility.
      */
-    public function getValueCount()
+    public function getValueCount(): int
     {
         return count($this->_collection);
     }
@@ -262,7 +258,7 @@ class SortUtility
      * Returns the SortableValue at the provided index, where
      * $index ranges from 0 to getvalueCount() - 1, inclusive.
      */
-    public function getValueAt($index)
+    public function getValueAt(int $index): ?SortableValue
     {
         if ($index >= 0 && $index < count($this->_collection)) {
             return $this->_collection[$index];
@@ -274,7 +270,7 @@ class SortUtility
     /**
      * Returns the name of the SortUtility.
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->_name;
     }
@@ -283,7 +279,7 @@ class SortUtility
      * Returns a SQL-snippet for use in an ORDER BY-context,
      * for example "name DESC, id".
      */
-    public function getOrderBy()
+    public function getOrderBy(): ?string
     {
         $val = $this->getSortingValue();
         if (isset($val)) {
@@ -300,7 +296,7 @@ class SortUtility
      * This should be used when building a link for reloading
      * the page for some reason, while keeping the sorting intact.
      */
-    public function getQueryStringForCurrentView($sortableValue = null)
+    public function getQueryStringForCurrentView(?SortableValue $sortableValue = null): string
     {
         $currentlySortedValue = $this->getSortingValue();
 
@@ -324,7 +320,7 @@ class SortUtility
      *
      * The argument defaults to the currently sorted value.
      */
-    public function getQueryStringForSortableValue($sortableValue)
+    public function getQueryStringForSortableValue(SortableValue $sortableValue): string
     {
         $currentlySortedValue = $this->getSortingValue();
 

--- a/pinc/Stopwatch.inc
+++ b/pinc/Stopwatch.inc
@@ -8,6 +8,7 @@ class Stopwatch
 {
     private bool $running;
     private float $seconds_from_completed_runs;
+    /** @var array<string, int> */
     private array $run_start_tod;
 
     // The time between a 'start' ('resume') and the subsequent 'stop' ('pause')
@@ -19,14 +20,14 @@ class Stopwatch
         $this->seconds_from_completed_runs = 0;
     }
 
-    public function start() // or resume
+    public function start(): void // or resume
     {
         assert(!$this->running);
         $this->run_start_tod = gettimeofday();
         $this->running = true;
     }
 
-    public function read()
+    public function read(): float
     {
         if ($this->running) {
             $now_tod = gettimeofday();
@@ -41,14 +42,14 @@ class Stopwatch
         }
     }
 
-    public function stop() // or pause
+    public function stop(): void // or pause
     {
         assert($this->running);
         $this->seconds_from_completed_runs = $this->read();
         $this->running = false;
     }
 
-    public function reset()
+    public function reset(): void
     {
         // A real stopwatch might let you push the reset button
         // while it's running. This one doesn't.
@@ -57,7 +58,7 @@ class Stopwatch
     }
 }
 
-function test_Stopwatch()
+function test_Stopwatch(): void
 {
     $watch = new Stopwatch();
     sleep(1);

--- a/pinc/TallyBoard.inc
+++ b/pinc/TallyBoard.inc
@@ -72,7 +72,7 @@ class TallyBoard
 
     // -------------------------------------------------------------------------
 
-    public function add_to_tally(string $holder_id, int $amount)
+    public function add_to_tally(string $holder_id, int $amount): void
     {
         $sql = sprintf(
             "
@@ -207,7 +207,7 @@ class TallyBoard
      * Return the given holder's rank, as determined by the current tallies
      * on this TallyBoard.
      */
-    public function get_rank($holder_id)
+    public function get_rank(int $holder_id): int
     {
         $sql = sprintf(
             "
@@ -254,8 +254,9 @@ class TallyBoard
      *
      * Parameters after `$radius` are an optimization for extracting
      * other info from the database at the same time.
+     * @return array<int, array<string, mixed>>
      */
-    public function get_neighborhood($target_holder_id, $radius)
+    public function get_neighborhood(int $target_holder_id, int $radius): array
     {
         assert($radius >= 0);
 
@@ -359,7 +360,7 @@ class TallyBoard
      *
      * If `$dry_run` is true, merely echo queries that would change db.
      */
-    public function take_snapshot($ascribe_time, $dry_run = false)
+    public function take_snapshot(int $ascribe_time, bool $dry_run = false): ?string
     {
         $prev_ascribe_time = $this->get_time_of_latest_snapshot();
 
@@ -513,6 +514,7 @@ class TallyBoard
         } else {
             DPDatabase::query($sql);
         }
+        return null;
     }
 
     // -------------------------------------------------------------------------
@@ -520,8 +522,9 @@ class TallyBoard
     /**
      * Return the ascribed timestamp of the latest snapshot for this TallyBoard,
      * or $default if there has been no snapshot yet.
+     * @return ($default is not null ? int : ?int)
      */
-    public function get_time_of_latest_snapshot($default = null)
+    public function get_time_of_latest_snapshot(?int $default = null): ?int
     {
         $sql = sprintf(
             "
@@ -552,13 +555,9 @@ class TallyBoard
     /**
      * Return an associative array of information about the given holder
      * from the latest snapshot.
-     *
-     * Keys are:
-     * - timestamp
-     * - tally_delta
-     * - tally_value
+     * @return array{timestamp: int, tally_delta: int, tally_value: int}
      */
-    public function get_info_from_latest_snapshot($holder_id)
+    public function get_info_from_latest_snapshot(int $holder_id): array
     {
         $sql = sprintf(
             "
@@ -578,21 +577,26 @@ class TallyBoard
         $result = DPDatabase::query($sql);
 
         $info = mysqli_fetch_assoc($result);
-        if (!$info) {
+        if ($info) {
+            $tally_delta = $info['tally_delta'];
+            $tally_value = $info['tally_value'];
+        } else {
             // That holder does not appear in any snapshot for this TallyBoard.
             // So we can infer that, at the latest snapshot:
             //     his tally would have been zero, and thus
             //     his delta would have been zero, and also
             //     his rank would have been zero (null rank).
 
-            $info = [
-                'tally_delta' => 0,
-                'tally_value' => 0,
-            ];
+            $tally_delta = 0;
+            $tally_value = 0;
         }
-        $info["timestamp"] = $this->get_time_of_latest_snapshot(0);
+        $timestamp = $this->get_time_of_latest_snapshot(0);
 
-        return $info;
+        return [
+            'tally_delta' => $tally_delta,
+            'tally_value' => $tally_value,
+            'timestamp' => $timestamp,
+        ];
     }
 
     // -------------------------------------------------------------------------
@@ -600,11 +604,12 @@ class TallyBoard
     /**
      * Return an array of the largest recorded delta on this TallyBoard
      *
+     * @return list{int, int}
      * Array consisting of:
      * - the given holder's largest recorded delta on this TallyBoard, and
      * - the earliest timestamp for which that delta was recorded.
      */
-    public function get_info_re_largest_delta($holder_id)
+    public function get_info_re_largest_delta(int $holder_id): array
     {
         $sql = sprintf(
             "
@@ -624,13 +629,14 @@ class TallyBoard
         $result = DPDatabase::query($sql);
 
         $info = mysqli_fetch_row($result);
-        if (!$info) {
+        if ($info) {
+            [$largest_delta, $timestamp] = $info;
+        } else {
             // That holder does not appear in any snapshot for this TallyBoard.
             $largest_delta = 0;
             $timestamp = $this->get_time_of_latest_snapshot(0);
-            $info = [$largest_delta, $timestamp];
         }
-        return $info;
+        return [$largest_delta, $timestamp];
     }
 
     // -------------------------------------------------------------------------
@@ -638,11 +644,12 @@ class TallyBoard
     /**
      * Return an array of the best recorded rank on this TallyBoard
      *
+     * @return list{int, int}
      * Array consisting of:
      * - the given holder's best recorded rank on this TallyBoard, and
      * - the earliest timestamp for which that rank was recorded.
      */
-    public function get_info_re_best_rank($holder_id)
+    public function get_info_re_best_rank(int $holder_id): array
     {
         $sql = sprintf(
             "
@@ -660,13 +667,14 @@ class TallyBoard
         $result = DPDatabase::query($sql);
 
         $info = mysqli_fetch_row($result);
-        if (!$info) {
+        if ($info) {
+            [$best_rank, $timestamp] = $info;
+        } else {
             // That holder does not appear on this TallyBoard.
             $best_rank = 0;
             $timestamp = $this->get_time_of_latest_snapshot(0);
-            $info = [$best_rank, $timestamp];
         }
-        return $info;
+        return [$best_rank, $timestamp];
     }
 
     // -------------------------------------------------------------------------
@@ -675,12 +683,13 @@ class TallyBoard
      * Return all tally deltas recorded for the given holder
      * since $min_timestamp and optionally before $max_timestamp
      *
+     * @return array<int, int>
      * Specifically, the result is an array of key => value pairs,
      * where key is the ascribed time of a snapshot,
      * and value is the tally delta recorded for that time.
      * (The items are sorted by timestamp.)
      */
-    public function get_deltas($holder_id, $min_timestamp, $max_timestamp = null)
+    public function get_deltas(int $holder_id, int $min_timestamp, ?int $max_timestamp = null): array
     {
         $addl_where = $max_timestamp === null ? "" : sprintf("AND timestamp < %d", $max_timestamp);
 
@@ -747,7 +756,7 @@ class TallyBoard
      * as the difference between the tally_value at those two times.
      * But summing the intervening deltas is the more general solution.
      */
-    public function get_delta_sum($holder_id, $start_timestamp, $end_timestamp)
+    public function get_delta_sum(int $holder_id, int $start_timestamp, int $end_timestamp): int
     {
         $sql = sprintf(
             "
@@ -768,12 +777,12 @@ class TallyBoard
         );
         $res = DPDatabase::query($sql);
         [$sum] = mysqli_fetch_row($res);
-        return $sum;
+        return $sum ?? 0; // SELECT SUM() WHERE 0; returns NULL
     }
 
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-    public function get_delta_since_latest_snapshot($holder_id)
+    public function get_delta_since_latest_snapshot(int $holder_id): int
     {
         $current_tally = $this->get_current_tally($holder_id);
         $snapshot_info = $this->get_info_from_latest_snapshot($holder_id);
@@ -787,7 +796,7 @@ class TallyBoard
      *
      * This is just a convenience function.
      */
-    public function get_vitals($holder_id)
+    public function get_vitals(int $holder_id): Object
     {
         $obj = new StdClass();
 
@@ -846,7 +855,7 @@ class Ranker
         // and is thus the first approximation to each item's rank.
     }
 
-    public function next($value)
+    public function next(int $value): int
     {
         $this->n++;
 

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -257,7 +257,7 @@ function move_project_rows_to_archive_db(string $projectid, string $table_name, 
     // this sleep gives the db server some time to recover
     // in between queries.
     global $archival_recovery_multiplier;
-    sleep($t_elapsed * $archival_recovery_multiplier);
+    sleep((int)ceil($t_elapsed * $archival_recovery_multiplier));
 }
 
 $archival_recovery_multiplier = 1;

--- a/pinc/filter_project_list.inc
+++ b/pinc/filter_project_list.inc
@@ -15,12 +15,17 @@ include_once($relPath.'Project.inc'); // get_project_difficulties()
 class ProjectFilterElement
 {
     private bool $active;
+    /** @var array<string, string> */
     public array $selected_options;
 
+    /**
+     * @param array<string, bool> $active_fields
+     * @param array<string, mixed> $data
+     */
     public function __construct(
         private readonly string $id,
         public readonly string $label,
-        protected readonly mixed $data,
+        protected readonly array $data,
         protected readonly string $state_sql,
         array $active_fields
     ) {
@@ -28,7 +33,7 @@ class ProjectFilterElement
         $this->selected_options = [];
     }
 
-    public function echo_html_control()
+    public function echo_html_control(): void
     {
         if (!$this->active) {
             return;
@@ -37,7 +42,7 @@ class ProjectFilterElement
     }
 
     // Difficulty overrides this
-    protected function echo_active_html_control()
+    protected function echo_active_html_control(): void
     {
         echo "<td>";
         echo "<b> " . html_safe("$this->label:") . "</b><br>";
@@ -45,7 +50,7 @@ class ProjectFilterElement
         echo "</td>\n";
     }
 
-    protected function echo_selector()
+    protected function echo_selector(): void
     {
         echo "<select name='{$this->id}[]' id=$this->id size='4' multiple>";
         $options = $this->get_options();
@@ -63,7 +68,8 @@ class ProjectFilterElement
     }
 
     // project manager and post processor use this function, others override it
-    protected function get_options()
+    /** @return array<string, string> */
+    protected function get_options(): array
     {
         $query = "SELECT distinct $this->id FROM projects WHERE ($this->state_sql) ORDER BY $this->id";
         $options = [];
@@ -75,7 +81,7 @@ class ProjectFilterElement
     }
 }
 
-function echo_option($key, $value, $selected)
+function echo_option(string $key, string $value, bool $selected): void
 {
     $selected_attr = $selected ? ' selected' : '';
     echo "<option value='" . attr_safe($key) . "'$selected_attr>$value</option>\n";
@@ -83,7 +89,8 @@ function echo_option($key, $value, $selected)
 
 class GenreElement extends ProjectFilterElement
 {
-    protected function get_options()
+    /** @return array<string, string> */
+    protected function get_options(): array
     {
         maybe_create_temporary_genre_translation_table();
         $query = "
@@ -102,7 +109,8 @@ class GenreElement extends ProjectFilterElement
 
 class SpecialDayElement extends ProjectFilterElement
 {
-    protected function get_options()
+    /** @return array<string, string> */
+    protected function get_options(): array
     {
         $query = "
             SELECT DISTINCT special_code, display_name
@@ -121,7 +129,8 @@ class SpecialDayElement extends ProjectFilterElement
 
 class LanguageElement extends ProjectFilterElement
 {
-    protected function get_options()
+    /** @return array<string, string> */
+    protected function get_options(): array
     {
         $options = [];
 
@@ -142,7 +151,7 @@ class LanguageElement extends ProjectFilterElement
         return $options;
     }
 
-    protected function echo_active_html_control()
+    protected function echo_active_html_control(): void
     {
         echo "<td>";
         echo "<b>" . html_safe("$this->label:") . "</b><br>";
@@ -166,7 +175,7 @@ class LanguageElement extends ProjectFilterElement
 
 class DifficultyElement extends ProjectFilterElement
 {
-    public function echo_active_html_control()
+    public function echo_active_html_control(): void
     {
         echo "<div class='flex_row'>";
         echo "<div class='entry'><b>" . html_safe("$this->label:") . "</b></div>";
@@ -192,8 +201,15 @@ class DifficultyElement extends ProjectFilterElement
     }
 }
 
-function process_and_display_project_filter_form($username, $filter_type, $filter_label, $data, $state_sql, ?array $custom_display_fields = null)
-{
+/** @param ?array<string, bool> $custom_display_fields */
+function process_and_display_project_filter_form(
+    string $username,
+    string $filter_type,
+    string $filter_label,
+    mixed $data,
+    string $state_sql,
+    ?array $custom_display_fields = null
+): void {
     $display_fields = [
         "language" => true,
         "genre" => true,
@@ -296,7 +312,7 @@ class ProjectSearchElement
     ) {
     }
 
-    public function get_sql_component()
+    public function get_sql_component(): string
     {
         $values = $this->data[$this->id] ?? [];
         if (empty($values)) {
@@ -308,7 +324,8 @@ class ProjectSearchElement
         return $this->construct_sql($values);
     }
 
-    public function construct_sql($values)
+    /** @param string[] $values */
+    public function construct_sql(array $values): string
     {
         $values_list = surround_and_join($values, "'", "'", ", ");
         return " AND $this->id IN ($values_list)";
@@ -317,7 +334,8 @@ class ProjectSearchElement
 
 class LanguageSearchElement extends ProjectSearchElement
 {
-    public function construct_sql($values)
+    /** @param string[] $values */
+    public function construct_sql(array $values): string
     {
         // some languages have regex special chars which need escaping
         $values = array_map('preg_quote', $values);
@@ -344,7 +362,7 @@ class LanguageSearchElement extends ProjectSearchElement
     }
 }
 
-function get_project_filter_sql($pguser, $filter_type)
+function get_project_filter_sql(string $pguser, string $filter_type): string
 {
     $data = get_saved_data($pguser, $filter_type);
     $search_elements = [
@@ -363,23 +381,24 @@ function get_project_filter_sql($pguser, $filter_type)
     return $filter;
 }
 
-function get_lang_match($data)
+/** @param array<string, mixed> $data */
+function get_lang_match(array $data): string
 {
     // set a default if not set
     return $data["lang-match"] ?? "primwith";
 }
 
-function save_data($pguser, $filter_type, $data)
+function save_data(string $pguser, string $filter_type, mixed $data): void
 {
     save_raw_data($pguser, "{$filter_type}_data", serialize($data));
 }
 
-function save_display($pguser, $filter_type, $data)
+function save_display(string $pguser, string $filter_type, string $data): void
 {
     save_raw_data($pguser, "{$filter_type}_display", $data);
 }
 
-function save_raw_data($pguser, $data_name, $data)
+function save_raw_data(string $pguser, string $data_name, string $data): void
 {
     $query = sprintf(
         "
@@ -394,17 +413,21 @@ function save_raw_data($pguser, $data_name, $data)
     DPDatabase::query($query);
 }
 
-function get_saved_data($pguser, $filter_type)
+/** @return array<string, mixed> */
+function get_saved_data(string $pguser, string $filter_type): array
 {
-    return unserialize(get_raw_saved_data($pguser, "{$filter_type}_data"));
+    $data = unserialize(get_raw_saved_data($pguser, "{$filter_type}_data"));
+    // The raw data "", which we get if there's no saved data for this
+    // user/filter PHP deserializes as false. We need an array.
+    return $data !== false ? $data : [];
 }
 
-function get_project_filter_display($pguser, $filter_type)
+function get_project_filter_display(string $pguser, string $filter_type): string
 {
     return get_raw_saved_data($pguser, "{$filter_type}_display");
 }
 
-function get_raw_saved_data($pguser, $data_name)
+function get_raw_saved_data(string $pguser, string $data_name): string
 {
     $query = sprintf(
         "

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -16,13 +16,12 @@ use voku\helper\UTF8;
  * You should be using the ?? operator moving forward as this function is deprecated:
  *    $arr[$key] ?? $default
  *
- * @param array $arr
- * @param string|int $key
+ * @param array<string, mixed> $arr
  * @param mixed $default
  * @return mixed
  * @deprecated
  */
-function array_get($arr, $key, $default)
+function array_get(array $arr, string|int $key, $default)
 {
     trigger_error("array_get() is deprecated, use the null coalescing operator instead", E_USER_DEPRECATED);
     if (isset($arr[$key])) {
@@ -35,7 +34,8 @@ function array_get($arr, $key, $default)
 /**
  * Given an array of arrays/objects, return the values of the desired field.
  *
- * @param array<array|object> $array
+ * @param array<string, array<string, mixed>|object> $array
+ * @return list<mixed>
  */
 function array_extract_field(array $array, string $field): array
 {
@@ -59,7 +59,7 @@ function array_extract_field(array $array, string $field): array
  * "foo"            -> ["foo"]
  * ["bar"]          -> ["bar"]
  * ["foo" => "bar"] -> ["foo" => "bar"]
- *
+ * @param ?array<string, mixed> $array
  * @param mixed $default
  * @return mixed
  */
@@ -76,8 +76,8 @@ function array_get_as_array(?array $array, string $key, $default)
  * Remove fields from the associative array `$array` that aren't in the valid list.
  *
  * Note: This is an in-place operation that mutates `$array`!
- *
- * @param string[] $valid_fields
+ * @param array<string, mixed> &$array
+ * @param ?string[] $valid_fields
  **/
 function array_remove_invalid_fields(array &$array, ?array $valid_fields): void
 {
@@ -137,20 +137,12 @@ function get_changed_fields_for_objects(object $new, object $old, bool $remove_n
  *   ```
  *
  * @param array<string, mixed> $arr
- * @param string $key
- * @param mixed $default
  * @param array<string|int> $choices
- * @param bool $allownull
- *
- * @return mixed
  *
  * @throws InvalidArgumentException
  */
-function get_enumerated_param(array $arr, string $key, $default, array $choices, bool $allownull = false)
+function get_enumerated_param(array $arr, string $key, mixed $default, array $choices, bool $allownull = false): mixed
 {
-    // TODO: On move to PHP 8.0 as a minimum version, add 'mixed' type def to
-    // $default and a return of mixed
-
     // sanity checks on the args
     if (empty($choices)) {
         throw new InvalidArgumentException("\$choices is an empty array");
@@ -264,13 +256,6 @@ function get_enumerated_param(array $arr, string $key, $default, array $choices,
  *   ```
  *
  * @param array<string, mixed> $arr
- * @param string $key
- * @param int|null $default
- * @param int|null $min
- * @param int|null $max
- * @param bool $allownull
- *
- * @return int|null
  *
  * @throws InvalidArgumentException
  *
@@ -290,13 +275,6 @@ function get_integer_param(array $arr, string $key, ?int $default = null, ?int $
  * If it's not defined, and `$default` is null and `$allownull` is true, return null.
  *
  * @param array<string, mixed> $arr
- * @param string $key
- * @param float|null $default
- * @param float|null $min
- * @param float|null $max
- * @param bool $allownull
- *
- * @return float|null
  *
  * @throws InvalidArgumentException
  *
@@ -313,22 +291,14 @@ function get_float_param(array $arr, string $key, ?float $default = null, ?float
  * This is the parent function of `get_integer_param()` and `get_float_param()`,
  * use those versions instead.
  *
- * @param string $type - One of "integer" or "float"
  * @param array<string, mixed> $arr
- * @param string $key
- * @param int|float|null $default
- * @param int|float|null $min
- * @param int|float|null $max
- * @param bool $allownull
- *
- * @return int|float|null
  *
  * @throws InvalidArgumentException
  *
  * @see get_integer_param()
  * @see get_float_param()
  */
-function get_numeric_param(string $type, array $arr, string $key, $default = null, $min = null, $max = null, bool $allownull = false)
+function get_numeric_param(string $type, array $arr, string $key, int|float|null $default = null, int|float|null $min = null, int|float|null $max = null, bool $allownull = false): int|float|null
 {
     // sanity checks on the args
     if ($type == 'integer') {
@@ -341,17 +311,6 @@ function get_numeric_param(string $type, array $arr, string $key, $default = nul
         }
     } else {
         throw new InvalidArgumentException("\$type must be 'integer' or 'float'");
-    }
-
-    // TODO: On move to PHP 8.0 as a minimum version, the following two checks
-    // (and the unit tests for them) can be removed as we can then use union
-    // type defs for $min and $max, eg: int|float|null $min. Also add a
-    // int_float_null as a return type for this function.
-    if (! (is_null($min) || is_numeric($min))) { /** @phpstan-ignore-line */
-        throw new TypeError("\$min must be of the type numeric or null");
-    }
-    if (! (is_null($max) || is_numeric($max))) { /** @phpstan-ignore-line */
-        throw new TypeError("\$max must be of the type numeric or null");
     }
 
     if (!is_null($default)) {
@@ -509,16 +468,11 @@ function get_bool_param(array $arr, string $key, ?bool $default = null, bool $al
  *   $word = get_param_matching_regex($_GET, 'word', NULL, '/^\w+$/')
  *   ```
  * @param array<string, mixed> $arr
- * @param string $key
- * @param string|null $default
  * @param string $regex
  *   For security, $regex should almost certainly be anchored at both ends,
  *   and should not contain:
  *   - any complemented character classes (e.g. "[^A-Z]"), or
  *   - (unescaped) '.' (e.g., in "/foo.+bar/").
- * @param bool $allownull
- *
- * @return string|null
  *
  * @throws InvalidArgumentException
  */
@@ -843,17 +797,15 @@ function surround_and_join(array $strings, string $L, string $R, string $joiner)
 /**
  * Return true if a non-null `$haystack` contains any of the `$needles` as a substring.
  *
- * @param null|string $haystack
+ * @param ?string $haystack
  *   The string to search. A null haystack can never contain a needle
- * @param null|string|array $needles
+ * @param null|string|string[] $needles
  *   Search term. If:
  *   * null - Returns true for any non-null haystack.
  *   * string - Returns true if haystack contains the needle.
  *   * array - Returns true if haystack contains any of the needles (false if array is empty).
- *
- * * @return boolean
  */
-function str_contains_any_of($haystack, $needles)
+function str_contains_any_of(?string $haystack, null|string|array $needles): bool
 {
     if (is_null($haystack)) {
         return false;
@@ -878,13 +830,11 @@ function str_contains_any_of($haystack, $needles)
  *  Ex $has_odd = any([6,5,0,2], fn ($i) => i % 2 == 1);
  *     $some_missing = any($items, is_null);
  *     $some_empty_strings = any($strings);
- *
- * @param iterable $input
+ * @template T
+ * @param iterable<T> $input
  *   The items to check the predicate against
- * @param ?callable $predicate
+ * @param ?callable(T): bool $predicate
  *   The (optional) function to call with each value
- *
- * @return bool
  */
 function any(iterable $input, ?callable $predicate = null): bool
 {
@@ -917,13 +867,11 @@ function any(iterable $input, ?callable $predicate = null): bool
  *  Ex $all_numbers = all($inputs, is_numeric);
  *     $valid_enums = all($items, fn $(i) => in_array(["foo", "bar", "baz"], $i);
  *     $all_nonempty = all($arrays);
- *
- * @param iterable $input
+ * @template T
+ * @param iterable<T> $input
  *   The items to check the predicate against
- * @param ?callable $predicate
+ * @param ?callable(T): bool $predicate
  *   The (optional) function to call with each value
- *
- * @return bool
  */
 function all(iterable $input, ?callable $predicate = null): bool
 {
@@ -979,14 +927,14 @@ function set_col_num(string $colname, int $i): string
  * Currently this function will set default values ("" for strings, 0 for
  * numeric values) for all fields that are not within $source_array.
  *
- * @param array $source_array
+ * @param array<string, mixed> $source_array
  *   An associative array where the keys are MySQL column
  *   names and the values are the desired values to set in the database
- * @param array $string_fields
+ * @param string[] $string_fields
  *    A list of keys such that `$source_array[$key]` should be a string,
  *    otherwise the value is assumed to be an integer
  */
-function create_mysql_update_string($source_array, $string_fields = [])
+function create_mysql_update_string(array $source_array, array $string_fields = []): string
 {
     $update_fields = [];
     foreach ($source_array as $field => $value) {
@@ -1006,12 +954,13 @@ function create_mysql_update_string($source_array, $string_fields = [])
  *
  * @param string $dirpath
  *   The directory to search in. May be relative to the cwd.
- * @param array $validext
+ * @param string[] $validext
  *   An array of extensions to check filenames against, may include the '.'
  * @param bool $with_path
  *   If true, the list of returned names has the directory prepended.
+ * @return false|string[]
  */
-function get_filelist($dirpath, $validext = [], $with_path = false)
+function get_filelist(string $dirpath, array $validext = [], bool $with_path = false): false|array
 {
     $filelist = [];
     if (false === ($d = opendir($dirpath))) {
@@ -1067,7 +1016,7 @@ function get_filelist($dirpath, $validext = [], $with_path = false)
  * If the first argument is not an existing directory, an InvalidArgumentException will be thrown.
  * If it is unable to flatten the directory, it will throw a RuntimeException.
  */
-function flatten_directory(string $directory_to_flatten)
+function flatten_directory(string $directory_to_flatten): void
 {
     if (!file_exists($directory_to_flatten) || !is_dir($directory_to_flatten)) {
         throw new InvalidArgumentException(sprintf(
@@ -1170,6 +1119,7 @@ function validate_zip_file(string $file_path, bool $ignore_extension_check = fal
  *
  * It uses the is_valid_zip_file function to check whether the argument is a valid zip file, if it
  * is not, an InvalidArgumentException is thrown.
+ * @return string[]
  */
 function list_files_in_zip(string $file_path): array
 {
@@ -1288,10 +1238,13 @@ function remove_common_basedir_from_zip(string $path_to_zip): void
 /**
  * Creates a zip archive containing the specified files.
  *
- * The first argument represents the files to add to the zip archive and globing is allowed.
- * If there is a directory the files from it are added with its name prefixed (only one level)
- * The second argument represents the path to the zip archive which should be created.
- *
+ * @param string[] $files_to_zip
+ *     The files to add to the zip archive and globing is allowed.
+ *     If there is a directory the files from it are added with its name
+ *     prefixed (only one level)
+ * @param string $path_to_zip
+ *     The path to the zip archive which should be created.
+ * @return bool
  * Returns whether the zip file was created successfully.
  *
  * Throws a InvalidArgumentException if:
@@ -1390,7 +1343,7 @@ function humanize_bytes(float $n): string
  * for all $i.
  *
  * @param string[] $strings
- * @return array{0: string, 1: string[], 2: string}
+ * @return list{string, string[], string}
  */
 function factor_strings(array $strings): array
 {
@@ -1518,8 +1471,10 @@ function factor_strings(array $strings): array
  *
  * If the requested function returns data that has localized strings, it's
  * important that $key_salt = get_desired_language();
+ * @param callable-string $function
+ * @param array<string|int, mixed> $args
  */
-function memoize_function(string $function, array $args = [], int $expiration = 3600, string $key_salt = "")
+function memoize_function(callable $function, array $args = [], int $expiration = 3600, string $key_salt = ""): mixed
 {
     // cache this connection for possible re-use during this page load
     static $memcache = null;

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -6,8 +6,9 @@ include_once($relPath.'links.inc'); // private_message_link
 
 /**
  * Given a project, return the rounds that contain useful data
+ * @return Round[]
  */
-function get_rounds_to_display($project)
+function get_rounds_to_display(Project $project): array
 {
     $project_round = get_Round_for_project_state($project->state);
 
@@ -73,22 +74,22 @@ function get_rounds_to_display($project)
  *
  * @param Project $project
  *   Project to get round data for
- * @param string|array $page_selector
+ * @param null|string|string[] $page_selector
  *   Select which pages to return in the query, possible values are:
  *   * null - all pages are returned
  *   * string - this user's pages from all rounds are returned
  *   * array - array of specific image names
- * @param object $work_round
+ * @param ?Round $work_round
  *   Round to limit a user's pages -- must be used with $page_selector set
  *   to a username.
- * @param array $only_rounds
+ * @param ?string[] $only_rounds
  *   Only return page details for a specific round, possible values are:
  *   * null - all rounds with data are returned
  *   * array of round objects and/or "OCR" - only these rounds are returned
  *
- * @return Generator<array>
+ * @return Generator<array<string, mixed>>
  */
-function fetch_page_table_data($project, $page_selector = null, $work_round = null, $only_rounds = null)
+function fetch_page_table_data(Project $project, $page_selector = null, ?Round $work_round = null, ?array $only_rounds = null)
 {
     if (!$project->pages_table_exists) {
         throw new NoProjectPageTable(_("Project page table does not exist."));
@@ -271,13 +272,14 @@ function fetch_page_table_data($project, $page_selector = null, $work_round = nu
     }
 }
 
+/** @param null|string|string[] $page_selector */
 function echo_page_table(
-    $project,
-    $show_image_size,
-    $disable_editing = false,
+    Project $project,
+    bool $show_image_size,
+    bool $disable_editing = false,
     $page_selector = null,
-    $proofed_in_round = null
-) {
+    ?Round $proofed_in_round = null
+): void {
     global $projects_dir, $code_url, $pguser;
 
     $can_edit = $project->can_be_managed_by_current_user;
@@ -527,11 +529,8 @@ function echo_page_table(
  * Can the currently logged in user see the usernames of users who have
  * worked on a particular page in a project?
  *
- * @param Project $project
  * @param string[] $proofer_usernames
  *   List of users who have proofed a page
- *
- * @return bool
  */
 function can_user_see_usernames_for_page(Project $project, array $proofer_usernames): bool
 {
@@ -552,6 +551,7 @@ function can_user_see_usernames_for_page(Project $project, array $proofer_userna
 /**
  * Returns an array of Rounds representing those rounds
  * for which the given project has some useful data.
+ * @return Round[]
  */
 function get_rounds_with_data(Project $project): array
 {
@@ -596,14 +596,14 @@ function get_rounds_with_data(Project $project): array
 }
 
 // -----------------------------------------------------------------------------
-
+/** @param array<string, mixed> $page_res */
 function echo_cells_for_round(
-    $round,
-    $diff_round, // <- These are the only "real" params.
-    $page_res,
-    $projectid,
-    $can_see_names_for_this_page
-) {
+    Round|stdClass $round,
+    Round|stdClass $diff_round, // <- These are the only "real" params.
+    array $page_res,
+    string $projectid,
+    bool $can_see_names_for_this_page
+): void {
     global $pguser, $code_url;
 
     $imagename = $page_res['image'];
@@ -704,7 +704,7 @@ function echo_cells_for_round(
 
 // -----------------------------------------------------------------------------
 
-function page_state_is_a($page_state, $desired_state)
+function page_state_is_a(string $page_state, string $desired_state): bool
 {
     static $state_cache = [];
     if (isset($state_cache[$desired_state][$page_state])) {
@@ -724,7 +724,7 @@ function page_state_is_a($page_state, $desired_state)
 
 // -----------------------------------------------------------------------------
 
-function echo_detail_legend()
+function echo_detail_legend(): void
 {
     ?>
 <table class='pagedetail'>

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -17,7 +17,8 @@ include_once($relPath.'User.inc');
 
 // -----------------------------------------------------------------------------
 
-function get_page_tally_names()
+/** @return array<string, string> */
+function get_page_tally_names(): array
 {
     $page_tally_names = [];
     foreach (Rounds::get_all() as $round) {
@@ -29,7 +30,8 @@ function get_page_tally_names()
 
 // -----------------------------------------------------------------------------
 
-function get_ELR_tallyboards()
+/** @return list{TallyBoard, TallyBoard} */
+function get_ELR_tallyboards(): array
 {
     global $ELR_round;
 
@@ -51,7 +53,7 @@ function get_ELR_tallyboards()
  * Add $amount to the user's page tally,
  * and to the page tally of each team that the user currently belongs to.
  */
-function page_tallies_add(string $tally_name, User $user, int $amount)
+function page_tallies_add(string $tally_name, User $user, int $amount): void
 {
     // update page tally for user
     $user_tallyboard = new TallyBoard($tally_name, 'U');
@@ -72,7 +74,7 @@ function page_tallies_add(string $tally_name, User $user, int $amount)
 
 // Not actually tally-specific, but that's all it's used for.
 
-function get_daily_average($start_time, $total)
+function get_daily_average(int $start_time, int $total): float
 {
     $now = time();
     $seconds_since_start = $now - $start_time;
@@ -116,8 +118,6 @@ function user_get_ELR_page_tally(User $user): int
 
 /**
  * Get the user's page tally neighborhood
- * @param string $tally_name
- * @param User $user
  * @param int $radius
  *   (maximum) number of neighbors (on each side) to include in
  *   the neighborhood. (It will include fewer than the maximum iff the target
@@ -132,7 +132,7 @@ function user_get_ELR_page_tally(User $user): int
  *
  * @return PageTally_Neighbor[]
  */
-function user_get_page_tally_neighborhood(string $tally_name, User $user, int $radius)
+function user_get_page_tally_neighborhood(string $tally_name, User $user, int $radius): array
 {
     $tallyboard = new TallyBoard($tally_name, 'U');
     $nb =
@@ -230,7 +230,7 @@ $SECONDS_TO_YESTERDAY = 1 + 3 * 60 * 60;
  * - prev_day_{goal,actual}
  * - curr_month_{goal,actual}
  */
-function get_site_page_tally_summary(string $tally_name)
+function get_site_page_tally_summary(string $tally_name): object
 {
     $site_stats = new StdClass();
 
@@ -283,7 +283,7 @@ function get_site_page_tally_summary(string $tally_name)
     return $site_stats;
 }
 
-function get_site_tally_goal_summed(string $tally_name, string $date_condition)
+function get_site_tally_goal_summed(string $tally_name, string $date_condition): int
 {
     $sql = sprintf(
         "
@@ -295,7 +295,7 @@ function get_site_tally_goal_summed(string $tally_name, string $date_condition)
     );
     $res = DPDatabase::query($sql);
     [$sum] = mysqli_fetch_row($res);
-    return $sum;
+    return $sum ?? 0; // SELECT SUM() returns null if there are no rows.
 }
 
 // -----------------------------------------------------------------------------
@@ -314,8 +314,8 @@ function get_site_tally_goal_summed(string $tally_name, string $date_condition)
  *
  * @param string $tally_name
  *   Tally name
- * @param string $grouped_into
- *   Which date format to group into, one of: date, year_month, year
+ * @param 'date'|'year_month'|'year' $grouped_into
+ *   Which date format to group into
  * @param ?int $min_timestamp
  *   Earliest timestamp to evaluate
  * @param ?int $max_timestamp
@@ -323,9 +323,10 @@ function get_site_tally_goal_summed(string $tally_name, string $date_condition)
  * @param ?int $limit
  *   Limit the number of rows to return
  * @param ?string $sort
- *   Field to sort on, one of: dateunit, tally_delta, goal
+ *   Field to sort on, one of dateunit, tally_delta, goal,
+ *   sort order asc/desc may be appended with a space
  *
- * @return array
+ * @return list{string, int, int}[]
  */
 function get_site_tally_grouped(
     string $tally_name,
@@ -343,8 +344,6 @@ function get_site_tally_grouped(
         $date_format = "%Y-%m";
     } elseif ($grouped_into == "year") {
         $date_format = "%Y";
-    } else {
-        throw new InvalidArgumentException("\$grouped_into is an invalid value");
     }
 
     $goal_where_time = "1 ";
@@ -447,8 +446,8 @@ function get_site_tally_grouped(
  *
  * @param string $tally_name
  *   Tally name
- * @param string $c_or_i
- *   One of: cumulative, increment
+ * @param 'increments'|'cumulative' $c_or_i
+ *   One of: cumulative, increments
  * @param int $start_timestamp
  *   Earliest timestamp to evaluate
  * @param int $end_timestamp
@@ -456,7 +455,7 @@ function get_site_tally_grouped(
  * @param int $days_to_average
  *   If using 'increment', number of days to calculate simple moving average
  *
- * @return array
+ * @return list{string[], int[], ?int[], ?float[]}
  */
 function get_site_tally_cumulative_or_incremental(
     string $tally_name,
@@ -534,13 +533,16 @@ function get_site_tally_cumulative_or_incremental(
             $datay1[] = 0;
         }
     }
-
     return [$datax, $datay1, $datay2, $moving_average];
 }
 
 /**
  * Given an array of numbers and a window, calculate the moving average over
  * the window.
+ *
+ * @param int[] $array
+ * @param int $window
+ * @return float[]
  */
 function calculate_tally_sma(array $array, int $window): array
 {
@@ -566,8 +568,10 @@ function calculate_tally_sma(array $array, int $window): array
  * where $days_back is either the string "all" or a positive integer.
  *
  * In the returned array, each key is a date-string of the form "YYYY-MM-DD".
+ *
+ * @return array<string, int>
  */
-function get_pages_per_day_for_past_n_days(string $tally_name, string $holder_type, int $holder_id, string|int $days_back)
+function get_pages_per_day_for_past_n_days(string $tally_name, string $holder_type, int $holder_id, string|int $days_back): array
 {
     global $SECONDS_TO_YESTERDAY;
 

--- a/pinc/page_tally.inc
+++ b/pinc/page_tally.inc
@@ -181,8 +181,9 @@ class PageTally_Neighbor
 
 /**
  * Should we anonymize information about the given user?
+ * @param PRIVACY_PRIVATE|PRIVACY_ANONYMOUS $user_privacy_setting
  */
-function should_anonymize(?string $username, int $user_privacy_setting)
+function should_anonymize(?string $username, int $user_privacy_setting): bool
 {
     return !can_reveal_details_about($username, $user_privacy_setting);
 }

--- a/pinc/pg.inc
+++ b/pinc/pg.inc
@@ -13,10 +13,11 @@ $PGLAF_inprogress_url = "https://inprogress.pglaf.org";
 /**
  * Given a PG etext number, return a URL for the PG catalog page for that text.
  */
-function get_pg_catalog_url_for_etext($etext_number)
+function get_pg_catalog_url_for_etext(?int $etext_number): string
 {
     global $PG_home_url;
-    return "$PG_home_url/ebooks/$etext_number";
+    $n = is_null($etext_number) ? "" : "$etext_number";
+    return "$PG_home_url/ebooks/$n";
 }
 
 // -----------------------------------------------------------------------------
@@ -25,7 +26,7 @@ function get_pg_catalog_url_for_etext($etext_number)
  * Given a PG etext number, return an HTML <a> element
  * that links to the PG catalog page for that text.
  */
-function get_pg_catalog_link_for_etext($etext_number, $link_text = null)
+function get_pg_catalog_link_for_etext(int $etext_number, ?string $link_text = null): string
 {
     $url = get_pg_catalog_url_for_etext($etext_number);
 

--- a/pinc/post_files.inc
+++ b/pinc/post_files.inc
@@ -6,8 +6,13 @@ include_once($relPath.'wordcheck_engine.inc');
 /**
  * Generate the files needed for post-processing.
  */
-function generate_post_files($project, $limit_round_id, $which_text, $include_proofers, $base_extra)
-{
+function generate_post_files(
+    Project $project,
+    string $limit_round_id,
+    string $which_text,
+    bool $include_proofers,
+    string $base_extra
+): void {
     if (!$project->pages_table_exists) {
         throw new Exception(_("Project table not found, it may have been deleted or archived."));
     }
@@ -21,7 +26,9 @@ function generate_post_files($project, $limit_round_id, $which_text, $include_pr
     // Generate comments html file.
     $comments_path = "{$pathbase}_comments.html";
     $fp = fopen($comments_path, "w");
-    // if ( $fp === FALSE ) ???
+    if ($fp === false) {
+        throw new Exception("Could not open $comments_path");
+    }
     write_project_comments($project, $fp);
     fclose($fp);
 
@@ -36,15 +43,19 @@ function generate_post_files($project, $limit_round_id, $which_text, $include_pr
     }
 
     $pages_res = page_info_query($project->projectid, $limit_round_id, $which_text);
-    // if ($pages_res === FALSE) ???
+    if ($pages_res === false) {
+        throw new Exception("Could not get $limit_round_id text for $project->projectid");
+    }
 
     // Join all the page texts into a plain text file...
     $plain_path = "{$pathbase}.txt";
     $fp = fopen($plain_path, "w");
-    // if ( $fp === FALSE ) ???
-    join_proofed_text($pages_res, $include_proofers, true, $fp);
+    if ($fp === false) {
+        throw new Exception("Could not open $plain_path");
+    }
+    join_proofed_text($pages_res, $include_proofers, $fp);
     fclose($fp);
-    //
+
     // and make a zip of that file (plus comments).
     // (for "Download Zipped Text")
     $plain_zip_path = "{$pathbase}.zip";
@@ -59,8 +70,12 @@ function generate_post_files($project, $limit_round_id, $which_text, $include_pr
 /**
  * Generate a zip file on the fly and download it
  */
-function generate_interim_file($project, $limit_round_id, $which_text, $include_proofers)
-{
+function generate_interim_file(
+    Project $project,
+    string $limit_round_id,
+    string $which_text,
+    bool $include_proofers
+): void {
     if (!$project->pages_table_exists) {
         throw new Exception(_("Project table not found, it may have been deleted or archived."));
     }
@@ -83,7 +98,7 @@ function generate_interim_file($project, $limit_round_id, $which_text, $include_
     }
 
     // join the page texts together
-    $filedata = join_proofed_text($pages_res, $include_proofers, false, '');
+    $filedata = join_proofed_text($pages_res, $include_proofers, null);
 
     // zip it all up
 
@@ -111,7 +126,7 @@ function generate_interim_file($project, $limit_round_id, $which_text, $include_
     // cleanup will get called whatever happens
 }
 
-function clean_up_temp($dirname, $textfile_path, $zip_path)
+function clean_up_temp(string $dirname, string $textfile_path, string $zip_path): void
 {
     // now we must clean up behind ourselves
     unlink($zip_path);
@@ -121,7 +136,8 @@ function clean_up_temp($dirname, $textfile_path, $zip_path)
 
 // -----------------------------------------------------------------------------
 
-function write_project_comments($project, $fp)
+/** @param resource $fp */
+function write_project_comments(Project $project, $fp): void
 {
     $header = "<HTML><BODY>";
     fputs($fp, $header);
@@ -138,8 +154,9 @@ function write_project_comments($project, $fp)
 
 /**
  * Return an array whose values are the page-texts in the query-result.
+ * @return string[]
  */
-function get_page_texts($pages_res)
+function get_page_texts(mysqli_result $pages_res): array
 {
     $page_texts = [];
     while (($row = page_info_fetch($pages_res)) !== false) {
@@ -154,7 +171,7 @@ function get_page_texts($pages_res)
  *
  * Similar to join_proofed_text, but without the page-separators.
  */
-function join_page_texts($pages_res)
+function join_page_texts(mysqli_result $pages_res): string
 {
     $text = "";
     while (($row = page_info_fetch($pages_res)) !== false) {
@@ -165,8 +182,8 @@ function join_page_texts($pages_res)
 }
 
 // -----------------------------------------------------------------------------
-
-function join_proofed_text($pages_res, $include_proofers, $save_files, $fp)
+/** @param ?resource $fp */
+function join_proofed_text(mysqli_result|false $pages_res, bool $include_proofers, $fp): string
 {
     // Join the round 2 page-texts of the given project,
     // and write the result to file-object $fp.
@@ -191,7 +208,7 @@ function join_proofed_text($pages_res, $include_proofers, $save_files, $fp)
         // and pad the string to length 75, if not wider than 75 chars.
         $separator_line = str_pad($info_str, 74, '-', STR_PAD_RIGHT) . '-';
         $fileinfo = $eol . $separator_line . $eol . $text_data;
-        if ($save_files) {
+        if (!is_null($fp)) {
             // SENDING PAGE-TEXT TO USER
             // It's a text-file, so no encoding is necessary.
             fputs($fp, $fileinfo);
@@ -200,7 +217,7 @@ function join_proofed_text($pages_res, $include_proofers, $save_files, $fp)
         }
     }
     // add a final newline
-    if ($save_files) {
+    if (!is_null($fp)) {
         fputs($fp, $eol);
     } else {
         $filedata .= $eol;
@@ -210,7 +227,7 @@ function join_proofed_text($pages_res, $include_proofers, $save_files, $fp)
 
 // -----------------------------------------------------------------------------
 
-function page_info_query($projectid, $limit_round_id, $which_text)
+function page_info_query(string $projectid, string $limit_round_id, string $which_text): mysqli_result|false
 {
     if ($limit_round_id == '[OCR]') { // somewhat kludgey
         // doesn't matter what $which_text is.
@@ -289,8 +306,10 @@ function page_info_query($projectid, $limit_round_id, $which_text)
  * - an array of the usernames of the users who worked on the page in the rounds.
  *
  * If there's no next page, return FALSE
+ *
+ * @return list{string, string, string[]}|false
  */
-function page_info_fetch($res)
+function page_info_fetch(mysqli_result $res): array|false
 {
     $a = mysqli_fetch_row($res);
     if (!$a) {
@@ -308,7 +327,7 @@ function page_info_fetch($res)
     ];
 }
 
-/** @return array{0: string, 1: string} */
+/** @return list{string, string} */
 function generate_project_images_zip(string $projectid): array
 {
     global $projects_dir;

--- a/pinc/post_processing.inc
+++ b/pinc/post_processing.inc
@@ -6,7 +6,7 @@
 global $pp_alert_threshold_days;
 $pp_alert_threshold_days = 90;
 
-function count_pp_projects_past_threshold($PPer = null)
+function count_pp_projects_past_threshold(?string $PPer = null): int
 {
     $columns = ["count(*) AS total"];
     $result = _run_pp_threshold_query_result(PROJ_POST_FIRST_CHECKED_OUT, $columns, $PPer);
@@ -15,7 +15,7 @@ function count_pp_projects_past_threshold($PPer = null)
     return $total;
 }
 
-function count_ppv_projects_past_threshold($PPVer = null)
+function count_ppv_projects_past_threshold(?string $PPVer = null): int
 {
     $columns = ["count(*) AS total"];
     $result = _run_pp_threshold_query_result(PROJ_POST_SECOND_CHECKED_OUT, $columns, $PPVer);
@@ -24,7 +24,11 @@ function count_ppv_projects_past_threshold($PPVer = null)
     return $total;
 }
 
-function get_pp_projects_past_threshold($PPer = null)
+/**
+ * @return ($PPer is null ? array<string, array<string, mixed>[]>
+ *                        :               array<string, mixed>[])
+ */
+function get_pp_projects_past_threshold(?string $PPer = null): array
 {
     $columns = [
         "nameofwork",
@@ -56,9 +60,12 @@ function get_pp_projects_past_threshold($PPer = null)
     }
 }
 
-// internal function to avoid duplicating the SQL logic that determines
-// projects past the PP alert threshold
-function _run_pp_threshold_query_result($state, $columns, $user, $ordering_criteria = null)
+/**
+ * internal function to avoid duplicating the SQL logic that determines
+ * projects past the PP alert threshold
+ * @param string[] $columns
+ */
+function _run_pp_threshold_query_result(string $state, array $columns, ?string $user, ?string $ordering_criteria = null): mysqli_result|bool
 {
     global $pp_alert_threshold_days;
 

--- a/pinc/privacy.inc
+++ b/pinc/privacy.inc
@@ -3,8 +3,9 @@ include_once($relPath.'prefs_options.inc'); // PRIVACY_*
 
 /**
  * Can we reveal (to the requestor) details about the given user?
+ * @param PRIVACY_PRIVATE|PRIVACY_ANONYMOUS $user_privacy_setting
  */
-function can_reveal_details_about($username, $user_privacy_setting)
+function can_reveal_details_about(string $username, int $user_privacy_setting): bool
 {
     global $pguser; // the "requestor"
 
@@ -17,9 +18,5 @@ function can_reveal_details_about($username, $user_privacy_setting)
             // Details are visible to the user him/herself and to Site Admins.
             // and Project Facilitators
             return !is_null($pguser) && ($pguser == $username || user_is_proj_facilitator());
-
-        default:
-            // Shouldn't happen.
-            throw new UnexpectedValueException("can_reveal_details_about(): bad privacy setting: '$user_privacy_setting'");
     }
 }

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -15,8 +15,9 @@ include_once($relPath.'job_log.inc');
 /**
  * Emit the opening markup and theme tags, and register a callback
  * to close the page after the caller finishes output.
+ * @param array<string, mixed> $extra_args
  */
-function output_header($nameofpage, $show_statsbar = false, $extra_args = [])
+function output_header(string $nameofpage, bool $show_statsbar = false, array $extra_args = []): void
 {
     global $code_url;
 
@@ -65,7 +66,7 @@ function output_header($nameofpage, $show_statsbar = false, $extra_args = [])
     register_shutdown_function('output_footer', $nameofpage, $show_statsbar);
 }
 
-function output_footer($nameofpage, $show_statsbar = true)
+function output_footer(string $nameofpage, bool $show_statsbar = true): void
 {
     global $code_url, $PAGE_START_TIME;
 
@@ -119,7 +120,7 @@ function output_footer($nameofpage, $show_statsbar = true)
     output_html_footer();
 }
 
-function html_logobar()
+function html_logobar(): void
 {
     global $code_url;
 
@@ -265,7 +266,7 @@ function html_logobar()
  * Display the horizontal bar containing links to various important points
  * within the site (and the login form if the user is not logged in).
  */
-function html_navbar()
+function html_navbar(): void
 {
     global $code_url;
 
@@ -421,6 +422,7 @@ function html_navbar()
     echo "</div>\n";
 }
 
+/** @param array{text: string, url?: string}[] $links */
 function headerbar_menu(string $menu_title, array $links, bool $align_right = false): string
 {
     $menu_style = "";
@@ -457,6 +459,8 @@ function headerbar_menu(string $menu_title, array $links, bool $align_right = fa
  * attribute on the <a> or <span> tag. The function also determines if the
  * current page is one of the urls and if so it doesn't create the link but
  * instead wraps the text in a span.currentpage tag.
+ * @param array{text: string, title?: string, target?: string, url?: string}[] $entries
+ * @return string[]
  */
 function resolve_headerbar_entries(array $entries): array
 {
@@ -516,6 +520,7 @@ function resolve_headerbar_entries(array $entries): array
  * Outputs entries in the navbar contained within $entries.
  *
  * See resolve_headerbar_entries() for $entries format.
+ * @param array{text: string, title?: string, target?: string, url?: string}[] $entries
  */
 function headerbar_text_array(array $entries): string
 {
@@ -526,7 +531,7 @@ function headerbar_text_array(array $entries): string
     return implode($divider, resolve_headerbar_entries($entries));
 }
 
-function html_statsbar($nameofpage)
+function html_statsbar(string $nameofpage): void
 {
     global $code_url, $PG_home_url;
     maybe_show_language_selector();
@@ -612,7 +617,7 @@ function html_statsbar($nameofpage)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function maybe_show_language_selector()
+function maybe_show_language_selector(): void
 {
     global $code_url;
 
@@ -649,15 +654,16 @@ function maybe_show_language_selector()
  * Return a list of round/stage links for the user
  *
  * The returned links are in a format usable by headerbar_text_array()
+ * @return array{url: string, text: string, title: string}[]
  */
-function get_activity_links()
+function get_activity_links(): array
 {
     global $ELR_round;
 
     $user = User::load_current();
 
     if (!$user) {
-        return;
+        return [];
     }
     // Should show links to stages that are accessible to people
     // that aren't logged in? (i.e., SR)?
@@ -704,7 +710,7 @@ function get_activity_links()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_tally_specific_stats($tally_name)
+function show_tally_specific_stats(string $tally_name): void
 {
     global $code_url;
 
@@ -825,7 +831,7 @@ function show_tally_specific_stats($tally_name)
     echo "</div>";
 }
 
-function show_tally_vs_goal($label, $goal, $actual)
+function show_tally_vs_goal(string $label, ?int $goal, int $actual): void
 {
     $goal = $goal == null ? 0 : $goal;
 
@@ -845,7 +851,7 @@ function show_tally_vs_goal($label, $goal, $actual)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_user_teams()
+function show_user_teams(): void
 {
     global $code_url;
 
@@ -882,7 +888,7 @@ function show_user_teams()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_birthdays()
+function show_birthdays(): void
 {
     $seconds_in_month = 30 * 24 * 60 * 60;
 
@@ -940,7 +946,7 @@ function show_birthdays()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_completed_projects($terse = false)
+function show_completed_projects(bool $terse = false): void
 {
     global $code_url;
 
@@ -1002,7 +1008,7 @@ function show_completed_projects($terse = false)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_key_help_links()
+function show_key_help_links(): void
 {
     $faq_central_url = get_faq_url("faq_central.php");
     $p_guide_url = get_faq_url("proofreading_guidelines.php");
@@ -1068,18 +1074,19 @@ function show_key_help_links()
  *   Actual value obtained
  * @param int $goal
  *   Goal for the day
- * @param mixed $prorate_goal_for_color
- *   if TRUE or 'day', the returned color will be calculated based
- *   on how much of the current day has passed. If set to 'month'
- *   the color will be based on how much of the month has passed.
+ * @param bool|'bar'|'month' $prorate_goal_for_color
+ *   - If true or 'bar', the returned color will be calculated based
+ *   on how much of the current day has passed.
+ *   - If 'month'  the color will be based on how much of the month has passed.
  *   This is useful so that at the beginning of a new timeframe the
  *   bar isn't at the low color.
- * @param array $color_thresholds
+ * @param ?array<int, string> $color_thresholds
  *   Associative array containing the class names to use for
  *   each percentage completed range, eg:
  *   `[100 => "goal-on-target", 75 => "goal-maybe", 0 => "goal-unlikely"]
+ * @return list{int, string, float}
  */
-function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_color = true, $color_thresholds = null)
+function calculate_progress_bar_properties(int $actual, int $goal, bool|string $prorate_goal_for_color = true, ?array $color_thresholds = null): array
 {
     // Define the color classes used for the status bar graph
     if (!is_array($color_thresholds)) {
@@ -1134,7 +1141,7 @@ function calculate_progress_bar_properties($actual, $goal, $prorate_goal_for_col
  *
  * If no image is found for the file name, the function returns NULL.
  */
-function get_dyn_image_url_for_file($filename)
+function get_dyn_image_url_for_file(string $filename): ?string
 {
     $image_extensions = ["", ".png", ".jpg", ".gif"];
 
@@ -1152,7 +1159,7 @@ function get_dyn_image_url_for_file($filename)
 /**
  * Given a page basename return an <img> element for it
  */
-function get_page_header_image($image)
+function get_page_header_image(string $image): string
 {
     // Try a locale-less image first
     $dyn_url = get_dyn_image_url_for_file("page_header/$image");
@@ -1174,7 +1181,7 @@ function get_page_header_image($image)
 /**
  * Output a tab bar of various view modes and a selected mode
  *
- * @param array $view_modes
+ * @param array<int|string, array{label: string, url?: string, postscript?: string}> $view_modes
  *   A complex associative array, eg:
  *   ```
  *   [
@@ -1195,12 +1202,17 @@ function get_page_header_image($image)
  * @param string $url_addition
  *   An optional string that will be appended to the URL. This can
  *   be other page parameters and/or a page anchor
- * @param string $display_mode
- *   One of "full" or "auto" - full will cause the bar to span the
- *   entire page while auto will only use as much horizontal space as needed.
+ * @param 'full'|'auto' $display_mode
+ *   - full will cause the bar to span the entire page
+ *   - auto will only use as much horizontal space as needed.
  */
-function output_tab_bar($view_modes, $selected_mode, $view_variable, $url_addition = "", $display_mode = "full")
-{
+function output_tab_bar(
+    array $view_modes,
+    string $selected_mode,
+    string $view_variable,
+    string $url_addition = "",
+    string $display_mode = "full"
+): void {
     $div_style = $display_mode == "auto" ? "style='width: auto;'" : "";
     $clear_style = $display_mode == "auto" ? "style='clear: left;'" : "style='clear: both;'";
 

--- a/pinc/user_project_info.inc
+++ b/pinc/user_project_info.inc
@@ -21,7 +21,7 @@ various places:
                         database updated to reflect that.
 */
 
-function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_row = false)
+function upi_set_t_latest_home_visit(string $username, string $projectid, int $timestamp, bool $ensure_row = false): void
 {
     if ($ensure_row) {
         $sql = sprintf(
@@ -54,7 +54,7 @@ function upi_set_t_latest_home_visit($username, $projectid, $timestamp, $ensure_
     DPDatabase::query($sql);
 }
 
-function upi_set_t_latest_page_event($username, $projectid, $timestamp)
+function upi_set_t_latest_page_event(string $username, string $projectid, int $timestamp): void
 {
     $sql = sprintf(
         "
@@ -76,7 +76,7 @@ function upi_set_t_latest_page_event($username, $projectid, $timestamp)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function upi_set_bookmark(string $username, string $projectid, bool $bookmark = true)
+function upi_set_bookmark(string $username, string $projectid, bool $bookmark = true): void
 {
     $sql = sprintf(
         "
@@ -96,7 +96,7 @@ function upi_set_bookmark(string $username, string $projectid, bool $bookmark = 
     DPDatabase::query($sql);
 }
 
-function upi_get_bookmark(string $username, string $projectid)
+function upi_get_bookmark(string $username, string $projectid): ?int
 {
     $sql = sprintf(
         "
@@ -114,6 +114,7 @@ function upi_get_bookmark(string $username, string $projectid)
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+/** @return array<string, string> */
 function get_subscribable_project_events()
 {
     $subscribable_project_events = [
@@ -129,10 +130,10 @@ function get_subscribable_project_events()
     return $subscribable_project_events;
 }
 
-function get_label_for_event($event)
+function get_label_for_event(string $event): string
 {
     $subscribable_project_events = get_subscribable_project_events();
-    $label = @$subscribable_project_events[$event];
+    $label = $subscribable_project_events[$event] ?? null;
     if (is_null($label)) {
         throw new UnexpectedValueException("Unknown event: '$event'");
     }
@@ -142,17 +143,17 @@ function get_label_for_event($event)
 // -----------------------------------------------------------------------------
 // "iste" = "is subscribed to event"
 
-function subscribe_user_to_project_event($username, $projectid, $event)
+function subscribe_user_to_project_event(string $username, string $projectid, string $event): void
 {
     set_user_project_event_subscription($username, $projectid, $event, 1);
 }
 
-function unsubscribe_user_from_project_event($username, $projectid, $event)
+function unsubscribe_user_from_project_event(string $username, string $projectid, string $event): void
 {
     set_user_project_event_subscription($username, $projectid, $event, 0);
 }
 
-function set_user_project_event_subscription($username, $projectid, $event, $bit)
+function set_user_project_event_subscription(string $username, string $projectid, string $event, int $bit): void
 {
     assert($bit === 0 || $bit === 1);
 
@@ -178,7 +179,7 @@ function set_user_project_event_subscription($username, $projectid, $event, $bit
     $res = DPDatabase::query($sql);
 }
 
-function user_is_subscribed_to_project_event($username, $projectid, $event)
+function user_is_subscribed_to_project_event(string $username, string $projectid, string $event): bool
 {
     $event_label = get_label_for_event($event);
     // Just to ensure that $event is valid; we don't use $event_label.
@@ -197,13 +198,13 @@ function user_is_subscribed_to_project_event($username, $projectid, $event)
     $row = mysqli_fetch_row($res);
     if (!$row) {
         // ($username,$projectid) pair does not appear in table.
-        return 0;
+        return false;
     } else {
-        return $row[0];
+        return (bool) $row[0];
     }
 }
 
-function can_user_subscribe_to_project_event($username, $projectid, $event)
+function can_user_subscribe_to_project_event(string $username, string $projectid, string $event): bool
 {
     // Disallow subscribing to SR report posted event for anyone who is not the PP for the project
     if ($event == 'sr_reported') {
@@ -218,7 +219,11 @@ function can_user_subscribe_to_project_event($username, $projectid, $event)
 
 // -----------------------------------------------------------------------------
 
-function notify_project_event_subscribers($project, $event, $extras = [])
+/**
+ * @param 'posted'|'round_available'|'round_complete'|'pp_enter'|'sr_available'|'sr_reported'|'sr_complete'|'ppv_enter' $event
+ * @param array{round?: Round} $extras
+ */
+function notify_project_event_subscribers(Project $project, string $event, array $extras = []): void
 {
     $projectid = $project->projectid;
     $title = $project->nameofwork;
@@ -288,9 +293,6 @@ function notify_project_event_subscribers($project, $event, $extras = [])
                 $msg_body .=
                     _("This project has entered post-processing verification.");
                 break;
-
-            default:
-                throw new UnexpectedValueException("Unexpected event $event");
         }
         $email = get_forum_email_address($username);
         send_mail(
@@ -322,8 +324,9 @@ function notify_project_event_subscribers($project, $event, $extras = [])
 /**
  * Return an array: keys are the same as array returned by get_subscribable_project_events(),
  * each value is the number of subscriptions to that event for the given project.
+ * @return array<string, int>
  */
-function get_n_users_subscribed_to_events_for_project($projectid)
+function get_n_users_subscribed_to_events_for_project(string $projectid)
 {
     $subscribable_project_events = get_subscribable_project_events();
     $items = [];
@@ -356,7 +359,7 @@ function get_n_users_subscribed_to_events_for_project($projectid)
  * current number of users that are subscribed to the project's 'posted' event.
  * ("nouste" = "number of users subscribed to event")
  */
-function create_temporary_project_event_subscription_summary_table()
+function create_temporary_project_event_subscription_summary_table(): void
 {
     $sql = "
         CREATE TEMPORARY TABLE project_event_subscriptions_grouped_by_project

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -52,7 +52,7 @@ define('WC_PAGE', 4);
  * - an array: each value is the name of a language that was used
  * - an array: each value is a warning/error.
  *
- * @param string $text
+ * @param string|string[] $text
  *   The text for which bad words are sought.
  *   This can be a string or an array of strings. If the latter, the
  *   strings are conceptually separated by whitespace.  (So it's never
@@ -60,12 +60,12 @@ define('WC_PAGE', 4);
  * @param string $projectid
  *   ID of project, needed for project languages and to load the custom
  *   dictionaries
- * @param array $languages
+ * @param string[] $languages
  *   Languages to check against.
- * @param array $adhoc_good_words
+ * @param string[] $adhoc_good_words
  *   Array of words to treat as good for this invocation only.
  *
- * @return array
+ * @return list{array<string, int>, string[], string[]}
  */
 function get_bad_word_freqs_for_project_text($text, $projectid, $languages, $adhoc_good_words = [])
 {
@@ -83,7 +83,7 @@ function get_bad_word_freqs_for_project_text($text, $projectid, $languages, $adh
  * - an array: each value is the name of a language that was used
  * - an array: each value is a warning/error.
  *
- * @param string $text
+ * @param string|string[] $text
  *   The text for which bad words are sought.
  *   This can be a string or an array of strings. If the latter, the
  *   strings are conceptually separated by whitespace.  (So it's never
@@ -91,12 +91,12 @@ function get_bad_word_freqs_for_project_text($text, $projectid, $languages, $adh
  * @param string $projectid
  *   ID of project, needed for project languages and to load the custom
  *   dictionaries
- * @param array $languages
+ * @param string[] $languages
  *   Languages to check against.
- * @param array $adhoc_good_words
+ * @param string[] $adhoc_good_words
  *   Array of words to treat as good for this invocation only.
  *
- * @return array
+ * @return list{array<string, int>, string[], string[]}
  */
 function get_bad_word_levels_for_project_text($text, $projectid, $languages, $adhoc_good_words = [])
 {
@@ -117,9 +117,8 @@ function get_bad_word_levels_for_project_text($text, $projectid, $languages, $ad
  * - an array: each value is the name of a language that was used
  * - an array: each value is a warning/error.
  *
- * @param string $which_result_values
- *   One of FREQS or LEVELS
- * @param string $text
+ * @param 'FREQS'|'LEVELS' $which_result_values
+ * @param string|string[] $text
  *   The text for which bad words are sought.
  *   This can be a string or an array of strings. If the latter, the
  *   strings are conceptually separated by whitespace.  (So it's never
@@ -127,12 +126,12 @@ function get_bad_word_levels_for_project_text($text, $projectid, $languages, $ad
  * @param string $projectid
  *   ID of project, needed for project languages and to load the custom
  *   dictionaries
- * @param array $languages
+ * @param string[] $languages
  *   Languages to check against.
- * @param array $adhoc_good_words
+ * @param string[] $adhoc_good_words
  *   Array of words to treat as good for this invocation only.
  *
- * @return array
+ * @return list{array<string, int>, string[], string[]}
  */
 function _get_bad_words_for_project_text($which_result_values, $text, $projectid, $languages, $adhoc_good_words)
 {
@@ -185,11 +184,17 @@ function _get_bad_words_for_project_text($which_result_values, $text, $projectid
  * - array of bad words
  * - array of possible warning/error messages
  *
- * @param string $text
+ * @param string|string[] $text
  *   String or array of strings containing page text
- * @param array $languages
+ * @param string[] $languages
  *   Array of language names to use for the dictionary
- * @param array $word_lists
+ * @param array{
+ *            site_good?: string[],
+ *            site_bad?: string[],
+ *            project_good?: string[],
+ *            project_bad?: string[],
+ *            adhoc_good?: string[],
+ *        } $word_lists
  *   Array with the keys:
  *   * site_good - array of site good words
  *   * site_bad  - array of site bad words
@@ -197,7 +202,7 @@ function _get_bad_words_for_project_text($which_result_values, $text, $projectid
  *   * project_bad - array of bad words from project
  *   * adhoc_good - array of adhoc good words
  *
- * @return array
+ * @return list{array<string, int>, array<string, int>, string[]}
  */
 function get_bad_words_for_text($text, $languages, $word_lists = [])
 {
@@ -305,13 +310,13 @@ class BadWordAccumulator
  * - an array of misspelled words,
  * - an array of messages (errors/warnings)
  *
- * @param array $input_words_w_freq
+ * @param array<string, int> $input_words_w_freq
  *   An array whose keys are the distinct words of the input text
  * @param string[] $languages
  *   Array of languages, used to load aspell dictionary
  *   for those languages if available
  *
- * @return array{0:string[], 1:string[]}
+ * @return list{string[], string[]}
  */
 function get_bad_words_via_external_checker($input_words_w_freq, $languages)
 {
@@ -408,7 +413,7 @@ function get_bad_words_via_external_checker($input_words_w_freq, $languages)
  * Returns:
  * - an array of bad words
  *
- * @param array $input_words_w_freq
+ * @param array<string, int> $input_words_w_freq
  *   An array whose keys are the distinct words of the input text
  *
  * @return string[]
@@ -455,9 +460,9 @@ function get_bad_words_with_diacritical_markup($input_words_w_freq): array
  * Returns:
  * - an array of bad words
  *
- * @param array $input_words_w_freq
+ * @param array<string, int> $input_words_w_freq
  *   An array whose keys are the distinct words of the input text
- * @param array $languages
+ * @param string[] $languages
  *   Array of languages to check against
  *
  * @return string[]
@@ -509,7 +514,7 @@ function get_bad_words_via_pattern($input_words_w_freq, $languages)
  *
  * @return string[]
  */
-function load_site_good_words($langcode3s)
+function load_site_good_words($langcode3s): array
 {
     return _load_site_words("good", $langcode3s);
 }
@@ -519,7 +524,7 @@ function load_site_good_words($langcode3s)
  *
  * @return string[]
  */
-function load_site_bad_words($langcode3s)
+function load_site_bad_words($langcode3s): array
 {
     return _load_site_words("bad", $langcode3s);
 }
@@ -529,12 +534,13 @@ function load_site_bad_words($langcode3s)
  *
  * @return string[]
  */
-function load_site_possible_bad_words($langcode3s)
+function load_site_possible_bad_words($langcode3s): array
 {
     return _load_site_words("possible_bad", $langcode3s);
 }
 
 /**
+ * @param 'good'|'bad'|'possible_bad' $type
  * @param string|string[] $langcode3s
  *
  * @return string[]
@@ -566,6 +572,7 @@ function load_project_good_words(string $projectid)
     return load_word_list($fileObject->abs_path);
 }
 
+/** @param string[] $words */
 function save_project_good_words(string $projectid, array $words): string
 {
     $fileObject = get_project_word_file($projectid, "good");
@@ -583,6 +590,7 @@ function load_project_bad_words(string $projectid)
     return load_word_list($fileObject->abs_path);
 }
 
+/** @param string[] $words */
 function save_project_bad_words(string $projectid, array $words): string
 {
     $fileObject = get_project_word_file($projectid, "bad");
@@ -618,7 +626,7 @@ function normalize_word_list(array $words): array
  *
  * This is called when deleting a project.
  */
-function delete_project_wordcheck_events($projectid)
+function delete_project_wordcheck_events(string $projectid): void
 {
     $sql = sprintf(
         "
@@ -686,7 +694,8 @@ function copy_project_wordcheck_events(string $from_projectid, string $to_projec
 
 // -----------------------------------------------------------------------------
 
-function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions)
+/** @param string[] $suggestions */
+function save_wordcheck_event(string $projectid, string $round, string $page, string $proofer, array $suggestions): void
 {
     $setters = join(", ", [
         set_col_str("projectid", $projectid),
@@ -712,7 +721,7 @@ function save_wordcheck_event($projectid, $round, $page, $proofer, $suggestions)
  * to counting the result of load_wordcheck_events, when one does
  * not need the precise number of suggested words.
  */
-function count_wordcheck_suggestion_events($projectid, $start_time = 0)
+function count_wordcheck_suggestion_events(string $projectid, int $start_time = 0): int
 {
     $sql = sprintf(
         "
@@ -732,7 +741,12 @@ function count_wordcheck_suggestion_events($projectid, $start_time = 0)
     return $row["numevents"];
 }
 
-function load_wordcheck_events($projectid, $start_time = 0)
+/**
+ * @return list{int, string, string, string, string[]}[]
+ *     An ordered array of events. Each event contains a timestamp,
+ *     round id, pagename, proofer, word list
+ */
+function load_wordcheck_events(string $projectid, int $start_time = 0): array
 {
     $sql = sprintf(
         "
@@ -788,7 +802,11 @@ function load_project_good_word_suggestions_flat(string $projectid, int $start_t
     return $words;
 }
 
-function load_project_good_word_suggestions($projectid, $start_time = 0)
+/**
+ * @return array<string, array<string, string[]>>
+ *    Returns an array like ["P3" => ["007.png" => ["shaken", "stirred"]]]
+ */
+function load_project_good_word_suggestions(string $projectid, int $start_time = 0): array
 {
     $eventArray = load_wordcheck_events($projectid, $start_time);
 
@@ -814,21 +832,24 @@ function load_project_good_word_suggestions($projectid, $start_time = 0)
 
 // -----------------------------------------------------------------------------
 
-function load_site_good_words_given_project($projectid)
+/** @return string[] */
+function load_site_good_words_given_project(string $projectid): array
 {
     $languages = get_project_languages($projectid);
     [$langcode3s, $messages] = get_langcode3s_for_languages($languages);
     return load_site_good_words($langcode3s);
 }
 
-function load_site_bad_words_given_project($projectid)
+/** @return string[] */
+function load_site_bad_words_given_project(string $projectid): array
 {
     $languages = get_project_languages($projectid);
     [$langcode3s, $messages] = get_langcode3s_for_languages($languages);
     return load_site_bad_words($langcode3s);
 }
 
-function load_site_possible_bad_words_given_project($projectid)
+/** @return string[] */
+function load_site_possible_bad_words_given_project(string $projectid): array
 {
     $languages = get_project_languages($projectid);
     [$langcode3s, $messages] = get_langcode3s_for_languages($languages);
@@ -840,8 +861,9 @@ function load_site_possible_bad_words_given_project($projectid)
 /**
  * Return an associative array that maps the good/bad shorthand to
  * the filenames on disk
+ * @return array{good: string, bad: string}
  */
-function get_wordcheck_file_names()
+function get_wordcheck_file_names(): array
 {
     return [
         'good' => 'good_words.txt',
@@ -859,7 +881,7 @@ function get_wordcheck_file_names()
  *
  * @see get_wordcheck_file_names()
  */
-function get_project_word_file($projectid, $code)
+function get_project_word_file(string $projectid, string $code): object
 {
     global $projects_dir, $projects_url;
 
@@ -878,7 +900,7 @@ function get_project_word_file($projectid, $code)
  *
  * @return string[]
  */
-function get_site_word_paths()
+function get_site_word_paths(): array
 {
     return [SiteConfig::get()->dyn_dir . "/words", SiteConfig::get()->dyn_url . "/words"];
 }
@@ -886,12 +908,9 @@ function get_site_word_paths()
 /**
  * Get a file info object for a site word list
  *
- * @param string $code
- *   Must match one of `good`, `bad`, `possible`
- *
- * @return object
+ * @param 'good'|'bad'|'possible_bad' $code
  */
-function get_site_word_file(string $langcode3, string $code)
+function get_site_word_file(string $langcode3, string $code): object
 {
     [$site_words_dir, $site_words_url] = get_site_word_paths();
 
@@ -922,7 +941,7 @@ function get_site_word_file(string $langcode3, string $code)
  * - mod_time: the time it was last modified, as a unix timestamp.
  * Size and mod_time are set to zero if the file doesn't exist.
  */
-function get_file_info_object($filename, $base_dir, $base_url)
+function get_file_info_object(string $filename, string $base_dir, string $base_url): Object
 {
     clearstatcache();
 
@@ -1000,7 +1019,7 @@ function _explode_no_empty(string $sep, string $string): array
  *
  * @param string[] $words
  */
-function save_word_list(string $path, array $words): string
+function save_word_list(string $path, $words): string
 {
     // standardize word list
     array_walk($words, 'rtrim_walk');
@@ -1158,11 +1177,12 @@ function get_site_word_files(string $pattern = "/txt$/"): array
  * `array_count_values(get_all_words_in_text($text))`
  * but (when appropriate) avoids reifying the intermediate array.
  *
- * @param string|array<string> $text
+ * @param string|string[] $text
  *    The text or texts to histogram
  *
- * @return array<string,int>
+ * @return array<string, int>
  *    A histogram of word frequencies in $text
+ *    Eg ["the" => 73, "hapax" => 1, "legomenon" => 1]
  */
 function get_distinct_words_in_text($text)
 {
@@ -1208,7 +1228,7 @@ function get_distinct_words_in_text($text)
         foreach ($text as $index => $chunk) {
             $partial_text .= " $chunk";
             if (strlen($partial_text) >= $break_point || $index == count($text) - 1) {
-                foreach (array_count_values(get_all_words_in_text($partial_text)) as $word => $count) {  // @phpstan-ignore foreach.emptyArray
+                foreach (array_count_values(get_all_words_in_text($partial_text)) as $word => $count) {
                     @$input_words_w_freq[$word] += $count;
                 }
                 $partial_text = "";
@@ -1239,6 +1259,9 @@ function get_distinct_words_in_text($text)
  * took roughly an hour just to print the first four items in the array!)
  * Note that it's *not* inefficient accessing an array with the same number
  * of items, but having consecutive integers as the keys!
+ * @return array<int, string>
+ *   Eg [0 => "The", 1 => "quick", 2 => "brown", 3 => "fox"]
+ *   Eg [0 => "The", 4 => "quick", 10 => "brown", 16 => "fox"]
  */
 function get_all_words_in_text(string $text, bool $with_offsets = false)
 {
@@ -1285,12 +1308,12 @@ function generate_frequencies(array $wordList): array
  * - array of langcode3s
  * - array of zero or more error/warning messages
  *
- * @param array $languages
+ * @param string[] $languages
  *   Array of language names
  *
- * @return array{0: string[], 1: string[]}
+ * @return list{string[], string[]}
  */
-function get_langcode3s_for_languages($languages)
+function get_langcode3s_for_languages(array $languages): array
 {
     $messages = [];
     $langcode3s = [];
@@ -1348,15 +1371,13 @@ function filter_words_to_script(array $words, string $script): array
  * Return a list of words where characters within a word contain "uncommon"
  * Unicode scripts.
  *
- * Returns:
- * - the array: [words[], found_scripts[]]
- *
  * @param string[] $words
  *   An array of words
  *
- * @return array{0: string[], 1: string[]}
+ * @return list{string[], string[]}
+ *      the array: [words[], found_scripts[]]
  */
-function get_words_with_uncommon_scripts($words)
+function get_words_with_uncommon_scripts(array $words): array
 {
     global $common_unicode_scripts;
 

--- a/project.php
+++ b/project.php
@@ -2066,7 +2066,7 @@ function do_page_table(): void
         echo "<p>" . _("It is <b>strongly</b> recommended that you view page differentials by right-clicking on a diff link and opening the link in a new window or tab.") . "</p>";
 
         // second arg. indicates to show size of image files.
-        echo_page_table($project, 1);
+        echo_page_table($project, true);
     }
 }
 

--- a/quiz/start.php
+++ b/quiz/start.php
@@ -30,11 +30,8 @@ $quiz_type_intro = [
 ];
 
 // show a level of quizzes
-if (
-    ($quiz_level_id = @$_GET['show_level'])
-    &&
-    ($quiz_level = @QuizLevel::$map_quiz_level_id_to_QuizLevel[$quiz_level_id])
-) {
+if (($quiz_level_id = ($_GET['show_level'] ?? null)) &&
+    ($quiz_level = QuizLevel::$map_quiz_level_id_to_QuizLevel[$quiz_level_id] ?? null) !== null) {
     output_header($quiz_level->level_name, SHOW_STATSBAR);
     echo "<h1>".$quiz_level->level_name."</h1>\n";
     echo $quiz_level->info;
@@ -51,11 +48,8 @@ if (
 }
 
 // show a whole category of quizzes (proofing or formatting)
-elseif (
-    ($so = @$_GET['show_only'])
-    &&
-    ($so == 'PQ' || $so == 'FQ' || isset($quiz_type_intro[$so]))
-) {
+elseif (($so = ($_GET['show_only']) ?? null) &&
+        ($so == 'PQ' || $so == 'FQ' || isset($quiz_type_intro[$so]))) {
     if ($so == 'PQ') {
         $activity_type = 'proof';
     } elseif ($so == 'FQ') {

--- a/stats/members/mbr_list.php
+++ b/stats/members/mbr_list.php
@@ -106,8 +106,8 @@ echo "</tr>";
 if (!empty($mRows)) {
     while ($row = mysqli_fetch_assoc($mResult)) {
         echo "<tr>";
-
-        if (can_reveal_details_about($row['username'], $row['u_privacy'])) {
+        $privacy = $row['u_privacy'] == 0 ? PRIVACY_PRIVATE : PRIVACY_ANONYMOUS;
+        if (can_reveal_details_about($row['username'], $privacy)) {
             echo "<td style='text-align: center;'><b>".$row['u_id']."</b></td>";
             echo "<td>".$row['username']."</td>";
             echo "<td style='text-align: center;'>".date("m/d/Y", (int)$row['date_created'])."</td>";

--- a/stats/members/mdetail.php
+++ b/stats/members/mdetail.php
@@ -20,8 +20,8 @@ if ($id === null) {
 
 $valid_tally_names = array_keys(get_page_tally_names());
 $tally_name = get_enumerated_param($_GET, 'tally_name', null, $valid_tally_names, true);
-
-$can_reveal = can_reveal_details_about($user->username, $user->u_privacy);
+$privacy = $user->u_privacy == 0 ? PRIVACY_PRIVATE : PRIVACY_ANONYMOUS;
+$can_reveal = can_reveal_details_about($user->username, $privacy);
 if ($user == User::load_current()) {
     $desc = _("Your user details");
 } else {

--- a/stats/requested_books.php
+++ b/stats/requested_books.php
@@ -78,7 +78,7 @@ dpsql_dump_themed_query(
 echo "<br>\n";
 echo "<h2>" . _("Most Requested Books Posted to Project Gutenberg") . "</h2>\n";
 
-$pg_url1 = DPDatabase::escape(sprintf("<a href='%s", get_pg_catalog_url_for_etext('')));
+$pg_url1 = DPDatabase::escape(sprintf("<a href='%s", get_pg_catalog_url_for_etext(null)));
 dpsql_dump_themed_query(
     "
     SELECT

--- a/tools/project_manager/edit_pages.php
+++ b/tools/project_manager/edit_pages.php
@@ -70,7 +70,7 @@ if (@$_REQUEST['confirmed'] == 'yes') {
 
     echo _("You selected the following page(s):") . "<br>\n";
     echo "<br>\n";
-    echo_page_table($project, 0, true, $selected_pages);
+    echo_page_table($project, false, true, $selected_pages);
     echo "<br>\n";
     echo "$your_request<br>\n";
     echo "<br>\n";

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -47,10 +47,10 @@ if (!$errors) {
     try {
         if ($save_files) {
             flush();
-            generate_post_files($project, $round_id, $which_text, $include_proofers, '');
+            generate_post_files($project, $round_id, $which_text, (bool) $include_proofers, '');
             echo "<p>" . _("Done.") . "</p>";
         } else {
-            generate_interim_file($project, $round_id, $which_text, $include_proofers);
+            generate_interim_file($project, $round_id, $which_text, (bool) $include_proofers);
         }
     } catch (Exception $exception) {
         $errors[] = $exception->getMessage();

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -149,7 +149,7 @@ if ($project->pages_table_exists) {
     }
     echo "</p>";
 
-    echo_page_table($project, $show_image_size, false, $username_for_page_selection, $round_for_page_selection);
+    echo_page_table($project, (bool)$show_image_size, false, $username_for_page_selection, $round_for_page_selection);
 } else {
     $warn_message = $project->pages_table_missing_reason();
     echo "<p class='warning'>$warn_message</p>\n";

--- a/tools/project_manager/show_good_word_suggestions.php
+++ b/tools/project_manager/show_good_word_suggestions.php
@@ -246,11 +246,6 @@ function _get_suggestions_word_list(string $projectid, int $timeCutoff): array
 
     // load the suggestions
     $suggestions = load_project_good_word_suggestions($projectid, $timeCutoff);
-    if (!is_array($suggestions)) {
-        $messages[] = sprintf(_("Unable to load suggestions: %s"), $suggestions);
-        return [[], [], [], [], [], [], $messages];
-    }
-
     if (count($suggestions) == 0) {
         return [[], [], [], [], [], [], $messages];
     }

--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -43,9 +43,6 @@ echo "<div style='padding: 0.5em;'>";
 
 // load the suggestions
 $suggestions = load_wordcheck_events($projectid, $timeCutoff);
-if (!is_array($suggestions)) {
-    $messages[] = sprintf(_("Unable to load suggestions: %s"), $suggestions);
-}
 
 // parse the suggestions complex array
 // it was pulled in the raw format


### PR DESCRIPTION
This is a second sweep of cleanups  to `pinc/` with the intention of making the entire codebase pass PHPStan's level 6 warnings.

This patchset requires a little more human judgement than the previous one, either because it
- makes API changes to (internal) functions, such as using `bool` instead of `int`, or using nullable arguments more appropriate
- it removes manual runtime argument checks for cases now caught by static analysis
- it uses some trickier PHPStan types
- it add some missing error handling, or removes some uses of `@`