### PR TITLE
diff.php: Fix exception when either side of the diff is OCR

### DIFF
--- a/SETUP/tests/smoketests/pageload_smoketest.py
+++ b/SETUP/tests/smoketests/pageload_smoketest.py
@@ -322,7 +322,9 @@ WEB_TESTS = [
     {'name': 'tools-pm-automodify', 'path': 'tools/project_manager/automodify.php'},
     {'name': 'tools-pm-bad-bytes-explainer', 'path': 'tools/project_manager/bad_bytes_explainer.php'},
     {'name': 'tools-pm-clearance-check', 'path': 'tools/project_manager/clearance_check.php'},
-    {'name': 'tools-pm-diff', 'path': 'tools/project_manager/diff.php?project=projectID5e23a810ef693&L_round=P1&R_round=P2&image=001.png'},
+    {'name': 'tools-pm-diff-p1-p2', 'path': 'tools/project_manager/diff.php?project=projectID5e23a810ef693&L_round=P1&R_round=P2&image=001.png'},
+    {'name': 'tools-pm-diff-ocr-p1', 'path': 'tools/project_manager/diff.php?project=projectID5e23a810ef693&L_round=OCR&R_round=P1&image=001.png'},
+    {'name': 'tools-pm-diff-p2-ocr', 'path': 'tools/project_manager/diff.php?project=projectID5e23a810ef693&L_round=P2&R_round=OCR&image=001.png'},
     # (deliberately) not clicking 'Confirm'...
     {'name': 'tools-pm-edit-pages', 'path': 'tools/project_manager/edit_pages.php?projectid=projectID5e23a810ef693&operation=clear&selected_pages[001.png]=on'},
     # TODO project dir doesn't exist

--- a/tools/project_manager/diff.php
+++ b/tools/project_manager/diff.php
@@ -185,8 +185,8 @@ if ($L_text != $R_text) {
 function get_navigation(
     Project $project,
     string $image,
-    Round $L_round,
-    Round $R_round,
+    Round|stdClass $L_round,
+    Round|stdClass $R_round,
     string $L_user,
     string $format,
     bool $only_nonempty_diffs,


### PR DESCRIPTION
We synthesise a fake OCR round object for this case and failed to allow it in all places.

Add a smoke test to catch this.