### PR TITLE
Re-enable PHPStan level 5 arguments.count warning, fix all warnings

### DIFF
--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -208,7 +208,7 @@ elseif ($func == "xtext") {
 // Perform the upload and compilation of a translation file
 elseif ($func == "upload") {
     $locale = validate_locale($_REQUEST['locale']);
-    do_upload($locale);
+    locale_do_upload($locale);
     echo "<p><a href='$translate_url?func=manage&amp;locale=$locale'>"
         . sprintf(_("Back to manage locale %s"), $locale) . "</a></p>";
 }
@@ -449,7 +449,7 @@ function manage_form(string $locale): void
     }
 }
 
-function do_upload(string $locale): void
+function locale_do_upload(string $locale): void
 {
     global $dyn_locales_dir;
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -41,7 +41,6 @@ parameters:
         - message: '#Function get_dpl_enforcement_for_user\(\) never returns null.*#'
           path: pinc/daily_page_limit.inc
 
-        - message: '#invoked with \d+ parameter(s?), \d+((-\d+)?) required#'
         - message: '#Variable .* might not be defined#'
         - message: '#Constant .* not found#'
 

--- a/pinc/archiving.inc
+++ b/pinc/archiving.inc
@@ -79,7 +79,7 @@ function archive_project(Project $project, bool $dry_run = false): void
             }
 
             if (!rename($project_dir, $new_dir)) {
-                throw new RuntimeException(sprintf(_('Unable to move %1$s to %2$s', $project_dir, $new_dir)));
+                throw new RuntimeException(sprintf(_('Unable to move %1$s to %2$s'), $project_dir, $new_dir));
             }
         }
     } else {

--- a/tools/changestate.php
+++ b/tools/changestate.php
@@ -48,7 +48,7 @@ function fatal_error(string $msg): never
 {
     global $project, $curr_state, $next_state;
 
-    output_page_header();
+    changestate_output_page_header();
 
     echo "<pre>\n";
     echo _("You requested:") . "\n";
@@ -65,7 +65,7 @@ function fatal_error(string $msg): never
 // If there's a question associated with this transition,
 // and we haven't just asked it, ask it now.
 if (!is_null($transition->confirmation_question) && $confirmed != 'yes') {
-    output_page_header();
+    changestate_output_page_header();
 
     echo "<p><b>" . _("Project ID") . ":</b> $projectid<br>\n";
     echo "<b>" . _("Title") . ":</b> " . html_safe($project->nameofwork) . "<br>\n";
@@ -150,7 +150,7 @@ function prepare_url(string $url_template): string
     return $url;
 }
 
-function output_page_header(): void
+function changestate_output_page_header(): void
 {
     $title = _("Change Project State");
     slim_header($title);

--- a/tools/proofers/my_projects.php
+++ b/tools/proofers/my_projects.php
@@ -66,7 +66,7 @@ $page_header = [
 
 output_header(get_usertext($page_header), NO_STATSBAR);
 
-output_link_box($username);
+projects_output_link_box($username);
 
 echo "<h1>" . get_usertext($page_header) . "</h1>";
 
@@ -104,7 +104,7 @@ if (mysqli_num_rows($res) == 0) {
 
     echo "<table class='themed theme_striped' style='width: auto;'>";
 
-    show_headings($colspecs, $round_sort, $username, 'round_sort', 'round_view');
+    projects_show_headings($colspecs, $round_sort, $username, 'round_sort', 'round_view');
 
     $n_rows_displayed = 0;
     while ($row = mysqli_fetch_object($res)) {
@@ -245,7 +245,7 @@ if ($num_projects == 0) {
 
     echo "<table class='themed theme_striped' style='width: auto;'>";
 
-    show_headings($colspecs, $pool_sort, $username, 'pool_sort', 'pool_view');
+    projects_show_headings($colspecs, $pool_sort, $username, 'pool_sort', 'pool_view');
 
     $pool_checkedout_states = [
         PROJ_POST_FIRST_CHECKED_OUT,
@@ -319,7 +319,7 @@ if ($num_projects == 0) {
 
 // --------------------------------------------------------------------------
 
-function output_link_box(string $username): void
+function projects_output_link_box(string $username): void
 {
     echo "<div id='linkbox'>";
     if (user_is_a_sitemanager() || user_is_proj_facilitator()) {
@@ -556,7 +556,7 @@ function get_sort_col_and_dir(string $sort): array
 }
 
 /** @param array<string, array{class?: string, label: string}> $colspecs */
-function show_headings(array $colspecs, string $sorting, string $username, string $sort_name, string $anchor): void
+function projects_show_headings(array $colspecs, string $sorting, string $username, string $sort_name, string $anchor): void
 {
     global $pguser;
 

--- a/tools/site_admin/manage_site_word_lists.php
+++ b/tools/site_admin/manage_site_word_lists.php
@@ -27,7 +27,7 @@ output_header($title, NO_STATSBAR);
 
 echo "<h1>$title</h1>";
 
-$display_list = _handle_action($action, $list_type, $language, $word_string);
+$display_list = manage_site_word_lists_handle_action($action, $list_type, $language, $word_string);
 
 if ($display_list) {
     echo "<h2>" . _("Create a new site word list") . "</h2>";
@@ -124,7 +124,7 @@ if ($display_list) {
  *
  * @return bool
  */
-function _handle_action($action, $list_type, $language, $word_string)
+function manage_site_word_lists_handle_action($action, $list_type, $language, $word_string)
 {
     // look up the langcode3 for the language passed-in
     $langcode3 = langcode3_for_langname($language);


### PR DESCRIPTION
Most of these were spurious and an effect of PHPStan treating all our *.php files as being in the same namespace: we occasionally have functions with identical names but different signatures defined in different *.php files and PHPStan gets confused by this.

The proper fix would be to add a unique `namespace Foo;` to the top of each PHP file, but for now I just add a unique prefix to the conflicting function name with.

arguments.count did catch one real error:
   `sprintf(_('template %1$s %2$s', $arg1, $arg2))` instead of
   `sprintf(_('template %1$s %2$s'), $arg1, $arg2))`