### PR TITLE
More PHPStan level 6 cleanups, enable level 6 by default

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,12 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - pinc/3rdparty/mediawiki/DairikiDiff.php
-              - pinc/3rdparty/mediawiki/DiffEngine.php
-              - pinc/3rdparty/mediawiki/DiffFormatter.php
-              - pinc/3rdparty/mediawiki/WordAccumulator.php
-              - pinc/3rdparty/mediawiki/TableDiffFormatter.php
-              - pinc/BBDiffFormatter.inc
               - api/api_common.inc
               - api/index.php
               - api/v1_projects.inc
@@ -105,9 +99,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - pinc/3rdparty/mediawiki/DairikiDiff.php
-              - pinc/3rdparty/mediawiki/DiffEngine.php
-              - pinc/BBDiffFormatter.inc
               - api/exceptions.inc
               - api/index.php
               - api/v1_projects.inc
@@ -165,9 +156,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.iterableValue
           paths:
-              - pinc/3rdparty/mediawiki/DiffFormatter.php
-              - pinc/3rdparty/mediawiki/WordLevelDiff.php
-              - pinc/BBDiffFormatter.inc
               - api/exceptions.inc
               - api/v1_docs.inc
               - api/v1_projects.inc
@@ -194,9 +182,6 @@ parameters:
               - tools/site_search.php
         - identifier: missingType.property
           paths:
-              - pinc/3rdparty/mediawiki/DiffEngine.php
-              - pinc/3rdparty/mediawiki/WordAccumulator.php
-              - pinc/BBDiffFormatter.inc
               - crontab/AutoModify.inc
 
         # Errors in third party code, and our interfaces to it
@@ -234,6 +219,28 @@ parameters:
         - message: "#^Access to an undefined property Pool::\\$states.$#"
           path: pinc/ProjectState.inc
           reportUnmatched: false
