### PR TITLE
unserialize() can be passed null

### DIFF
--- a/tools/project_manager/editproject.php
+++ b/tools/project_manager/editproject.php
@@ -624,7 +624,7 @@ class ProjectInfoHolder
         return base64_encode(serialize($value));
     }
 
-    private function unserialize(string $value): mixed
+    private function unserialize(?string $value): mixed
     {
         return $value ? unserialize(base64_decode($value)) : null;
     }


### PR DESCRIPTION
Having the function accept null for the case when a variable isn't included in a POST seems more sensible than checking the POST and passing the function an empty string.

I updated TEST with the latest code, clicked around on a lot of things, and this was the only thing I found from my initial testing.