### PR TITLE
Reduce pgdp prod commits

### DIFF
--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -100,6 +100,10 @@ class SiteConfig
     public ?string $image_sources_manager_addr;
     public ?string $translation_coordinator_email_addr;
 
+    // New feature deployment timestamps
+    public int $wordcheck_deployed = 0;
+    public int $format_preview_tracking_deployed = 0;
+
     // Misc configuration
     public bool $use_secure_cookies = false;
     public string $php_cli_executable = '/usr/bin/php';

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -73,6 +73,12 @@ class SiteConfig
     public string $uploads_subdir_commons = "Commons";
     public string $uploads_subdir_users = "Users";
     public ?string $antivirus_executable = null;
+    // When setting uploads_max_size_mb, review the following settings in clamd.conf:
+    //     MaxScanSize -- should be set to twice the desired max upload size
+    //     AlertExceedsMax -- should be set to true if you wish files that cannot
+    //                        be scanned at that limit to be rejected.
+    // See `man clamd.conf` for more detailed info
+    public int $uploads_max_size_mb = 1024;
 
     // WordCheck & locales
     public string $aspell_executable = '/usr/bin/aspell';

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -102,6 +102,7 @@ class SiteConfig
 
     // New feature deployment timestamps
     public int $wordcheck_deployed = 0;
+    public int $unicode_deployed = 0;
     public int $format_preview_tracking_deployed = 0;
 
     // Misc configuration

--- a/pinc/misc.inc
+++ b/pinc/misc.inc
@@ -1571,22 +1571,6 @@ function is_url_for_current_page(string $url): bool
 }
 
 /**
- * Given a humanized size of bytes return the number of bytes
- *
- * From http://php.net/manual/en/function.ini-get.php
- */
-function return_bytes(string $size_str): int
-{
-    switch (substr($size_str, -1)) {
-        case 'M': case 'm': return (int)$size_str * 1048576;
-        case 'K': case 'k': return (int)$size_str * 1024;
-        case 'G': case 'g': return (int)$size_str * 1073741824;
-        default: return (int)$size_str;
-    }
-}
-
-
-/**
  * Encode a string using base64 with a variant alphabet that's safe to use in URL query values.
  * See https://datatracker.ietf.org/doc/html/rfc4648
  */

--- a/pinc/page_table.inc
+++ b/pinc/page_table.inc
@@ -673,6 +673,8 @@ function echo_cells_for_round(
             $wordcheck_status = '';
         } elseif ($round_data["wordcheck_ran"]) {
             $wordcheck_status = '&nbsp;<span title="' . _('This page was WordChecked.') . '">&check;</span>';
+        } elseif ($R_time < SiteConfig::get()->wordcheck_deployed) {
+            $wordcheck_status = '&nbsp;<span title="' . _('This page was saved before WordCheck was deployed.') . '">?</span>';
         } else {
             $wordcheck_status = '&nbsp;<span title="' . _('This page was not WordChecked.') . '">&#x2717;</span>';
         }