+
+        # Level 6 errors in third party code, and our interfaces to it
+        - message: '#^Property .* has no type specified\.$#'
+          paths:
+            - pinc/BBDiffFormatter.inc
+            - pinc/3rdparty/mediawiki/*.php
+        - message: '#^Method .* has parameter \$.* with no type specified\.$#'
+          paths:
+            - pinc/BBDiffFormatter.inc
+            - pinc/3rdparty/mediawiki/*.php
+        - message: '#^Method .* has no return type specified\.$#'
+          paths:
+            - pinc/BBDiffFormatter.inc
+            - pinc/3rdparty/mediawiki/*.php
+        - message: '#^Method .* has parameter \$.* with no value type specified in iterable type array.$#'
+          paths:
+            - pinc/BBDiffFormatter.inc
+            - pinc/3rdparty/mediawiki/*.php
+        - message: '#^Method .* return type has no value type specified in iterable type array.$#'
+          paths:
+            - pinc/3rdparty/mediawiki/*.php
+
     typeAliases:
         # TODO: data.y should be numeric list, but callers needs fixing
         GraphConfig: """

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -58,3 +58,25 @@ parameters:
         - message: "#^Access to an undefined property Pool::\\$states.$#"
           path: pinc/ProjectState.inc
           reportUnmatched: false
+    typeAliases:
+        # TODO: data.y should be numeric list, but callers needs fixing
+        GraphConfig: """
+            array{
+                width?: int,
+                height?: int,
+                axisLeft?: bool,
+                yAxisLabel?: string,
+                xAxisHeight?: int,
+                yAxisTickCount?: int,
+                groupBars?: bool,
+                barColors?: string[],
+                title?: string,
+                downloadLabel?: string,
+                legendAdjustment?: array{x?: int, y?: int},
+                bottomLegend?: string,
+                data: array<
+                    string,
+                    array{type?: string, x: string[], y: mixed[]}
+                    >,
+            }
+            """

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -275,3 +275,16 @@ parameters:
                 option_label?: string,
             }
             """
+        HeaderExtraArgs: """
+            array{
+                frameset?: bool,          // false (default) | true
+                head_data?: string,       // string to output as-is in <head> tag
+                css_files?: string[],     // CSS files to include in the page
+                css_data?: string,        // CSS to include in the page
+                js_data?: string,         // JS code to include in the page,
+                js_files?: string[],      // array of .js files to link to
+                js_modules?: string[],    // array of .js files to link astype=module
+                js_module_data?: string,  // <script type='module'> code to include
+                body_attributes?: string, // body tag attributes to output
+            }
+            """

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,9 +20,185 @@ parameters:
 
     # https://phpstan.org/user-guide/rule-levels
     # We want to gradually ratchet up the level here.
-    level: 5
+    level: 6
 
     ignoreErrors:
+        # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
+        - identifier: missingType.return
+          paths:
+              - pinc/3rdparty/mediawiki/DairikiDiff.php
+              - pinc/3rdparty/mediawiki/DiffEngine.php
+              - pinc/3rdparty/mediawiki/DiffFormatter.php
+              - pinc/3rdparty/mediawiki/WordAccumulator.php
+              - pinc/3rdparty/mediawiki/TableDiffFormatter.php
+              - pinc/BBDiffFormatter.inc
+              - api/api_common.inc
+              - api/index.php
+              - api/v1_projects.inc
+              - api/v1_stats.inc
+              - accounts/addproofer.php
+              - accounts/login.php
+              - credits.php
+              - crontab/NotifyOldPP.inc
+              - faq/font_sample.php
+              - faq/privacy.php
+              - faq/prooffacehelp.php
+              - faq/wordcheck_data.php
+              - index.php
+              - locale/translators/index.php
+              - quiz/generic/quiz_page.inc
+              - quiz/generic/returnfeed.php
+              - quiz/generic/wizard/checks.php
+              - quiz/generic/wizard/messages.php
+              - quiz/generic/wizard/output.php
+              - quiz/generic/wizard/output_quiz.php
+              - quiz/generic/wizard/quiz_pages.php
+              - quiz/small_theme.inc
+              - stats/equilibria.php
+              - stats/includes/common.inc
+              - stats/includes/member.inc
+              - stats/includes/team.inc
+              - stats/index.php
+              - stats/misc_stats1.php
+              - stats/pp_stage_goal.php
+              - stats/round_backlog.php
+              - stats/round_backlog_days.php
+              - tasks.php
+              - tools/changestate.php
+              - tools/modify_access.php
+              - tools/post_proofers/ppv_report.php
+              - tools/project_manager/bad_bytes_explainer.php
+              - tools/project_manager/clearance_check.php
+              - tools/project_manager/diff.php
+              - tools/project_manager/edit_common.inc
+              - tools/project_manager/edit_project_word_lists.php
+              - tools/project_manager/editproject.php
+              - tools/project_manager/external_catalog_search.php
+              - tools/project_manager/generate_post_files.php
+              - tools/project_manager/handle_bad_page.php
+              - tools/project_manager/manage_image_sources.php
+              - tools/project_manager/page_detail.php
+              - tools/project_manager/page_operations.inc
+              - tools/project_manager/projectmgr.inc
+              - tools/project_manager/projectmgr.php
+              - tools/project_manager/remote_file_manager.php
+              - tools/project_manager/show_good_word_suggestions_detail.php
+              - tools/project_manager/show_image_sources.php
+              - tools/project_manager/show_specials.php
+              - tools/project_manager/update_illos.php
+              - tools/project_manager/word_freq_table.inc
+              - tools/proofers/for_mentors.php
+              - tools/proofers/image_block_enh.inc
+              - tools/proofers/images_index.php
+              - tools/proofers/mktable.php
+              - tools/proofers/my_projects.php
+              - tools/proofers/my_suggestions.php
+              - tools/proofers/preview.inc
+              - tools/proofers/proof_frame.php
+              - tools/proofers/proof_frame_enh.inc
+              - tools/proofers/proof_frame_std.inc
+              - tools/proofers/review_work.php
+              - tools/proofers/spellcheck_text.inc
+              - tools/set_project_event_subs.php
+              - tools/site_admin/projects_with_odd_values.php
+              - tools/site_search.php
+              - tools/upload_resumable_file.php
+        - identifier: missingType.parameter
+          paths:
+              - pinc/3rdparty/mediawiki/DairikiDiff.php
+              - pinc/3rdparty/mediawiki/DiffEngine.php
+              - pinc/BBDiffFormatter.inc
+              - api/exceptions.inc
+              - api/index.php
+              - api/v1_projects.inc
+              - api/v1_stats.inc
+              - credits.php
+              - crontab/NotifyOldPP.inc
+              - faq/font_sample.php
+              - faq/privacy.php
+              - faq/prooffacehelp.php
+              - faq/wordcheck_data.php
+              - locale/translators/index.php
+              - quiz/generic/quiz_page.inc
+              - quiz/generic/returnfeed.php
+              - quiz/generic/wizard/messages.php
+              - quiz/generic/wizard/output.php
+              - quiz/generic/wizard/output_quiz.php
+              - quiz/generic/wizard/quiz_pages.php
+              - quiz/small_theme.inc
+              - stats/equilibria.php
+              - stats/includes/common.inc
+              - stats/includes/member.inc
+              - stats/includes/team.inc
+              - stats/index.php
+              - stats/misc_stats1.php
+              - stats/pp_stage_goal.php
+              - tasks.php
+              - tools/changestate.php
+              - tools/modify_access.php
+              - tools/post_proofers/ppv_report.php
+              - tools/project_manager/bad_bytes_explainer.php
+              - tools/project_manager/clearance_check.php
+              - tools/project_manager/diff.php
+              - tools/project_manager/edit_common.inc
+              - tools/project_manager/edit_project_word_lists.php
+              - tools/project_manager/editproject.php
+              - tools/project_manager/generate_post_files.php
+              - tools/project_manager/handle_bad_page.php
+              - tools/project_manager/manage_image_sources.php
+              - tools/project_manager/page_operations.inc
+              - tools/project_manager/projectmgr.php
+              - tools/project_manager/show_good_word_suggestions_detail.php
+              - tools/project_manager/update_illos.php
+              - tools/project_manager/word_freq_table.inc
+              - tools/proofers/images_index.php
+              - tools/proofers/mktable.php
+              - tools/proofers/my_projects.php
+              - tools/proofers/my_suggestions.php
+              - tools/proofers/proof_frame.php
+              - tools/proofers/proof_frame_enh.inc
+              - tools/proofers/proof_frame_std.inc
+              - tools/proofers/review_work.php
+              - tools/proofers/spellcheck_text.inc
+              - tools/set_project_event_subs.php
+              - tools/site_admin/projects_with_odd_values.php
+              - tools/upload_resumable_file.php
+        - identifier: missingType.iterableValue
+          paths:
+              - pinc/3rdparty/mediawiki/DiffFormatter.php
+              - pinc/3rdparty/mediawiki/WordLevelDiff.php
+              - pinc/BBDiffFormatter.inc
+              - api/exceptions.inc
+              - api/v1_docs.inc
+              - api/v1_projects.inc
+              - api/v1_queues.inc
+              - api/v1_stats.inc
+              - api/v1_storage.inc
+              - api/v1_validators.inc
+              - credits.php
+              - index.php
+              - tasks.php
+              - tools/project_manager/page_compare.php
+              - tools/project_manager/show_adhoc_word_details.php
+              - tools/project_manager/show_all_good_word_suggestions.php
+              - tools/project_manager/show_current_flagged_words.php
+              - tools/project_manager/show_good_word_suggestions.php
+              - tools/project_manager/show_project_possible_bad_words.php
+              - tools/project_manager/show_project_stealth_scannos.php
+              - tools/project_manager/word_freq_table.inc
+              - tools/proofers/for_mentors.php
+              - tools/proofers/spellcheck_text.inc
+              - tools/site_admin/copy_pages.php
+              - tools/site_admin/delete_pages.php
+              - tools/site_admin/shared_postednums.php
+              - tools/site_search.php
+        - identifier: missingType.property
+          paths:
+              - pinc/3rdparty/mediawiki/DiffEngine.php
+              - pinc/3rdparty/mediawiki/WordAccumulator.php
+              - pinc/BBDiffFormatter.inc
+              - crontab/AutoModify.inc
+
         # Errors in third party code, and our interfaces to it
         - message: '#Property .* does not accept false#'
           path: pinc/3rdparty/mediawiki/DairikiDiff.php
@@ -78,5 +254,24 @@ parameters:
                     string,
                     array{type?: string, x: string[], y: mixed[]}
                     >,
+            }
+            """
+        # TODO: Fix duplication between this and class SpecialDay
+        SpecialDayInfo: """
+            array{
+                spec_code?: string,
+                display_name: string,
+                enable?: int,
+                comment?: string,
+                color: string,
+                open_day?: int,
+                open_month?: int,
+                close_day?: int,
+                close_month?: int,
+                date_changes?: string,
+                info_url?: string,
+                image_url?: string,
+                symbol: string,
+                option_label?: string,
             }
             """

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -3,6 +3,7 @@
 include_once($relPath.'dpsql.inc');
 include_once($relPath.'page_tally.inc');
 
+/** @return array{string, string} */
 function get_graph_js_files()
 {
     global $code_url;
@@ -12,7 +13,8 @@ function get_graph_js_files()
     ];
 }
 
