### PR TITLE
Simplify sorting code using PHP 7.0, 7.4, & 8.0 features

### DIFF
--- a/pinc/UserSuggestions.inc
+++ b/pinc/UserSuggestions.inc
@@ -390,7 +390,7 @@ class UserSuggestions
         }
         mysqli_free_result($result);
 
-        uasort($projects, "compare_array_by_priority");
+        uasort($projects, fn ($a, $b) => $a['priority'] <=> $b['priority']);
 
         $user = new User($this->_username);
         $return_projects = [];
@@ -446,17 +446,4 @@ class UserSuggestions
         mysqli_free_result($result);
         return $field_counts;
     }
-}
-
-/**
- * @param array{priority: mixed, ...} $a
- * @param array{priority: mixed, ...} $b
- */
-function compare_array_by_priority(array $a, array $b): int
-{
-    if ($a["priority"] == $b["priority"]) {
-        return 0;
-    }
-
-    return ($a["priority"] < $b["priority"]) ? -1 : 1;
 }

--- a/pinc/wordcheck_engine.inc
+++ b/pinc/wordcheck_engine.inc
@@ -1024,7 +1024,8 @@ function save_word_list(string $path, $words): string
     // standardize word list
     array_walk($words, 'rtrim_walk');
     $words = array_unique($words);
-    uasort($words, "deterministicStrnatcasecmp");
+
+    natcasesort($words);
 
     // remove any empty words
     $words = array_diff($words, ['']);
@@ -1329,17 +1330,6 @@ function get_langcode3s_for_languages(array $languages): array
     return [$langcode3s, $messages];
 }
 
-/**
- * Comparison function for similar to strnatcasecmp but deterministic
- *
- * Without the strnatcmp() call if the words are the same discounting case,
- * the calling sort function would be non-deterministic based on PHP
- * docs (see online docs for usort()) and manual confirmation.
- */
-function deterministicStrnatcasecmp(string $a, string $b): int
-{
-    return ($cmp = strnatcasecmp($a, $b)) != 0 ? $cmp : strnatcmp($a, $b);
-}
 
 /**
  * rtrim version to use in array_walk

--- a/tools/site_admin/manage_site_charsuites.php
+++ b/tools/site_admin/manage_site_charsuites.php
@@ -53,9 +53,7 @@ echo "<th>" . _("Short Name") . "</th>";
 echo "<th>" . _("Enabled") . "</th>";
 echo "<th class='right-align'>" . _("# Projects") . "</th>";
 echo "</tr>";
-usort($all_charsuites, function ($a, $b) {
-    return strcmp($a->title, $b->title);
-});
+usort($all_charsuites, fn ($a, $b) => $a->title <=> $b->title);
 foreach ($all_charsuites as $charsuite) {
     echo "<tr>";
     $charsuite_slug = attr_safe($charsuite->name);


### PR DESCRIPTION
PHP 7.0: spaceship comparison operator <=> which returns -1,0,+1
PHP 7.4: fat-arrow functions  fn($x) => ...
PHP 8.0: Guarantees that natcasesort has stable ordering
         See https://www.php.net/manual/en/array.sorting.php and
             https://www.php.net/manual/en/function.natcasesort.php