@@ -681,6 +683,8 @@ function echo_cells_for_round(
             $format_preview_status = '';
         } elseif ($round_data["format_preview_ran"]) {
             $format_preview_status = '&nbsp;<span title="' . _('Format Preview was used on this page.') . '">&check;</span>';
+        } elseif ($R_time < SiteConfig::get()->format_preview_tracking_deployed) {
+            $format_preview_status = '&nbsp;<span title="' . _('This page was saved before Format Preview usage was tracked.') . '">?</span>';
         } else {
             $format_preview_status = '&nbsp;<span title="' . _('Format Preview was not used on this page.') . '">&#x2717;</span>';
         }

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -36,7 +36,7 @@ function detect_too_large(): void
 
 function get_max_upload_size(): int
 {
-    return return_bytes(ini_get("upload_max_filesize"));
+    return ini_parse_quantity(ini_get("upload_max_filesize"));
 }
 
 function get_big_upload_blurb(): string

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -12,7 +12,7 @@
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
-define("RESUMABLE_UPLOAD_SIZE", 1024 * 1024 * 1024);  // 1GB
+define("RESUMABLE_UPLOAD_SIZE", SiteConfig::get()->uploads_max_size_mb * 1024 * 1024);
 
 /**
  * Detect too-large file uploads

--- a/project.php
+++ b/project.php
@@ -827,6 +827,8 @@ function recentlyproofed(int $wlist): void
                 $format_preview_status = '';
             } elseif ($row["format_preview_status"] > 0) {
                 $format_preview_status = '&nbsp;<span title="' . _('Format Preview was used on this page.') . '">&check;</span>';
+            } elseif ($timestamp < SiteConfig::get()->wordcheck_deployed) {
+                $format_preview_status = '&nbsp;<span title="' . _('This page was saved before Format Preview usage was tracked.') . '">?</span>';
             } else {
                 $format_preview_status = '&nbsp;<span title="' . _('Format Preview was not used on this page.') . '">&#x2717;</span>';
             }
@@ -835,6 +837,8 @@ function recentlyproofed(int $wlist): void
                 $wordcheck_status = '';
             } elseif ($row["wordcheck_status"] > 0) {
                 $wordcheck_status = '&nbsp;<span title="' . _('This page was WordChecked.') . '">&check;</span>';
+            } elseif ($timestamp < SiteConfig::get()->wordcheck_deployed) {
+                $wordcheck_status = '&nbsp;<span title="' . _('This page was saved before WordCheck was deployed.') . '">?</span>';
             } else {
                 $wordcheck_status = '&nbsp;<span title="' . _('This page was not WordChecked.') . '">&#x2717;</span>';
             }

--- a/project.php
+++ b/project.php
@@ -1673,6 +1673,9 @@ function echo_download_zip(string $link_text, string $discriminator): void
     echo "</a>";
     echo_byte_size($filesize_b);
     echo_last_modified($last_modified);
+    if ($discriminator == "" && $last_modified && $last_modified < SiteConfig::get()->unicode_deployed) {
+        echo "<br><span class='warning'>" . _("This file was generated before the Unicode conversion. If you are just starting to PP this project, please ask a site administrator to regenerate the file.") . "</span>";
+    }
     echo "</li>";
     echo "\n";
 }

--- a/tools/project_manager/show_project_wordcheck_usage.php
+++ b/tools/project_manager/show_project_wordcheck_usage.php
@@ -47,7 +47,7 @@ echo "</ul>";
 <?php
 
 // identifying pages that were proofread pre-WordCheck requires
-// $t_wordcheck_start being defined in site_vars.php
+// $wordcheck_deployed being defined in site_vars.php
 // with its value set to the timestamp of when WordCheck was
 // deployed on the site
 
@@ -121,7 +121,7 @@ while ($result = mysqli_fetch_assoc($res)) {
             $data = "$timesChecked: $lastProoferLink";
         }
         // if the page was finished before WordCheck was deployed on the site
-        elseif ($pageIsDoneInRound && $timesChecked == 0 && $timeProofed < @$t_wordcheck_start) {
+        elseif ($pageIsDoneInRound && $timesChecked == 0 && $timeProofed < SiteConfig::get()->wordcheck_deployed) {
             $class = "class='preWC'";
             $data = $lastProoferLink;
         }


### PR DESCRIPTION
This moves several commits from `pgdp-production` into `master` and sets the variables in the SiteConfig that control them. This branch has a final commit that will go in `pgdp-production` to set these variables to the value we care about (because we don't yet have a way to easily do that in `site_vars.php`).

Sandbox: https://www.pgdp.org/~cpeel/c.branch/reduce-pgdp-prod-commits/

* [RFM](https://www.pgdp.org/~cpeel/c.branch/reduce-pgdp-prod-commits/tools/project_manager/remote_file_manager.php) shows the 200MB file upload limit
* [this project](https://www.pgdp.org/~cpeel/c.branch/reduce-pgdp-prod-commits/tools/project_manager/page_detail.php?project=projectID5e255a56c4683&show_image_size=0) shows `$format_preview_tracking_deployed` at work: most of the F1 pages were done before this time, a few were done after it