-function build_svg_graph_inits($graphs)
+/** @param list{string, string, GraphConfig}[] $graphs */
+function build_svg_graph_inits(array $graphs): string
 {
     foreach ($graphs as [$type, $id, $config]) {
         $js_data[] = "$type('$id', " . json_encode($config) . ");";
@@ -20,7 +22,8 @@ function build_svg_graph_inits($graphs)
     return "window.addEventListener('DOMContentLoaded', function(){" . join($js_data) . "});";
 }
 
-function cumulative_total_proj_summary_graph()
+/** @return GraphConfig */
+function cumulative_total_proj_summary_graph(): array
 {
     $max_num_data = 0;
     $data = [];
@@ -61,7 +64,12 @@ function cumulative_total_proj_summary_graph()
     ];
 }
 
-function user_logging_on($past, $preceding)
+/**
+ * @param 'year'|'day' $past
+ * @param 'hour'|'day'|'week'|'fourweek' $preceding
+ * @return GraphConfig
+ */
+function user_logging_on(string $past, string $preceding): array
 {
     // For each hour in the $past interval,
     // show the number of (distinct) users who had logged in
@@ -139,7 +147,8 @@ function user_logging_on($past, $preceding)
     ];
 }
 
-function tallyboard_deltas($tally_name, $holder_type, $holder_id, $days_back)
+/** @return GraphConfig */
+function tallyboard_deltas(string $tally_name, string $holder_type, int $holder_id, int $days_back): array
 {
     $valid_tally_names = array_keys(get_page_tally_names());
 
@@ -173,7 +182,8 @@ function tallyboard_deltas($tally_name, $holder_type, $holder_id, $days_back)
     ];
 }
 
