### PR TITLE
More PHPStan level 6 cleanups, last of the *.php files

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,7 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - tools/post_proofers/ppv_report.php
               - tools/project_manager/bad_bytes_explainer.php
               - tools/project_manager/clearance_check.php
               - tools/project_manager/diff.php
@@ -53,7 +52,6 @@ parameters:
               - tools/site_admin/projects_with_odd_values.php
         - identifier: missingType.parameter
           paths:
-              - tools/post_proofers/ppv_report.php
               - tools/project_manager/bad_bytes_explainer.php
               - tools/project_manager/clearance_check.php
               - tools/project_manager/diff.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -49,7 +49,6 @@ parameters:
               - tools/proofers/my_suggestions.php
               - tools/proofers/proof_frame.php
               - tools/proofers/review_work.php
-              - tools/site_admin/projects_with_odd_values.php
         - identifier: missingType.parameter
           paths:
               - tools/project_manager/bad_bytes_explainer.php
@@ -69,7 +68,6 @@ parameters:
               - tools/proofers/my_suggestions.php
               - tools/proofers/proof_frame.php
               - tools/proofers/review_work.php
-              - tools/site_admin/projects_with_odd_values.php
         - identifier: missingType.iterableValue
           paths:
               - tools/project_manager/page_compare.php
@@ -80,9 +78,6 @@ parameters:
               - tools/project_manager/show_project_possible_bad_words.php
               - tools/project_manager/show_project_stealth_scannos.php
               - tools/proofers/for_mentors.php
-              - tools/site_admin/copy_pages.php
-              - tools/site_admin/delete_pages.php
-              - tools/site_admin/shared_postednums.php
 
         # Errors in third party code, and our interfaces to it
         - message: '#Property .* does not accept false#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,48 +23,6 @@ parameters:
     level: 6
 
     ignoreErrors:
-        # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
-        - identifier: missingType.return
-          paths:
-              - tools/project_manager/bad_bytes_explainer.php
-              - tools/project_manager/clearance_check.php
-              - tools/project_manager/diff.php
-              - tools/project_manager/edit_project_word_lists.php
-              - tools/project_manager/editproject.php
-              - tools/project_manager/external_catalog_search.php
-              - tools/project_manager/generate_post_files.php
-              - tools/project_manager/handle_bad_page.php
-              - tools/project_manager/manage_image_sources.php
-              - tools/project_manager/page_detail.php
-              - tools/project_manager/projectmgr.php
-              - tools/project_manager/remote_file_manager.php
-              - tools/project_manager/show_good_word_suggestions_detail.php
-              - tools/project_manager/show_image_sources.php
-              - tools/project_manager/show_specials.php
-              - tools/project_manager/update_illos.php
-        - identifier: missingType.parameter
-          paths:
-              - tools/project_manager/bad_bytes_explainer.php
-              - tools/project_manager/clearance_check.php
-              - tools/project_manager/diff.php
-              - tools/project_manager/edit_project_word_lists.php
-              - tools/project_manager/editproject.php
-              - tools/project_manager/generate_post_files.php
-              - tools/project_manager/handle_bad_page.php
-              - tools/project_manager/manage_image_sources.php
-              - tools/project_manager/projectmgr.php
-              - tools/project_manager/show_good_word_suggestions_detail.php
-              - tools/project_manager/update_illos.php
-        - identifier: missingType.iterableValue
-          paths:
-              - tools/project_manager/page_compare.php
-              - tools/project_manager/show_adhoc_word_details.php
-              - tools/project_manager/show_all_good_word_suggestions.php
-              - tools/project_manager/show_current_flagged_words.php
-              - tools/project_manager/show_good_word_suggestions.php
-              - tools/project_manager/show_project_possible_bad_words.php
-              - tools/project_manager/show_project_stealth_scannos.php
-
         # Errors in third party code, and our interfaces to it
         - message: '#Property .* does not accept false#'
           path: pinc/3rdparty/mediawiki/DairikiDiff.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,8 +26,6 @@ parameters:
         # TODO(bpfoley) PHPStan level 6 errors we haven't fixed yet
         - identifier: missingType.return
           paths:
-              - tools/changestate.php
-              - tools/modify_access.php
               - tools/post_proofers/ppv_report.php
               - tools/project_manager/bad_bytes_explainer.php
               - tools/project_manager/clearance_check.php
@@ -52,14 +50,9 @@ parameters:
               - tools/proofers/my_suggestions.php
               - tools/proofers/proof_frame.php
               - tools/proofers/review_work.php
-              - tools/set_project_event_subs.php
               - tools/site_admin/projects_with_odd_values.php
-              - tools/site_search.php
-              - tools/upload_resumable_file.php
         - identifier: missingType.parameter
           paths:
-              - tools/changestate.php
-              - tools/modify_access.php
               - tools/post_proofers/ppv_report.php
               - tools/project_manager/bad_bytes_explainer.php
               - tools/project_manager/clearance_check.php
@@ -78,9 +71,7 @@ parameters:
               - tools/proofers/my_suggestions.php
               - tools/proofers/proof_frame.php
               - tools/proofers/review_work.php
-              - tools/set_project_event_subs.php
               - tools/site_admin/projects_with_odd_values.php
-              - tools/upload_resumable_file.php
         - identifier: missingType.iterableValue
           paths:
               - tools/project_manager/page_compare.php
@@ -94,7 +85,6 @@ parameters:
               - tools/site_admin/copy_pages.php
               - tools/site_admin/delete_pages.php
               - tools/site_admin/shared_postednums.php
-              - tools/site_search.php
 
         # Errors in third party code, and our interfaces to it
         - message: '#Property .* does not accept false#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,13 +42,6 @@ parameters:
               - tools/project_manager/show_image_sources.php
               - tools/project_manager/show_specials.php
               - tools/project_manager/update_illos.php
-              - tools/proofers/for_mentors.php
-              - tools/proofers/images_index.php
-              - tools/proofers/mktable.php
-              - tools/proofers/my_projects.php
-              - tools/proofers/my_suggestions.php
-              - tools/proofers/proof_frame.php
-              - tools/proofers/review_work.php
         - identifier: missingType.parameter
           paths:
               - tools/project_manager/bad_bytes_explainer.php
@@ -62,12 +55,6 @@ parameters:
               - tools/project_manager/projectmgr.php
               - tools/project_manager/show_good_word_suggestions_detail.php
               - tools/project_manager/update_illos.php
-              - tools/proofers/images_index.php
-              - tools/proofers/mktable.php
-              - tools/proofers/my_projects.php
-              - tools/proofers/my_suggestions.php
-              - tools/proofers/proof_frame.php
-              - tools/proofers/review_work.php
         - identifier: missingType.iterableValue
           paths:
               - tools/project_manager/page_compare.php
@@ -77,7 +64,6 @@ parameters:
               - tools/project_manager/show_good_word_suggestions.php
               - tools/project_manager/show_project_possible_bad_words.php
               - tools/project_manager/show_project_stealth_scannos.php
-              - tools/proofers/for_mentors.php
 
         # Errors in third party code, and our interfaces to it
         - message: '#Property .* does not accept false#'

