### PR TITLE
forum_interface_*: Make sure JSON & PHPBB3 have same interfaces

### DIFF
--- a/pinc/forum_interface_json.inc
+++ b/pinc/forum_interface_json.inc
@@ -214,7 +214,6 @@ function get_reset_password_url(): string
 
 /**
  * @return ?array<string, mixed>
- * @phpstan-ignore return.unusedType
  */
 function get_forum_user_details(string $username): ?array
 // Given a username, return details about the user.
@@ -255,7 +254,10 @@ function get_forum_user_details(string $username): ?array
     ];
 
     $userManager = new ForumJsonUser();
-    $user = $userManager->load($username) ?? [];
+    $user = $userManager->load($username);
+    if (is_null($user)) {
+        return null;
+    }
 
     $return_data = [];
 
@@ -284,9 +286,7 @@ function get_forum_user_id(string $username): ?int
     $user = $userManager->load($username);
 
     if (!$user) {
-        // there might be users in the DP DB that aren't in the JSON
-        // file, so return 0
-        return 0;
+        return null;
     }
 
     // update the cache
@@ -431,7 +431,7 @@ function get_last_post_time_in_topic(int $topic_id): ?int
 }
 
 /**
- * @return array<string, mixed>
+ * @return ?array<string, mixed>
  *    Returns the following details about a topic as an associative array.
  *        topic_id         - the ID of the topic (for completeness)
  *        title            - the title of the topic
@@ -440,12 +440,12 @@ function get_last_post_time_in_topic(int $topic_id): ?int
  *        forum_id         - the id of the forum the topic is in
  *        creator_username - the username of the topic creator
  */
-function get_topic_details(int $topic_id): array
+function get_topic_details(int $topic_id): ?array
 {
     $postManager = new ForumJsonPost();
     $posts = $postManager->load_topic($topic_id);
     if (!$posts) {
-        return [];
+        return null;
     }
 
     return [

--- a/pinc/forum_interface_phpbb3.inc
+++ b/pinc/forum_interface_phpbb3.inc
@@ -475,11 +475,7 @@ function get_forum_rank_title(int $rank): ?string
     $row = mysqli_fetch_assoc($res);
     mysqli_free_result($res);
 
-    if (!$row) {
-        return null;
-    }
-
-    return $row["rank_title"];
+    return $row["rank_title"] ?? null;
 }
 
 /**
@@ -682,11 +678,7 @@ function get_last_post_time_in_topic(int $topic_id): ?int
     $row = mysqli_fetch_assoc($res);
     mysqli_free_result($res);
 
-    if (!$row) {
-        return null;
-    }
-
-    return $row["max_post_time"];
+    return $row["max_post_time"] ?? null;
 }
 
 /**
@@ -699,9 +691,9 @@ function get_last_post_time_in_topic(int $topic_id): ?int
  * - forum_name       - name of the forum the topic is in
  * - forum_id         - the id of the forum the topic is in
  * - creator_username - the username of the topic creator
- * @return array<string, mixed>
+ * @return ?array<string, mixed>
  */
-function get_topic_details(int $topic_id): array
+function get_topic_details(int $topic_id): ?array
 {
     $forums_phpbb_dir = SiteConfig::get()->forums_phpbb_dir;
 
@@ -757,12 +749,9 @@ function topic_create(
     $topic_id = call_phpbb_function('create_topic', $args);
 
     if (!preg_match('/^\d+$/', $topic_id)) {
-        $topic_id = null;
-    } else {
-        $topic_id = (int)$topic_id;
+        return null;
     }
-
-    return $topic_id;
+    return (int)$topic_id;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
After a 'Return value must be of type array, null returned' error reported by mrducky.

This should in theory have been caught by pageload_smoketest.py, but unfortunately can't currently be, because the CI environment runs only with the forum_interface_json.inc code, and we'd need to set up an entire phpbb3 install to catch this in CI.

In particular, make sure that all the phpb33 functions that return rows from the database have nullable return types.

Fix some inconsistencies where, e.g., JSON returns 0 and PHPBB3 returns null for a non-existent user.

While here, make some error handling code less verbose.