-function new_users($time_interval)
+/** @return GraphConfig */
+function new_users(string $time_interval): array
 {
     $time_interval_options = [
         'day' => [
@@ -223,7 +233,8 @@ function new_users($time_interval)
     ];
 }
 
-function average_hour_users_logging_on()
+/** @return GraphConfig */
+function average_hour_users_logging_on(): array
 {
     ///////////////////////////////////////////////////
     //Numbers of users logging on in each hour of the day, since the start of stats
@@ -251,7 +262,8 @@ function average_hour_users_logging_on()
     ];
 }
 
-function users_by_language()
+/** @return GraphConfig */
+function users_by_language(): array
 {
     $res = DPDatabase::query("
         SELECT IFNULL(LEFT(u_intlang, 2), '') AS intlang, COUNT(*) AS num
@@ -288,7 +300,8 @@ function users_by_language()
     ];
 }
 
-function users_by_country()
+/** @return GraphConfig */
+function users_by_country(): array
 {
     $res = DPDatabase::query("
         SELECT SUBSTRING_INDEX(email, '.' ,-1) AS domain, COUNT(*) AS num
@@ -320,8 +333,10 @@ function users_by_country()
 
 /**
  * Return the array defined by $result[$i] = $arr[$i+1] - $arr[$i]
+ * @param mixed[] $arr
+ * @return mixed[]
  */
-function array_successive_differences($arr)
+function array_successive_differences(array $arr): array
 {
     $result = [];
     foreach ($arr as $key => $value) {
@@ -334,7 +349,7 @@ function array_successive_differences($arr)
     return $result;
 }
 
-function get_number_of_days_in_current_month()
+function get_number_of_days_in_current_month(): int
 {
     $current = getdate();
     // The last day of this month is the "zeroth" day of next month.
@@ -344,7 +359,8 @@ function get_number_of_days_in_current_month()
     return $last_day['mday'];
 }
 
-function curr_month_proj($which)
+/** @return GraphConfig */
+function curr_month_proj(string $which): array
 {
     // Create "projects Xed per day" graph for current month
 
@@ -398,8 +414,10 @@ function curr_month_proj($which)
 
 /**
  * Return the array defined by $result[$i] = $arr[$i] - $arr[0]
+ * @param mixed[] $arr
+ * @return mixed[]
  */
-function array_subtract_first_from_each($arr)
+function array_subtract_first_from_each(array $arr): array
 {
     $result = [];
     foreach ($arr as $key => $value) {
@@ -411,7 +429,8 @@ function array_subtract_first_from_each($arr)
     return $result;
 }
 
-function cumulative_month_proj($which)
+/** @return GraphConfig */
+function cumulative_month_proj(string $which): array
 {
     // Create "projects Xed per day" graph for current month
 
@@ -468,7 +487,8 @@ function cumulative_month_proj($which)
     ];
 }
 
-function total_proj_graph($which)
+/** @return GraphConfig */
+function total_proj_graph(string $which): array
 {
     //Create "projects Xed per day" graph for all known history
 
@@ -503,7 +523,8 @@ function total_proj_graph($which)
     ];
 }
 
-function cumulative_total_proj_graph($which)
+/** @return GraphConfig */
+function cumulative_total_proj_graph(string $which): array
 {
     // Create "cumulative projects Xed per day" graph for all days
     // since state stats started being recorded up to yesterday
@@ -539,7 +560,8 @@ function cumulative_total_proj_graph($which)
     ];
 }
 
-function total_pages_by_month_graph($tally_name)
+/** @return GraphConfig */
+function total_pages_by_month_graph(string $tally_name): array
 {
     ///////////////////////////////////////////////////
     //Total pages by month since beginning of stats
@@ -574,8 +596,10 @@ function total_pages_by_month_graph($tally_name)
 
 /**
  * Return the array defined by: $result[$i] = sum( $arr[$j] for $j up to and including $i )
+ * @param mixed[] $arr
+ * @return mixed[]
  */
-function array_accumulate($arr)
+function array_accumulate(array $arr): array
 {
     $result = [];
     $sum = 0;
@@ -586,7 +610,11 @@ function array_accumulate($arr)
     return $result;
 }
 
-function pages_daily(string $tally_name, string $c_or_i, string $timeframe)
+/**
+ * @param 'increments'|'cumulative' $c_or_i
+ * @return GraphConfig
+ */
+function pages_daily(string $tally_name, string $c_or_i, string $timeframe): array
 {
     $now_timestamp = time();
     $now_assoc = getdate($now_timestamp);
@@ -679,8 +707,9 @@ function pages_daily(string $tally_name, string $c_or_i, string $timeframe)
  *
  * @param string $which
  *   A word denoting a round ID or a phase (NEW, PP, GB)
+ * @param string[]|string|null $desired_states
  */
-function _get_project_state_selector($which, $desired_states = null)
+function _get_project_state_selector(string $which, array|string|null $desired_states = null): string
 {
     if (null == $desired_states) {
         $desired_states = ["unavailable", "waiting", "bad", "available", "complete"];
@@ -717,7 +746,11 @@ function _get_project_state_selector($which, $desired_states = null)
     throw new UnexpectedValueException("bad value for 'which': '$which'");
 }
 
-function get_round_backlog_stats($interested_phases)
+/**
+ * @param string[] $interested_phases
+ * @return int[]
+ */
+function get_round_backlog_stats(array $interested_phases): array
 {
     // Pull the stats data out of the database
     $stats = [];
@@ -754,11 +787,16 @@ function get_round_backlog_stats($interested_phases)
 /**
  * Given a function and arguments that will generate graph data, attempt
  * to cache the value.
+ * A very thin wrapper around memoize_function that returns `GraphConfig`
+ * rather than `mixed` to make it clearer to PHPStan what's happening.
  *
  * Note that the graph function might include _() so it's important that we
  * include the user's language in the key.
+ * @param callable-string $function
+ * @param mixed[] $args
+ * @return GraphConfig
  */
-function query_graph_cache($function, $args = [], $expiration = 3600)
+function query_graph_cache(string $function, array $args = [], int $expiration = 3600): array
 {
     return memoize_function($function, $args, $expiration, get_desired_language());
 }

--- a/pinc/html_page_common.inc
+++ b/pinc/html_page_common.inc
@@ -13,7 +13,7 @@ define('SHOW_STATSBAR', true);
  * Output the opening HTML page code, including pulling in common styles,
  * page title, etc.
  *
- * @param array<string, mixed> $extra_args
+ * @param HeaderExtraArgs $extra_args
  */
 function output_html_header(?string $nameofpage, array $extra_args = [], bool $show_statsbar = true): void
 {

--- a/pinc/slim_header.inc
+++ b/pinc/slim_header.inc
@@ -3,18 +3,9 @@ include_once($relPath."html_page_common.inc");
 
 /**
  * Output valid HTML to begin a non-themed page.
- *
- * @param array $extra_args
- *   An associative array to control what exactly is output. Valid keys:
- *   - 'frameset' => FALSE (default) | TRUE
- *   - 'head_data' => strings to output as-is in <head> tag
- *   - 'css_files' => CSS files to include in the page
- *   - 'css_data' => CSS to include in the page
- *   - 'js_data'  => JS code to include in the page,
- *   - 'js_files' => array of .js files to link to
- *   - 'body_attributes' => body tag attributes to output
+ * @param HeaderExtraArgs $extra_args
  */
-function slim_header($title = "", $extra_args = [])
+function slim_header(string $title = "", array $extra_args = []): void
 {
     global $code_url;
 
@@ -31,13 +22,15 @@ function slim_header($title = "", $extra_args = [])
     register_shutdown_function('slim_footer', $extra_args);
 }
 
-function slim_header_frameset($title = "", $extra_args = [])
+/** @param HeaderExtraArgs $extra_args */
+function slim_header_frameset(string $title = "", array $extra_args = []): void
 {
     $extra_args['frameset'] = true;
     slim_header($title, $extra_args);
 }
 
-function slim_footer($extra_args = [])
+/** @param array<string, mixed> $extra_args */
+function slim_footer(array $extra_args = []): void
 {
     // Despite not needing to, some pages may still be calling slim_footer
     // so check to see if we've already output the footer.

--- a/pinc/special_colors.inc
+++ b/pinc/special_colors.inc
@@ -1,9 +1,9 @@
 <?php
-
 /**
  * Return a set of hard-coded special days keyed by spec_code
+ * @return array<string, SpecialDayInfo>
  */
-function load_common_special_days()
+function load_common_special_days(): array
 {
     return [
         "_BIRTHDAY_RECENT" => [
@@ -24,7 +24,8 @@ function load_common_special_days()
     ];
 }
 
-function load_special_days($load_common = false)
+/** @return array<string, SpecialDayInfo> */
+function load_special_days(bool $load_common = false): array
 {
     if ($load_common) {
         $specials_array = load_common_special_days();
@@ -62,10 +63,13 @@ function load_special_days($load_common = false)
         );
     }
 
-    return $specials_array;
+    return $specials_array; // @phpstan-ignore-line return.type
 }
-
-function sort_special_days(&$special_days, $sort_by = "display_name")
+/**
+ * @param SpecialDayInfo[] $special_days
+ * @param 'display_name'|'open_month,open_day' $sort_by
+ */
+function sort_special_days(array &$special_days, string $sort_by = "display_name"): void
 {
     $display_name = array_column($special_days, "display_name");
     $display_name = array_map('strtolower', $display_name);
@@ -100,8 +104,9 @@ function sort_special_days(&$special_days, $sort_by = "display_name")
 /**
  * Returns the special day array associated with this
  * project, or null if no such special day is specified.
+ * @return ?SpecialDayInfo
  */
-function get_special_day($special_code)
+function get_special_day(?string $special_code): ?array
 {
     static $specials_array = [];
     if (!$specials_array) {
@@ -146,7 +151,7 @@ function get_special_day($special_code)
  * specified by $projects_where_clause (WHERE keyword NOT needed)
  * for use as a legend.
  */
-function echo_special_legend($projects_where_clause)
+function echo_special_legend(string $projects_where_clause): void
 {
     global $code_url;
 
@@ -207,8 +212,10 @@ function echo_special_legend($projects_where_clause)
 
 /**
  * Given a special day, return building blocks to construct a cell for a row
+ * @param SpecialDayInfo $special_day
+ * @return list{string, string}
  */
-function get_special_day_cell_parts($special_day, $include_title = true)
+function get_special_day_cell_parts(array $special_day, bool $include_title = true): array
 {
     $background_color = str_replace("#", "", $special_day['color']);
     $text_color = pick_text_color_given_bgcolor($background_color, "white", "black");
@@ -230,7 +237,7 @@ function get_special_day_cell_parts($special_day, $include_title = true)
  *
  * From https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
  */
-function pick_text_color_given_bgcolor($bg_color, $light_color, $dark_color)
+function pick_text_color_given_bgcolor(string $bg_color, string $light_color, string $dark_color): string
 {
     $color = str_replace("#", "", $bg_color);
 

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -15,7 +15,7 @@ include_once($relPath.'job_log.inc');
 /**
  * Emit the opening markup and theme tags, and register a callback
  * to close the page after the caller finishes output.
- * @param array<string, mixed> $extra_args
+ * @param HeaderExtraArgs $extra_args
  */
 function output_header(string $nameofpage, bool $show_statsbar = false, array $extra_args = []): void
 {

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -49,7 +49,7 @@ function get_big_upload_blurb(): string
 /**
  * This supplies the arguments for the header in the page containing the upload
  * form below
- * @return array<string, string|string[]>
+ * @return HeaderExtraArgs
  */
 function get_upload_args(): array
 {

--- a/stats/pages_proofed_graphs.php
+++ b/stats/pages_proofed_graphs.php
@@ -20,32 +20,32 @@ $graphs = [
     [
         "barLineGraph",
         "pages_daily_increments_curr_month",
-        query_graph_cache("pages_daily", [$tally_name, "increments", "curr_month"], $tomorrow_midnight->format("U")),
+        query_graph_cache("pages_daily", [$tally_name, "increments", "curr_month"], $tomorrow_midnight->getTimestamp()),
     ],
     [
         "barLineGraph",
         "pages_daily_cumulative_curr_month",
-        query_graph_cache("pages_daily", [$tally_name, "cumulative", "curr_month"], $tomorrow_midnight->format("U")),
+        query_graph_cache("pages_daily", [$tally_name, "cumulative", "curr_month"], $tomorrow_midnight->getTimestamp()),
     ],
     [
         "barLineGraph",
         "pages_daily_increments_prev_month",
-        query_graph_cache("pages_daily", [$tally_name, "increments", "prev_month"], $first_next_month->format("U")),
+        query_graph_cache("pages_daily", [$tally_name, "increments", "prev_month"], $first_next_month->getTimestamp()),
     ],
     [
         "barLineGraph",
         "pages_daily_increments_all_time",
-        query_graph_cache("pages_daily", [$tally_name, "increments", "all_time"], $first_next_week->format("U")),
+        query_graph_cache("pages_daily", [$tally_name, "increments", "all_time"], $first_next_week->getTimestamp()),
     ],
     [
         "barLineGraph",
         "pages_daily_cumulative_all_time",
-        query_graph_cache("pages_daily", [$tally_name, "cumulative", "all_time"], $first_next_week->format("U")),
+        query_graph_cache("pages_daily", [$tally_name, "cumulative", "all_time"], $first_next_week->getTimestamp()),
     ],
     [
         "barLineGraph",
         "total_pages_by_month_graph",
-        query_graph_cache("total_pages_by_month_graph", [$tally_name], $first_next_month->format("U")),
+        query_graph_cache("total_pages_by_month_graph", [$tally_name], $first_next_month->getTimestamp()),
     ],
 ];
 

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -36,7 +36,7 @@ function _get_pages_posted_data($start_timestamp)
 // Get the total pages for projects that have posted in current month
 $start_timestamp = mktime(0, 0, 0, (int)date('m'), 1, (int)date('Y'));
 // cache pages posted data for 1 hour
-$pp_pages_total = query_graph_cache("_get_pages_posted_data", [$start_timestamp], 60 * 60);
+$pp_pages_total = memoize_function("_get_pages_posted_data", [$start_timestamp], 60 * 60);
 
 // calculate the goal percent as long as $pp_page_goal isn't zero
 if ($pp_page_goal != 0) {

--- a/tools/site_admin/manage_special_days.php
+++ b/tools/site_admin/manage_special_days.php
@@ -213,7 +213,9 @@ class SpecialDay
         echo "</form>\n";
         echo "</td>\n";
         echo "<td>" . html_safe($this->display_name) . "</td>";
-        [$style, $cell] = get_special_day_cell_parts((array)$this);
+        /** @var SpecialDayInfo */
+        $sd = (array) $this;
+        [$style, $cell] = get_special_day_cell_parts($sd);
         echo "<td style='$style'>$cell</td>";
         echo "<td>" . $this->color . "</td>\n";
         echo $this->_get_status_cell($this->enable, ' pb') . "\n";


### PR DESCRIPTION
This time, take some large and widely used associative arrays and define their array shapes as type aliases in `phpstan.neon`.

This allows us to cleanly identify the graph generation functions in `pinc/graph_data.inc`, for example -- they're the functions that return a `GraphConfig`.

Notes:

- `GraphConfig` is most naturally represented as an array, as it exists to be serialized into a JSON string that's passed to the JavaScript plotting library. We could potentially make  into a DTO, but then we'd need to write a custom JSON serialiser (using reflection) to ignore default fields, and I don't think it's worth it. Also config.data.y cannot easily be declared as `(int|float)[]` until we do a lot of cleanup elsewhere in the code.
- `SpecialDayInfo` should perhaps be converted into a DTO. Also some of its functionality overlaps with `class SpecialDay` in `tools/site_admin/manage_special_days.php`. This ball of string should be disentangled, but that's another project.
- `HeaderExtraArgs` could also be a DTO. 