--- a/pinc/theme.inc
+++ b/pinc/theme.inc
@@ -1181,7 +1181,7 @@ function get_page_header_image(string $image): string
 /**
  * Output a tab bar of various view modes and a selected mode
  *
- * @param array<int|string, array{label: string, url?: string, postscript?: string}> $view_modes
+ * @param array<int|string, array{label: string, url?: string, postscript?: string, ...}> $view_modes
  *   A complex associative array, eg:
  *   ```
  *   [

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -44,7 +44,7 @@ if ($transition->why_disabled($project) == 'SR') {
     fatal_error($body);
 }
 
-function fatal_error($msg)
+function fatal_error(string $msg): never
 {
     global $project, $curr_state, $next_state;
 
@@ -136,7 +136,7 @@ metarefresh(2, $refresh_url, $title, $body);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function prepare_url($url_template)
+function prepare_url(string $url_template): string
 {
     global $projectid, $return_uri;
 
@@ -150,7 +150,7 @@ function prepare_url($url_template)
     return $url;
 }
 
-function output_page_header()
+function output_page_header(): void
 {
     $title = _("Change Project State");
     slim_header($title);

--- a/tools/modify_access.php
+++ b/tools/modify_access.php
@@ -140,7 +140,8 @@ echo "Hit 'Back' to return to user's detail page. (And you may need to reload.)<
 
 // -----------------------------------------------------------------------------
 
-function notify_user($user, $actions)
+/** @param array<string, string> $actions */
+function notify_user(User $user, array $actions): string
 {
     if ((count($actions) == 1) && (array_search('grant', $actions) !== false)) {
         // Special case: If the user has been granted access to

--- a/tools/post_proofers/ppv_report.php
+++ b/tools/post_proofers/ppv_report.php
@@ -160,7 +160,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
     $i5 = $i4 . "    ";
     $i6 = $i5 . "    ";
 
-    function tr_w_one_cell_centered($class, $content)
+    function tr_w_one_cell_centered(string $class, string $content): string
     {
         global $i4, $i5;
         return ""
@@ -169,7 +169,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
             . "\n$i4</tr>";
     }
 
-    function tr_w_two_cells($left_content, $right_content)
+    function tr_w_two_cells(string $left_content, string $right_content): string
     {
         global $i4, $i5;
         return ""
@@ -185,7 +185,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
 
     $n_form_problems = 0;
 
-    function maybe_report_form_problem($message)
+    function maybe_report_form_problem(string $message): string
     {
         if ($message == "") {
             return "";
@@ -197,7 +197,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
     }
 
     // Checkboxes to record level of complexity for a feature; Basic, Average, Complex
-    function feature_level_combo($feature_type)
+    function feature_level_combo(string $feature_type): string
     {
         global $action;
         $feature_label_map = get_feature_labels(true);
@@ -240,7 +240,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
 
     // Checkbox to record hard feature, which always counts as Complex
     // Optional argument to provide hyperlink to further information
-    function hard_check_box($feature_type, $info_url = "")
+    function hard_check_box(string $feature_type, string $info_url = ""): string
     {
         $feature_label_map = get_feature_labels(true);
 
@@ -251,7 +251,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         return check_box("hrd_".$feature_type, $label);
     }
 
-    function check_box($id, $label, $checked_in_blank_form = false)
+    function check_box(string $id, string $label, bool $checked_in_blank_form = false): string
     {
         global $i6;
         return ""
@@ -261,7 +261,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
             . "</p>";
     }
 
-    function _checkbox($id, $label, $checked_in_blank_form = false)
+    function _checkbox(string $id, string $label, bool $checked_in_blank_form = false): string
     {
         global $action;
         if ($action == SHOW_BLANK_ENTRY_FORM) {
@@ -274,7 +274,8 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         return "<input type='checkbox' name='$id' id='$id'$checked_attr><label for='$id'>$label</label>";
     }
 
-    function number_box($id, $label, $options = [])
+    /** @param array{size?: int, use_a_label_element?: bool, put_label_on_left?: bool} $options */
+    function number_box(string $id, string $label, array $options = []): string
     {
         global $action;
         $problem = "";
@@ -310,7 +311,8 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
             . "</p>";
     }
 
-    function _textbox($id, $label, $options = [])
+    /** @param array{size?: int, use_a_label_element?: bool, put_label_on_left?: bool} $options */
+    function _textbox(string $id, string $label, array $options = []): string
     {
         global $action;
         if ($action == SHOW_BLANK_ENTRY_FORM) {
@@ -347,7 +349,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         return $result;
     }
 
-    function comment_box($id)
+    function comment_box(string $id): string
     {
         global $action;
         if ($action == SHOW_BLANK_ENTRY_FORM) {
@@ -361,13 +363,13 @@ if ($action == SHOW_BLANK_ENTRY_FORM || $action == HANDLE_ENTRY_FORM_SUBMISSION)
         return "<textarea rows='4' cols='67' name='$id' id='$id' wrap='hard'>$esc_text</textarea>";
     }
 
-    function is_decimal_digits($s)
+    function is_decimal_digits(string $s): bool
     {
-        assert(is_string($s));
         return ctype_digit($s);
     }
 
-    function get_feature_labels($translate)
+    /** @return array<string, string> */
+    function get_feature_labels(bool $translate): array
     {
         return [
             "poetry" => $translate ? _("Poetry") : "Poetry",
@@ -642,14 +644,14 @@ if ($action == SHOW_BLANK_ENTRY_FORM) {
         $pp_difficulty_level = "Easy";
     }
 
-    function number_of_errors_allowed($size_per)
+    function number_of_errors_allowed(int $size_per): int
     {
         $project_size = $_POST["kb_size"];
         if ($project_size <= $size_per) {
             return 1;
         }
 
-        return round($project_size / $size_per);
+        return (int) round($project_size / $size_per);
     }
 
     if ($level_2_errors == 0) {
@@ -901,7 +903,7 @@ if ($action == SHOW_BLANK_ENTRY_FORM) {
  * Wrap a string to about 72 characters wide so it's
  * suitable for displaying in <pre>-formatted HTML email.
  */
-function ppv_report_wrap($string)
+function ppv_report_wrap(string $string): string
 {
     $string = wordwrap($string, 72);
     $string = str_replace("\n    ", "\n", $string); // Remove 4 blank spaces if they are there
@@ -909,7 +911,8 @@ function ppv_report_wrap($string)
     return $string;
 }
 
-function report_error_counts($errors)
+/** @param array<string, string> $errors */
+function report_error_counts(array $errors): string
 {
     $result = "";
     foreach ($errors as $id => $label) {
@@ -923,7 +926,8 @@ function report_error_counts($errors)
     return $result;
 }
 
-function report_recommendations($recommendations)
+/** @param array<string, string> $recommendations */
+function report_recommendations(array $recommendations): string
 {
     $result = "";
     foreach ($recommendations as $id => $label) {
@@ -937,7 +941,7 @@ function report_recommendations($recommendations)
     return $result;
 }
 
-function report_comments($base_indent, $id, $label)
+function report_comments(string $base_indent, string $id, string $label): string
 {
     $comments = $_POST[$id] ?? '';
     if (empty($comments)) {

--- a/tools/project_manager/bad_bytes_explainer.php
+++ b/tools/project_manager/bad_bytes_explainer.php
@@ -148,7 +148,7 @@ echo "
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_a_table_of_bads($desired_badness)
+function show_a_table_of_bads(string $desired_badness): void
 {
     echo "
         <table class='basic striped'>

--- a/tools/project_manager/clearance_check.php
+++ b/tools/project_manager/clearance_check.php
@@ -76,7 +76,7 @@ echo "</table>";
 
 //---------------------------------------------------------------------------
 
-function get_table_query_resource($username, $view_mode)
+function get_table_query_resource(string $username, string $view_mode): mysqli_result
 {
     $sql = "
         SELECT projectid, nameofwork, authorsname, username, state, clearance

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -183,16 +183,16 @@ if ($L_text != $R_text) {
  * again at the bottom of the page
  */
 function get_navigation(
-    $project,
-    $image,
-    $L_round,
-    $R_round,
-    $L_user,
-    $format,
-    $only_nonempty_diffs,
-    $bb_diffs,
-    $diff_font
-) {
+    Project $project,
+    string $image,
+    Round $L_round,
+    Round $R_round,
+    string $L_user,
+    string $format,
+    bool $only_nonempty_diffs,
+    bool $bb_diffs,
+    string $diff_font
+): string {
     global $diff_fonts;
 
     $navigation_text = "";
@@ -302,7 +302,7 @@ function get_navigation(
 /**
  * Discover whether the user is allowed to see proofreader names for this page
  */
-function can_see_names_for_page($projectid, $image)
+function can_see_names_for_page(string $projectid, string $image): bool
 {
     global $pguser;
 
@@ -342,7 +342,7 @@ function can_see_names_for_page($projectid, $image)
 /**
  * Discover whether the user is allowed to navigate by proofreader for this page
  */
-function can_navigate_by_proofer($projectid, $L_user)
+function can_navigate_by_proofer(string $projectid, string $L_user): bool
 {
     global $pguser;
     $answer = false;

--- a/tools/project_manager/edit_project_word_lists.php
+++ b/tools/project_manager/edit_project_word_lists.php
@@ -83,13 +83,13 @@ class ProjectWordListHolder
     public int $gwl_timestamp;
 
 
-    public function __construct($projectid)
+    public function __construct(string $projectid)
     {
         $this->projectid = $projectid;
         $this->project = new Project($projectid);
     }
 
-    public function validate_project_and_access()
+    public function validate_project_and_access(): ?string
     {
         if (!$this->project->dir_exists) {
             return _("Project directory does not exist, unable to manage word lists.");
@@ -102,7 +102,8 @@ class ProjectWordListHolder
         return null;
     }
 
-    public function set_from_files($load_good_words = true, $load_bad_words = true)
+    /** @return string[] */
+    public function set_from_files(bool $load_good_words = true, bool $load_bad_words = true): array
     {
         $errors = [];
 
@@ -134,7 +135,7 @@ class ProjectWordListHolder
         return $errors;
     }
 
-    public function set_from_post()
+    public function set_from_post(): void
     {
         $this->good_words = @$_POST['good_words'];
         $this->bad_words = @$_POST['bad_words'];
@@ -145,7 +146,8 @@ class ProjectWordListHolder
 
     // -------------------------------------------------------------------------
 
-    public function save_to_files()
+    /** @return list{bool, bool, string[]} */
+    public function save_to_files(): array
     {
         $good_word_conflict = $bad_word_conflict = false;
         $messages = [];
@@ -187,7 +189,7 @@ class ProjectWordListHolder
 
     // =========================================================================
 
-    public function show_form()
+    public function show_form(): void
     {
         echo "<form method='post' enctype='multipart/form-data' action='". attr_safe($_SERVER['PHP_SELF']) ."'>";
 
@@ -222,7 +224,7 @@ class ProjectWordListHolder
 
     // -------------------------------------------------------------------------
 
-    public function show_hidden_controls()
+    public function show_hidden_controls(): void
     {
         global $return;
 
@@ -233,7 +235,7 @@ class ProjectWordListHolder
     }
 
 
-    public function show_visible_controls()
+    public function show_visible_controls(): void
     {
         $goodWordData = html_safe($this->good_words);
         $badWordData = html_safe($this->bad_words);
@@ -425,7 +427,7 @@ class ProjectWordListHolder
     }
 
 
-    public function number_of_pages_in_round($round)
+    public function number_of_pages_in_round(?Round $round): int
     {
         if (!$this->project->pages_table_exists) {
             return 0;

--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -131,7 +131,7 @@ class ProjectInfoHolder
     /** @var string[] */
     private array $hold_states;
 
-    public function set_from_nothing()
+    public function set_from_nothing(): null
     {
         global $pguser;
 
@@ -141,11 +141,12 @@ class ProjectInfoHolder
         $this->project->text_preparer = $pguser;
         $this->project->difficulty = ($pguser == "BEGIN" ? "beginner" : "average");
         $this->charsuites = SiteConfig::get()->default_project_char_suites;
+        return null;
     }
 
     // -------------------------------------------------------------------------
 
-    public function set_from_marc_record()
+    public function set_from_marc_record(): ?string
     {
         $encoded_marc_array = $_POST["rec"] ?? "";
         if (!$encoded_marc_array) {
@@ -156,11 +157,12 @@ class ProjectInfoHolder
         $this->project->populate_from_marc_record($encoded_marc_array);
 
         $this->original_marc_array_encd = $encoded_marc_array;
+        return null;
     }
 
     // -------------------------------------------------------------------------
 
-    public function set_from_clone($projectid)
+    public function set_from_clone(string $projectid): null
     {
         // initialize the project from $projectid but record that it's a
         // clone as we'll use this later
@@ -186,10 +188,11 @@ class ProjectInfoHolder
         $this->project->postednum = null;
         $this->project->deletion_reason = '';
         $this->project->state = '';
+        return null;
     }
 
     // edit an existing project
-    public function set_from_db()
+    public function set_from_db(): ?string
     {
         $projectid = $_GET['project'];
         if ($projectid == '') {
@@ -214,11 +217,13 @@ class ProjectInfoHolder
         foreach ($this->project->get_charsuites(false) as $project_charsuite) {
             array_push($this->charsuites, $project_charsuite->name);
         }
+        return null;
     }
 
     // -------------------------------------------------------------------------
 
-    public function set_from_post()
+    /** @return string[]|string|null */
+    public function set_from_post(): array|string|null
     {
         global $pguser;
 
@@ -351,7 +356,7 @@ class ProjectInfoHolder
 
     // -------------------------------------------------------------------------
 
-    public function save_to_db()
+    public function save_to_db(): void
     {
         global $pguser;
 
@@ -409,7 +414,7 @@ class ProjectInfoHolder
 
     // =========================================================================
 
-    public function show_form()
+    public function show_form(): void
     {
         echo "<form method='post' enctype='multipart/form-data' action='#preview'>";
 
@@ -437,7 +442,7 @@ class ProjectInfoHolder
 
     // -------------------------------------------------------------------------
 
-    public function show_hidden_controls()
+    public function show_hidden_controls(): void
     {
         global $return;
 
@@ -460,7 +465,7 @@ class ProjectInfoHolder
 
     // -------------------------------------------------------------------------
 
-    public function show_visible_controls()
+    public function show_visible_controls(): void
     {
         global $pguser;
 
@@ -567,7 +572,7 @@ class ProjectInfoHolder
 
     // =========================================================================
 
-    public function preview()
+    public function preview(): void
     {
         // format Markdown to HTML
         $comments = parse_project_comments($this->project);
@@ -606,7 +611,7 @@ class ProjectInfoHolder
      * In the project's text fields, replace sequences of space characters
      * with a unique space, and trim beginning and end space
      */
-    public function normalize_spaces()
+    public function normalize_spaces(): void
     {
         $this->project->nameofwork = preg_replace('/\s+/', ' ', trim($this->project->nameofwork));
         $this->project->authorsname = preg_replace('/\s+/', ' ', trim($this->project->authorsname));
@@ -614,17 +619,13 @@ class ProjectInfoHolder
         $this->project->extra_credits = preg_replace('/\s+/', ' ', trim($this->project->extra_credits));
     }
 
-    private function serialize($value)
+    private function serialize(mixed $value): string
     {
         return base64_encode(serialize($value));
     }
 
-    private function unserialize($value)
+    private function unserialize(string $value): mixed
     {
-        if ($value) {
-            return unserialize(base64_decode($value));
-        } else {
-            return null;
-        }
+        return $value ? unserialize(base64_decode($value)) : null;
     }
 }

--- a/tools/project_manager/external_catalog_search.php
+++ b/tools/project_manager/external_catalog_search.php
@@ -58,7 +58,7 @@ if ($action == 'show_query_form') {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function show_query_form()
+function show_query_form(): void
 {
     global $search_params;
     global $PGLAF_inprogress_url;
@@ -144,7 +144,7 @@ function show_query_form()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function do_search_and_show_hits()
+function do_search_and_show_hits(): void
 {
     output_header("Search Results");
     echo "<br>";
@@ -346,7 +346,7 @@ function display_record_table(MARCRecord $marc_record, bool $hide_nontext): void
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function query_format()
+function query_format(): string
 {
     global $serial_attrs;
     // Build a Z39.50 Type-1 query.

--- a/tools/project_manager/generate_post_files.php
+++ b/tools/project_manager/generate_post_files.php
@@ -66,7 +66,7 @@ if ($errors) {
     exit();
 }
 
-function output_page_header($project)
+function output_page_header(Project $project): void
 {
     global $round_id, $which_text, $include_proofers, $save_files;
 

--- a/tools/project_manager/handle_bad_page.php
+++ b/tools/project_manager/handle_bad_page.php
@@ -163,7 +163,7 @@ if (!$resolution) {
 
 //----------------------------------------------------------------------------
 
-function get_round_name($round_number)
+function get_round_name(int $round_number): string
 {
     if ($round_number == 0) {
         return _("OCR");
@@ -173,7 +173,7 @@ function get_round_name($round_number)
     return $round->id;
 }
 
-function show_resolution_form($projectid, $image, $state, $project_round, $is_a_bad_page, $b_user, $b_code)
+function show_resolution_form(string $projectid, string $image, string $state, Round $project_round, bool $is_a_bad_page, string $b_user, string $b_code): void
 {
     global $code_url, $PAGE_BADNESS_REASONS;
 
@@ -239,7 +239,7 @@ function show_resolution_form($projectid, $image, $state, $project_round, $is_a_
     echo "</ul>";
 }
 
-function show_text_update_form($projectid, $image, $prev_text, $text_column, $modify = 'current_text')
+function show_text_update_form(string $projectid, string $image, string $prev_text, string $text_column, string $modify = 'current_text'): void
 {
     echo "<h2>" . _("Update page text") . "</h2>";
 
@@ -286,7 +286,7 @@ function show_text_update_form($projectid, $image, $prev_text, $text_column, $mo
     echo "</div>";
 }
 
-function show_image_update_form($projectid, $image)
+function show_image_update_form(string $projectid, string $image): void
 {
     echo "<h2>" . _("Update page image") . "</h2>";
 
@@ -302,7 +302,7 @@ function show_image_update_form($projectid, $image)
     echo "</form>";
 }
 
-function update_image($projectid, $image)
+function update_image(string $projectid, string $image): void
 {
     global $projects_dir;
 

--- a/tools/project_manager/manage_image_sources.php
+++ b/tools/project_manager/manage_image_sources.php
@@ -156,7 +156,7 @@ class ImageSource
     public ?string $internal_comment;
     public int $is_active;
 
-    public function __construct($code_name = null)
+    public function __construct(?string $code_name = null)
     {
         $this->new_source = true;
         $this->code_name = null;
@@ -180,7 +180,7 @@ class ImageSource
         }
     }
 
-    public function show_listing_row($count)
+    public function show_listing_row(int $count): void
     {
         global $page_url;
         $sid = html_safe($this->code_name);
@@ -255,7 +255,7 @@ class ImageSource
         }
     }
 
-    public function show_buttons()
+    public function show_buttons(): void
     {
         echo "<input type='submit' name='edit' value='".attr_safe(_('Edit'))."'> ";
         echo "<br>\n";
@@ -272,7 +272,7 @@ class ImageSource
         }
     }
 
-    public function show_edit_form()
+    public function show_edit_form(): void
     {
         global $page_url;
         echo "<form method='post' action='$page_url&amp;action=update_oneshot#$this->code_name'>\n";
@@ -298,7 +298,7 @@ class ImageSource
             </td></tr></table></form>\n";
     }
 
-    public function _show_edit_row($field, $label, $textarea = false, $maxlength = null, $required = false)
+    public function _show_edit_row(string $field, string $label, bool $textarea = false, ?int $maxlength = null, bool $required = false): void
     {
         $value = $this->new_source
             ? (empty($_REQUEST[$field]) ? '' : $_REQUEST[$field])
@@ -320,7 +320,7 @@ class ImageSource
             "</tr>\n";
     }
 
-    public function _show_edit_permissions_row()
+    public function _show_edit_permissions_row(): void
     {
         $cols = [
             ['field' => 'ok_keep_images', 'label' => _('Images may be stored')],
@@ -379,7 +379,7 @@ class ImageSource
         $this->_show_summary_row(_('Permissions'), $editing, false);
     }
 
-    public function save_from_post()
+    public function save_from_post(): void
     {
         global $can_edit;
 
@@ -443,18 +443,18 @@ class ImageSource
         DPDatabase::query($sql);
     }
 
-    public function enable()
+    public function enable(): void
     {
         $this->_set_field('is_active', 1);
     }
 
-    public function disable()
+    public function disable(): void
     {
         $this->_set_field('is_active', 0);
     }
 
 
-    public function approve()
+    public function approve(): void
     {
         global $pguser;
         $this->_set_field('is_active', 1);
@@ -482,7 +482,7 @@ class ImageSource
         }
     }
 
-    public function _set_field($field, $value)
+    public function _set_field(string $field, string $value): void
     {
         $sql = sprintf(
             "
@@ -498,7 +498,7 @@ class ImageSource
     }
 
 
-    public function _show_summary_row($label, $value, $htmlspecialchars = true)
+    public function _show_summary_row(string $label, string $value, bool $htmlspecialchars = true): void
     {
         echo "  <tr>" .
             "<th class='label'>$label</th>" .
@@ -506,7 +506,7 @@ class ImageSource
             "</tr>\n";
     }
 
-    public function _get_status_cell($status, $class = '')
+    public function _get_status_cell(int $status, string $class = ''): string
     {
         switch ($status) {
             case 1:
@@ -535,7 +535,7 @@ class ImageSource
         }
     }
 
-    public function _showto($show_to)
+    public function _showto(string $show_to): string
     {
         switch ($show_to) {
             case '0':
@@ -554,7 +554,7 @@ class ImageSource
         return $to_whom;
     }
 
-    public function log_request_for_approval($requestor_username)
+    public function log_request_for_approval(string $requestor_username): void
     {
         $userSettings = & Settings::get_Settings($requestor_username);
         $userSettings->add_value('is_approval_notify', $this->code_name);
@@ -583,7 +583,7 @@ class ImageSource
 
 // ----------------------------------------------------------------------------
 
-function show_is_toolbar($action)
+function show_is_toolbar(string $action): void
 {
     $pages = [
         'add_source' => _('Add New Source'),

--- a/tools/project_manager/page_compare.php
+++ b/tools/project_manager/page_compare.php
@@ -149,6 +149,7 @@ class Comparator
         echo "</p>";
     }
 
+    /** @param string[] $rounds */
     private function selector_string(Round $selected_round, string $name, array $rounds): string
     {
         $sel_str = "<select name=$name>";

--- a/tools/project_manager/page_detail.php
+++ b/tools/project_manager/page_detail.php
@@ -81,7 +81,7 @@ foreach ($errors as $error) {
 echo "<p>" . return_to_project_page_link($projectid, ["expected_state=$state"]) . "</p>\n";
 
 
-function echo_filter_box(string $projectid, int $show_image_size, ?string $username, ?Round $round)
+function echo_filter_box(string $projectid, int $show_image_size, ?string $username, ?Round $round): void
 {
     $username = $username === '' ? User::current_username() : $username;
     $roundid = $round ? $round->id : '';

--- a/tools/project_manager/projectmgr.php
+++ b/tools/project_manager/projectmgr.php
@@ -108,7 +108,8 @@ if ($show_view == "blank") {
 
 $search_results->render($condition);
 
-function echo_shortcut_links($show_view)
+/** @param 'search'|'blank' $show_view */
+function echo_shortcut_links(string $show_view): void
 {
     $views = [
         "user_avail" => [

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -792,7 +792,7 @@ function get_current_dir_relative_path(string $home_dirname): string
     return preg_replace("#^$abs_uploads_dir/*#", "", $abspath);
 }
 
-function get_access_mode(string $username)
+function get_access_mode(string $username): ?string
 {
     $userSettings = & Settings::get_settings($username);
     return $userSettings->get_value("remote_file_manager");

--- a/tools/project_manager/show_adhoc_word_details.php
+++ b/tools/project_manager/show_adhoc_word_details.php
@@ -152,6 +152,10 @@ if (count($queryWords)) {
 //---------------------------------------------------------------------------
 // supporting page functions
 
+/**
+ * @param string[] $queryWords
+ * @return list{array<string, int>, string[]}
+ */
 function _get_adhoc_word_list(string $projectid, array $queryWords): array
 {
     $messages = [];

--- a/tools/project_manager/show_all_good_word_suggestions.php
+++ b/tools/project_manager/show_all_good_word_suggestions.php
@@ -200,6 +200,7 @@ echo "</div></div>";
 //---------------------------------------------------------------------------
 // supporting page functions
 
+/** @return list{array<string, int>, array<string, int>} */
 function _get_all_suggestions_word_list(string $projectid, int $time_cutoff): array
 {
     $suggestions = load_project_good_word_suggestions_flat($projectid, $time_cutoff);
@@ -246,6 +247,7 @@ function _get_all_suggestions_word_list(string $projectid, int $time_cutoff): ar
     return [$all_suggestions_w_freq, $all_suggestions_w_occurrences];
 }
 
+/** @return array<string, list{string, string}> */
 function _get_projects_for_pm(string $pm): array
 {
     $returnArray = [];
@@ -268,6 +270,7 @@ function _get_projects_for_pm(string $pm): array
     return $returnArray;
 }
 
+/** @return string[] */
 function _get_project_states_in_order(): array
 {
     $projectStates = [];

--- a/tools/project_manager/show_current_flagged_words.php
+++ b/tools/project_manager/show_current_flagged_words.php
@@ -138,6 +138,7 @@ echo_checkbox_form_end();
 //---------------------------------------------------------------------------
 // supporting page functions
 
+/** @return list{array<string, int>, string[]} */
 function _get_current_flagged_word_list(string $projectid): array
 {
     $messages = [];

--- a/tools/project_manager/show_good_word_suggestions.php
+++ b/tools/project_manager/show_good_word_suggestions.php
@@ -240,6 +240,17 @@ echo_checkbox_form_end();
 //---------------------------------------------------------------------------
 // supporting page functions
 
+/**
+ * @return list{
+ *             array<string, int>,                // $all_suggestions_w_freq
+ *             array<string, int>,                // $all_suggestions_w_occurrences
+ *             array<string, array<string, int>>, // $round_suggestions_w_freq
+ *             array<string, array<string, int>>, // $round_suggestions_w_occurrences
+ *             string[],                          // $rounds
+ *             int[],                             // $round_page_count
+ *             string[],                          // $messages
+ *         }
+ */
 function _get_suggestions_word_list(string $projectid, int $timeCutoff): array
 {
     $messages = [];

--- a/tools/project_manager/show_good_word_suggestions_detail.php
+++ b/tools/project_manager/show_good_word_suggestions_detail.php
@@ -106,7 +106,8 @@ echo "<p style='margin: 0.5em;'>" . _("Select one of the page links to view the 
 echo "</div>";
 echo "</div>";
 
-function _get_word_context_on_page($projectid, $page, $roundid, $word)
+/** @return list{array<int, string>, int} */
+function _get_word_context_on_page(string $projectid, string $page, string $roundid, string $word): array
 {
     $page_text = Page_getText($projectid, $page, get_Round_for_round_id($roundid)->text_column_name);
     return _get_word_context_from_text($page_text, $word);

--- a/tools/project_manager/show_image_sources.php
+++ b/tools/project_manager/show_image_sources.php
@@ -273,7 +273,8 @@ if (!$imso_code) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function load_image_source_stats()
+/** @return array<string, array<string, mixed>> */
+function load_image_source_stats(): array
 {
     $stats = [];
     $sql = "

--- a/tools/project_manager/show_project_possible_bad_words.php
+++ b/tools/project_manager/show_project_possible_bad_words.php
@@ -122,6 +122,7 @@ echo_checkbox_form_end();
 //---------------------------------------------------------------------------
 // supporting page functions
 
+/** @return list{array<string, int>, string[]} */
 function _get_possible_bad_word_list(string $projectid): array
 {
     $messages = [];

--- a/tools/project_manager/show_project_stealth_scannos.php
+++ b/tools/project_manager/show_project_stealth_scannos.php
@@ -155,6 +155,7 @@ $checkbox_form["projectid"] = $projectid;
 echo_checkbox_form_start($checkbox_form);
 echo_checkbox_form_submit(_("Add selected words to Bad Words List"));
 
+/** @var array<string, numeric-string> $percent_changed */
 printTableFrequencies($initialFreq, $cutoffOptions, $percent_changed, [$instances_changed_to, $instances_changed, $instances_left, $instances_total, $context_array, $word_notes], $word_checkbox);
 
 echo_checkbox_form_submit(_("Add selected words to Bad Words List"));
@@ -164,6 +165,15 @@ echo_checkbox_form_end();
 //---------------------------------------------------------------------------
 // supporting page functions
 
+/**
+ * @return list{
+ *             array<string, numeric-string>, // $percent_changed
+ *             array<string, int>,            // $possible_scannos_w_freq
+ *             string[],                      // $messages
+ *             array<string, string>,         // $possible_scannos_w_correction
+ *             array<string, int>             // $possible_scannos_w_count
+ *         }
+ */
 function _get_stealth_scanno_word_list(string $projectid): array
 {
     $temp_dir = sys_get_temp_dir();

--- a/tools/project_manager/show_specials.php
+++ b/tools/project_manager/show_specials.php
@@ -73,7 +73,7 @@ echo "<br>\n";
 
 // =============================================================================
 
-function output_column_headers()
+function output_column_headers(): void
 {
     echo "<tr>";
     echo "<th>" . _("Symbol") . "</th>";

--- a/tools/project_manager/update_illos.php
+++ b/tools/project_manager/update_illos.php
@@ -155,8 +155,9 @@ if ($operation == 'replace') {
  *
  * If there's a problem, return a string containing an error message.
  * If no problem, return the empty string.
+ * @param array<string, mixed> $replacement_image_info
  */
-function handle_upload($projectid, $image, $replacement_image_info)
+function handle_upload(string $projectid, string $image, array $replacement_image_info): string
 {
     global $projects_dir;
 
@@ -199,7 +200,7 @@ function handle_upload($projectid, $image, $replacement_image_info)
  * If there's a problem, return a string containing an error message.
  * If no problem, return the empty string.
  */
-function handle_delete($projectid, $image)
+function handle_delete(string $projectid, string $image): string
 {
     global $projects_dir;
 
@@ -218,8 +219,9 @@ function handle_delete($projectid, $image)
  *
  * If there's a problem, return a string containing an error message.
  * If no problem, return the empty string.
+ * @param string[] $nonpage_image_names
  */
-function handle_delete_all($projectid, $nonpage_image_names)
+function handle_delete_all(string $projectid, array $nonpage_image_names): string
 {
     global $projects_dir;
 

--- a/tools/project_manager/word_freq_table.inc
+++ b/tools/project_manager/word_freq_table.inc
@@ -27,7 +27,7 @@ function get_cutoff_string(array $cutoffOptions, string $labelSuffix = ""): stri
  * Given the list of cutoff options and the word count
  * make sure the initial cutoff shows something
  * @param int[] $cutoffOptions
- * @param ?array<string, int> $wordCount
+ * @param ?array<string, int|numeric-string> $wordCount
  */
 function getInitialCutoff(int $idealCutoff, array $cutoffOptions, ?array $wordCount = null): int
 {
@@ -70,7 +70,7 @@ function getInitialCutoff(int $idealCutoff, array $cutoffOptions, ?array $wordCo
  *   Initial cutoff frequency, anything after this is hidden
  * @param int[] $cutoffOptions
  *   List of javascript cutoff options (eg: [1,2,3,4,5])
- * @param array<string, int> $wordCount
+ * @param array<string, int|numeric-string> $wordCount
  *   A table containing the word/frequency pairs already
  *   sorted and ready for display.
  *   Can contain the following special keys used for formatting
@@ -389,7 +389,7 @@ function parse_posted_words(array $words): array
 }
 
 /**
- * @param array<string, int> $array
+ * @param array<string, int|numeric-string> $array
  * @return string[]
  */
 function build_checkbox_array(array $array, string $instance = "0"): array

--- a/tools/proofers/for_mentors.php
+++ b/tools/proofers/for_mentors.php
@@ -97,7 +97,7 @@ if ($projects_available) {
     echo "<ol>";
     foreach ($projects_available as $proj_obj) {
         echo "<li><a href='#$proj_obj->projectid'>";
-        echo output_project_label($proj_obj->nameofwork, $proj_obj->authorsname, $proj_obj->t_left_mentee_round);
+        output_project_label($proj_obj->nameofwork, $proj_obj->authorsname, $proj_obj->t_left_mentee_round);
         echo "</a></li>";
     }
     echo "</ol>";
@@ -118,7 +118,7 @@ if ($projects_waiting) {
     foreach ($projects_waiting as $proj_obj) {
         $project = new Project($proj_obj->projectid);
         echo "<li>";
-        echo output_project_label($proj_obj->nameofwork, $proj_obj->authorsname, $proj_obj->t_left_mentee_round);
+        output_project_label($proj_obj->nameofwork, $proj_obj->authorsname, $proj_obj->t_left_mentee_round);
         if (in_array($mentoring_round->project_waiting_state, $project->get_hold_states())) {
             // TRANSLATORS: string indicates that the project is "on hold"
             echo sprintf(" <b>[%s]</b>", _("On hold"));
@@ -137,7 +137,7 @@ foreach ($projects_available as $proj_obj) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function output_project_label(string $nameofwork, string $authorsname, ?int $date = null)
+function output_project_label(string $nameofwork, string $authorsname, ?int $date = null): void
 {
     // TRANSLATORS: format is <title> by <author>.
     echo sprintf(_("%1\$s by %2\$s"), $nameofwork, $authorsname);
@@ -151,7 +151,7 @@ function output_project_label(string $nameofwork, string $authorsname, ?int $dat
  * For each mentorable project (in this round), show a summary (one line per mentee)
  * and then a listing (one line per page).
  */
-function output_project_details(Round $mentoring_round, Round $mentored_round, string $projectid, string $nameofwork, string $authorsname)
+function output_project_details(Round $mentoring_round, Round $mentored_round, string $projectid, string $nameofwork, string $authorsname): void
 {
     global $code_url;
 
@@ -180,7 +180,7 @@ function output_project_details(Round $mentoring_round, Round $mentored_round, s
  * We do this per-project instead of at the top so that messages about the
  * checkout are included with the project on the page.
  */
-function checkout_return_project_pages(Round $mentoring_round, Round $mentored_round, string $projectid)
+function checkout_return_project_pages(Round $mentoring_round, Round $mentored_round, string $projectid): void
 {
     // return if the user hasn't requested checkouts/returns for this project
     if ((!isset($_POST["checkout_proofreader"]) && !isset($_POST["return_proofreader"]))
@@ -273,6 +273,7 @@ function checkout_return_project_pages(Round $mentoring_round, Round $mentored_r
 
 // -------------------------------------------------------------------
 
+/** @return object[] */
 function get_beginner_projects_in_state(string $state, Round $mentored_round): array
 {
     $mentored_round_detail = $mentored_round->project_complete_state;
@@ -307,7 +308,7 @@ function get_beginner_projects_in_state(string $state, Round $mentored_round): a
 
 // -------------------------------------------------------------------
 
-function output_page_summary_table(Round $mentored_round, string $projectid)
+function output_page_summary_table(Round $mentored_round, string $projectid): void
 {
     global $code_url;
 
@@ -390,7 +391,7 @@ function output_page_summary_table(Round $mentored_round, string $projectid)
 
 // -------------------------------------------------------------------
 
-function output_page_list_table(Round $mentored_round, string $projectid)
+function output_page_list_table(Round $mentored_round, string $projectid): void
 {
     echo "<input type='hidden' name='projectid' value='$projectid'>";
     echo "<table class='striped basic'>";

--- a/tools/proofers/images_index.php
+++ b/tools/proofers/images_index.php
@@ -93,7 +93,8 @@ if (!is_null($zip_type)) {
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function list_images($project, $image_names, $these_are_page_images)
+/** @param string[] $image_names */
+function list_images(Project $project, array $image_names, bool $these_are_page_images): void
 {
     global $code_url;
 
@@ -170,7 +171,8 @@ function list_images($project, $image_names, $these_are_page_images)
     echo "</table>\n";
 }
 
-function show_dl_link($projectid, $image_names, $these_are_page_images)
+/** @param string[] $image_names */
+function show_dl_link(string $projectid, array $image_names, bool $these_are_page_images): void
 {
     global $code_url;
 
@@ -191,7 +193,8 @@ function show_dl_link($projectid, $image_names, $these_are_page_images)
     }
 }
 
-function show_delete_all_link($project, $image_names)
+/** @param string[] $image_names */
+function show_delete_all_link(Project $project, array $image_names): void
 {
     global $code_url;
 

--- a/tools/proofers/mktable.php
+++ b/tools/proofers/mktable.php
@@ -150,7 +150,14 @@ for ($i = 0; $i < $row; $i++) {
 
 //----------------------------------------------------------------------------
 
-function generate_ascii_table($row, $col, $a, $al, $tll, $val, $lng, $bord)
+/**
+ * @param string[][][] $a
+ * @param int[] $al
+ * @param int[] $tll
+ * @param int[] $val
+ * @param int[] $lng
+ */
+function generate_ascii_table(int $row, int $col, array $a, array $al, array $tll, array $val, array $lng, bool $bord): void
 {
     global $charset;
 
@@ -184,7 +191,8 @@ function generate_ascii_table($row, $col, $a, $al, $tll, $val, $lng, $bord)
     }
 }
 
-function hline($col, $lng, $bord)
+/** @param int[] $lng */
+function hline(int $col, array $lng, bool $bord): void
 {
     if ($bord) {
         echo "+";
@@ -199,12 +207,16 @@ function hline($col, $lng, $bord)
     echo "\n";
 }
 
-function str_not_empty($str)
+function str_not_empty(string $str): bool
 {
     return $str !== "";
 }
 
-function array_pad_internal($input, $pad_size, $pad_type)
+/**
+ * @param string[][] $input
+ * @return string[][]
+ */
+function array_pad_internal(array $input, int $pad_size, int $pad_type): array
 {
     if ($pad_type == ARRAY_PAD_BOTH) {
         return array_pad(
@@ -221,7 +233,11 @@ function array_pad_internal($input, $pad_size, $pad_type)
     }
 }
 
-function table_pad($table, $rows, $columns, $value = "")
+/**
+ * @param string[][] $table
+ * @return string[][]
+ */
+function table_pad(array $table, int $rows, int $columns, string $value = ""): array
 {
     for ($i = 0; $i < $rows; $i++) {
         if (!isset($table[$i])) {

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -19,8 +19,8 @@ if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
 }
 $focus_user = new User($username);
 
-[$round_view_options, $pool_view_options] = get_view_options($username);
-[$round_column_specs, $pool_column_specs] = get_table_column_specs();
+[$round_view_options, $pool_view_options] = projects_get_view_options($username);
+[$round_column_specs, $pool_column_specs] = projects_get_table_column_specs();
 $round_sort_options = get_sort_options($round_column_specs);
 $pool_sort_options = get_sort_options($pool_column_specs);
 
@@ -94,7 +94,7 @@ foreach (Rounds::get_all() as $round) {
 
 echo "<h2 id='round_view'>" . html_safe($proof_heading) . "</h2>";
 
-show_page_menu($round_view_options, $round_view, $username, 'round_view');
+projects_show_page_menu($round_view_options, $round_view, $username, 'round_view');
 
 [$res, $colspecs] = get_round_query_result($round_view, $round_sort, $round_column_specs, $username);
 if (mysqli_num_rows($res) == 0) {
@@ -234,7 +234,7 @@ if (!$can_view_post_processing) {
 
 echo "<h2 id='pool_view'>" . html_safe($pool_heading) . "</h2>\n";
 
-show_page_menu($pool_view_options, $pool_view, $username, 'pool_view');
+projects_show_page_menu($pool_view_options, $pool_view, $username, 'pool_view');
 
 [$res, $colspecs, $pool_sort] = get_pool_query_result($pool_view, $pool_sort, $pool_column_specs, $username);
 $num_projects = mysqli_num_rows($res);
@@ -319,7 +319,7 @@ if ($num_projects == 0) {
 
 // --------------------------------------------------------------------------
 
-function output_link_box($username)
+function output_link_box(string $username): void
 {
     echo "<div id='linkbox'>";
     if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
@@ -345,10 +345,16 @@ function output_link_box($username)
 
 // --------------------------------------------------------------------------
 
-function get_table_column_specs()
+/**
+ * @return list{
+ *             array<string, array{label: string, sql: string, class?: string}>,
+ *             array<string, array{label: string, sql: string, class?: string}>
+ *         }
+ */
+function projects_get_table_column_specs(): array
 {
     // $colspecs = array (
-    //     $id => array ( 'label' => $label, 'sql' => $sql )
+    //     $id => ['label' => $label, 'sql' => $sql]
     // );
     // $id is the column name as passed by GET argument.
     // $label is the translatable label displayed in the column header
@@ -429,7 +435,11 @@ function get_table_column_specs()
     return [$round_columns, $pool_columns];
 }
 
-function get_sort_options($colspecs)
+/**
+ * @param array<string, mixed> $colspecs
+ * @return string[]
+ */
+function get_sort_options(array $colspecs): array
 {
     $sort_options = [];
     $columns = array_keys($colspecs);
@@ -441,7 +451,8 @@ function get_sort_options($colspecs)
 }
 
 // to make sure that some projects are displayed, iterate over the view order
-function get_view_options($username)
+/** @return list{array<string, array<string, string>>, array<string, array<string, string>>} */
+function projects_get_view_options(string $username): array
 {
     $round_view_options = [
         "available" => [
@@ -500,7 +511,8 @@ function get_view_options($username)
     return [$round_view_options, $pool_view_options];
 }
 
-function get_usertext($text_options)
+/** @param array<string, string> $text_options */
+function get_usertext(array $text_options): string
 {
     global $pguser, $username;
 
@@ -511,8 +523,8 @@ function get_usertext($text_options)
     }
 }
 
-
-function show_page_menu($all_view_modes, $round_view, $username, $key)
+/** @param array<int|string, array{label: string, ...}> $all_view_modes */
+function projects_show_page_menu(array $all_view_modes, string $round_view, string $username, string $key): void
 {
     global $pguser;
 
@@ -524,7 +536,8 @@ function show_page_menu($all_view_modes, $round_view, $username, $key)
     output_tab_bar($all_view_modes, $round_view, $key, "$qs_username#$key");
 }
 
-function sql_order_spec($colspecs, $order_col, $order_dir)
+/** @param array<string, array{sql: string, ...}> $colspecs */
+function sql_order_spec(array $colspecs, string $order_col, string $order_dir): string
 {
     return
         $colspecs[$order_col]['sql']
@@ -532,7 +545,8 @@ function sql_order_spec($colspecs, $order_col, $order_dir)
         . ($order_dir == 'A' ? 'ASC' : 'DESC');
 }
 
-function get_sort_col_and_dir($sort)
+/** @return list{string, string} */
+function get_sort_col_and_dir(string $sort): array
 {
     // The sort string is already a valid one when we get here, we just need
     // to parse the column and direction apart.
@@ -541,7 +555,8 @@ function get_sort_col_and_dir($sort)
     return [$order_col, $order_dir];
 }
 
-function show_headings($colspecs, $sorting, $username, $sort_name, $anchor)
+/** @param array<string, array{class?: string, label: string}> $colspecs */
+function show_headings(array $colspecs, string $sorting, string $username, string $sort_name, string $anchor): void
 {
     global $pguser;
 
@@ -579,7 +594,11 @@ function show_headings($colspecs, $sorting, $username, $sort_name, $anchor)
     echo "</tr>\n";
 }
 
-function get_round_query_result($round_view, $round_sort, $round_column_specs, $username)
+/**
+ * @param array<string, mixed> $round_column_specs
+ * @return list{mysqli_result, array<string, mixed>}
+ */
+function get_round_query_result(string $round_view, string $round_sort, array $round_column_specs, string $username): array
 {
     [$order_col, $order_dir] = get_sort_col_and_dir($round_sort);
     $sql_order = sql_order_spec($round_column_specs, $order_col, $order_dir);
@@ -669,7 +688,12 @@ function get_round_query_result($round_view, $round_sort, $round_column_specs, $
     return [DPDatabase::query($sql), $round_column_specs];
 }
 
-function get_pool_query_result($pool_view, $pool_sort, $pool_column_specs, $username)
+/**
+ * @param 'reserved'|'active'|'posted' $pool_view
+ * @param array<string, mixed> $pool_column_specs
+ * @return list{mysqli_result, array<string, mixed>, string}
+ */
+function get_pool_query_result(string $pool_view, string $pool_sort, array $pool_column_specs, string $username): array
 {
     $created = get_project_status_descriptor('created');
     $proofed = get_project_status_descriptor('proofed');

--- a/tools/proofers/my_suggestions.php
+++ b/tools/proofers/my_suggestions.php
@@ -9,7 +9,7 @@ include_once($relPath.'graph_data.inc'); // get_round_backlog_stats()
 
 require_login();
 
-$verbose = get_integer_param($_GET, "verbose", 0, 0, 1);
+$verbose = get_bool_param($_GET, "verbose", false);
 $flush_cache = get_bool_param($_GET, "flush_cache", false);
 
 $username = User::current_username();
@@ -98,7 +98,7 @@ if ($verbose) {
 
 // --------------------------------------------------------------------------
 
-function output_link_box($username, $verbose)
+function output_link_box(string $username, bool $verbose): void
 {
     echo "<div id='linkbox'>";
     if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
@@ -115,7 +115,8 @@ function output_link_box($username, $verbose)
 
 // --------------------------------------------------------------------------
 
-function get_table_column_specs()
+/** @return array<string, array{label: string, class?: string}> */
+function get_table_column_specs(): array
 {
     // $colspecs = array (
     //     $id => array ( 'label' => $label, 'class' => $class )
@@ -161,7 +162,9 @@ function get_table_column_specs()
 }
 
 // to make sure that some projects are displayed, iterate over the view order
-function get_view_options($username)
+
+/** @return array<string, array{label: string, text_none: string, text_verbose: string}> */
+function get_view_options(string $username): array
 {
     return [
         "impact" => [
@@ -192,7 +195,8 @@ function get_view_options($username)
     ];
 }
 
-function show_page_menu($all_view_modes, $round_view, $username, $verbose, $key)
+/** @param array<int|string, array{label: string, ...}> $all_view_modes */
+function show_page_menu(array $all_view_modes, string $round_view, string $username, bool $verbose, string $key): void
 {
     $qs_username = "";
     if (User::current_username() != $username) {
@@ -210,7 +214,8 @@ function show_page_menu($all_view_modes, $round_view, $username, $verbose, $key)
     output_tab_bar($all_view_modes, $round_view, $key, "$qs_username$qs_verbose");
 }
 
-function show_headings($colspecs, $username, $anchor)
+/** @param array<string, array{class?: string, label: string}> $colspecs */
+function show_headings(array $colspecs, string $username): void
 {
     echo "<tr>\n";
     foreach ($colspecs as $col_id => $colspec) {
@@ -229,13 +234,17 @@ function show_headings($colspecs, $username, $anchor)
     echo "</tr>\n";
 }
 
-function output_suggestion_table($projects, $colspecs, $username)
+/**
+ * @param array<string, mixed>[] $projects
+ * @param array<string, array{class?: string, label: string}> $colspecs
+ */
+function output_suggestion_table(array $projects, array $colspecs, string $username): void
 {
     global $code_url;
 
     echo "<table class='themed theme_striped' style='width: auto;'>";
 
-    show_headings($colspecs, $username, 'round_view');
+    show_headings($colspecs, $username);
 
     foreach ($projects as $row) {
         echo "<tr>\n";
@@ -316,7 +325,14 @@ function output_suggestion_table($projects, $colspecs, $username)
     echo "<br>\n";
 }
 
-function output_selection_criteria($criteria)
+/**
+ * @param array{
+ *            filters: array<string, string[]|string|bool>,
+ *            weights: array<string, float>,
+ *            ...
+ *        } $criteria
+ */
+function output_selection_criteria(array $criteria): void
 {
     echo "<p>";
     echo _("Available selection criteria. Not all views use all criteria and there is special logic for beginners.");
@@ -364,7 +380,8 @@ function output_selection_criteria($criteria)
     echo "</p>";
 }
 
-function array_get_first($array, $part)
+/** @param array<string, mixed> $array */
+function array_get_first(array $array, string $part): mixed
 {
     $key = array_keys($array)[0];
     if ($part == "key") {

--- a/tools/proofers/proof_frame.php
+++ b/tools/proofers/proof_frame.php
@@ -123,13 +123,14 @@ echo_proof_frame($ppage);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-function setDebounceInfo($project)
+function setDebounceInfo(string $project): void
 {
     dpsession_page_set($project . '|' . time());
 }
 
-function getDebounceInfo()
+/** @return array{project: string, pageTime: int} */
+function getDebounceInfo(): array
 {
     [$project, $time] = explode("|", dpsession_page_get());
-    return ['project' => $project, 'pageTime' => $time];
+    return ['project' => $project, 'pageTime' => (int) $time];
 }

--- a/tools/proofers/review_work.php
+++ b/tools/proofers/review_work.php
@@ -87,7 +87,7 @@ echo "</table>";
 echo "<input type='submit' value='", attr_safe(_("Search")), "'>";
 echo "</form>";
 
-function _echo_eval_query_select($selected)
+function _echo_eval_query_select(string $selected): void
 {
     $options = [1 => _("Yes"), 0 => _("No")];
     foreach ($options as $value => $name) {
@@ -99,7 +99,8 @@ function _echo_eval_query_select($selected)
     }
 }
 
-function _echo_round_select($rounds, $selected_round)
+/** @param Round[] $rounds */
+function _echo_round_select(array $rounds, ?Round $selected_round): void
 {
     foreach ($rounds as $round) {
         echo "<option value='" . attr_safe($round->id) . "'";

--- a/tools/set_project_event_subs.php
+++ b/tools/set_project_event_subs.php
@@ -39,7 +39,8 @@ _html_ul(
     $unsubs
 );
 
-function _html_ul($header, $items)
+/** @param string[] $items */
+function _html_ul(string $header, array $items): void
 {
     echo "<p>" . html_safe($header) . "</p>";
     echo "<ul>\n";

--- a/tools/site_admin/copy_pages.php
+++ b/tools/site_admin/copy_pages.php
@@ -146,6 +146,10 @@ switch ($action) {
         break;
 }
 
+/**
+ * @param array{from: string, to: string} $projectid_
+ * @param array{lo: string, hi: string} $from_image_
+ */
 function display_copy_pages_form(
     ?array $projectid_,
     ?array $from_image_,
@@ -242,6 +246,10 @@ function do_radio_button_pair(string $prompt, string $input_name, bool $repeatin
     echo "</td></tr>\n";
 }
 
+/**
+ * @param array{from: string, to: string} $projectid_
+ * @param array{lo: string, hi: string} $from_image_
+ */
 function display_hiddens(
     array $projectid_,
     array $from_image_,
@@ -260,6 +268,10 @@ function display_hiddens(
     echo "\n<input type='hidden' name='copy_format_preview_data' value='" . ($copy_format_preview_data ? 1 : 0) . "'>";
 }
 
+/**
+ * @param ?array{from: string, to: string} $projectid_
+ * @param ?array{lo: string, hi: string} $from_image_
+ */
 function copy_pages(
     ?array $projectid_,
     ?array $from_image_,

--- a/tools/site_admin/delete_pages.php
+++ b/tools/site_admin/delete_pages.php
@@ -56,6 +56,7 @@ switch ($action) {
         break;
 }
 
+/** @param ?array{lo: string, hi: string} $from_image_ */
 function display_delete_pages_form(string $action, ?string $projectid, ?array $from_image_): void
 {
     echo "<form method='post'>\n";
@@ -97,6 +98,7 @@ function display_delete_pages_form(string $action, ?string $projectid, ?array $f
     echo "<p><b>Note:</b> 'pages' are specified by their designation in the project table: e.g., '001.png'</p>\n";
 }
 
+/** @param ?array{lo: string, hi: string} $from_image_ */
 function delete_pages(?string $projectid, ?array $from_image_, bool $just_checking): void
 {
     echo "<pre>";

--- a/tools/site_admin/projects_with_odd_values.php
+++ b/tools/site_admin/projects_with_odd_values.php
@@ -48,7 +48,8 @@ foreach (load_projects_with_bad_values($lc) as $property => $projects) {
 
 // ---------------------------------------------------------------------------
 
-function load_common_values()
+/** @return array<string, array<string, int>> */
+function load_common_values(): array
 {
     $lc = [];
 
@@ -85,7 +86,11 @@ function load_common_values()
     return $lc;
 }
 
-function load_projects_with_bad_values($lc)
+/**
+ * @param array<string, array<string, int>> $lc
+ * @return array<string, Project[]>
+ */
+function load_projects_with_bad_values($lc): array
 {
     $projects_with_bad = [];
 

--- a/tools/site_admin/shared_postednums.php
+++ b/tools/site_admin/shared_postednums.php
@@ -69,6 +69,7 @@ while ([$postednum, $count] = mysqli_fetch_row($res)) {
 
 /**
  * Determine if the given strings contain numerals '1', '2', '3' that go up
+ * @param string[] $strings
  */
 function strings_count_up(array $strings): bool
 {

--- a/tools/site_search.php
+++ b/tools/site_search.php
@@ -110,6 +110,7 @@ echo "</ul>";
 
 //----------------------------------------------------------------------------
 
+/** @return array<string, array{url: string, desc: string, alias?: string}> */
 function get_prefix_searches(bool $flatten_aliases = false): array
 {
     global $code_url, $wiki_url;
@@ -173,6 +174,7 @@ function get_prefix_searches(bool $flatten_aliases = false): array
     return $prefix_searches;
 }
 
+/** @return array<string, array{url: string, desc: string, alias?: string}> */
 function get_jump_words(bool $flatten_aliases = false): array
 {
     global $code_url;
@@ -275,6 +277,7 @@ function get_jump_words(bool $flatten_aliases = false): array
     return $jump_words;
 }
 
+/** @return array<string, string> */
 function get_activity_jumps(): array
 {
     global $code_url;
@@ -294,7 +297,7 @@ function get_activity_jumps(): array
     return $activity_jumps;
 }
 
-function jump_search(string $query)
+function jump_search(string $query): void
 {
     $query = strtolower($query);
     $jump_words = get_jump_words(true);
@@ -303,7 +306,7 @@ function jump_search(string $query)
     }
 }
 
-function smart_search(string $query)
+function smart_search(string $query): void
 {
     global $code_url;
 
@@ -322,7 +325,7 @@ function smart_search(string $query)
     }
 }
 
-function prefix_search(string $query)
+function prefix_search(string $query): void
 {
     $matches = [];
     if (!preg_match('/^(\w+):\s*(.*)$/', $query, $matches)) {

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -83,7 +83,7 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
  * edge failure cases where all of the parts have been uploaded in a prior
  * attempt but not yet reassembled.
  */
-function reassemble()
+function reassemble(): void
 {
     global $root_staging_dir, $staging_dir, $hashed_filename;
     global $total_chunks, $total_size;
@@ -130,7 +130,7 @@ function reassemble()
     }
 }
 
-function report_error($error, $response_code = 204)
+function report_error(string $error, int $response_code = 204): void
 {
     // by default return a 204 which will cause the resumable upload
     // to retry the chunk upload


### PR DESCRIPTION
Some of this, in particular the `tools/project_manager/*.php` code is a bit of a maze of arrays being passed around, and sometimes large lists of return values.

I've done the minimum to add types and array shapes, but definitely more could be done.

This allows us to remove the rest of the `missingType.*` warning suppressions in `phpstan.neon`.