### PR TITLE
Handle config defaults better

### DIFF
--- a/feeds/backend.php
+++ b/feeds/backend.php
@@ -34,7 +34,7 @@ echo $rssfeed;
  * @return string
  *   The XML document for the RSS feed
  */
-function generate_rss_feed(string $content, string $site_name, string $code_url, string $site_manager_email_addr)
+function generate_rss_feed(string $content, string $site_name, string $code_url, ?string $site_manager_email_addr)
 {
     $limit = 20; // Number of rows we query from the table, number of items in RSS feed
 
@@ -104,6 +104,9 @@ function generate_rss_feed(string $content, string $site_name, string $code_url,
         }
 
         $lastupdated = date("r");
+        $webmaster = $site_manager_email_addr ?
+            xmlencode($site_manager_email_addr)." (" . xmlencode(_("Site Manager")) .")" :
+            xmlencode(_("Site Manager"));
         $rssfeed = "<"."?"."xml version=\"1.0\" encoding=\"UTF-8\" ?".">
             <rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\">
             <channel>
@@ -111,7 +114,7 @@ function generate_rss_feed(string $content, string $site_name, string $code_url,
             <title>".xmlencode($site_name)." - " . _("Latest Releases") . "</title>
             <link>".xmlencode($link)."</link>
             <description>".xmlencode($desc)."</description>
-            <webMaster>".xmlencode($site_manager_email_addr)." (" . xmlencode(_("Site Manager")) . ")</webMaster>
+            <webMaster>".xmlencode($webmaster)."</webMaster>
             <pubDate>".xmlencode($lastupdated)."</pubDate>
             <lastBuildDate>".xmlencode($lastupdated)."</lastBuildDate>
             $data

--- a/pinc/BackgroundJob.inc
+++ b/pinc/BackgroundJob.inc
@@ -1,6 +1,7 @@
 <?php
 include_once($relPath."Stopwatch.inc");
 include_once($relPath."job_log.inc");
+include_once($relPath."SiteConfig.inc");
 
 abstract class BackgroundJob
 {
@@ -10,7 +11,7 @@ abstract class BackgroundJob
     // The maximum amount of time a BackgroundJob running within a web
     // context should try to stay within. This should be under the TimeOut
     // set by the web server.
-    protected int $web_context_max_runtime_s = MAX_RUNTIME_TARGET_S;
+    protected int $web_context_max_runtime_s;
 
     protected ?string $start_message = null;
     protected ?string $stop_message = null;
@@ -22,6 +23,7 @@ abstract class BackgroundJob
     public function __construct()
     {
         $this->watch = new Stopwatch();
+        $this->web_context_max_runtime_s = SiteConfig::get()->max_runtime_target_s;
     }
 
     public function start(?string $message = null): void

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -1440,6 +1440,11 @@ class Project
         // determine appropriate forum to create thread in
         $forum_id = ProjectStates::get_forum($this->state);
 
+        // if there is no forum defined, we can't do anything
+        if ($forum_id == null) {
+            return null;
+        }
+
         $post_subject = "\"{$this->nameofwork}\" by {$this->authorsname}";
 
         validate_projectID($this->projectid);

--- a/pinc/ProjectState.inc
+++ b/pinc/ProjectState.inc
@@ -51,12 +51,12 @@ class ProjectStates
         return self::$states[$state]->label ?? '';
     }
 
-    public static function get_forum(?string $state): int
+    public static function get_forum(?string $state): ?int
     {
         if (is_null($state)) {
-            return -1;
+            return null;
         }
-        return self::$states[$state]->forum ?? -1;
+        return self::$states[$state]->forum ?? null;
     }
 
     public static function get_phase(?string $state): string

--- a/pinc/ProjectTransition.inc
+++ b/pinc/ProjectTransition.inc
@@ -311,11 +311,14 @@ class ProjectTransition
 
         if ($project->topic_id != "") {
             // The project has a discussion topic.
-            // Ensure it's in the appropriate forum for the project's new state.
-            topic_change_forum(
-                $project->topic_id,
-                ProjectStates::get_forum($this->to_state)
-            );
+            // Ensure it's in the appropriate forum for the project's new state
+            // if the forum exists for the new state
+            if (($forum_id = ProjectStates::get_forum($this->to_state)) !== null) {
+                topic_change_forum(
+                    $project->topic_id,
+                    $forum_id
+                );
+            }
         }
 
         if ($this->collateral_actions) {

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -122,6 +122,10 @@ class SiteConfig
     public array $default_project_char_suites = ["basic-latin"];
     public bool $testing = false;
 
+    // The maximum runtime in seconds a script should try to stay within,
+    // this should be below the TimeOut for the webserver.
+    public int $max_runtime_target_s = 120;
+
     protected function __construct(string $filename)
     {
         if (! is_file($filename)) {

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -124,10 +124,14 @@ class SiteConfig
 
     protected function __construct(string $filename)
     {
+        if (! is_file($filename)) {
+            throw new RuntimeException("Configuration file $filename not found.");
+        }
+
         try {
             require $filename;
         } catch (Error $error) {
-            throw new RuntimeException("Configuration file $filename not found");
+            throw new RuntimeException("Error when importing file $filename; possibly syntax error.");
         }
 
         $ro = new ReflectionObject($this);

--- a/pinc/SiteConfig.inc
+++ b/pinc/SiteConfig.inc
@@ -34,7 +34,7 @@ class SiteConfig
     public string $projects_url;
     public string $dyn_dir;
     public string $dyn_url;
-    public string $dyn_locales_dir;
+    public ?string $dyn_locales_dir;
     public ?string $blog_url;
     public ?string $wiki_url;
 

--- a/pinc/gettext_setup.inc
+++ b/pinc/gettext_setup.inc
@@ -66,7 +66,9 @@ function configure_gettext(string $locale): void
     // Specify location of translation tables and choose domain
     $gettext_domain = 'messages';
     if (function_exists('bindtextdomain')) {
-        bindtextdomain($gettext_domain, SiteConfig::get()->dyn_locales_dir);
+        if (SiteConfig::get()->dyn_locales_dir) {
+            bindtextdomain($gettext_domain, SiteConfig::get()->dyn_locales_dir);
+        }
         bindtextdomain("iso_639", SiteConfig::get()->system_locales_dir);
         if (function_exists("bind_textdomain_codeset")) {
             bind_textdomain_codeset($gettext_domain, 'UTF-8');

--- a/pinc/gradual.inc
+++ b/pinc/gradual.inc
@@ -111,9 +111,12 @@ function welcome_see_beginner_forum(int $pagesproofed, string $page_id, ?string 
             echo _("It's best to select a \"BEGINNERS ONLY\" project if one is available in a language in which you are proficient. These projects have been specially prepared to teach you our style of proofreading. You can expect to receive feedback from a mentor on pages you proofread in BEGINNERS ONLY projects. This feedback will likely come at least a few days after you have completed the pages.");
             echo "</p>";
         }
-        echo "<p>";
-        echo sprintf(_("Please see our <a href='%s'>Beginner's Forum</a> for answers to common questions."), get_url_to_view_forum(SiteConfig::get()->beginners_site_forum_idx));
-        echo "</p>";
+
+        if (SiteConfig::get()->beginners_site_forum_idx) {
+            echo "<p>";
+            echo sprintf(_("Please see our <a href='%s'>Beginner's Forum</a> for answers to common questions."), get_url_to_view_forum(SiteConfig::get()->beginners_site_forum_idx));
+            echo "</p>";
+        }
 
         echo "<p><small>";
         echo _("After a period of time, this message will no longer appear.");

--- a/pinc/languages.inc
+++ b/pinc/languages.inc
@@ -166,7 +166,11 @@ function get_installed_locale_translations($state = "all", bool $reload_cache = 
         "disabled" => [],
     ];
 
-    $files = @scandir(SiteConfig::get()->dyn_locales_dir);
+    if (! SiteConfig::get()->dyn_locales_dir || ! is_dir(SiteConfig::get()->dyn_locales_dir)) {
+        return $translation_cache[$state];
+    }
+
+    $files = scandir(SiteConfig::get()->dyn_locales_dir);
     if (!$files) {
         return $translation_cache[$state];
     }

--- a/pinc/site_vars.php.template
+++ b/pinc/site_vars.php.template
@@ -128,7 +128,3 @@ $auto_post_to_project_topic = <<AUTO_POST_TO_PROJECT_TOPIC>>;
 $ordinary_users_can_see_queue_settings = <<ORDINARY_USERS_CAN_SEE_QUEUE_SETTINGS>>;
 $external_catalog_locator = '<<EXTERNAL_CATALOG_LOCATOR>>';
 $default_project_char_suites = <<DEFAULT_CHAR_SUITES>>;
-
-// The maximum runtime in seconds a script should try to stay within,
-// this should be below the TimeOut for the webserver.
-define("MAX_RUNTIME_TARGET_S", 120);

--- a/pinc/stages.inc
+++ b/pinc/stages.inc
@@ -278,7 +278,7 @@ new Pool(
             get_faq_url("post_proof.php")
         ),
         _("Select an easy work to get started on (usually fiction with a low page count is a good starter book; projects whose manager is BEGIN make excellent first projects for a new post-processor)."),
-        sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum(SiteConfig::get()->post_processing_forum_idx)),
+        SiteConfig::get()->post_processing_forum_idx ? sprintf(_("Check out the <a href='%s'>Post-Processing Forum</a> to post all your questions."), get_url_to_view_forum(SiteConfig::get()->post_processing_forum_idx)) : "",
         _("If nothing interests you right now, check back later and there will be more!"),
         "</p>",
 
@@ -331,12 +331,11 @@ new Pool(
         ),
         "</p>",
 
-        "<p>",
-        sprintf(
-            _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
-            get_url_to_view_forum(SiteConfig::get()->post_processing_forum_idx)
-        ),
-        "</p>",
+        SiteConfig::get()->post_processing_forum_idx ?
+            "<p>" . sprintf(
+                _("As always, the <a href='%s'>Post-Processing Forum</a> is available for any of your questions."),
+                get_url_to_view_forum(SiteConfig::get()->post_processing_forum_idx)
+            ) ."</p>" : "",
     ]
 );
 

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -9,6 +9,8 @@
 // <input type='file'> with name='uploaded_file' Then validate_uploaded_file()
 // can be used to process the upload.
 
+include_once($relPath."SiteConfig.inc");
+
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
@@ -260,7 +262,7 @@ function virus_check(string $file_path, bool $verbose): void
     // value = 0. we use -- to not parse any further arguments starting
     // with -/-- as options
     $process = new Process([$antivirus_executable, "--", $file_path]);
-    $process->setTimeout(MAX_RUNTIME_TARGET_S);
+    $process->setTimeout(SiteConfig::get()->max_runtime_target_s);
     try {
         $av_retval = $process->run();
     } catch (ProcessTimedOutException $exception) {


### PR DESCRIPTION
This is a set of small commits that better support the default (often `null`) configuration values set in `SiteConfig`. These are always set on TEST and PROD but new sites and test configurations don't necessarily need to set them and the default of `null` should work.

This is prep work to remove the bash-based configuration mechanism.