### PR TITLE
More PHPStan level 6 cleanups, some *.php files

### DIFF
--- a/accounts/addproofer.php
+++ b/accounts/addproofer.php
@@ -214,7 +214,7 @@ include($relPath.'/../faq/privacy.php');
 /**
  * Validate the user input fields for the page.
  *
- * Returns an empty string or Null upon success and an error message upon failure.
+ * Returns an empty string on success and an error message on failure.
  */
 function _validate_fields(
     string $real_name,
@@ -226,7 +226,7 @@ function _validate_fields(
     bool $email_updates,
     string $referrer,
     string $referrer_details
-) {
+): string {
     // Make sure that password and confirmed password are equal.
     if ($userpass != $userpass2) {
         return _("The passwords you entered were not equal.");
@@ -254,8 +254,7 @@ function _validate_fields(
 
     // Do some validity-checks on inputted username, password, e-mail and real name
 
-    $err = check_username($username, true);
-    if ($err != '') {
+    if (($err = check_username($username, true)) != '') {
         return $err;
     }
 
@@ -264,8 +263,7 @@ function _validate_fields(
     // thinks the domain should end in a 2-63 character top level
     // domain, so disable the address check for testing.
     if (!SiteConfig::get()->testing) {
-        $err = check_email_address($email);
-        if ($err != '') {
+        if (($err = check_email_address($email)) != '') {
             return $err;
         }
     }
@@ -303,7 +301,7 @@ function _validate_fields(
     return '';
 }
 
-function _validate_csrf()
+function _validate_csrf(): string
 {
     try {
         validate_csrf_token();

--- a/accounts/login.php
+++ b/accounts/login.php
@@ -127,7 +127,7 @@ metarefresh(0, $url);
  * @param string $destination
  *   A URL where the user should be redirected back to upon a successful login.
  */
-function login_failure($error_code, $destination)
+function login_failure(string $error_code, string $destination): never
 {
     global $code_url;
 

--- a/api/index.php
+++ b/api/index.php
@@ -28,7 +28,7 @@ api();
 
 // ---------------------------------------------------------------------------
 
-function api()
+function api(): void
 {
     $username = api_authenticate();
 
@@ -43,7 +43,7 @@ function api()
     api_output_response($router->response());
 }
 
-function api_authenticate()
+function api_authenticate(): string
 {
     global $pguser;
 
@@ -71,7 +71,7 @@ function api_authenticate()
     return $pguser;
 }
 
-function api_rate_limit($key)
+function api_rate_limit(string $key): void
 {
     if (!SiteConfig::get()->api_rate_limit) {
         return;
@@ -124,13 +124,13 @@ function api_rate_limit($key)
     header("X-Rate-Limit-Reset: $seconds_before_reset");
 }
 
-function api_get_request_body(bool $raw = false)
+function api_get_request_body(bool $raw = false): mixed
 {
     $router = ApiRouter::get_router();
     return $router->request($raw);
 }
 
-function api_output_response(string $data, int $response_code = 200)
+function api_output_response(string $data, int $response_code = 200): never
 {
     // drop the output buffer we've been storing to prevent errant output
     // from violating the JSON response
@@ -141,7 +141,8 @@ function api_output_response(string $data, int $response_code = 200)
     exit();
 }
 
-function api_send_pagination_header($query_params, $total_rows, $per_page, $page)
+/** @param array<string, string|string[]> $query_params */
+function api_send_pagination_header(array $query_params, int $total_rows, int $per_page, int $page): void
 {
     header("X-Results-Total: $total_rows");
 
@@ -203,7 +204,7 @@ function api_send_pagination_header($query_params, $total_rows, $per_page, $page
     header("Link: " . implode(", ", $link_header));
 }
 
-function handle_cors_headers()
+function handle_cors_headers(): void
 {
     // Enable CORS for some sites
     $allowed_origins = [

--- a/credits.php
+++ b/credits.php
@@ -25,38 +25,51 @@ echo "<h2>" . _("Dependencies"). "</h2>";
 
 echo "<p>" . _("The following open source dependencies are used by the dproofreaders code.") . "</p>";
 
+class CreditDetails
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $license,
+        public readonly ?string $url,
+        public readonly ?string $license_url
+    ) {
+    }
+}
+
 $credit_details = array_merge(
     load_composer_credit_details(),
     load_npm_credit_details()
 );
-uksort($credit_details, "strcasecmp");
+uksort($credit_details, strcasecmp(...));
 output_credit_details($credit_details);
 
 //----------------------------------------------------------------------------
 
-function output_credit_details($credit_details)
+/** @param array<string, CreditDetails> $credit_details */
+function output_credit_details(array $credit_details): void
 {
     echo "<ul>";
     foreach ($credit_details as $detail) {
         echo "<li>";
         echo "<b>";
-        if ($detail["url"]) {
-            echo "<a href='" . $detail["url"] . "'>" . html_safe($detail["name"]) . "</a>";
+        if ($detail->url) {
+            echo "<a href='" . $detail->url . "'>" . html_safe($detail->name) . "</a>";
         } else {
-            echo html_safe($detail["name"]);
+            echo html_safe($detail->name);
         }
         echo "</b><br>";
-        if (isset($detail["license_url"])) {
-            echo _("License") . ": <a href='" . $detail["license_url"] . "'>" . html_safe($detail["license"]) . "</a>";
+        if (isset($detail->license_url)) {
+            echo _("License") . ": <a href='" . $detail->license_url . "'>" . html_safe($detail->license) . "</a>";
         } else {
-            echo _("License") . ": " . html_safe($detail["license"]);
+            echo _("License") . ": " . html_safe($detail->license);
         }
         echo "</li>";
     }
     echo "</ul>";
 }
 
-function load_bundled_credit_details($code_dir)
+/** @return array<string, CreditDetails> */
+function load_bundled_credit_details(string $code_dir): array
 {
     $credit_details = [];
     $files = new RecursiveIteratorIterator(
@@ -74,30 +87,38 @@ function load_bundled_credit_details($code_dir)
             $details = [$details];
         }
         foreach ($details as $detail) {
-            $credit_details[$detail["name"]] = $detail;
+            $credit_details[$detail["name"]] = new CreditDetails(
+                name: $detail["name"],
+                url: $detail["url"] ?? null,
+                license: $detail["license"],
+                license_url: $detail["license_url"] ?? null
+            );
         }
     }
 
-    uksort($credit_details, "strcasecmp");
+    uksort($credit_details, strcasecmp(...));
     return $credit_details;
 }
 
+/** @return array<string, CreditDetails> */
 function load_composer_credit_details()
 {
     global $code_dir;
 
     $packages = json_decode(file_get_contents("$code_dir/composer.lock"));
     foreach ($packages->packages as $index => $package) {
-        $credit_details[$package->name] = [
-            "name" => $package->name,
-            "url" => $package->homepage ?? null,
-            "license" => join(", ", $package->license),
-        ];
+        $credit_details[$package->name] = new CreditDetails(
+            name: $package->name,
+            url: $package->homepage ?? null,
+            license: join(", ", $package->license),
+            license_url: null
+        );
     }
 
     return $credit_details;
 }
 
+/** @return array<string, CreditDetails> */
 function load_npm_credit_details()
 {
     global $code_dir;
@@ -111,11 +132,12 @@ function load_npm_credit_details()
     foreach ($packages["packages"] as $name => $package) {
         $short_name = str_replace("node_modules/", "", $name);
         if (in_array($short_name, $dependencies)) {
-            $credit_details[$short_name] = [
-                "name" => $short_name,
-                "url" => null,
-                "license" => $package["license"],
-            ];
+            $credit_details[$short_name] = new CreditDetails(
+                name: $short_name,
+                url: null,
+                license: $package["license"],
+                license_url: null,
+            );
         }
     }
 
@@ -126,8 +148,9 @@ function load_npm_credit_details()
  * Detect if an array is associative or sequential
  *
  * From https://stackoverflow.com/questions/173400/how-to-check-if-php-array-is-associative-or-sequential
+ * @param array<mixed, mixed>|list<mixed> $arr
  */
-function isAssoc(array $arr)
+function isAssoc(array $arr): bool
 {
     if ([] === $arr) {
         return false;

--- a/faq/font_sample.php
+++ b/faq/font_sample.php
@@ -72,7 +72,7 @@ foreach ($character_sets as $set) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_font_specimen($name, $font)
+function show_font_specimen(string $name, string $font): void
 {
     echo "<div style='float: left; margin-right: 1em; margin-top: 0;'>";
     //echo "<h3>$name</h3>";

--- a/faq/privacy.php
+++ b/faq/privacy.php
@@ -114,7 +114,7 @@ output_section(
 
 //---------------------------------------------------------------------------
 
-function insert_site_name($sentence)
+function insert_site_name(string $sentence): string
 {
     return sprintf($sentence, SiteConfig::get()->site_name);
 }
@@ -123,8 +123,9 @@ function insert_site_name($sentence)
  * Output a paragraph of sentences.
  *
  * Each sentence will have the first sprintf argument replaced with $site_name.
+ * @param string[] $sentences
  */
-function output_paragraph($sentences)
+function output_paragraph(array $sentences): void
 {
     echo "<p>";
     echo implode(" ", array_map("insert_site_name", $sentences));
@@ -138,13 +139,12 @@ function output_paragraph($sentences)
  * The number of arguments this function accepts is variable, and is of the
  * format ($header, $paragraph1, $paragraph2, ...) where each paragraph is
  * an array of strings (ie: sentences).
+ * @param string[] ...$paragraphs
  */
-function output_section()
+function output_section(string $header, array ...$paragraphs): void
 {
-    $arguments = func_get_args();
-    $header = array_shift($arguments);
     echo "<h3>$header</h3>";
-    foreach ($arguments as $paragraph) {
+    foreach ($paragraphs as $paragraph) {
         output_paragraph($paragraph);
     }
 }

--- a/faq/prooffacehelp.php
+++ b/faq/prooffacehelp.php
@@ -425,7 +425,7 @@ COLSPAN="2">
 
 <?php
 
-function echo_row($name, $tooltip, $button_image_base, $accelerator)
+function echo_row(string $name, string $tooltip, string $button_image_base, string $accelerator): void
 {
     global $help;
     echo "<TR><TD class='top-align'>\n";

--- a/faq/wordcheck_data.php
+++ b/faq/wordcheck_data.php
@@ -21,7 +21,8 @@ echo "<p>" . _("Possible Bad word lists are used to suggest possible Bad words f
 
 createWordListTable(get_site_possible_bad_word_lists());
 
-function createWordListTable($word_lists)
+/** @param array<string, string> $word_lists */
+function createWordListTable(array $word_lists): void
 {
     // return if there aren't any word_lists
     if (count($word_lists) == 0) {

--- a/index.php
+++ b/index.php
@@ -154,7 +154,11 @@ echo sprintf(
 );
 echo "</p>\n";
 
-function _get_user_counts(array $days_back_set)
+/**
+ * @param int[] $days_back_set
+ * @return array<int, int>
+ */
+function _get_user_counts(array $days_back_set): array
 {
     $results = [];
     foreach ($days_back_set as $days_back) {

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -225,7 +225,7 @@ elseif ($func == "merge") {
 }
 
 
-function main_form()
+function main_form(): void
 {
     // display the list of languages with links to the downloadable PO files
 
@@ -348,7 +348,7 @@ function main_form()
 }
 
 
-function manage_form($locale)
+function manage_form(string $locale): void
 {
     global $dyn_locales_dir, $translate_url;
 
@@ -449,7 +449,7 @@ function manage_form($locale)
     }
 }
 
-function do_upload($locale)
+function do_upload(string $locale): void
 {
     global $dyn_locales_dir;
 
@@ -518,7 +518,7 @@ function do_upload($locale)
     }
 }
 
-function do_merge($locale, $fuzzy)
+function do_merge(string $locale, ?string $fuzzy): void
 {
     global $dyn_locales_dir;
 
@@ -553,7 +553,7 @@ function do_merge($locale, $fuzzy)
     }
 }
 
-function validate_locale($locale, $check_dir_exists = true)
+function validate_locale(?string $locale, bool $check_dir_exists = true): string
 {
     global $dyn_locales_dir;
 
@@ -566,7 +566,7 @@ function validate_locale($locale, $check_dir_exists = true)
     return $locale;
 }
 
-function generate_js_only_po($po_filename)
+function generate_js_only_po(string $po_filename): string
 {
     if (!$tempfile = tempnam(sys_get_temp_dir(), "js_only")) {
         throw new RuntimeException("Unable to create temporary file");
@@ -588,7 +588,7 @@ function generate_js_only_po($po_filename)
     return $tempfile;
 }
 
-function build_translation_js()
+function build_translation_js(): void
 {
     global $dyn_locales_dir;
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,7 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - api/index.php
               - accounts/addproofer.php
               - accounts/login.php
               - credits.php
@@ -81,7 +80,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - api/index.php
               - credits.php
               - faq/font_sample.php
               - faq/privacy.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,12 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - stats/equilibria.php
-              - stats/index.php
-              - stats/misc_stats1.php
-              - stats/pp_stage_goal.php
-              - stats/round_backlog.php
-              - stats/round_backlog_days.php
               - tools/changestate.php
               - tools/modify_access.php
               - tools/post_proofers/ppv_report.php
@@ -64,10 +58,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - stats/equilibria.php
-              - stats/index.php
-              - stats/misc_stats1.php
-              - stats/pp_stage_goal.php
               - tools/changestate.php
               - tools/modify_access.php
               - tools/post_proofers/ppv_report.php
@@ -179,7 +169,9 @@ parameters:
                 downloadLabel?: string,
                 legendAdjustment?: array{x?: int, y?: int},
                 bottomLegend?: string,
-                data: array<
+                labels?: string[],
+                error?: string,
+                data: int[]|array<
                     string,
                     array{type?: string, x: string[], y: mixed[]}
                     >,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,8 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - accounts/addproofer.php
-              - accounts/login.php
               - credits.php
               - faq/font_sample.php
               - faq/privacy.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,12 +26,10 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - credits.php
               - faq/font_sample.php
               - faq/privacy.php
               - faq/prooffacehelp.php
               - faq/wordcheck_data.php
-              - index.php
               - locale/translators/index.php
               - quiz/generic/returnfeed.php
               - quiz/generic/wizard/checks.php
@@ -45,7 +43,6 @@ parameters:
               - stats/pp_stage_goal.php
               - stats/round_backlog.php
               - stats/round_backlog_days.php
-              - tasks.php
               - tools/changestate.php
               - tools/modify_access.php
               - tools/post_proofers/ppv_report.php
@@ -78,7 +75,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - credits.php
               - faq/font_sample.php
               - faq/privacy.php
               - faq/prooffacehelp.php
@@ -93,7 +89,6 @@ parameters:
               - stats/index.php
               - stats/misc_stats1.php
               - stats/pp_stage_goal.php
-              - tasks.php
               - tools/changestate.php
               - tools/modify_access.php
               - tools/post_proofers/ppv_report.php
@@ -119,9 +114,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.iterableValue
           paths:
-              - credits.php
-              - index.php
-              - tasks.php
               - tools/project_manager/page_compare.php
               - tools/project_manager/show_adhoc_word_details.php
               - tools/project_manager/show_all_good_word_suggestions.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,7 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - locale/translators/index.php
               - quiz/generic/returnfeed.php
               - quiz/generic/wizard/checks.php
               - quiz/generic/wizard/messages.php
@@ -71,7 +70,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - locale/translators/index.php
               - quiz/generic/returnfeed.php
               - quiz/generic/wizard/messages.php
               - quiz/generic/wizard/output.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,10 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - faq/font_sample.php
-              - faq/privacy.php
-              - faq/prooffacehelp.php
-              - faq/wordcheck_data.php
               - locale/translators/index.php
               - quiz/generic/returnfeed.php
               - quiz/generic/wizard/checks.php
@@ -75,10 +71,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - faq/font_sample.php
-              - faq/privacy.php
-              - faq/prooffacehelp.php
-              - faq/wordcheck_data.php
               - locale/translators/index.php
               - quiz/generic/returnfeed.php
               - quiz/generic/wizard/messages.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,12 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - quiz/generic/returnfeed.php
-              - quiz/generic/wizard/checks.php
-              - quiz/generic/wizard/messages.php
-              - quiz/generic/wizard/output.php
-              - quiz/generic/wizard/output_quiz.php
-              - quiz/generic/wizard/quiz_pages.php
               - stats/equilibria.php
               - stats/index.php
               - stats/misc_stats1.php
@@ -70,11 +64,6 @@ parameters:
               - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - quiz/generic/returnfeed.php
-              - quiz/generic/wizard/messages.php
-              - quiz/generic/wizard/output.php
-              - quiz/generic/wizard/output_quiz.php
-              - quiz/generic/wizard/quiz_pages.php
               - stats/equilibria.php
               - stats/index.php
               - stats/misc_stats1.php

--- a/pinc/graph_data.inc
+++ b/pinc/graph_data.inc
@@ -748,7 +748,7 @@ function _get_project_state_selector(string $which, array|string|null $desired_s
 
 /**
  * @param string[] $interested_phases
- * @return int[]
+ * @return array<string, int>
  */
 function get_round_backlog_stats(array $interested_phases): array
 {
@@ -763,7 +763,7 @@ function get_round_backlog_stats(array $interested_phases): array
         ";
         $res = DPDatabase::query($sql);
         while ($result = mysqli_fetch_assoc($res)) {
-            $stats[$phase] = $result["num_pages"];
+            $stats[$phase] = $result["num_pages"] ?? 0; // SELECT SUM() WHERE 0; returns NULL
         }
         mysqli_free_result($res);
     }

--- a/pinc/metarefresh.inc
+++ b/pinc/metarefresh.inc
@@ -10,8 +10,7 @@
  * client (determined if headers have been sent or if the output buffer
  * has contents in it).
  */
-/** @return never */
-function metarefresh(int $seconds, string $url, string $title = "", string $body = "", bool $allow_external = false)
+function metarefresh(int $seconds, string $url, string $title = "", string $body = "", bool $allow_external = false): never
 {
     global $code_url;
 

--- a/quiz/generic/returnfeed.php
+++ b/quiz/generic/returnfeed.php
@@ -34,7 +34,7 @@ echo "\n</div>\n";
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function remove_insignificant_whitespace($x)
+function remove_insignificant_whitespace(string $x): string
 {
     // Remove blank lines at the bottom of the text
     // (and whitespace at the end of the last non-blank line).
@@ -42,18 +42,13 @@ function remove_insignificant_whitespace($x)
 
     // Remove whitespace at the end of each line.
     // (Note that this also converts line-ends from CRLF to just LF.)
-    $arr = explode("\n", $x);
-    foreach ($arr as $line) {
-        $out[] = rtrim($line);
-    }
-
-    return implode("\n", $out);
+    return implode("\n", array_map(rtrim(...), explode("\n", $x)));
 
     // This function is similar to _normalize_page_text() in pinc/DPage.inc.
     // Should we just call that one instead?
 }
 
-function handle_anticipated_error()
+function handle_anticipated_error(): bool
 {
     global $tests, $text;
 
@@ -68,7 +63,7 @@ function handle_anticipated_error()
     return false;
 }
 
-function handle_unanticipated_error()
+function handle_unanticipated_error(): bool
 {
     global $text;
 
@@ -77,7 +72,7 @@ function handle_unanticipated_error()
     return qp_compare_texts($text, $solution);
 }
 
-function handle_solved()
+function handle_solved(): bool
 {
     global $pguser;
     global $quiz_page_id;

--- a/quiz/generic/wizard/checks.php
+++ b/quiz/generic/wizard/checks.php
@@ -12,7 +12,7 @@ if (!user_is_a_sitemanager()) {
 
 output_header(_('Quiz Wizard'));
 
-function evalchecks()
+function evalchecks(): void
 {
     $test['type'] = $_POST['type'];
     if ($test['type'] == '') {

--- a/quiz/generic/wizard/messages.php
+++ b/quiz/generic/wizard/messages.php
@@ -13,7 +13,7 @@ if (!user_is_a_sitemanager()) {
 
 output_header(_('Quiz Wizard'));
 
-function evalmessages()
+function evalmessages(): bool
 {
     if (isset($_SESSION['quiz_data']['messages'][$_POST['name']]) || $_POST['name'] == '') {
         return false;
@@ -39,7 +39,7 @@ function evalmessages()
 }
 
 
-function evalstart()
+function evalstart(): void
 {
     $_SESSION['quiz_data']['browser_title'] = $_POST['browser_title'];
     $_SESSION['quiz_data']['welcome'] = $_POST['welcome'];
@@ -69,12 +69,10 @@ function evalstart()
     $_SESSION['quiz_data']['links_out'] = $_POST['links_out'];
 }
 
-function filltext($x)
+function filltext(string $x): string
 {
     global $fill;
-    if ($fill) {
-        return html_safe($_POST[$x]);
-    }
+    return $fill ? html_safe($_POST[$x]) : "";
 }
 
 

--- a/quiz/generic/wizard/output.php
+++ b/quiz/generic/wizard/output.php
@@ -12,24 +12,33 @@ if (!user_is_a_sitemanager()) {
 
 output_header(_('Quiz Wizard'), NO_STATSBAR);
 
-function ssqs($x)
+function ssqs(string $x): string
 {
     return str_replace('\\\'', '\'', $x);
 }
 
-function enl($x)
+function enl(string $x): string
 {
     $out = str_replace("\r\n", '\n', $x);
     return str_replace("\n", '\n', $out);
 }
 
-function sdbsn($x)
+function sdbsn(string $x): string
 {
     return str_replace('\\\\n', '\\n', $x);
 }
 
+/**
+ * @param array<string, string> $a
+ * @return array<string, string>
+ */
+function ssqs_sdbsn_a(array $a): array
+{
+    $out = str_replace('\\\\n', '\\n', $a);
+    return str_replace('\\\'', '\'', $out);
+}
 
-function make_output()
+function make_output(): string
 {
     $out = '<?php' . "\n\n";
     $out .= 'function quizsolved()';
@@ -135,7 +144,7 @@ function make_output()
             $out .= '"';
         } elseif ($test['type'] == 'forbiddentext') {
             $out .= ', "searchtext" =>  array(';
-            foreach (ssqs(sdbsn($test['searchtext'])) as $numsearch => $search) {
+            foreach (ssqs_sdbsn_a($test['searchtext']) as $numsearch => $search) {
                 if ($numsearch != 0) {
                     $out .= ', ';
                 }
@@ -152,7 +161,7 @@ function make_output()
             $out .= '"';
         } elseif ($test['type'] == 'expectedtext') {
             $out .= ', "searchtext" =>  array(';
-            foreach (ssqs(sdbsn($test['searchtext'])) as $numsearch => $search) {
+            foreach (ssqs_sdbsn_a($test['searchtext']) as $numsearch => $search) {
                 if ($numsearch != 0) {
                     $out .= ', ';
                 }

--- a/quiz/generic/wizard/output_quiz.php
+++ b/quiz/generic/wizard/output_quiz.php
@@ -11,24 +11,24 @@ if (!user_is_a_sitemanager()) {
 
 output_header(_('Quiz Wizard'));
 
-function ssqs($x)
+function ssqs(string $x): string
 {
     return str_replace('\\\'', '\'', $x);
 }
 
-function enl($x)
+function enl(string $x): string
 {
     $out = str_replace("\r\n", '\n', $x);
     return str_replace("\n", '\n', $out);
 }
 
-function sdbsn($x)
+function sdbsn(string $x): string
 {
     return str_replace('\\\\n', '\\n', $x);
 }
 
 
-function make_output()
+function make_output(): string
 {
     $out = '$' . ssqs($_SESSION['quiz_data']['quiz_id']) . " = new Quiz(\n";
     $out .= ' "' . ssqs($_SESSION['quiz_data']['quiz_id']) . "\",\n";

--- a/quiz/generic/wizard/quiz_pages.php
+++ b/quiz/generic/wizard/quiz_pages.php
@@ -11,7 +11,7 @@ if (!user_is_a_sitemanager()) {
 
 output_header(_('Quiz Wizard'));
 
-function evalpages()
+function evalpages(): bool
 {
     if (isset($_SESSION['quiz_data']['pages'][$_POST['page_id']])) {
         return false;
@@ -21,7 +21,7 @@ function evalpages()
     }
 }
 
-function evalstart()
+function evalstart(): void
 {
     $_SESSION['quiz_data']['quiz_id'] = $_POST['quiz_id'];
     $_SESSION['quiz_data']['quiz_name'] = $_POST['quiz_name'];
@@ -30,12 +30,10 @@ function evalstart()
     $_SESSION['quiz_data']['thread'] = $_POST['thread'];
 }
 
-function filltext($x)
+function filltext(string $x): string
 {
     global $fill;
-    if ($fill) {
-        return html_safe($_POST[$x]);
-    }
+    return $fill ? html_safe($_POST[$x]) : "";
 }
 
 echo "<h2>" . _("Add Quiz Pages") . "</h2>";

--- a/stats/equilibria.php
+++ b/stats/equilibria.php
@@ -5,12 +5,12 @@ include_once($relPath.'theme.inc');
 include_once($relPath.'page_tally.inc');
 include_once($relPath.'graph_data.inc');
 
-$day_options = ["0", "1", "7", "28", "180"];
-$days = get_enumerated_param($_GET, "days", null, $day_options, true);
+$day_options = [0, 1, 7, 28, 180];
 
 $title = _("Equilibria");
 
-function display_graph($d)
+/** @return GraphConfig */
+function display_graph(int $d): array
 {
     $total_pages = 0;
 

--- a/stats/index.php
+++ b/stats/index.php
@@ -57,7 +57,7 @@ show_news_for_page("STATS");
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //General site stats with links to view the queue's
 
-function count_books_in_state($state, $clauses = "")
+function count_books_in_state(string $state, string $clauses = ""): int
 {
     $sql = sprintf(
         "

--- a/stats/misc_stats1.php
+++ b/stats/misc_stats1.php
@@ -75,7 +75,7 @@ show_month_sums('all_by_pages');
 
 // -----------------------------------------------------------------------------
 
-function show_all_time_total()
+function show_all_time_total(): void
 {
     global $tally_name;
 
@@ -91,7 +91,8 @@ function show_all_time_total()
     echo "<br>\n";
 }
 
-function show_top_days($limit, $when)
+/** @param 'ever' $when */
+function show_top_days(int $limit, string $when): void
 {
     global $tally_name, $curr_year, $curr_year_month;
 
@@ -127,7 +128,8 @@ function show_top_days($limit, $when)
     echo "<br>\n";
 }
 
-function show_month_sums($which)
+/** @param 'top_ten'|'all_chron'|'all_by_pages' $which */
+function show_month_sums(string $which): void
 {
     global $tally_name, $curr_year_month;
 

--- a/stats/pp_stage_goal.php
+++ b/stats/pp_stage_goal.php
@@ -16,7 +16,7 @@ foreach (Activities::get_all() as $activity) {
 $site_stats = get_site_page_tally_summary($round_before_PP);
 $pp_page_goal = $site_stats->curr_month_actual;
 
-function _get_pages_posted_data($start_timestamp)
+function _get_pages_posted_data(int $start_timestamp): int
 {
     $page_res = DPDatabase::query(sprintf(
         "
@@ -30,7 +30,7 @@ function _get_pages_posted_data($start_timestamp)
     ));
 
     $row = mysqli_fetch_row($page_res);
-    return $row[0];
+    return $row[0] ?? 0; // SELECT SUM() WHERE 0; returns NULL
 }
 
 // Get the total pages for projects that have posted in current month

--- a/stats/round_backlog.php
+++ b/stats/round_backlog.php
@@ -17,7 +17,8 @@ include_once($relPath.'slim_header.inc');
 $width = 300;
 $height = 200;
 
-function _get_round_backlog_data()
+/** @return array<string, int> */
+function _get_round_backlog_data(): array
 {
     // Pull all interested phases, primarily all the rounds and PP
     $interested_phases = Rounds::get_ids();

--- a/stats/round_backlog_days.php
+++ b/stats/round_backlog_days.php
@@ -15,7 +15,8 @@ include_once($relPath.'slim_header.inc');
 $width = 300;
 $height = 200;
 
-function _get_round_backlog_days_data()
+/** @return array<string, int|float> */
+function _get_round_backlog_days_data(): array
 {
     // Pull all interested phases, primarily all the rounds and PP
     $interested_phases = Rounds::get_ids();

--- a/tasks.php
+++ b/tasks.php
@@ -355,6 +355,7 @@ function SearchParams_echo_controls(): void
  * Return a SQL condition that expresses the restriction on tasks
  * implied by the values (if any) supplied for the search parameters
  * by the current request.
+ * @param array<string, mixed> $request_params
  */
 function SearchParams_get_sql_condition(array $request_params): string
 {
@@ -445,6 +446,7 @@ function make_default_task_object(): object
     return $task;
 }
 
+/** @param array<string, mixed> $formsub */
 function create_task_from_form_submission(array $formsub): ?string
 {
     global $task_assignees_array;
@@ -1028,6 +1030,7 @@ function TaskHeader(string $header, bool $show_new_alert = false): void
 
 /**
  * Encode an array into text for insertion into the database.
+ * @param mixed[] $a
  */
 function encode_array(array $a): string
 {
@@ -1040,6 +1043,7 @@ function encode_array(array $a): string
  * This should return an array, but if $str is empty,
  * unserialize("") === bool(false). In that case we explicitly return
  * an empty array.
+ * @return mixed[]
  */
 function decode_array(string $str): array
 {
@@ -1057,6 +1061,7 @@ function list_all_open_tasks(): void
     select_and_list_tasks("date_closed = 0");
 }
 
+/** @param array<string, mixed> $request_params */
 function search_and_list_tasks(array $request_params): void
 {
     $condition = SearchParams_get_sql_condition($request_params);
@@ -1229,6 +1234,7 @@ function TaskForm(object $task): void
 
 /**
  * Echo a <tr> element containing a label and a <select> for the given property.
+ * @param array<string|int, string> $options
  */
 function property_echo_select_tr(string $property_id, string $current_value, array $options): void
 {
@@ -1351,8 +1357,8 @@ function TaskDetails(int $tid, string $action): void
     }
 }
 
-/** param mixed $row */
-function property_echo_value_tr(string $property_id, $row, bool $show_if_empty = true): void
+/** @param array<string, mixed> $row */
+function property_echo_value_tr(string $property_id, array $row, bool $show_if_empty = true): void
 {
     $label = property_get_label($property_id, false);
     $formatted_value = property_format_value($property_id, $row, false);
@@ -1368,7 +1374,7 @@ function property_echo_value_tr(string $property_id, $row, bool $show_if_empty =
     echo "\n";
 }
 
-function get_me_too_count($task_id, $requester_u_id)
+function get_me_too_count(int $task_id, int $requester_u_id): int
 {
     $sql = sprintf(
         "
@@ -1384,7 +1390,7 @@ function get_me_too_count($task_id, $requester_u_id)
     return $meTooCheck;
 }
 
-function MeToo($tid, $os, $browser)
+function MeToo(int $tid, int $os, int $browser): void
 {
     global $tasks_url;
     global $requester_u_id;
@@ -1426,7 +1432,7 @@ function MeToo($tid, $os, $browser)
     echo "</td></tr></table></form></div>";
 }
 
-function ShowError($message, $goback = false)
+function ShowError(string $message, bool $goback = false): void
 {
     TaskHeader(_("Task Error"));
     echo "<p class='error'>";
@@ -1436,12 +1442,12 @@ function ShowError($message, $goback = false)
     echo "$message</p>\n";
 }
 
-function create_anchor_for_comment($u_id, $comment_date)
+function create_anchor_for_comment(int $u_id, mixed $comment_date): string
 {
     return "$u_id" . '_' . "$comment_date";
 }
 
-function TaskComments($tid, $action)
+function TaskComments(int $tid, string $action): void
 {
     global $tasks_url, $requester_u_id, $now_sse;
     $sql = sprintf(
@@ -1500,7 +1506,7 @@ function TaskComments($tid, $action)
     }
 }
 
-function NotificationMail($tid, $message, $new_task = false)
+function NotificationMail(int $tid, string $message, bool $new_task = false): void
 {
     global $tasks_url, $pguser;
 
@@ -1537,7 +1543,7 @@ function NotificationMail($tid, $message, $new_task = false)
     }
 }
 
-function RelatedTasks($tid)
+function RelatedTasks(int $tid): void
 {
     global $tasks_url, $tasks_status_array;
     echo "<h2>" . _("Related Tasks") . "</h2>";
@@ -1572,7 +1578,8 @@ function RelatedTasks($tid)
     echo "</table>";
 }
 
-function load_related_tasks($task_id)
+/** @return int[] */
+function load_related_tasks(int $task_id): array
 {
     $sql = sprintf(
         "
@@ -1600,7 +1607,7 @@ function load_related_tasks($task_id)
     return $related_tasks;
 }
 
-function insert_related_task($task1, $task2)
+function insert_related_task(int $task1, int $task2): void
 {
     $task_id_1 = min($task1, $task2);
     $task_id_2 = max($task1, $task2);
@@ -1635,12 +1642,12 @@ function insert_related_task($task1, $task2)
     $result = DPDatabase::query($sql);
 }
 
-function remove_related_task($task1, $task2)
+function remove_related_task(int $task1, int $task2): void
 {
     $task_id_1 = min($task1, $task2);
     $task_id_2 = max($task1, $task2);
 
-    // Now do the insertion
+    // Now do the removal
     $sql = sprintf(
         "
         DELETE FROM tasks_related_tasks
@@ -1653,7 +1660,7 @@ function remove_related_task($task1, $task2)
     $result = DPDatabase::query($sql);
 }
 
-function RelatedPostings($tid)
+function RelatedPostings(int $tid): void
 {
     global $tasks_url;
     $task = load_task($tid);
@@ -1702,7 +1709,7 @@ function RelatedPostings($tid)
     echo "</table>";
 }
 
-function property_get_label($property_id, $for_list_of_tasks)
+function property_get_label(string $property_id, bool $for_list_of_tasks): string
 {
     switch ($property_id) {
         case 'date_edited':
@@ -1744,8 +1751,10 @@ function property_get_label($property_id, $for_list_of_tasks)
         case 'percent_complete':
             return ($for_list_of_tasks ? _("Progress") : _("Percent Complete"));
     }
+    throw new ValueError("Bad task property id: $property_id");
 }
 
+/** @param array<string, mixed> $task_a */
 function property_format_value(string $property_id, array $task_a, bool $for_list_of_tasks): string
 {
     global $tasks_url;
@@ -1981,8 +1990,9 @@ function title_string_for_task(object $pre_task): string
  * Get key corresponding to a task properties string
  *
  * Input string must be a valid property value
+ * @param array<int, string> $array
  */
-function get_property_key(string $value, array $array): string
+function get_property_key(string $value, array $array): int
 {
     if (($key = array_search($value, $array)) === false) {
         throw new ValueError("Bad task property value: $value");


### PR DESCRIPTION
This is mostly adding function type hints, but in a few cases we:

- Change the function signature/behaviour to make a little more sense
- Add a variation of the function to handle polymorphic functions that can work on strings or associative arrays
- Restrict the function return value (eg `""` instead of `null`) to match the intended behaivour
- Remove a little unused code
- Fix a couple of erroneous function return types or array shape definitions (my bad)
- Use a DTO instead of an array where it seems worth it 
- Express a variadic function more directly rather than using `func_get_args`