### PR TITLE
Update php-cs-fixer from PHP74Migration to PHP8x5Migration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,7 +14,7 @@ $config = new PhpCsFixer\Config();
 $config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
 $config->setRules([
         '@PSR12' => true,
-        '@PHP74Migration' => true,
+        '@PHP8x5Migration' => true,
         // PHP tags
         'linebreak_after_opening_tag' => true,
         'blank_line_after_opening_tag' => false,

--- a/crontab/AutoModify.inc
+++ b/crontab/AutoModify.inc
@@ -16,7 +16,7 @@ class AutoModify extends BackgroundJob
         // Capture the automodify output to a log file
         $logs_dir = SiteConfig::get()->dyn_dir . "/stats/automodify_logs";
         if (! is_dir($logs_dir)) {
-            mkdir($logs_dir, 0777, true);
+            mkdir($logs_dir, 0o777, true);
         }
         $this->logfile = sprintf("$logs_dir/%s.txt", date("Y-m-d_H:i:s_T"));
         $this->filehandle = fopen($this->logfile, "wt");

--- a/locale/translators/index.php
+++ b/locale/translators/index.php
@@ -125,8 +125,8 @@ elseif ($func == "newtranslation2") {
             . _("Back to the Translation Center") . "</a></p>";
     }
 
-    mkdir("$dyn_locales_dir/$locale", 0755);
-    mkdir("$dyn_locales_dir/$locale/LC_MESSAGES/", 0755);
+    mkdir("$dyn_locales_dir/$locale", 0o755);
+    mkdir("$dyn_locales_dir/$locale/LC_MESSAGES/", 0o755);
 
     $po_filename = "$dyn_locales_dir/$locale/LC_MESSAGES/messages.po";
     $po_file = new POFile($po_filename);

--- a/pinc/POFile.inc
+++ b/pinc/POFile.inc
@@ -255,7 +255,7 @@ class POFile
         if (!rename($tempfile, $pot_filename)) {
             throw new RuntimeException("Unable to rename $tempfile to $pot_filename");
         }
-        if (!chmod($pot_filename, 0644)) {
+        if (!chmod($pot_filename, 0o644)) {
             throw new RuntimeException("Unable to chmod $pot_filename");
         }
     }

--- a/pinc/Project.inc
+++ b/pinc/Project.inc
@@ -622,7 +622,7 @@ class Project
             $this->log_project_event(User::current_username(), 'creation');
 
             // Make the project directory
-            if (!mkdir($this->dir, 0777, true)) {
+            if (!mkdir($this->dir, 0o777, true)) {
                 throw new RuntimeException("Unable to mkdir '$this->dir'");
             }
 

--- a/pinc/post_files.inc
+++ b/pinc/post_files.inc
@@ -104,7 +104,7 @@ function generate_interim_file(
 
     // first find a unique place to operate in:
     $dirname = sys_get_temp_dir() . "/" . uniqid("post_files");
-    mkdir($dirname, 0777);
+    mkdir($dirname, 0o777);
 
     $textfile_path = "{$dirname}/{$filename}.txt";
     $zip_path = "{$dirname}/{$filename}.zip";
@@ -383,7 +383,7 @@ function generate_project_images_zip(string $projectid): array
     }
 
     if (!is_dir(dirname($zipfile_path))) {
-        mkdir(dirname($zipfile_path), 0777, true /* recursive */);
+        mkdir(dirname($zipfile_path), 0o777, true /* recursive */);
     }
 
     // Get a list of image filenames

--- a/pinc/upload_file.inc
+++ b/pinc/upload_file.inc
@@ -182,7 +182,7 @@ function validate_uploaded_file(bool $verbose): array
                 throw new FileUploadException(_("You may only upload one file"));
             }
             // allow anti_virus to read it
-            chmod($file_path, 0644);
+            chmod($file_path, 0o644);
         } else {
             // resumable upload
             $root_staging_dir = "/tmp/resumable_uploads";

--- a/stats/includes/team.inc
+++ b/stats/includes/team.inc
@@ -580,14 +580,14 @@ function uploadImages(bool $preview, null|int|string $tid, string $type): ?array
 
     // see if $team_avatars_dir exists and if not try to create it
     if (! is_dir($team_avatars_dir)) {
-        if (!mkdir($team_avatars_dir, 0777, true)) {
+        if (!mkdir($team_avatars_dir, 0o777, true)) {
             throw new RuntimeException(_("Error creating team avatar directory."));
         }
     }
 
     // ditto $team_icons_dir
     if (! is_dir($team_icons_dir)) {
-        if (!mkdir($team_icons_dir, 0777, true)) {
+        if (!mkdir($team_icons_dir, 0o777, true)) {
             throw new RuntimeException(_("Error creating team icons directory."));
         }
     }

--- a/tools/project_manager/add_files.php
+++ b/tools/project_manager/add_files.php
@@ -91,8 +91,8 @@ if (substr($abs_source, -4) == ".zip") {
     // We will unpack it to a sibling directory.
     $source_project_dir = substr($abs_source, 0, -4);
     if (!file_exists($source_project_dir)) {
-        mkdir($source_project_dir, 0777);
-        chmod($source_project_dir, 0777);
+        mkdir($source_project_dir, 0o777);
+        chmod($source_project_dir, 0o777);
     }
 
     extract_zip_to($abs_source, $source_project_dir);

--- a/tools/project_manager/remote_file_manager.php
+++ b/tools/project_manager/remote_file_manager.php
@@ -90,12 +90,12 @@ $home_path = "$uploads_dir/$home_dirname";
 if (!is_dir($home_path)) {
     // attempt to create $home_path recursively, so that if
     // $users_rel_dir doesn't exist, we create that too
-    if (!mkdir($home_path, 0777, true)) {
+    if (!mkdir($home_path, 0o777, true)) {
         show_message('error', _("Could not create home folder!"));
         exit();
     }
     if (SiteConfig::get()->testing) {
-        chmod($home_path, 0777);
+        chmod($home_path, 0o777);
         // so that it's easier to clean up test cases.
 
         // (mkdir's mode arg is 0777 by default,

--- a/tools/upload_resumable_file.php
+++ b/tools/upload_resumable_file.php
@@ -52,7 +52,7 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
             // Suppress warning by mkdir because despite the check above
             // race conditions from other processes can result in the
             // directory existing when we try to create it here.
-            @mkdir($staging_dir, 0777, true);
+            @mkdir($staging_dir, 0o777, true);
         }
 
         if (!move_uploaded_file($file['tmp_name'], $chunk_filename)) {


### PR DESCRIPTION
The only new rule that fired was octal_notation from PHP8x1Migration. Support for this newer (and less potentially confusing) notation was added in PHP 8.1.

Apply fixes (all to `mkdir` and `chmod`, unsurprisingly).